### PR TITLE
API Marshaler: Fix RESTXML protocol marshaler code generation for locationName

### DIFF
--- a/awstesting/cmd/svcoutput/main.go
+++ b/awstesting/cmd/svcoutput/main.go
@@ -1,0 +1,636 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go/service/applicationdiscoveryservice"
+	"github.com/aws/aws-sdk-go/service/appstream"
+	"github.com/aws/aws-sdk-go/service/athena"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/aws/aws-sdk-go/service/budgets"
+	"github.com/aws/aws-sdk-go/service/clouddirectory"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudhsm"
+	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
+	"github.com/aws/aws-sdk-go/service/cloudsearch"
+	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/aws/aws-sdk-go/service/codecommit"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/aws/aws-sdk-go/service/codepipeline"
+	"github.com/aws/aws-sdk-go/service/codestar"
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go/service/cognitosync"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/aws/aws-sdk-go/service/costandusagereportservice"
+	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/aws/aws-sdk-go/service/dax"
+	"github.com/aws/aws-sdk-go/service/devicefarm"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/efs"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/aws/aws-sdk-go/service/elastictranscoder"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/emr"
+	"github.com/aws/aws-sdk-go/service/firehose"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/aws/aws-sdk-go/service/glacier"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/aws/aws-sdk-go/service/greengrass"
+	"github.com/aws/aws-sdk-go/service/health"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/inspector"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/aws/aws-sdk-go/service/iotdataplane"
+	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
+	"github.com/aws/aws-sdk-go/service/lexruntimeservice"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/aws/aws-sdk-go/service/machinelearning"
+	"github.com/aws/aws-sdk-go/service/marketplacecommerceanalytics"
+	"github.com/aws/aws-sdk-go/service/marketplaceentitlementservice"
+	"github.com/aws/aws-sdk-go/service/marketplacemetering"
+	"github.com/aws/aws-sdk-go/service/migrationhub"
+	"github.com/aws/aws-sdk-go/service/mobile"
+	"github.com/aws/aws-sdk-go/service/mobileanalytics"
+	"github.com/aws/aws-sdk-go/service/mturk"
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/aws/aws-sdk-go/service/opsworkscm"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/aws/aws-sdk-go/service/polly"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/aws/aws-sdk-go/service/rekognition"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53domains"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/servicecatalog"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go/service/simpledb"
+	"github.com/aws/aws-sdk-go/service/sms"
+	"github.com/aws/aws-sdk-go/service/snowball"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/support"
+	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/aws/aws-sdk-go/service/workdocs"
+	"github.com/aws/aws-sdk-go/service/workspaces"
+	"github.com/aws/aws-sdk-go/service/xray"
+)
+
+func main() {
+	w := writer{
+		buf:       bytes.NewBuffer(nil),
+		indentStr: "\t",
+	}
+	server := setupServer(w.Indent())
+	defer server.Close()
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		Endpoint:               &server.URL,
+		Region:                 aws.String(endpoints.UsWest2RegionID),
+		Credentials:            credentials.AnonymousCredentials,
+		S3ForcePathStyle:       aws.Bool(true),
+		DisableParamValidation: aws.Bool(true),
+		//		LogLevel:               aws.LogLevel(aws.LogDebugWithHTTPBody),
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+	}))
+	sess.Handlers.Send.PushFront(func(r *request.Request) {
+		w.Writef("%s.%s:", r.ClientInfo.ServiceName, r.Operation.Name)
+	})
+
+	for _, service := range createServices(sess) {
+		fmt.Println("Processing:", service.name)
+		if err := callService(service.value); err != nil {
+			panic(fmt.Sprintf("Service, %s failed, %v", service.name, err))
+		}
+	}
+
+	io.Copy(os.Stdout, w.buf)
+}
+
+const (
+	allowedRecursion = 2
+	sliceSize        = 3
+)
+
+func callService(svcV reflect.Value) error {
+	params := []reflect.Value{
+		reflect.ValueOf(aws.BackgroundContext()),
+		reflect.Value{},
+		reflect.ValueOf(request.Option(
+			func(r *request.Request) {
+				origURL, _ := url.Parse(*r.Config.Endpoint)
+				r.Handlers.Build.PushBack(func(req *request.Request) {
+					// Fix URL mutation caused by machinelearning predictendpoint customization
+					newURL := r.HTTPRequest.URL
+					r.HTTPRequest.URL = origURL
+					r.HTTPRequest.URL.Path = newURL.Path
+					if !strings.HasPrefix(r.HTTPRequest.URL.Path, "/") {
+						r.HTTPRequest.URL.Path = "/" + r.HTTPRequest.URL.Path
+					}
+					r.HTTPRequest.URL.RawPath = newURL.RawPath
+					r.HTTPRequest.URL.RawQuery = newURL.RawQuery
+
+					// Correct ContentLength fields for S3 operations
+					if r.ClientInfo.ServiceName == "s3" {
+						switch r.Operation.Name {
+						case "PutObject", "UploadPart":
+							n, _ := computeBodyLength(r.GetBody())
+							r.HTTPRequest.Header.Set("Content-Length", strconv.FormatInt(n, 10))
+						}
+					}
+				})
+				r.Handlers.Unmarshal.PushBack(func(req *request.Request) {
+					if r.ClientInfo.ServiceName == "sqs" {
+						// Ignore validation performed by the SQS handlers
+						switch r.Operation.Name {
+						case "SendMessage", "SendMessageBatch", "ReceiveMessage":
+							aerr, ok := r.Error.(awserr.Error)
+							if !ok {
+								return
+							}
+							if aerr.Code() == "InvalidChecksum" {
+								r.Error = nil
+							}
+						}
+					}
+				})
+				r.Handlers.Complete.PushBack(func(req *request.Request) {
+					if r.Error != nil {
+						fmt.Println(r.Params)
+					}
+				})
+			},
+		)),
+	}
+
+	svcT := svcV.Type()
+	n := svcT.NumMethod()
+
+	for i := 0; i < n; i++ {
+		fv := svcV.Method(i)
+		fm := svcT.Method(i)
+		ft := fm.Type
+		fName := fm.Name
+		if !strings.HasSuffix(fName, "WithContext") || strings.HasSuffix(fName, "PagesWithContext") || strings.HasPrefix(fName, "WaitUntil") {
+			continue
+		}
+		fmt.Println("-", fm.Name)
+
+		it := ft.In(2)
+		iv := valueForType(it, visitType(it))
+
+		params[1] = iv
+		ovs := fv.Call(params)
+		if v := ovs[1]; !v.IsNil() {
+			return v.Interface().(error)
+		}
+	}
+
+	return nil
+}
+
+func asVisited(v map[reflect.Type]int, t reflect.Type) (map[reflect.Type]int, bool) {
+	if c, ok := v[t]; ok {
+		if c == 0 {
+			return v, false
+		}
+		c--
+		v[t] = c
+	} else {
+		v[t] = allowedRecursion
+	}
+
+	return v, true
+}
+
+var ioReadSeekerType = reflect.TypeOf((*io.ReadSeeker)(nil)).Elem()
+var emptyInterfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
+
+func valueForType(vt reflect.Type, visited *visitedType) reflect.Value {
+	var v reflect.Value
+
+	vtt := vt
+	if vtt.Kind() == reflect.Ptr {
+		vtt = vtt.Elem()
+	}
+
+	switch vtt.Kind() {
+	case reflect.Map:
+		v = reflect.MakeMap(vtt)
+		kt := vtt.Key()
+		kv := valueForType(kt, visited)
+		et := vtt.Elem()
+		ev := valueForType(et, visited)
+		v.SetMapIndex(kv, ev)
+
+	case reflect.Slice:
+		v = reflect.MakeSlice(vtt, sliceSize, sliceSize)
+		vet := vtt.Elem()
+		for i := 0; i < sliceSize; i++ {
+			sv := v.Index(i)
+			nsv := valueForType(vet, visited)
+			sv.Set(nsv)
+		}
+
+	case reflect.Interface:
+		switch vtt {
+		case ioReadSeekerType:
+			v = reflect.New(vtt)
+			v.Elem().Set(reflect.ValueOf(bytes.NewReader([]byte("byte value"))))
+		case emptyInterfaceType:
+			v = reflect.ValueOf("empty interface value")
+		default:
+			panic("value for interface, unknown type" + vtt.String())
+		}
+
+	case reflect.String:
+		v = reflect.New(vtt)
+		v.Elem().SetString("stringValue")
+
+	case reflect.Bool:
+		v = reflect.New(vtt)
+		v.Elem().SetBool(true)
+
+	case reflect.Uint8: // byte
+		v = reflect.New(vtt)
+		v.Elem().Set(reflect.ValueOf(uint8('b')))
+
+	case reflect.Int64:
+		v = reflect.New(vtt)
+		v.Elem().SetInt(987654321)
+
+	case reflect.Float64:
+		v = reflect.New(vtt)
+		v.Elem().SetFloat(123456789.321)
+
+	case reflect.Struct:
+		v = reflect.New(vtt)
+		ve := v.Elem()
+		n := ve.NumField()
+		for i := 0; i < n; i++ {
+			fv := ve.Field(i)
+			fs := vtt.Field(i)
+			ft := fv.Type()
+			if len(fs.PkgPath) != 0 {
+				continue
+			}
+			nested, keep := visited.Visit(ft)
+			if !keep {
+				continue
+			}
+			nfv := valueForType(ft, nested)
+			fv.Set(nfv)
+		}
+	default:
+		panic("unknown type, " + vtt.String())
+	}
+
+	if vt.Kind() != reflect.Ptr && v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	return v
+}
+
+func setupServer(out writer) *httptest.Server {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		out.Writef("Path:")
+		out.Indent().Writef(r.URL.Path)
+		out.Writef("Query:")
+
+		var keys []string
+		query := r.URL.Query()
+		for k := range query {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			for _, v := range query[k] {
+				out.Indent().Writef("%s: %s", k, v)
+			}
+		}
+		out.Writef("Headers:")
+		keys = keys[0:0]
+		for k := range r.Header {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			for _, v := range r.Header[k] {
+				out.Indent().Writef("%s: %s", k, v)
+			}
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		r.Body.Close()
+		out.Writef("Body:")
+		//out.Indent().Writef(base64.StdEncoding.EncodeToString(body))
+		out.Indent().Writef(string(body))
+	}))
+
+	return server
+}
+
+type writer struct {
+	buf       *bytes.Buffer
+	indent    int
+	indentStr string
+}
+
+func (w writer) Writef(format string, args ...interface{}) error {
+	indent := strings.Repeat(w.indentStr, w.indent)
+	w.buf.WriteString(indent)
+	w.buf.WriteString(fmt.Sprintf(format, args...))
+	w.buf.WriteRune('\n')
+	return nil
+}
+func (w writer) Indent() writer {
+	newW := w
+	newW.indent++
+	return newW
+}
+
+type visitedType struct {
+	typ  reflect.Type
+	left int
+	next *visitedType
+}
+
+func visitType(t reflect.Type) *visitedType {
+	return &visitedType{
+		typ:  t,
+		left: allowedRecursion,
+	}
+}
+
+func (v *visitedType) String() string {
+	if v == nil {
+		return "END"
+	}
+	return fmt.Sprintf("Type:%v,Kind:%v,Left:%v->%v", v.typ.Name(), v.typ.Kind(), v.left, v.next.String())
+}
+
+func (v *visitedType) copy() *visitedType {
+	nv := &visitedType{}
+
+	oldNext := v
+	newNext := nv
+
+	for {
+		*newNext = *oldNext
+		oldNext = oldNext.next
+
+		if oldNext == nil {
+			break
+		}
+
+		newNext.next = &visitedType{}
+		newNext = newNext.next
+	}
+
+	return nv
+}
+
+func (v *visitedType) Visit(t reflect.Type) (*visitedType, bool) {
+	if v == nil {
+		return visitType(t), true
+	}
+
+	nv := v.copy()
+
+	last := nv
+	next := nv
+	for next != nil {
+		last = next
+		if next.typ != t {
+			next = next.next
+			continue
+		}
+
+		next.left--
+		return nv, next.left >= 0
+	}
+
+	last.next = visitType(t)
+
+	return nv, true
+}
+
+type service struct {
+	name  string
+	value reflect.Value
+}
+
+func createServices(sess *session.Session) []service {
+	return []service{
+		{name: "acm", value: reflect.ValueOf(acm.New(sess))},
+		{name: "apigateway", value: reflect.ValueOf(apigateway.New(sess))},
+		{name: "applicationautoscaling", value: reflect.ValueOf(applicationautoscaling.New(sess))},
+		{name: "applicationdiscoveryservice", value: reflect.ValueOf(applicationdiscoveryservice.New(sess))},
+		{name: "appstream", value: reflect.ValueOf(appstream.New(sess))},
+		{name: "athena", value: reflect.ValueOf(athena.New(sess))},
+		{name: "autoscaling", value: reflect.ValueOf(autoscaling.New(sess))},
+		{name: "batch", value: reflect.ValueOf(batch.New(sess))},
+		{name: "budgets", value: reflect.ValueOf(budgets.New(sess))},
+		{name: "clouddirectory", value: reflect.ValueOf(clouddirectory.New(sess))},
+		{name: "cloudformation", value: reflect.ValueOf(cloudformation.New(sess))},
+		{name: "cloudfront", value: reflect.ValueOf(cloudfront.New(sess))},
+		{name: "cloudhsm", value: reflect.ValueOf(cloudhsm.New(sess))},
+		{name: "cloudhsmv2", value: reflect.ValueOf(cloudhsmv2.New(sess))},
+		{name: "cloudsearch", value: reflect.ValueOf(cloudsearch.New(sess))},
+		{name: "cloudsearchdomain", value: reflect.ValueOf(cloudsearchdomain.New(sess))},
+		{name: "cloudtrail", value: reflect.ValueOf(cloudtrail.New(sess))},
+		{name: "cloudwatch", value: reflect.ValueOf(cloudwatch.New(sess))},
+		{name: "cloudwatchevents", value: reflect.ValueOf(cloudwatchevents.New(sess))},
+		{name: "cloudwatchlogs", value: reflect.ValueOf(cloudwatchlogs.New(sess))},
+		{name: "codebuild", value: reflect.ValueOf(codebuild.New(sess))},
+		{name: "codecommit", value: reflect.ValueOf(codecommit.New(sess))},
+		{name: "codedeploy", value: reflect.ValueOf(codedeploy.New(sess))},
+		{name: "codepipeline", value: reflect.ValueOf(codepipeline.New(sess))},
+		{name: "codestar", value: reflect.ValueOf(codestar.New(sess))},
+		{name: "cognitoidentity", value: reflect.ValueOf(cognitoidentity.New(sess))},
+		{name: "cognitoidentityprovider", value: reflect.ValueOf(cognitoidentityprovider.New(sess))},
+		{name: "cognitosync", value: reflect.ValueOf(cognitosync.New(sess))},
+		{name: "configservice", value: reflect.ValueOf(configservice.New(sess))},
+		{name: "costandusagereportservice", value: reflect.ValueOf(costandusagereportservice.New(sess))},
+		{name: "databasemigrationservice", value: reflect.ValueOf(databasemigrationservice.New(sess))},
+		{name: "datapipeline", value: reflect.ValueOf(datapipeline.New(sess))},
+		{name: "dax", value: reflect.ValueOf(dax.New(sess))},
+		{name: "devicefarm", value: reflect.ValueOf(devicefarm.New(sess))},
+		{name: "directconnect", value: reflect.ValueOf(directconnect.New(sess))},
+		{name: "directoryservice", value: reflect.ValueOf(directoryservice.New(sess))},
+		{name: "dynamodb", value: reflect.ValueOf(dynamodb.New(sess))},
+		{name: "dynamodbstreams", value: reflect.ValueOf(dynamodbstreams.New(sess))},
+		{name: "ec2", value: reflect.ValueOf(ec2.New(sess))},
+		{name: "ecr", value: reflect.ValueOf(ecr.New(sess))},
+		{name: "ecs", value: reflect.ValueOf(ecs.New(sess))},
+		{name: "efs", value: reflect.ValueOf(efs.New(sess))},
+		{name: "elasticache", value: reflect.ValueOf(elasticache.New(sess))},
+		{name: "elasticbeanstalk", value: reflect.ValueOf(elasticbeanstalk.New(sess))},
+		{name: "elasticsearchservice", value: reflect.ValueOf(elasticsearchservice.New(sess))},
+		{name: "elastictranscoder", value: reflect.ValueOf(elastictranscoder.New(sess))},
+		{name: "elb", value: reflect.ValueOf(elb.New(sess))},
+		{name: "elbv2", value: reflect.ValueOf(elbv2.New(sess))},
+		{name: "emr", value: reflect.ValueOf(emr.New(sess))},
+		{name: "firehose", value: reflect.ValueOf(firehose.New(sess))},
+		{name: "gamelift", value: reflect.ValueOf(gamelift.New(sess))},
+		{name: "glacier", value: reflect.ValueOf(glacier.New(sess))},
+		{name: "glue", value: reflect.ValueOf(glue.New(sess))},
+		{name: "greengrass", value: reflect.ValueOf(greengrass.New(sess))},
+		{name: "health", value: reflect.ValueOf(health.New(sess))},
+		{name: "iam", value: reflect.ValueOf(iam.New(sess))},
+		{name: "inspector", value: reflect.ValueOf(inspector.New(sess))},
+		{name: "iot", value: reflect.ValueOf(iot.New(sess))},
+		{name: "iotdataplane", value: reflect.ValueOf(iotdataplane.New(sess))},
+		{name: "kinesis", value: reflect.ValueOf(kinesis.New(sess))},
+		{name: "kinesisanalytics", value: reflect.ValueOf(kinesisanalytics.New(sess))},
+		{name: "kms", value: reflect.ValueOf(kms.New(sess))},
+		{name: "lambda", value: reflect.ValueOf(lambda.New(sess))},
+		{name: "lexmodelbuildingservice", value: reflect.ValueOf(lexmodelbuildingservice.New(sess))},
+		{name: "lexruntimeservice", value: reflect.ValueOf(lexruntimeservice.New(sess))},
+		{name: "lightsail", value: reflect.ValueOf(lightsail.New(sess))},
+		{name: "machinelearning", value: reflect.ValueOf(machinelearning.New(sess))},
+		{name: "marketplacecommerceanalytics", value: reflect.ValueOf(marketplacecommerceanalytics.New(sess))},
+		{name: "marketplaceentitlementservice", value: reflect.ValueOf(marketplaceentitlementservice.New(sess))},
+		{name: "marketplacemetering", value: reflect.ValueOf(marketplacemetering.New(sess))},
+		{name: "migrationhub", value: reflect.ValueOf(migrationhub.New(sess))},
+		{name: "mobile", value: reflect.ValueOf(mobile.New(sess))},
+		{name: "mobileanalytics", value: reflect.ValueOf(mobileanalytics.New(sess))},
+		{name: "mturk", value: reflect.ValueOf(mturk.New(sess))},
+		{name: "opsworks", value: reflect.ValueOf(opsworks.New(sess))},
+		{name: "opsworkscm", value: reflect.ValueOf(opsworkscm.New(sess))},
+		{name: "organizations", value: reflect.ValueOf(organizations.New(sess))},
+		{name: "pinpoint", value: reflect.ValueOf(pinpoint.New(sess))},
+		{name: "polly", value: reflect.ValueOf(polly.New(sess))},
+		{name: "rds", value: reflect.ValueOf(rds.New(sess))},
+		{name: "redshift", value: reflect.ValueOf(redshift.New(sess))},
+		{name: "rekognition", value: reflect.ValueOf(rekognition.New(sess))},
+		{name: "resourcegroupstaggingapi", value: reflect.ValueOf(resourcegroupstaggingapi.New(sess))},
+		{name: "route53", value: reflect.ValueOf(route53.New(sess))},
+		{name: "route53domains", value: reflect.ValueOf(route53domains.New(sess))},
+		{name: "s3", value: reflect.ValueOf(s3.New(sess))},
+		{name: "servicecatalog", value: reflect.ValueOf(servicecatalog.New(sess))},
+		{name: "ses", value: reflect.ValueOf(ses.New(sess))},
+		{name: "sfn", value: reflect.ValueOf(sfn.New(sess))},
+		{name: "shield", value: reflect.ValueOf(shield.New(sess))},
+		{name: "simpledb", value: reflect.ValueOf(simpledb.New(sess))},
+		{name: "sms", value: reflect.ValueOf(sms.New(sess))},
+		{name: "snowball", value: reflect.ValueOf(snowball.New(sess))},
+		{name: "sns", value: reflect.ValueOf(sns.New(sess))},
+		{name: "sqs", value: reflect.ValueOf(sqs.New(sess))},
+		{name: "ssm", value: reflect.ValueOf(ssm.New(sess))},
+		{name: "storagegateway", value: reflect.ValueOf(storagegateway.New(sess))},
+		{name: "sts", value: reflect.ValueOf(sts.New(sess))},
+		{name: "support", value: reflect.ValueOf(support.New(sess))},
+		{name: "swf", value: reflect.ValueOf(swf.New(sess))},
+		{name: "waf", value: reflect.ValueOf(waf.New(sess))},
+		{name: "wafregional", value: reflect.ValueOf(wafregional.New(sess))},
+		{name: "workdocs", value: reflect.ValueOf(workdocs.New(sess))},
+		{name: "workspaces", value: reflect.ValueOf(workspaces.New(sess))},
+		{name: "xray", value: reflect.ValueOf(xray.New(sess))},
+	}
+}
+
+func computeBodyLength(r io.ReadSeeker) (int64, error) {
+	seekable := true
+	// Determine if the seeker is actually seekable. ReaderSeekerCloser
+	// hides the fact that a io.Readers might not actually be seekable.
+	switch v := r.(type) {
+	case aws.ReaderSeekerCloser:
+		seekable = v.IsSeeker()
+	case *aws.ReaderSeekerCloser:
+		seekable = v.IsSeeker()
+	}
+	if !seekable {
+		return -1, nil
+	}
+
+	curOffset, err := r.Seek(0, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	endOffset, err := r.Seek(0, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = r.Seek(curOffset, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return endOffset - curOffset, nil
+}

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -383,6 +383,7 @@ func generateTestSuite(filename string) string {
 		svcPrefix := inout + "Service" + strconv.Itoa(i+1)
 		suite.API.Metadata.ServiceAbbreviation = svcPrefix + "ProtocolTest"
 		suite.API.Operations = map[string]*api.Operation{}
+
 		for idx, c := range suite.Cases {
 			c.Given.ExportedName = svcPrefix + "TestCaseOperation" + strconv.Itoa(idx+1)
 			suite.API.Operations[c.Given.ExportedName] = c.Given
@@ -394,6 +395,9 @@ func generateTestSuite(filename string) string {
 		suite.API.NoConstServiceNames = true // don't generate service names
 		suite.API.Setup()
 		suite.API.Metadata.EndpointPrefix = suite.API.PackageName()
+
+		// TODO until generated marshalers are all supported
+		suite.API.EnableSelectGeneratedMarshalers()
 
 		// Sort in order for deterministic test generation
 		names := make([]string, 0, len(suite.API.Shapes))

--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -1692,5 +1692,78 @@
         }
       }
     ]
+  },
+  {
+    "description": "Structure payload",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "FooShape"
+          }
+        }
+      },
+      "FooShape": {
+        "locationName": "foo",
+        "type": "structure",
+        "members": {
+          "baz": {
+            "shape": "BazShape"
+          }
+        }
+      },
+      "BazShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": {
+            "baz": "bar"
+          }
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "<foo><baz>bar</baz></foo>",
+          "uri": "/"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {},
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/"
+        }
+      }
+    ]
   }
 ]

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -46,6 +46,10 @@ type API struct {
 	// Set to true to not generate struct field accessors
 	NoGenStructFieldAccessors bool
 
+	// Set to true to not generate (un)marshalers
+	NoGenMarshalers   bool
+	NoGenUnmarshalers bool
+
 	SvcClientImportPath string
 
 	initialized bool
@@ -270,6 +274,9 @@ func (a *API) APIGoCode() string {
 	a.imports["github.com/aws/aws-sdk-go/aws/request"] = true
 	if a.OperationHasOutputPlaceholder() {
 		a.imports["github.com/aws/aws-sdk-go/private/protocol/"+a.ProtocolPackage()] = true
+		a.imports["github.com/aws/aws-sdk-go/private/protocol"] = true
+	}
+	if !a.NoGenMarshalers || !a.NoGenUnmarshalers {
 		a.imports["github.com/aws/aws-sdk-go/private/protocol"] = true
 	}
 

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -47,6 +47,21 @@ func (a *API) customizationPasses() {
 	if fn := svcCustomizations[a.PackageName()]; fn != nil {
 		fn(a)
 	}
+
+	// TODO until generated marshalers are all supported
+	a.EnableSelectGeneratedMarshalers()
+}
+
+func (a *API) EnableSelectGeneratedMarshalers() {
+	// Selectivily enable generated marshalers as available
+	a.NoGenMarshalers = true
+	a.NoGenUnmarshalers = true
+
+	// Enable generated marshalers
+	switch a.Metadata.Protocol {
+	case "rest-xml", "rest-json":
+		a.NoGenMarshalers = false
+	}
 }
 
 // s3Customizations customizes the API generation to replace values specific to S3.

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -61,6 +61,15 @@ func (a *API) resolveReferences() {
 			o.ErrorRefs[i].Shape.IsError = true
 		}
 	}
+
+	for _, s := range a.Shapes {
+		switch s.Type {
+		case "list":
+			s.MemberRef.Shape.UsedInList = true
+		case "map":
+			s.ValueRef.Shape.UsedInMap = true
+		}
+	}
 }
 
 // A referenceResolver provides a way to resolve shape references to

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -78,6 +78,9 @@ type Shape struct {
 
 	OrigShapeName string `json:"-"`
 
+	UsedInMap  bool
+	UsedInList bool
+
 	// Defines if the shape is a placeholder and should not be used directly
 	Placeholder bool
 
@@ -185,10 +188,18 @@ func (s *Shape) GoStructValueType(name string, ref *ShapeRef) string {
 	return v
 }
 
+func (s *Shape) IsRefPayload(name string) bool {
+	return s.Payload == name
+}
+
+func (s *Shape) IsRefPayloadReader(name string, ref *ShapeRef) bool {
+	return (ref.Streaming || ref.Shape.Streaming) && s.IsRefPayload(name)
+}
+
 // GoStructType returns the type of a struct field based on the API
 // model definition.
 func (s *Shape) GoStructType(name string, ref *ShapeRef) string {
-	if (ref.Streaming || ref.Shape.Streaming) && s.Payload == name {
+	if s.IsRefPayloadReader(name, ref) {
 		rtype := "io.ReadSeeker"
 		if strings.HasSuffix(s.ShapeName, "Output") {
 			rtype = "io.ReadCloser"
@@ -513,7 +524,9 @@ func (s *Shape) NestedShape() *Shape {
 }
 
 var structShapeTmpl = template.Must(template.New("StructShape").Funcs(template.FuncMap{
-	"GetCrosslinkURL": GetCrosslinkURL,
+	"GetCrosslinkURL":      GetCrosslinkURL,
+	"MarshalShapeGoCode":   MarshalShapeGoCode,
+	"UnmarshalShapeGoCode": UnmarshalShapeGoCode,
 }).Parse(`
 {{ .Docstring }}
 {{ if ne $.OrigShapeName "" -}}
@@ -597,6 +610,13 @@ func (s *{{ $builderShapeName }}) get{{ $name }}() (v {{ $context.GoStructValueT
 
 {{ end }}
 {{ end }}
+
+{{ if not $.API.NoGenMarshalers -}}
+{{ MarshalShapeGoCode $ }}
+{{- end }}
+{{ if not $.API.NoGenUnmarshalers -}}
+{{ UnmarshalShapeGoCode $ }}
+{{- end }}
 `))
 
 var enumShapeTmpl = template.Must(template.New("EnumShape").Parse(`

--- a/private/model/api/shape_marshal.go
+++ b/private/model/api/shape_marshal.go
@@ -1,0 +1,518 @@
+// +build codegen
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// MarshalShapeGoCode renders the shape's MarshalFields method with marshalers
+// for each field within the shape. A string is returned of the rendered Go code.
+//
+// Will panic if error.
+func MarshalShapeGoCode(s *Shape) string {
+	w := &bytes.Buffer{}
+	if err := marshalShapeTmpl.Execute(w, s); err != nil {
+		panic(fmt.Sprintf("failed to render shape's fields marshaler, %v", err))
+	}
+
+	return w.String()
+}
+
+// MarshalShapeRefGoCode renders protocol encode for the shape ref's type.
+//
+// Will panic if error.
+func MarshalShapeRefGoCode(refName string, ref *ShapeRef, context *Shape) string {
+	if ref.XMLAttribute {
+		return "// Skipping " + refName + " XML Attribute."
+	}
+	if context.IsRefPayloadReader(refName, ref) {
+		if strings.HasSuffix(context.ShapeName, "Output") {
+			return "// Skipping " + refName + " Output type's body not valid."
+		}
+	}
+
+	mRef := marshalShapeRef{
+		Name:    refName,
+		Ref:     ref,
+		Context: context,
+	}
+
+	switch mRef.Location() {
+	case "StatusCode":
+		return "// ignoring invalid encode state, StatusCode. " + refName
+	}
+
+	w := &bytes.Buffer{}
+	if err := marshalShapeRefTmpl.ExecuteTemplate(w, "encode field", mRef); err != nil {
+		panic(fmt.Sprintf("failed to marshal shape ref, %s, %v", ref.Shape.Type, err))
+	}
+
+	return w.String()
+}
+
+var marshalShapeTmpl = template.Must(template.New("marshalShapeTmpl").Funcs(
+	map[string]interface{}{
+		"MarshalShapeRefGoCode": MarshalShapeRefGoCode,
+	},
+).Parse(`
+{{ $shapeName := $.ShapeName -}}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *{{ $shapeName }}) MarshalFields(e protocol.FieldEncoder) error {
+	{{ range $name, $ref := $.MemberRefs -}}
+		{{ MarshalShapeRefGoCode $name $ref $ }}
+	{{ end }}
+	return nil
+}
+
+{{ if $.UsedInList -}}
+func encode{{ $shapeName }}List(vs []*{{ $shapeName }}) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+{{- end }}
+
+{{ if $.UsedInMap -}}
+func encode{{ $shapeName }}Map(vs map[string]*{{ $shapeName }}) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+{{- end }}
+`))
+
+var marshalShapeRefTmpl = template.Must(template.New("marshalShapeRefTmpl").Parse(`
+{{ define "encode field" -}}
+	{{ if $.IsIdempotencyToken -}}
+		{{ template "idempotency token" $ }}
+	{
+		v := {{ $.Name }}
+	{{ else -}}
+	if {{ template "is ref set" $ }} {
+		v := {{ template "ref value" $ }}
+	{{- end }}
+		{{ if $.HasAttributes -}}
+			{{ template "attributes" $ }}
+		{{- end }}
+		e.Set{{ $.MarshalerType }}(protocol.{{ $.Location }}Target, "{{ $.LocationName }}", {{ template "marshaler" $ }}, {{ template "metadata" $ }})
+	}
+{{- end }}
+
+{{ define "marshaler" -}}
+	{{- if $.IsShapeType "list" -}}
+		{{- $helperName := $.EncodeHelperName "list" -}}
+		{{- if $helperName -}}
+			{{ $helperName }}
+		{{- else -}}
+			func(le protocol.ListEncoder) {
+				{{ $memberRef := $.ListMemberRef -}}
+				for _, item := range v {
+					v := {{ if $memberRef.Ref.UseIndirection }}*{{ end }}item
+					le.ListAdd{{ $memberRef.MarshalerType }}({{ template "marshaler" $memberRef }})
+				}
+			}
+		{{- end -}}
+	{{- else if $.IsShapeType "map" -}}
+		{{- $helperName := $.EncodeHelperName "map" -}}
+		{{- if $helperName -}}
+			{{ $helperName }}
+		{{- else -}}
+			func(me protocol.MapEncoder) {
+				{{ $valueRef := $.MapValueRef -}}
+				for k, item := range v {
+					v := {{ if $valueRef.Ref.UseIndirection }}*{{ end }}item
+					me.MapSet{{ $valueRef.MarshalerType }}(k, {{ template "marshaler" $valueRef }})
+				}
+			}
+		{{- end -}}
+	{{- else if $.IsShapeType "structure" -}}
+		v
+	{{- else if $.IsShapeType "timestamp" -}}
+		protocol.TimeValue{V: v, Format: {{ $.TimeFormat }} }
+	{{- else if $.IsShapeType "jsonvalue" -}}
+		protocol.JSONValue{V: v {{ if eq $.Location "Header" }}, Base64: true{{ end }} }
+	{{- else if $.IsPayloadStream -}}
+		protocol.{{ $.GoType }}{{ $.MarshalerType }}{V:v}
+	{{- else -}}
+		protocol.{{ $.GoType }}{{ $.MarshalerType }}(v)
+	{{- end -}}
+{{- end }}
+
+{{ define "metadata" -}}
+	protocol.Metadata{
+		{{- if $.IsFlattened -}}
+			Flatten: true,
+		{{- end -}}
+
+		{{- if $.HasAttributes -}}
+			Attributes: attrs,
+		{{- end -}}
+
+		{{- if $.XMLNamespacePrefix -}}
+			XMLNamespacePrefix: "{{ $.XMLNamespacePrefix }}",
+		{{- end -}}
+
+		{{- if $.XMLNamespaceURI -}}
+			XMLNamespaceURI: "{{ $.XMLNamespaceURI }}",
+		{{- end -}}
+
+		{{- if $.ListLocationName -}}
+			ListLocationName: "{{ $.ListLocationName }}",
+		{{- end -}}
+
+		{{- if $.MapLocationNameKey -}}
+			MapLocationNameKey: "{{ $.MapLocationNameKey }}",
+		{{- end -}}
+
+		{{- if $.MapLocationNameValue -}}
+			MapLocationNameValue: "{{ $.MapLocationNameValue }}",
+		{{- end -}}
+	}
+{{- end }}
+
+{{ define "ref value" -}}
+	{{ if $.Ref.UseIndirection }}*{{ end }}s.{{ $.Name }}
+{{- end}}
+
+{{ define "is ref set" -}}
+	{{ $isList := $.IsShapeType "list" -}}
+	{{ $isMap := $.IsShapeType "map" -}}
+	{{- if or $isList $isMap -}}
+		len(s.{{ $.Name }}) > 0
+	{{- else -}}
+		s.{{ $.Name }} != nil
+	{{- end -}}
+{{- end }}
+
+{{ define "attributes" -}}
+	attrs := make([]protocol.Attribute, 0, {{ $.NumAttributes }})
+
+	{{ range $name, $child := $.ChildrenRefs -}}
+		{{ if $child.Ref.XMLAttribute -}}
+			if s.{{ $.Name }}.{{ $name }} != nil {
+				v := {{ if $child.Ref.UseIndirection }}*{{ end }}s.{{ $.Name }}.{{ $name }}
+				attrs = append(attrs, protocol.Attribute{Name: "{{ $child.LocationName }}", Value: {{ template "marshaler" $child }}, Meta: {{ template "metadata" $child }}})
+			}
+		{{- end }}
+	{{- end }}
+{{- end }}
+
+{{ define "idempotency token" -}}
+    var {{ $.Name }} string
+	if {{ template "is ref set" $ }} {
+		{{ $.Name }} = {{ template "ref value" $ }}
+	} else {
+		{{ $.Name }} = protocol.GetIdempotencyToken()
+	}
+{{- end }}
+`))
+
+type marshalShapeRef struct {
+	Name    string
+	Ref     *ShapeRef
+	Context *Shape
+}
+
+func (r marshalShapeRef) ListMemberRef() marshalShapeRef {
+	return marshalShapeRef{
+		Name:    r.Name + "ListMember",
+		Ref:     &r.Ref.Shape.MemberRef,
+		Context: r.Ref.Shape,
+	}
+}
+func (r marshalShapeRef) MapValueRef() marshalShapeRef {
+	return marshalShapeRef{
+		Name:    r.Name + "MapValue",
+		Ref:     &r.Ref.Shape.ValueRef,
+		Context: r.Ref.Shape,
+	}
+}
+func (r marshalShapeRef) ChildrenRefs() map[string]marshalShapeRef {
+	children := map[string]marshalShapeRef{}
+
+	for name, ref := range r.Ref.Shape.MemberRefs {
+		children[name] = marshalShapeRef{
+			Name:    name,
+			Ref:     ref,
+			Context: r.Ref.Shape,
+		}
+	}
+
+	return children
+}
+func (r marshalShapeRef) IsShapeType(typ string) bool {
+	return r.Ref.Shape.Type == typ
+}
+func (r marshalShapeRef) IsPayloadStream() bool {
+	return r.Context.IsRefPayloadReader(r.Name, r.Ref)
+}
+func (r marshalShapeRef) MarshalerType() string {
+	switch r.Ref.Shape.Type {
+	case "list":
+		return "List"
+	case "map":
+		return "Map"
+	case "structure":
+		return "Fields"
+	default:
+		// Streams have a special case
+		if r.Context.IsRefPayload(r.Name) {
+			return "Stream"
+		}
+		return "Value"
+	}
+}
+func (r marshalShapeRef) EncodeHelperName(typ string) string {
+	if r.Ref.Shape.Type != typ {
+		return ""
+	}
+
+	var memberRef marshalShapeRef
+	switch r.Ref.Shape.Type {
+	case "map":
+		memberRef = r.MapValueRef()
+	case "list":
+		memberRef = r.ListMemberRef()
+	default:
+		return ""
+	}
+
+	switch memberRef.Ref.Shape.Type {
+	case "list", "map":
+		return ""
+	case "structure":
+		shapeName := memberRef.Ref.Shape.ShapeName
+		return "encode" + shapeName + strings.Title(typ) + "(v)"
+	default:
+		return "protocol.Encode" + memberRef.GoType() + strings.Title(typ) + "(v)"
+	}
+}
+func (r marshalShapeRef) GoType() string {
+	switch r.Ref.Shape.Type {
+	case "boolean":
+		return "Bool"
+	case "string", "character":
+		return "String"
+	case "integer", "long":
+		return "Int64"
+	case "float", "double":
+		return "Float64"
+	case "timestamp":
+		return "Time"
+	case "jsonvalue":
+		return "JSONValue"
+	case "blob":
+		if r.Context.IsRefPayloadReader(r.Name, r.Ref) {
+			if strings.HasSuffix(r.Context.ShapeName, "Output") {
+				return "ReadCloser"
+			}
+			return "ReadSeeker"
+		}
+		return "Bytes"
+	default:
+		panic(fmt.Sprintf("unknown marshal shape ref type, %s", r.Ref.Shape.Type))
+	}
+}
+func (r marshalShapeRef) Location() string {
+	var loc string
+	if l := r.Ref.Location; len(l) > 0 {
+		loc = l
+	} else if l := r.Ref.Shape.Location; len(l) > 0 {
+		loc = l
+	}
+
+	switch loc {
+	case "querystring":
+		return "Query"
+	case "header":
+		return "Header"
+	case "headers": // headers means key is header prefix
+		return "Headers"
+	case "uri":
+		return "Path"
+	case "statusCode":
+		return "StatusCode"
+	default:
+		if len(loc) != 0 {
+			panic(fmt.Sprintf("unknown marshal shape ref location, %s", loc))
+		}
+
+		if r.Context.IsRefPayload(r.Name) {
+			return "Payload"
+		}
+
+		return "Body"
+	}
+}
+func (r marshalShapeRef) LocationName() string {
+	if l := r.Ref.QueryName; len(l) > 0 {
+		// Special case for EC2 query
+		return l
+	}
+
+	locName := r.Name
+	if l := r.Ref.LocationName; len(l) > 0 {
+		locName = l
+	} else if l := r.Ref.Shape.LocationName; len(l) > 0 {
+		locName = l
+	}
+
+	return locName
+}
+func (r marshalShapeRef) IsFlattened() bool {
+	return r.Ref.Flattened || r.Ref.Shape.Flattened
+}
+func (r marshalShapeRef) XMLNamespacePrefix() string {
+	if v := r.Ref.XMLNamespace.Prefix; len(v) != 0 {
+		return v
+	}
+	return r.Ref.Shape.XMLNamespace.Prefix
+}
+func (r marshalShapeRef) XMLNamespaceURI() string {
+	if v := r.Ref.XMLNamespace.URI; len(v) != 0 {
+		return v
+	}
+	return r.Ref.Shape.XMLNamespace.URI
+}
+func (r marshalShapeRef) ListLocationName() string {
+	if v := r.Ref.Shape.MemberRef.LocationName; len(v) > 0 {
+		if !(r.Ref.Shape.Flattened || r.Ref.Flattened) {
+			return v
+		}
+	}
+	return ""
+}
+func (r marshalShapeRef) MapLocationNameKey() string {
+	return r.Ref.Shape.KeyRef.LocationName
+}
+func (r marshalShapeRef) MapLocationNameValue() string {
+	return r.Ref.Shape.ValueRef.LocationName
+}
+func (r marshalShapeRef) HasAttributes() bool {
+	for _, ref := range r.Ref.Shape.MemberRefs {
+		if ref.XMLAttribute {
+			return true
+		}
+	}
+	return false
+}
+func (r marshalShapeRef) NumAttributes() (n int) {
+	for _, ref := range r.Ref.Shape.MemberRefs {
+		if ref.XMLAttribute {
+			n++
+		}
+	}
+	return n
+}
+func (r marshalShapeRef) IsIdempotencyToken() bool {
+	return r.Ref.IdempotencyToken || r.Ref.Shape.IdempotencyToken
+}
+func (r marshalShapeRef) TimeFormat() string {
+	switch r.Location() {
+	case "Header", "Headers":
+		return "protocol.RFC822TimeFromat"
+	default:
+		switch r.Context.API.Metadata.Protocol {
+		case "json", "rest-json":
+			return "protocol.UnixTimeFormat"
+		case "rest-xml", "ec2", "query":
+			return "protocol.ISO8601TimeFormat"
+		default:
+			panic(fmt.Sprintf("unable to determine time format for %s ref", r.Name))
+		}
+	}
+}
+
+// UnmarshalShapeGoCode renders the shape's UnmarshalAWS method with unmarshalers
+// for each field within the shape. A string is returned of the rendered Go code.
+//
+// Will panic if error.
+func UnmarshalShapeGoCode(s *Shape) string {
+	w := &bytes.Buffer{}
+	if err := unmarshalShapeTmpl.Execute(w, s); err != nil {
+		panic(fmt.Sprintf("failed to render shape's fields unmarshaler, %v", err))
+	}
+
+	return w.String()
+}
+
+var unmarshalShapeTmpl = template.Must(template.New("unmarshalShapeTmpl").Funcs(
+	template.FuncMap{
+		"UnmarshalShapeRefGoCode": UnmarshalShapeRefGoCode,
+	},
+).Parse(`
+{{ $shapeName := $.ShapeName -}}
+
+// UnmarshalAWS decodes the AWS API shape using the passed in protocol decoder.
+func (s *{{ $shapeName }}) UnmarshalAWS(d protocol.FieldDecoder) {
+	{{ range $name, $ref := $.MemberRefs -}}
+		{{ UnmarshalShapeRefGoCode $name $ref $ }}
+	{{ end }}
+}
+
+{{ if $.UsedInList -}}
+func decode{{ $shapeName }}List(vsp *[]*{{ $shapeName }}) func(int, protocol.ListDecoder) {
+	return func(n int, ld protocol.ListDecoder) {
+		vs := make([]{{ $shapeName }}, n)
+		*vsp = make([]*{{ $shapeName }}, n)
+		for i := 0; i < n; i++ {
+			ld.ListGetUnmarshaler(&vs[i])
+			(*vsp)[i] = &vs[i]
+		}
+	}
+}
+{{- end }}
+
+{{ if $.UsedInMap -}}
+func decode{{ $shapeName }}Map(vsp *map[string]*{{ $shapeName }}) func([]string, protocol.MapDecoder) {
+	return func(ks []string, md protocol.MapDecoder) {
+		vs := make(map[string]*{{ $shapeName }}, n)
+		for _, k range ks {
+			v := &{{ $shapeName }}{}
+			md.MapGetUnmarshaler(k, v)
+			vs[k] = v
+		}
+	}
+}
+{{- end }}
+`))
+
+// UnmarshalShapeRefGoCode generates the Go code to unmarshal an API shape.
+func UnmarshalShapeRefGoCode(refName string, ref *ShapeRef, context *Shape) string {
+	if ref.XMLAttribute {
+		return "// Skipping " + refName + " XML Attribute."
+	}
+
+	mRef := marshalShapeRef{
+		Name:    refName,
+		Ref:     ref,
+		Context: context,
+	}
+
+	switch mRef.Location() {
+	case "Path":
+		return "// ignoring invalid decode state, Path. " + refName
+	case "Query":
+		return "// ignoring invalid decode state, Query. " + refName
+	}
+
+	w := &bytes.Buffer{}
+	if err := unmarshalShapeRefTmpl.ExecuteTemplate(w, "decode", mRef); err != nil {
+		panic(fmt.Sprintf("failed to decode shape ref, %s, %v", ref.Shape.Type, err))
+	}
+
+	return w.String()
+}
+
+var unmarshalShapeRefTmpl = template.Must(template.New("unmarshalShapeRefTmpl").Parse(`
+//  Decode {{ $.Name }} {{ $.GoType }} {{ $.MarshalerType }} to {{ $.Location }} at {{ $.LocationName }}
+`))

--- a/private/protocol/decode.go
+++ b/private/protocol/decode.go
@@ -1,0 +1,112 @@
+package protocol
+
+import (
+	"io"
+	"time"
+)
+
+// FieldUnmarshaler used by protocol unmarshaling to unmarshal a type's nested fields.
+type FieldUnmarshaler interface {
+	UnmarshalFields(FieldDecoder) error
+}
+
+// A FieldValue is a value that will be unmarshalered from the decoder to
+// a concrete value.
+type FieldValue interface{}
+
+// ListDecoder provides the interface for unmarshaling list elements from the
+// underlying decoder.
+type ListDecoder interface {
+	ListGet(fn func(v FieldValue))
+	ListGetList(fn func(n int, ld ListDecoder))
+	ListGetMap(fn func(ks []string, md MapDecoder))
+	ListGetFields(m FieldUnmarshaler)
+}
+
+// MapDecoder provides the interface for unmarshaling map elements from the
+// underlying decoder. The map key the value is retrieved from is k.
+type MapDecoder interface {
+	MapGet(k string, fn func(v FieldValue))
+	MapGetList(k string, fn func(n int, ld ListDecoder))
+	MapGetMap(k string, fn func(ks []string, fd FieldDecoder))
+	MapGetFields(k string, fn func() FieldUnmarshaler)
+}
+
+// FieldDecoder provides the interface for unmarshaling values from a type. The
+// value is retrieved from the location referenced to by the Target. The field
+// name that the value is retrieved from is k.
+type FieldDecoder interface {
+	Get(t Target, k string, fn func(v FieldValue), meta Metadata)
+	GetList(t Target, k string, fn func(n int, ld ListDecoder), meta Metadata)
+	GetMap(t Target, k string, fn func(ks []string, md MapDecoder), meta Metadata)
+	GetFields(t Target, k string, fn func() FieldUnmarshaler, meta Metadata)
+}
+
+// DecodeBool converts a FieldValue into a bool pointer, updating the value
+// pointed to by the input.
+func DecodeBool(vp **bool) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(bool)
+		**vp = v.(bool)
+	}
+}
+
+// DecodeString converts a FieldValue into a string pointer, updating the value
+// pointed to by the input.
+func DecodeString(vp **string) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(string)
+		**vp = v.(string)
+	}
+}
+
+// DecodeInt64 converts a FieldValue into an int64 pointer, updating the value
+// pointed to by the input.
+func DecodeInt64(vp **int64) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(int64)
+		**vp = v.(int64)
+	}
+}
+
+// DecodeFloat64 converts a FieldValue into a float64 pointer, updating the value
+// pointed to by the input.
+func DecodeFloat64(vp **float64) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(float64)
+		**vp = v.(float64)
+	}
+}
+
+// DecodeTime converts a FieldValue into a time pointer, updating the value
+// pointed to by the input.
+func DecodeTime(vp **time.Time) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = new(time.Time)
+		**vp = v.(time.Time)
+	}
+}
+
+// DecodeBytes converts a FieldValue into a bytes slice, updating the value
+// pointed to by the input.
+func DecodeBytes(vp *[]byte) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.([]byte)
+	}
+}
+
+// DecodeReadCloser converts a FieldValue into an io.ReadCloser, updating the value
+// pointed to by the input.
+func DecodeReadCloser(vp *io.ReadCloser) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.(io.ReadCloser)
+	}
+}
+
+// DecodeReadSeeker converts a FieldValue into an io.ReadCloser, updating the value
+// pointed to by the input.
+func DecodeReadSeeker(vp *io.ReadSeeker) func(FieldValue) {
+	return func(v FieldValue) {
+		*vp = v.(io.ReadSeeker)
+	}
+}

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -1,0 +1,166 @@
+package protocol
+
+import (
+	"io"
+	"time"
+)
+
+// A FieldMarshaler interface is used to marshal struct fields when encoding.
+type FieldMarshaler interface {
+	MarshalFields(FieldEncoder) error
+}
+
+// ValueMarshaler provides a generic type for all encoding field values to be
+// passed into a encoder's methods with.
+type ValueMarshaler interface {
+	MarshalValue() (string, error)
+	MarshalValueBuf([]byte) ([]byte, error)
+}
+
+// A StreamMarshaler interface is used to marshal a stream when encoding.
+type StreamMarshaler interface {
+	MarshalStream() (io.ReadSeeker, error)
+}
+
+// A ListEncoder provides the interface for encoders that will encode List elements.
+type ListEncoder interface {
+	ListAddValue(v ValueMarshaler)
+	ListAddList(fn func(ListEncoder))
+	ListAddMap(fn func(MapEncoder))
+	ListAddFields(m FieldMarshaler)
+}
+
+// A MapEncoder provides the interface for encoders that will encode map elements.
+type MapEncoder interface {
+	MapSetValue(k string, v ValueMarshaler)
+	MapSetList(k string, fn func(ListEncoder))
+	MapSetMap(k string, fn func(MapEncoder))
+	MapSetFields(k string, m FieldMarshaler)
+}
+
+// A FieldEncoder provides the interface for encoding struct field members.
+type FieldEncoder interface {
+	SetValue(t Target, k string, v ValueMarshaler, meta Metadata)
+	SetStream(t Target, k string, v StreamMarshaler, meta Metadata)
+	SetList(t Target, k string, fn func(ListEncoder), meta Metadata)
+	SetMap(t Target, k string, fn func(MapEncoder), meta Metadata)
+	SetFields(t Target, k string, m FieldMarshaler, meta Metadata)
+}
+
+// EncodeStringList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeStringList(vs []*string) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(StringValue(*v))
+		}
+	}
+}
+
+// EncodeStringMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeStringMap(vs map[string]*string) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, StringValue(*v))
+		}
+	}
+}
+
+// EncodeInt64List returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeInt64List(vs []*int64) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(Int64Value(*v))
+		}
+	}
+}
+
+// EncodeInt64Map returns a function that will add the map's values to
+// a map Encoder.
+func EncodeInt64Map(vs map[string]*int64) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, Int64Value(*v))
+		}
+	}
+}
+
+// EncodeFloat64List returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeFloat64List(vs []*float64) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(Float64Value(*v))
+		}
+	}
+}
+
+// EncodeFloat64Map returns a function that will add the map's values to
+// a map Encoder.
+func EncodeFloat64Map(vs map[string]*float64) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, Float64Value(*v))
+		}
+	}
+}
+
+// EncodeBoolList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeBoolList(vs []*bool) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(BoolValue(*v))
+		}
+	}
+}
+
+// EncodeBoolMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeBoolMap(vs map[string]*bool) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, BoolValue(*v))
+		}
+	}
+}
+
+// EncodeTimeList returns a function that will add the slice's values to
+// a list Encoder.
+func EncodeTimeList(vs []*time.Time) func(ListEncoder) {
+	return func(le ListEncoder) {
+		for _, v := range vs {
+			le.ListAddValue(TimeValue{V: *v})
+		}
+	}
+}
+
+// EncodeTimeMap returns a function that will add the map's values to
+// a map Encoder.
+func EncodeTimeMap(vs map[string]*time.Time) func(MapEncoder) {
+	return func(me MapEncoder) {
+		for k, v := range vs {
+			me.MapSetValue(k, TimeValue{V: *v})
+		}
+	}
+}
+
+// A FieldBuffer provides buffering of fields so the number of
+// allocations are reduced by providng a persistent buffer that is
+// used between fields.
+type FieldBuffer struct {
+	buf []byte
+}
+
+// GetValue will retrieve the ValueMarshaler's value by appending the
+// value to the buffer. Will return the buffer that was populated.
+//
+// This buffer is only valid until the next time GetValue is called.
+func (b *FieldBuffer) GetValue(m ValueMarshaler) ([]byte, error) {
+	v, err := m.MarshalValueBuf(b.buf)
+	b.buf = v
+	b.buf = b.buf[0:0]
+	return v, err
+}

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -10,6 +10,16 @@ type FieldMarshaler interface {
 	MarshalFields(FieldEncoder) error
 }
 
+// FieldMarshalerFunc is a helper utility that wrapps a function and allows
+// that function to be called as a FieldMarshaler.
+type FieldMarshalerFunc func(FieldEncoder) error
+
+// MarshalFields will call the underlying function passing in the field encoder
+// with the protocol field encoder.
+func (fn FieldMarshalerFunc) MarshalFields(e FieldEncoder) error {
+	return fn(e)
+}
+
 // ValueMarshaler provides a generic type for all encoding field values to be
 // passed into a encoder's methods with.
 type ValueMarshaler interface {

--- a/private/protocol/encode.go
+++ b/private/protocol/encode.go
@@ -170,7 +170,8 @@ type FieldBuffer struct {
 // This buffer is only valid until the next time GetValue is called.
 func (b *FieldBuffer) GetValue(m ValueMarshaler) ([]byte, error) {
 	v, err := m.MarshalValueBuf(b.buf)
-	b.buf = v
-	b.buf = b.buf[0:0]
+	if len(v) > len(b.buf) {
+		b.buf = v
+	}
 	return v, err
 }

--- a/private/protocol/fields.go
+++ b/private/protocol/fields.go
@@ -1,0 +1,208 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+// BoolValue provies encoding of bool for AWS protocols.
+type BoolValue bool
+
+// MarshalValue formats the value into a string for encoding.
+func (v BoolValue) MarshalValue() (string, error) {
+	return strconv.FormatBool(bool(v)), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v BoolValue) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+	return strconv.AppendBool(b, bool(v)), nil
+}
+
+// BytesValue provies encoding of string for AWS protocols.
+type BytesValue string
+
+// MarshalValue formats the value into a string for encoding.
+func (v BytesValue) MarshalValue() (string, error) {
+	return base64.StdEncoding.EncodeToString([]byte(v)), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v BytesValue) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+	m := []byte(v)
+
+	n := base64.StdEncoding.EncodedLen(len(m))
+	if cap(b) < n {
+		b = make([]byte, n)
+	}
+	base64.StdEncoding.Encode(b, m)
+	return b, nil
+}
+
+// StringValue provies encoding of string for AWS protocols.
+type StringValue string
+
+// MarshalValue formats the value into a string for encoding.
+func (v StringValue) MarshalValue() (string, error) {
+	return string(v), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v StringValue) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+	return append(b, v...), nil
+}
+
+// Int64Value provies encoding of int64 for AWS protocols.
+type Int64Value int64
+
+// MarshalValue formats the value into a string for encoding.
+func (v Int64Value) MarshalValue() (string, error) {
+	return strconv.FormatInt(int64(v), 10), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v Int64Value) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+	return strconv.AppendInt(b, int64(v), 10), nil
+}
+
+// Float64Value provies encoding of float64 for AWS protocols.
+type Float64Value float64
+
+// MarshalValue formats the value into a string for encoding.
+func (v Float64Value) MarshalValue() (string, error) {
+	return strconv.FormatFloat(float64(v), 'f', -1, 64), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v Float64Value) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+	return strconv.AppendFloat(b, float64(v), 'f', -1, 64), nil
+}
+
+// JSONValue provies encoding of aws.JSONValues for AWS protocols.
+type JSONValue struct {
+	V      aws.JSONValue
+	Base64 bool
+}
+
+// MarshalValue formats the value into a string for encoding.
+func (v JSONValue) MarshalValue() (string, error) {
+	b, err := json.Marshal(v.V)
+	if err != nil {
+		return "", err
+	}
+
+	if v.Base64 {
+		return base64.StdEncoding.EncodeToString(b), nil
+	}
+
+	return string(b), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v JSONValue) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+
+	m, err := json.Marshal(v.V)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.Base64 {
+		return BytesValue(m).MarshalValueBuf(b)
+	}
+
+	return append(b, m...), nil
+}
+
+// Time formats for protocol time fields.
+const (
+	ISO8601TimeFormat = "2006-01-02T15:04:05Z"         // ISO 8601 formated time.
+	RFC822TimeFromat  = "Mon, 2 Jan 2006 15:04:05 GMT" // RFC822 formatted time.
+	UnixTimeFormat    = "unix time format"             // Special case for Unix time
+)
+
+// TimeValue provies encoding of time.Time for AWS protocols.
+type TimeValue struct {
+	V      time.Time
+	Format string
+}
+
+// MarshalValue formats the value into a string givin a format for encoding.
+func (v TimeValue) MarshalValue() (string, error) {
+	t := time.Time(v.V)
+
+	if v.Format == UnixTimeFormat {
+		return strconv.FormatInt(t.UTC().Unix(), 10), nil
+	}
+	return t.UTC().Format(v.Format), nil
+}
+
+// MarshalValueBuf formats the value into a byte slice for encoding.
+// If there is enough room in the passed in slice v will be appended to it.
+//
+// Will reset the length of the passed in slice to 0.
+func (v TimeValue) MarshalValueBuf(b []byte) ([]byte, error) {
+	b = b[0:0]
+
+	m, err := v.MarshalValue()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(b, m...), nil
+}
+
+// A ReadSeekerStream wrapps an io.ReadSeeker to be used as a StreamMarshaler.
+type ReadSeekerStream struct {
+	V io.ReadSeeker
+}
+
+// MarshalStream returns the wrapped io.ReadSeeker for encoding.
+func (v ReadSeekerStream) MarshalStream() (io.ReadSeeker, error) {
+	return v.V, nil
+}
+
+// A BytesStream aliases a byte slice to be used as a StreamMarshaler.
+type BytesStream []byte
+
+// MarshalStream marshals a byte slice into an io.ReadSeeker for encoding.
+func (v BytesStream) MarshalStream() (io.ReadSeeker, error) {
+	return bytes.NewReader([]byte(v)), nil
+}
+
+// A StringStream aliases a string to be used as a StreamMarshaler.
+type StringStream string
+
+// MarshalStream marshals a string into an io.ReadSeeker for encoding.
+func (v StringStream) MarshalStream() (io.ReadSeeker, error) {
+	return strings.NewReader(string(v)), nil
+}

--- a/private/protocol/fields.go
+++ b/private/protocol/fields.go
@@ -39,18 +39,15 @@ func (v BytesValue) MarshalValue() (string, error) {
 
 // MarshalValueBuf formats the value into a byte slice for encoding.
 // If there is enough room in the passed in slice v will be appended to it.
-//
-// Will reset the length of the passed in slice to 0.
 func (v BytesValue) MarshalValueBuf(b []byte) ([]byte, error) {
-	b = b[0:0]
 	m := []byte(v)
 
 	n := base64.StdEncoding.EncodedLen(len(m))
-	if cap(b) < n {
+	if len(b) < n {
 		b = make([]byte, n)
 	}
 	base64.StdEncoding.Encode(b, m)
-	return b, nil
+	return b[:n], nil
 }
 
 // StringValue provies encoding of string for AWS protocols.

--- a/private/protocol/header_encoder.go
+++ b/private/protocol/header_encoder.go
@@ -1,0 +1,106 @@
+package protocol
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HeaderMapEncoder builds a map valu
+type HeaderMapEncoder struct {
+	Prefix string
+	Header http.Header
+	Err    error
+}
+
+// MapSetValue adds a single value to the header.
+func (e *HeaderMapEncoder) MapSetValue(k string, v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	e.Header.Set(k, str)
+}
+
+// MapSetList executes the passed in callback with a list encoder based on
+// the context of this HeaderMapEncoder.
+func (e *HeaderMapEncoder) MapSetList(k string, fn func(le ListEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := HeaderListEncoder{Key: k, Header: e.Header}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetMap sets the header element with nested maps appending the
+// passed in k to the prefix if one was set.
+func (e *HeaderMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := HeaderMapEncoder{Prefix: k, Header: e.Header}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetFields Is not implemented, query map of FieldMarshaler is undefined.
+func (e *HeaderMapEncoder) MapSetFields(k string, m FieldMarshaler) {
+	e.Err = fmt.Errorf("header map encoder MapSetFields not supported, %s", k)
+}
+
+// HeaderListEncoder will encode list values nested into a header key.
+type HeaderListEncoder struct {
+	Key    string
+	Header http.Header
+	Err    error
+}
+
+// ListAddValue encodes an individual list value into the header.
+func (e *HeaderListEncoder) ListAddValue(v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	e.Header.Add(e.Key, str)
+}
+
+// ListAddList Is not implemented, header list of list is undefined.
+func (e *HeaderListEncoder) ListAddList(fn func(ListEncoder)) {
+	e.Err = fmt.Errorf("header list encoder ListAddList not supported, %s", e.Key)
+}
+
+// ListAddMap Is not implemented, header list of map is undefined.
+func (e *HeaderListEncoder) ListAddMap(fn func(MapEncoder)) {
+	e.Err = fmt.Errorf("header list encoder ListAddMap not supported, %s", e.Key)
+}
+
+// ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
+func (e *HeaderListEncoder) ListAddFields(m FieldMarshaler) {
+	e.Err = fmt.Errorf("header list encoder ListAddFields not supported, %s", e.Key)
+}

--- a/private/protocol/json/encode.go
+++ b/private/protocol/json/encode.go
@@ -1,0 +1,271 @@
+package json
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of the AWS JSON protocol. This encoder will will
+// write all content to JSON. Only supports body and payload targets.
+type Encoder struct {
+	encoder
+	root bool
+}
+
+// NewEncoder creates a new encoder for encoding AWS JSON protocol. Only encodes
+// fields into the JSON body, and error is returned if target is anything other
+// than Body or Payload.
+func NewEncoder() *Encoder {
+	e := &Encoder{
+		encoder: encoder{
+			buf:      bytes.NewBuffer([]byte{'{'}),
+			fieldBuf: &protocol.FieldBuffer{},
+		},
+		root: true,
+	}
+
+	return e
+}
+
+// Encode returns the encoded XMl reader. An error will be returned if one was
+// encountered while building the JSON body.
+func (e *Encoder) Encode() (io.ReadSeeker, error) {
+	b, err := e.encode()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 2 {
+		// Account for first starting object in buffer
+		return nil, nil
+	}
+
+	return bytes.NewReader(b), nil
+}
+
+// SetValue sets an individual value to the JSON body.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeValue(v)
+}
+
+// SetStream is not supported for JSON protocol marshaling.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	e.err = fmt.Errorf("json encoder SetStream not supported, %s, %s", t, k)
+}
+
+// SetList creates an JSON list and calls the passed in fn callback with a list encoder.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// SetMap creates an JSON map and calls the passed in fn callback with a map encoder.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// SetFields sets the nested fields to the JSON body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if t == protocol.PayloadTarget {
+		// Ignore payload key and only marshal body without wrapping in object first.
+		nested := Encoder{
+			encoder: encoder{
+				buf:      e.encoder.buf,
+				fieldBuf: e.encoder.fieldBuf,
+			},
+		}
+		m.MarshalFields(&nested)
+		e.err = nested.err
+		return
+	}
+
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+// A listEncoder encodes elements within a list for the JSON encoder.
+type listEncoder struct {
+	encoder
+}
+
+// ListAddValue will add the value to the list.
+func (e *listEncoder) ListAddValue(v protocol.ValueMarshaler) {
+	e.writeSep()
+	e.writeValue(v)
+}
+
+// ListAddList adds a list nested within another list.
+func (e *listEncoder) ListAddList(fn func(le protocol.ListEncoder)) {
+	e.writeSep()
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// ListAddMap adds a map nested within a list.
+func (e *listEncoder) ListAddMap(fn func(me protocol.MapEncoder)) {
+	e.writeSep()
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// ListAddFields will set the nested type's fields to the list.
+func (e *listEncoder) ListAddFields(m protocol.FieldMarshaler) {
+	e.writeSep()
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+// A mapEncoder encodes key values pair map values for the JSON encoder.
+type mapEncoder struct {
+	encoder
+}
+
+// MapSetValue sets a map value.
+func (e *mapEncoder) MapSetValue(k string, v protocol.ValueMarshaler) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeValue(v)
+}
+
+// MapSetList encodes a list nested within the map.
+func (e *mapEncoder) MapSetList(k string, fn func(le protocol.ListEncoder)) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeList(func(enc encoder) error {
+		nested := listEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// MapSetMap encodes a map nested within another map.
+func (e *mapEncoder) MapSetMap(k string, fn func(me protocol.MapEncoder)) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := mapEncoder{encoder: enc}
+		fn(&nested)
+		return nested.err
+	})
+}
+
+// MapSetFields will set the nested type's fields under the map.
+func (e *mapEncoder) MapSetFields(k string, m protocol.FieldMarshaler) {
+	e.writeSep()
+	e.writeKey(k)
+	e.writeObject(func(enc encoder) error {
+		nested := Encoder{encoder: enc}
+		m.MarshalFields(&nested)
+		return nested.err
+	})
+}
+
+type encoder struct {
+	buf      *bytes.Buffer
+	fieldBuf *protocol.FieldBuffer
+	started  bool
+	err      error
+}
+
+func (e encoder) encode() ([]byte, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	// Close the root object
+	e.buf.WriteByte('}')
+
+	return e.buf.Bytes(), nil
+}
+
+func (e *encoder) writeSep() {
+	if e.started {
+		e.buf.WriteByte(',')
+	} else {
+		e.started = true
+	}
+
+}
+func (e *encoder) writeKey(k string) {
+	e.buf.WriteByte('"')
+	e.buf.WriteString(k) // TODO escape?
+	e.buf.WriteByte('"')
+	e.buf.WriteByte(':')
+}
+
+func (e *encoder) writeValue(v protocol.ValueMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	b, err := e.fieldBuf.GetValue(v)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	var asStr bool
+	switch v.(type) {
+	case protocol.StringValue, protocol.BytesValue:
+		asStr = true
+	}
+
+	if asStr {
+		escapeStringBytes(e.buf, b)
+	} else {
+		e.buf.Write(b)
+	}
+}
+
+func (e *encoder) writeList(fn func(encoder) error) {
+	if e.err != nil {
+		return
+	}
+
+	e.buf.WriteByte('[')
+	e.err = fn(encoder{buf: e.buf, fieldBuf: e.fieldBuf})
+	e.buf.WriteByte(']')
+}
+
+func (e *encoder) writeObject(fn func(encoder) error) {
+	if e.err != nil {
+		return
+	}
+
+	e.buf.WriteByte('{')
+	e.err = fn(encoder{buf: e.buf, fieldBuf: e.fieldBuf})
+	e.buf.WriteByte('}')
+}

--- a/private/protocol/json/encode_test.go
+++ b/private/protocol/json/encode_test.go
@@ -1,0 +1,302 @@
+package json
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Nested: &nestedShape{
+				Value: aws.String("expected value"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"nested":{"value":"expected value"}}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapStr: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"mapstr":{"abc":"123"}}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+				"123": {IntVal: aws.Int64(123)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"mapShape":{"abc":{"value":"1"},"123":{"intval":123}}}`
+
+	awstesting.AssertJSON(t, expect, string(b), "expect bodies to match")
+}
+func TestEncodeListString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListStr: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"liststr":["abc","123"]}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlatten(t *testing.T) {
+	// TODO no JSON flatten
+}
+func TestEncodeListFlattened(t *testing.T) {
+	// TODO No json flatten
+}
+func TestEncodeListNamed(t *testing.T) {
+	// TODO no json named
+}
+func TestEncodeListShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+				{IntVal: aws.Int64(123)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"listShape":[{"value":"abc"},{"value":"123"},{"intval":123}]}`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type baseShape struct {
+	Payload *payloadShape
+}
+
+func (s *baseShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		e.SetFields(protocol.PayloadTarget, "payload", s.Payload, protocol.Metadata{})
+	}
+	return nil
+}
+
+type payloadShape struct {
+	Value            *string
+	IntVal           *int64
+	TimeVal          *time.Time
+	Nested           *nestedShape
+	MapStr           map[string]*string
+	MapFlatten       map[string]*string
+	MapNamed         map[string]*string
+	MapShape         map[string]*nestedShape
+	MapFlattenShape  map[string]*nestedShape
+	MapNamedShape    map[string]*nestedShape
+	ListStr          []*string
+	ListFlatten      []*string
+	ListNamed        []*string
+	ListShape        []*nestedShape
+	ListFlattenShape []*nestedShape
+	ListNamedShape   []*nestedShape
+}
+
+func (s *payloadShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.IntVal != nil {
+		e.SetValue(protocol.BodyTarget, "intval", protocol.Int64Value(*s.IntVal), protocol.Metadata{})
+	}
+	if s.TimeVal != nil {
+		e.SetValue(protocol.BodyTarget, "timeval", protocol.TimeValue{
+			V: *s.TimeVal, Format: protocol.UnixTimeFormat,
+		}, protocol.Metadata{})
+	}
+	if s.Nested != nil {
+		e.SetFields(protocol.BodyTarget, "nested", s.Nested, protocol.Metadata{})
+	}
+	if len(s.MapStr) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapstr", func(me protocol.MapEncoder) {
+			for k, v := range s.MapStr {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.MapFlatten) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlatten", func(me protocol.MapEncoder) {
+			for k, v := range s.MapFlatten {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamed) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamed", func(me protocol.MapEncoder) {
+			for k, v := range s.MapNamed {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.MapShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapShape", encodeNestedShapeMap(s.MapShape), protocol.Metadata{})
+	}
+	if len(s.MapFlattenShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlattenShape", encodeNestedShapeMap(s.MapFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamedShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamedShape", encodeNestedShapeMap(s.MapNamedShape), protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.ListStr) > 0 {
+		e.SetList(protocol.BodyTarget, "liststr", func(le protocol.ListEncoder) {
+			for _, v := range s.ListStr {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.ListFlatten) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlatten", func(le protocol.ListEncoder) {
+			for _, v := range s.ListFlatten {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamed) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamed", func(le protocol.ListEncoder) {
+			for _, v := range s.ListNamed {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	if len(s.ListShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listShape", encodeNestedShapeList(s.ListShape), protocol.Metadata{})
+	}
+	if len(s.ListFlattenShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlattenShape", encodeNestedShapeList(s.ListFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamedShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamedShape", encodeNestedShapeList(s.ListNamedShape), protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value    *string
+	IntVal   *int64
+	Prefixed *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.IntVal != nil {
+		e.SetValue(protocol.BodyTarget, "intval", protocol.Int64Value(*s.IntVal), protocol.Metadata{})
+	}
+	if s.Prefixed != nil {
+		e.SetValue(protocol.BodyTarget, "prefixed", protocol.StringValue(*s.Prefixed), protocol.Metadata{})
+	}
+	return nil
+}
+func encodeNestedShapeMap(vs map[string]*nestedShape) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+func encodeNestedShapeList(vs []*nestedShape) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encode(s baseShape) (io.ReadSeeker, error) {
+	e := NewEncoder()
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/json/escape.go
+++ b/private/protocol/json/escape.go
@@ -1,0 +1,198 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copied and modified from Go 1.8 stdlib's encoding/json/#safeSet
+
+package json
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}
+
+// copied from Go 1.8 stdlib's encoding/json/#hex
+var hex = "0123456789abcdef"
+
+// escapeStringBytes escapes and writes the passed in string bytes to the dst
+// buffer
+//
+// Copied and modifed from Go 1.8 stdlib's encodeing/json/#encodeState.stringBytes
+func escapeStringBytes(e *bytes.Buffer, s []byte) {
+	e.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				e.Write(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				e.WriteByte('\\')
+				e.WriteByte(b)
+			case '\n':
+				e.WriteByte('\\')
+				e.WriteByte('n')
+			case '\r':
+				e.WriteByte('\\')
+				e.WriteByte('r')
+			case '\t':
+				e.WriteByte('\\')
+				e.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				e.WriteString(`\u00`)
+				e.WriteByte(hex[b>>4])
+				e.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRune(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\u202`)
+			e.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		e.Write(s[start:])
+	}
+	e.WriteByte('"')
+}

--- a/private/protocol/metadata.go
+++ b/private/protocol/metadata.go
@@ -1,0 +1,24 @@
+package protocol
+
+// An Attribute is a FieldValue that resides within the imediant context of
+// another field. Such as XML attribute for tags.
+type Attribute struct {
+	Name  string
+	Value ValueMarshaler
+	Meta  Metadata
+}
+
+// Metadata is a collection of configuration flags for encoders to render the
+// output.
+type Metadata struct {
+	Attributes []Attribute
+
+	Flatten bool
+
+	ListLocationName     string
+	MapLocationNameKey   string
+	MapLocationNameValue string
+
+	XMLNamespacePrefix string
+	XMLNamespaceURI    string
+}

--- a/private/protocol/path_replace.go
+++ b/private/protocol/path_replace.go
@@ -1,0 +1,136 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const (
+	uriTokenStart = '{'
+	uriTokenStop  = '}'
+	uriTokenSkip  = '+'
+)
+
+func bufCap(b []byte, n int) []byte {
+	if cap(b) < n {
+		return make([]byte, 0, n)
+	}
+
+	return b[0:0]
+}
+
+// PathReplace replaces path elements using field buffers
+type PathReplace struct {
+	// May mutate path slice
+	path     []byte
+	rawPath  []byte
+	fieldBuf []byte
+}
+
+// NewPathReplace creats a built PathReplace value that can be used to replace
+// path elements.
+func NewPathReplace(path string) PathReplace {
+	return PathReplace{
+		path:    []byte(path),
+		rawPath: []byte(path),
+	}
+}
+
+// Encode returns an unescaped path, and escaped path.
+func (r *PathReplace) Encode() (path string, rawPath string) {
+	return string(r.path), string(r.rawPath)
+}
+
+// ReplaceElement replaces a single element in the path string.
+func (r *PathReplace) ReplaceElement(key, val string) (err error) {
+	r.path, r.fieldBuf, err = replacePathElement(r.path, r.fieldBuf, key, val, false)
+	r.rawPath, r.fieldBuf, err = replacePathElement(r.rawPath, r.fieldBuf, key, val, true)
+	return err
+}
+
+func replacePathElement(path, fieldBuf []byte, key, val string, escape bool) ([]byte, []byte, error) {
+	fieldBuf = bufCap(fieldBuf, len(key)+3) // { <key> [+] }
+	fieldBuf = append(fieldBuf, uriTokenStart)
+	fieldBuf = append(fieldBuf, key...)
+
+	start := bytes.Index(path, fieldBuf)
+	end := start + len(fieldBuf)
+	if start < 0 || len(path[end:]) == 0 {
+		// TODO what to do about error?
+		return path, fieldBuf, fmt.Errorf("invalid path index, start=%d,end=%d. %s", start, end, path)
+	}
+
+	encodeSep := true
+	if path[end] == uriTokenSkip {
+		// '+' token means do not escape slashes
+		encodeSep = false
+		end++
+	}
+
+	if escape {
+		val = escapePath(val, encodeSep)
+	}
+
+	if path[end] != uriTokenStop {
+		return path, fieldBuf, fmt.Errorf("invalid path element, does not contain token stop, %s", path)
+	}
+	end++
+
+	fieldBuf = bufCap(fieldBuf, len(val))
+	fieldBuf = append(fieldBuf, val...)
+
+	keyLen := end - start
+	valLen := len(fieldBuf)
+
+	if keyLen == valLen {
+		copy(path[start:], fieldBuf)
+		return path, fieldBuf, nil
+	}
+
+	newLen := len(path) + (valLen - keyLen)
+	if len(path) < newLen {
+		path = path[:cap(path)]
+	}
+	if cap(path) < newLen {
+		newURI := make([]byte, newLen)
+		copy(newURI, path)
+		path = newURI
+	}
+
+	// shift
+	copy(path[start+valLen:], path[end:])
+	path = path[:newLen]
+	copy(path[start:], fieldBuf)
+
+	return path, fieldBuf, nil
+}
+
+// copied from rest.EscapePath
+// escapes part of a URL path in Amazon style
+func escapePath(path string, encodeSep bool) string {
+	var buf bytes.Buffer
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if noEscape[c] || (c == '/' && !encodeSep) {
+			buf.WriteByte(c)
+		} else {
+			fmt.Fprintf(&buf, "%%%02X", c)
+		}
+	}
+	return buf.String()
+}
+
+var noEscape [256]bool
+
+func init() {
+	for i := 0; i < len(noEscape); i++ {
+		// AWS expects every character except these to be escaped
+		noEscape[i] = (i >= 'A' && i <= 'Z') ||
+			(i >= 'a' && i <= 'z') ||
+			(i >= '0' && i <= '9') ||
+			i == '-' ||
+			i == '.' ||
+			i == '_' ||
+			i == '~'
+	}
+}

--- a/private/protocol/path_replace_test.go
+++ b/private/protocol/path_replace_test.go
@@ -1,0 +1,74 @@
+package protocol
+
+import "testing"
+
+func TestPathReplace(t *testing.T) {
+	cases := []struct {
+		Orig, ExpPath, ExpRawPath, Key, Val string
+	}{
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/123/{key+}",
+			ExpRawPath: "/123/{key+}",
+			Key:        "bucket", Val: "123",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/{bucket}/abc",
+			ExpRawPath: "/{bucket}/abc",
+			Key:        "key", Val: "abc",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/{bucket}/a/b/c",
+			ExpRawPath: "/{bucket}/a/b/c",
+			Key:        "key", Val: "a/b/c",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/1/2/3/{key+}",
+			ExpRawPath: "/1%2F2%2F3/{key+}",
+			Key:        "bucket", Val: "1/2/3",
+		},
+		{
+			Orig:       "/{bucket}/{key+}",
+			ExpPath:    "/reallylongvaluegoesheregrowingarray/{key+}",
+			ExpRawPath: "/reallylongvaluegoesheregrowingarray/{key+}",
+			Key:        "bucket", Val: "reallylongvaluegoesheregrowingarray",
+		},
+	}
+
+	for i, c := range cases {
+		r := NewPathReplace(c.Orig)
+
+		r.ReplaceElement(c.Key, c.Val)
+		path, rawPath := r.Encode()
+		if e, a := c.ExpPath, path; a != e {
+			t.Errorf("%d, expect uri path to be %q got %q", i, e, a)
+		}
+		if e, a := c.ExpRawPath, rawPath; a != e {
+			t.Errorf("%d, expect uri raw path to be %q got %q", i, e, a)
+		}
+	}
+}
+
+func TestPathReplace_Multiple(t *testing.T) {
+	const (
+		origURI    = "/{bucket}/{key+}"
+		expPath    = "/something/123/other/thing"
+		expRawPath = "/something%2F123/other/thing"
+	)
+
+	r := NewPathReplace(origURI)
+
+	r.ReplaceElement("bucket", "something/123")
+	r.ReplaceElement("key", "other/thing")
+
+	path, rawPath := r.Encode()
+	if e, a := expPath, path; a != e {
+		t.Errorf("expect uri path to be %q got %q", e, a)
+	}
+	if e, a := expRawPath, rawPath; a != e {
+		t.Errorf("expect uri path to be %q got %q", e, a)
+	}
+}

--- a/private/protocol/query_encoder.go
+++ b/private/protocol/query_encoder.go
@@ -1,0 +1,105 @@
+package protocol
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// QueryMapEncoder builds a query string.
+type QueryMapEncoder struct {
+	Prefix string
+	Query  url.Values
+	Err    error
+}
+
+// MapSetValue adds a single value to the query.
+func (e *QueryMapEncoder) MapSetValue(k string, v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	e.Query.Add(k, str)
+}
+
+// MapSetList executes the passed in callback with a list encoder based on
+// the context of this QueryMapEncoder.
+func (e *QueryMapEncoder) MapSetList(k string, fn func(le ListEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := QueryListEncoder{Key: k, Query: e.Query}
+	fn(&nested)
+	e.Err = nested.Err
+}
+
+// MapSetMap sets the query string element with nested maps appending the
+// passed in k to the prefix if one was set.
+func (e *QueryMapEncoder) MapSetMap(k string, fn func(me MapEncoder)) {
+	if e.Err != nil {
+		return
+	}
+
+	if len(e.Prefix) > 0 {
+		k = e.Prefix + k
+	}
+
+	nested := QueryMapEncoder{Prefix: k, Query: e.Query}
+	e.Err = nested.Err
+}
+
+// MapSetFields Is not implemented, query map of map is undefined.
+func (e *QueryMapEncoder) MapSetFields(k string, m FieldMarshaler) {
+	e.Err = fmt.Errorf("query map encoder MapSetFields not supported, %s", e.Prefix)
+}
+
+// QueryListEncoder will encode list values nested into a query key.
+type QueryListEncoder struct {
+	Key   string
+	Query url.Values
+	Err   error
+}
+
+// ListAddValue encodes an individual list value into the querystring.
+func (e *QueryListEncoder) ListAddValue(v ValueMarshaler) {
+	if e.Err != nil {
+		return
+	}
+
+	str, err := v.MarshalValue()
+	if err != nil {
+		e.Err = err
+		return
+	}
+
+	e.Query.Add(e.Key, str)
+}
+
+// ListAddList Is not implemented, query list of list is undefined.
+func (e *QueryListEncoder) ListAddList(fn func(le ListEncoder)) {
+	e.Err = fmt.Errorf("query list encoder ListAddList not supported, %s", e.Key)
+}
+
+// ListAddMap Is not implemented, query list of map is undefined.
+func (e *QueryListEncoder) ListAddMap(fn func(fe MapEncoder)) {
+	e.Err = fmt.Errorf("query list encoder ListAddMap not supported, %s", e.Key)
+}
+
+// ListAddFields Is not implemented, query list of FieldMarshaler is undefined.
+func (e *QueryListEncoder) ListAddFields(m FieldMarshaler) {
+	e.Err = fmt.Errorf("query list encoder ListAddFields not supported, %s", e.Key)
+}

--- a/private/protocol/rest/encode.go
+++ b/private/protocol/rest/encode.go
@@ -1,0 +1,150 @@
+package rest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of REST URI path, query, and header components
+// of an HTTP request. Can also encode a stream as the payload.
+//
+// Does not support SetFields.
+type Encoder struct {
+	req *http.Request
+
+	path protocol.PathReplace
+
+	query  url.Values
+	header http.Header
+
+	payload io.ReadSeeker
+
+	err error
+}
+
+// NewEncoder creates a new encoder from the passed in request. All query and
+// header values will be added on top of the request's existing values. Overwriting
+// duplicate values.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		req: req,
+
+		path:   protocol.NewPathReplace(req.URL.Path),
+		query:  req.URL.Query(),
+		header: req.Header,
+	}
+
+	return e
+}
+
+// Encode will return the request and body if one was set. If the body
+// payload was not set the io.ReadSeeker will be nil.
+//
+// returns any error if one occured while encoding the API's parameters.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	if e.err != nil {
+		return nil, nil, e.err
+	}
+
+	e.req.URL.Path, e.req.URL.RawPath = e.path.Encode()
+	e.req.URL.RawQuery = e.query.Encode()
+	e.req.Header = e.header
+
+	return e.req, e.payload, nil
+}
+
+// SetValue will set a value to the header, path, query.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	var str string
+	str, e.err = v.MarshalValue()
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		e.header.Set(k, str)
+	case protocol.PathTarget:
+		e.path.ReplaceElement(k, str)
+	case protocol.QueryTarget:
+		e.query.Set(k, str)
+	case protocol.BodyTarget:
+		if e.req.Method != "GET" {
+			e.err = fmt.Errorf("body target not supported for rest non-GET methods %s, %s", t, k)
+			return
+		}
+		e.query.Set(k, str)
+	default:
+		e.err = fmt.Errorf("unknown SetValue rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.payload, e.err = v.MarshalStream()
+	default:
+		e.err = fmt.Errorf("unknown SetStream rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetList will set the nested list values to the header or query.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		nested := protocol.QueryListEncoder{Key: k, Query: e.query}
+		fn(&nested)
+		e.err = nested.Err
+	case protocol.HeaderTarget:
+		nested := protocol.HeaderListEncoder{Key: k, Header: e.header}
+		fn(&nested)
+		e.err = nested.Err
+	default:
+		e.err = fmt.Errorf("unknown SetList rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header or query.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(fe protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		nested := protocol.QueryMapEncoder{Query: e.query}
+		fn(&nested)
+		e.err = nested.Err
+	case protocol.HeadersTarget:
+		nested := protocol.HeaderMapEncoder{Prefix: k, Header: e.header}
+		fn(&nested)
+		e.err = nested.Err
+	default:
+		e.err = fmt.Errorf("unknown SetMap rest encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields is not supported for REST encoder.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	e.err = fmt.Errorf("rest encoder SetFields not supported, %s, %s", t, k)
+}

--- a/private/protocol/rest/encode_test.go
+++ b/private/protocol/rest/encode_test.go
@@ -1,0 +1,357 @@
+package rest
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+type shape struct {
+	HeaderValue   *string
+	PathValue     *string
+	QueryValue    *string
+	QueryList     []*string
+	HeadersMap    map[string]*string
+	QueryMap      map[string]*string
+	QueryMapList  map[string][]*string
+	BodyValue     *string
+	PayloadString *string
+	PayloadBytes  []byte
+	PayloadReader io.ReadSeeker
+}
+
+func (s *shape) MarshalAWS(e protocol.FieldEncoder) {
+	if s.HeaderValue != nil {
+		e.SetValue(protocol.HeaderTarget, "header-value", protocol.StringValue(*s.HeaderValue), protocol.Metadata{})
+	}
+	if s.PathValue != nil {
+		e.SetValue(protocol.PathTarget, "key", protocol.StringValue(*s.PathValue), protocol.Metadata{})
+	}
+	if s.QueryValue != nil {
+		e.SetValue(protocol.QueryTarget, "queryKey", protocol.StringValue(*s.QueryValue), protocol.Metadata{})
+	}
+	if len(s.QueryList) > 0 {
+		e.SetList(protocol.QueryTarget, "queryKey", func(le protocol.ListEncoder) {
+			for _, v := range s.QueryList {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.HeadersMap) > 0 {
+		e.SetMap(protocol.HeadersTarget, "prefix-", func(me protocol.MapEncoder) {
+			for k, v := range s.HeadersMap {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.QueryMap) > 0 {
+		e.SetMap(protocol.QueryTarget, "unused", func(me protocol.MapEncoder) {
+			for k, v := range s.QueryMap {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.QueryMapList) > 0 {
+		e.SetMap(protocol.QueryTarget, "unused", func(me protocol.MapEncoder) {
+			for k, v := range s.QueryMapList {
+				me.MapSetList(k, func(le protocol.ListEncoder) {
+					for _, v := range v {
+						le.ListAddValue(protocol.StringValue(*v))
+					}
+				})
+			}
+		}, protocol.Metadata{})
+	}
+	if s.BodyValue != nil {
+		e.SetValue(protocol.BodyTarget, "bodyValue", protocol.StringValue(*s.BodyValue), protocol.Metadata{})
+	}
+	if s.PayloadString != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadString", protocol.StringStream(*s.PayloadString), protocol.Metadata{})
+	}
+	if s.PayloadBytes != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadBytes", protocol.BytesStream(s.PayloadBytes), protocol.Metadata{})
+	}
+	if s.PayloadReader != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadReader}, protocol.Metadata{})
+	}
+}
+
+func TestSetHeaderValue(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		HeaderValue: aws.String("thevalue"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := "thevalue", req.Header.Get("header-value"); e != a {
+		t.Errorf("expect %s header value, got %s", e, a)
+	}
+}
+
+func TestSetPathValue(t *testing.T) {
+	req, body, err := encode("GET", "/{key}", shape{
+		PathValue: aws.String("value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := "/value", req.URL.Path; e != a {
+		t.Errorf("expect %s path, got %s", e, a)
+	}
+}
+
+func TestSetQueryValue(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryValue: aws.String("queryValue"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	if e, a := "queryValue", query.Get("queryKey"); e != a {
+		t.Errorf("expect %s for 'queryKey' querystring, got %s", e, a)
+	}
+}
+
+func TestSetBody(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		BodyValue: aws.String("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	if e, a := "a value", query.Get("bodyValue"); e != a {
+		t.Errorf("expect %s for 'bodyValue' querystring, got %s", e, a)
+	}
+}
+
+func TestSetBody_Error(t *testing.T) {
+	req, body, err := encode("POST", "/path", shape{
+		BodyValue: aws.String("a value"),
+	})
+
+	if err == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "body target not supported", err.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %q to be in error %q, was not", e, a)
+	}
+
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+	if req != nil {
+		t.Errorf("expect no req, got %v", req)
+	}
+}
+
+func TestSetQueryList(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryList: []*string{aws.String("a"), aws.String("b")},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 1, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	vs, ok := query["queryKey"]
+	if !ok {
+		t.Fatalf("expect queryKey to exist, was not found")
+	}
+	for i, v := range []string{"a", "b"} {
+		if e, a := v, vs[i]; e != a {
+			t.Errorf("expect %s for 'queryKey[%d]' querystring, got %s", e, i, a)
+		}
+	}
+}
+
+func TestSetHeadersMap(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		HeadersMap: map[string]*string{
+			"abc":  aws.String("123"),
+			"else": aws.String("other"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	if e, a := 2, len(req.Header); e != a {
+		t.Errorf("expect %d header values, got %d", e, a)
+	}
+	for k, v := range map[string]string{"abc": "123", "else": "other"} {
+		if e, a := v, req.Header.Get("prefix-"+k); e != a {
+			t.Errorf("expect %s for 'prefix-%s' header, got %s", e, k, a)
+		}
+	}
+}
+
+func TestSetQueryMap(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryMap: map[string]*string{
+			"a": aws.String("abc"),
+			"b": aws.String("123"),
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 2, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	for k, v := range map[string]string{"a": "abc", "b": "123"} {
+		if e, a := v, query.Get(k); e != a {
+			t.Errorf("expect %s for '%s' querystring, got %s", e, k, a)
+		}
+	}
+}
+
+func TestSetQueryMapList(t *testing.T) {
+	req, body, err := encode("GET", "/path", shape{
+		QueryMapList: map[string][]*string{
+			"a": {aws.String("a1"), aws.String("a2")},
+			"b": {aws.String("b1"), aws.String("b2")},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if body != nil {
+		t.Errorf("expect no body, got %v", body)
+	}
+
+	query := req.URL.Query()
+	if e, a := 2, len(query); e != a {
+		t.Errorf("expect %d query values, got %d", e, a)
+	}
+	for k, vs := range map[string][]string{"a": []string{"a1", "a2"}, "b": []string{"b1", "b2"}} {
+		as, ok := query[k]
+		if !ok {
+			t.Fatalf("expect %s to exist, was not", k)
+		}
+		for i, v := range vs {
+			if e, a := v, as[i]; e != a {
+				t.Errorf("expect %s for '%s' querystring, got %s", e, k, a)
+			}
+		}
+	}
+}
+
+func TestSetPayloadString(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadString: aws.String("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+func TestSetPayloadBytes(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadBytes: []byte("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+func TestSetPayloadReader(t *testing.T) {
+	_, body, err := encode("POST", "/path", shape{
+		PayloadReader: strings.NewReader("a value"),
+	})
+
+	if err != nil {
+		t.Fatalf("expect no encode error, got %v", err)
+	}
+	if body == nil {
+		t.Fatalf("expect body, got none")
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		t.Fatalf("expect no body read error, got %v", err)
+	}
+	if e, a := "a value", string(b); e != a {
+		t.Errorf("expect %s body, got %s", e, a)
+	}
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalAWS(e)
+	return e.Encode()
+}

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -180,7 +180,6 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -190,7 +189,6 @@ type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -343,7 +341,6 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFiel
 
 		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -353,7 +350,6 @@ type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -506,7 +502,6 @@ func (s *InputService3TestShapeInputService3TestCaseOperation1Input) MarshalFiel
 
 		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -516,7 +511,6 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -669,7 +663,6 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFiel
 
 		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -679,7 +672,6 @@ type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -845,7 +837,6 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFiel
 
 		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -855,7 +846,6 @@ type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1026,7 +1016,6 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFiel
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1036,7 +1025,6 @@ type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1247,7 +1235,6 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1270,7 +1257,6 @@ func (s *InputService7TestShapeInputService7TestCaseOperation2Input) MarshalFiel
 
 		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1280,7 +1266,6 @@ type InputService7TestShapeInputService7TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService7TestShapeInputService7TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1444,6 +1429,11 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPipeline
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Ascending != nil {
 		v := *s.Ascending
 
@@ -1454,12 +1444,6 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFiel
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PipelineId != nil {
-		v := *s.PipelineId
-
-		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -1469,7 +1453,6 @@ type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1641,27 +1624,26 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetPipeline
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Ascending != nil {
-		v := *s.Ascending
-
-		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Config != nil {
 		v := s.Config
 
 		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
-	}
-	if s.PageToken != nil {
-		v := *s.PageToken
-
-		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.PipelineId != nil {
 		v := *s.PipelineId
 
 		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Ascending != nil {
+		v := *s.Ascending
 
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -1671,7 +1653,6 @@ type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1707,7 +1688,6 @@ func (s *InputService9TestShapeStructType) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1887,32 +1867,31 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetPipeli
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Ascending != nil {
-		v := *s.Ascending
+	if s.Config != nil {
+		v := s.Config
 
-		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
 	}
 	if s.Checksum != nil {
 		v := *s.Checksum
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-checksum", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Config != nil {
-		v := s.Config
+	if s.PipelineId != nil {
+		v := *s.PipelineId
 
-		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.PageToken != nil {
 		v := *s.PageToken
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PipelineId != nil {
-		v := *s.PipelineId
-
-		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -1922,7 +1901,6 @@ type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1958,7 +1936,6 @@ func (s *InputService10TestShapeStructType) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2136,11 +2113,6 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetVaultN
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
-	}
 	if s.Checksum != nil {
 		v := *s.Checksum
 
@@ -2151,7 +2123,11 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFi
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Body != nil {
+		v := s.Body
 
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -2161,7 +2137,6 @@ type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2342,7 +2317,6 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFi
 
 		e.SetValue(protocol.PathTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2352,7 +2326,6 @@ type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2563,7 +2536,6 @@ type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2586,7 +2558,6 @@ func (s *InputService13TestShapeInputService13TestCaseOperation2Input) MarshalFi
 
 		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2596,7 +2567,6 @@ type InputService13TestShapeInputService13TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService13TestShapeInputService13TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2820,7 +2790,6 @@ func (s *InputService14TestShapeFooShape) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2830,7 +2799,6 @@ type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2853,7 +2821,6 @@ func (s *InputService14TestShapeInputService14TestCaseOperation2Input) MarshalFi
 
 		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2863,7 +2830,6 @@ type InputService14TestShapeInputService14TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService14TestShapeInputService14TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3074,7 +3040,6 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3097,7 +3062,6 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3107,7 +3071,6 @@ type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3602,7 +3565,6 @@ type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3612,7 +3574,6 @@ type InputService16TestShapeInputService16TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3622,7 +3583,6 @@ type InputService16TestShapeInputService16TestCaseOperation3Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3632,7 +3592,6 @@ type InputService16TestShapeInputService16TestCaseOperation4Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3642,7 +3601,6 @@ type InputService16TestShapeInputService16TestCaseOperation5Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3665,7 +3623,6 @@ func (s *InputService16TestShapeInputService16TestCaseOperation6Input) MarshalFi
 
 		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3675,7 +3632,6 @@ type InputService16TestShapeInputService16TestCaseOperation6Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3737,7 +3693,6 @@ func (s *InputService16TestShapeRecursiveStructType) MarshalFields(e protocol.Fi
 
 		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3964,7 +3919,6 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4000,7 +3954,6 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4010,7 +3963,6 @@ type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4163,7 +4115,6 @@ func (s *InputService18TestShapeInputService18TestCaseOperation1Input) MarshalFi
 
 		e.SetValue(protocol.BodyTarget, "timestamp_location", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4173,7 +4124,6 @@ type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4326,7 +4276,6 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFi
 
 		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4336,7 +4285,6 @@ type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4547,7 +4495,6 @@ type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4576,7 +4523,6 @@ func (s *InputService20TestShapeInputService20TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4586,7 +4532,6 @@ type InputService20TestShapeInputService20TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService20TestShapeInputService20TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4894,7 +4839,6 @@ func (s *InputService21TestShapeBodyStructure) MarshalFields(e protocol.FieldEnc
 
 		e.SetList(protocol.BodyTarget, "BodyListField", protocol.EncodeJSONValueList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4904,7 +4848,6 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4914,7 +4857,6 @@ type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4948,22 +4890,21 @@ func (s *InputService21TestShapeInputService21TestCaseOperation3Input) SetQueryF
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetFields(protocol.PayloadTarget, "Body", v, protocol.Metadata{})
-	}
 	if s.HeaderField != nil {
 		v := s.HeaderField
 
 		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetFields(protocol.PayloadTarget, "Body", v, protocol.Metadata{})
 	}
 	if s.QueryField != nil {
 		v := s.QueryField
 
 		e.SetValue(protocol.QueryTarget, "Bar", protocol.JSONValue{V: v}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4973,7 +4914,6 @@ type InputService21TestShapeInputService21TestCaseOperation3Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -178,8 +178,20 @@ type InputService1TestShapeInputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService2ProtocolTest provides the API operation methods for making requests to
@@ -324,8 +336,25 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService3ProtocolTest provides the API operation methods for making requests to
@@ -470,8 +499,25 @@ func (s *InputService3TestShapeInputService3TestCaseOperation1Input) SetFoo(v st
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService4ProtocolTest provides the API operation methods for making requests to
@@ -616,8 +662,25 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetItems(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService5ProtocolTest provides the API operation methods for making requests to
@@ -770,8 +833,30 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetQueryDoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService6ProtocolTest provides the API operation methods for making requests to
@@ -924,8 +1009,35 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetQueryDoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService7ProtocolTest provides the API operation methods for making requests to
@@ -1133,6 +1245,12 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -1145,8 +1263,25 @@ func (s *InputService7TestShapeInputService7TestCaseOperation2Input) SetBoolQuer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BoolQuery != nil {
+		v := *s.BoolQuery
+
+		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService8ProtocolTest provides the API operation methods for making requests to
@@ -1307,8 +1442,35 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService9ProtocolTest provides the API operation methods for making requests to
@@ -1477,8 +1639,40 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetPipeline
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService9TestShapeStructType struct {
@@ -1499,6 +1693,22 @@ func (s *InputService9TestShapeStructType) SetA(v string) *InputService9TestShap
 func (s *InputService9TestShapeStructType) SetB(v string) *InputService9TestShapeStructType {
 	s.B = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.A != nil {
+		v := *s.A
+
+		e.SetValue(protocol.BodyTarget, "A", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.B != nil {
+		v := *s.B
+
+		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService10ProtocolTest provides the API operation methods for making requests to
@@ -1675,8 +1885,45 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetPipeli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService10TestShapeStructType struct {
@@ -1697,6 +1944,22 @@ func (s *InputService10TestShapeStructType) SetA(v string) *InputService10TestSh
 func (s *InputService10TestShapeStructType) SetB(v string) *InputService10TestShapeStructType {
 	s.B = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.A != nil {
+		v := *s.A
+
+		e.SetValue(protocol.BodyTarget, "A", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.B != nil {
+		v := *s.B
+
+		e.SetValue(protocol.BodyTarget, "B", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService11ProtocolTest provides the API operation methods for making requests to
@@ -1871,8 +2134,35 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetVaultN
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService12ProtocolTest provides the API operation methods for making requests to
@@ -2040,8 +2330,30 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.PathTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService13ProtocolTest provides the API operation methods for making requests to
@@ -2249,6 +2561,12 @@ type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation2Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
@@ -2261,8 +2579,25 @@ func (s *InputService13TestShapeInputService13TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService14ProtocolTest provides the API operation methods for making requests to
@@ -2478,8 +2813,25 @@ func (s *InputService14TestShapeFooShape) SetBaz(v string) *InputService14TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Baz != nil {
+		v := *s.Baz
+
+		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService14TestShapeInputService14TestCaseOperation2Input struct {
@@ -2494,8 +2846,25 @@ func (s *InputService14TestShapeInputService14TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService15ProtocolTest provides the API operation methods for making requests to
@@ -2703,6 +3072,12 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -2715,8 +3090,25 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService16ProtocolTest provides the API operation methods for making requests to
@@ -3208,20 +3600,50 @@ type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeInputService16TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeInputService16TestCaseOperation6Input struct {
@@ -3236,8 +3658,25 @@ func (s *InputService16TestShapeInputService16TestCaseOperation6Input) SetRecurs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation6Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService16TestShapeRecursiveStructType struct {
@@ -3274,6 +3713,48 @@ func (s *InputService16TestShapeRecursiveStructType) SetRecursiveMap(v map[strin
 func (s *InputService16TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService16TestShapeRecursiveStructType) *InputService16TestShapeRecursiveStructType {
 	s.RecursiveStruct = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeRecursiveStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoRecurse != nil {
+		v := *s.NoRecurse
+
+		e.SetValue(protocol.BodyTarget, "NoRecurse", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveList) > 0 {
+		v := s.RecursiveList
+
+		e.SetList(protocol.BodyTarget, "RecursiveList", encodeInputService16TestShapeRecursiveStructTypeList(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveMap) > 0 {
+		v := s.RecursiveMap
+
+		e.SetMap(protocol.BodyTarget, "RecursiveMap", encodeInputService16TestShapeRecursiveStructTypeMap(v), protocol.Metadata{})
+	}
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService16TestShapeRecursiveStructTypeList(vs []*InputService16TestShapeRecursiveStructType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encodeInputService16TestShapeRecursiveStructTypeMap(vs map[string]*InputService16TestShapeRecursiveStructType) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // InputService17ProtocolTest provides the API operation methods for making requests to
@@ -3481,6 +3962,12 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -3501,8 +3988,30 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArg != nil {
+		v := *s.TimeArg
+
+		e.SetValue(protocol.BodyTarget, "TimeArg", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TimeArgInHeader != nil {
+		v := *s.TimeArgInHeader
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService18ProtocolTest provides the API operation methods for making requests to
@@ -3647,8 +4156,25 @@ func (s *InputService18TestShapeInputService18TestCaseOperation1Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArg != nil {
+		v := *s.TimeArg
+
+		e.SetValue(protocol.BodyTarget, "timestamp_location", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService19ProtocolTest provides the API operation methods for making requests to
@@ -3793,8 +4319,25 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService20ProtocolTest provides the API operation methods for making requests to
@@ -4002,6 +4545,12 @@ type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -4014,8 +4563,31 @@ func (s *InputService20TestShapeInputService20TestCaseOperation2Input) SetToken(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	var Token string
+	if s.Token != nil {
+		Token = *s.Token
+	} else {
+		Token = protocol.GetIdempotencyToken()
+	}
+	{
+		v := Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService21ProtocolTest provides the API operation methods for making requests to
@@ -4310,12 +4882,40 @@ func (s *InputService21TestShapeBodyStructure) SetBodyListField(v []aws.JSONValu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeBodyStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BodyField != nil {
+		v := s.BodyField
+
+		e.SetValue(protocol.BodyTarget, "BodyField", protocol.JSONValue{V: v}, protocol.Metadata{})
+	}
+	if len(s.BodyListField) > 0 {
+		v := s.BodyListField
+
+		e.SetList(protocol.BodyTarget, "BodyListField", protocol.EncodeJSONValueList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService21TestShapeInputService21TestCaseOperation3Input struct {
@@ -4346,8 +4946,35 @@ func (s *InputService21TestShapeInputService21TestCaseOperation3Input) SetQueryF
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetFields(protocol.PayloadTarget, "Body", v, protocol.Metadata{})
+	}
+	if s.HeaderField != nil {
+		v := s.HeaderField
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.QueryField != nil {
+		v := s.QueryField
+
+		e.SetValue(protocol.QueryTarget, "Bar", protocol.JSONValue{V: v}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 //

--- a/private/protocol/restjson/encode.go
+++ b/private/protocol/restjson/encode.go
@@ -1,0 +1,162 @@
+package restjson
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/json"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
+)
+
+// An Encoder provides encoding of the AWS RESTJSON protocol. This encoder combindes
+// the JSON and REST encoders deligating to them for their associated targets.
+//
+// It is invalid to set a JSON and stream payload on the same encoder.
+type Encoder struct {
+	method      string
+	reqEncoder  *rest.Encoder
+	bodyEncoder *json.Encoder
+
+	buf *bytes.Buffer
+	err error
+}
+
+// NewEncoder creates a new encoder for encoding the AWS RESTJSON protocol.
+// The request passed in will be the base the path, query, and headers encoded
+// will be set on top of.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		method:      req.Method,
+		reqEncoder:  rest.NewEncoder(req),
+		bodyEncoder: json.NewEncoder(),
+	}
+
+	return e
+}
+
+// Encode returns the encoded request, and body payload. If no payload body was
+// set nil will be returned.  If an error occurred while encoding the API an
+// error will be returned.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	req, payloadBody, err := e.reqEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jsonBody, err := e.bodyEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	havePayload := payloadBody != nil
+	haveJSON := jsonBody != nil
+
+	if havePayload == haveJSON && haveJSON {
+		return nil, nil, fmt.Errorf("unexpected JSON body and request payload for AWSMarshaler")
+	}
+
+	body := payloadBody
+	if body == nil {
+		body = jsonBody
+	}
+
+	return req, body, err
+}
+
+// SetValue will set a value to the header, path, query, or body.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PathTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeaderTarget:
+		e.reqEncoder.SetValue(t, k, v, meta)
+	case protocol.BodyTarget:
+		fallthrough
+	case protocol.PayloadTarget:
+		if e.method == "GET" {
+			e.reqEncoder.SetValue(t, k, v, meta)
+		} else {
+			e.bodyEncoder.SetValue(t, k, v, meta)
+		}
+	default:
+		e.err = fmt.Errorf("unknown SetValue restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.reqEncoder.SetStream(t, k, v, meta)
+	default:
+		e.err = fmt.Errorf("invalid target %s, for SetStream, must be PayloadTarget", t)
+	}
+}
+
+// SetList will set the nested list values to the header, query, or body.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		e.reqEncoder.SetList(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetList(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetList restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header, query, or body.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeadersTarget:
+		e.reqEncoder.SetMap(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetMap(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMap restjson encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields will set the nested type's fields to the body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		fallthrough
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetFields(t, k, m, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMarshaler restjson encode target, %s, %s", t, k)
+	}
+}

--- a/private/protocol/restjson/encode_test.go
+++ b/private/protocol/restjson/encode_test.go
@@ -1,0 +1,111 @@
+package restjson
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		NestedShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"nestedShape":{"value":"some value"}}`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodePayloadShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `{"value":"some value"}`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodePayloadStream(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadStream: strings.NewReader("some value"),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := "some value"
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type shape struct {
+	NestedShape   *nestedShape
+	PayloadShape  *nestedShape
+	PayloadStream io.ReadSeeker
+}
+
+func (s *shape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NestedShape != nil {
+		e.SetFields(protocol.BodyTarget, "nestedShape", s.NestedShape, protocol.Metadata{})
+	}
+	if s.PayloadShape != nil {
+		e.SetFields(protocol.PayloadTarget, "payloadShape", s.PayloadShape, protocol.Metadata{})
+	}
+	if s.PayloadStream != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadStream}, protocol.Metadata{})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	return nil
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -7,11 +7,13 @@ package restjson
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 )
@@ -30,6 +32,25 @@ var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.restjson.Unmarsha
 
 // Build builds a request for the REST JSON protocol.
 func Build(r *request.Request) {
+	if m, ok := r.Params.(protocol.FieldMarshaler); ok {
+		e := NewEncoder(r.HTTPRequest)
+
+		m.MarshalFields(e)
+
+		var body io.ReadSeeker
+		var err error
+		r.HTTPRequest, body, err = e.Encode()
+		if err != nil {
+			r.Error = awserr.New(request.ErrCodeSerialization, "failed to encode rest JSON request", err)
+			return
+		}
+		if body != nil {
+			r.SetReaderBody(body)
+		}
+		return
+	}
+
+	// Fall back to old reflection based marshaler
 	rest.Build(r)
 
 	if t := rest.PayloadType(r.Params); t == "structure" || t == "" {

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -177,7 +177,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -295,16 +294,6 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
 	}
-	if s.ImaHeader != nil {
-		v := *s.ImaHeader
-
-		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.ImaHeaderLocation != nil {
-		v := *s.ImaHeaderLocation
-
-		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Long != nil {
 		v := *s.Long
 
@@ -315,7 +304,6 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "Num", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	// ignoring invalid encode state, StatusCode. Status
 	if s.Str != nil {
 		v := *s.Str
 
@@ -326,7 +314,17 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
 	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
 
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. Status
 	return nil
 }
 
@@ -477,7 +475,6 @@ func (s *OutputService2TestShapeBlobContainer) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.BodyTarget, "foo", protocol.BytesValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -487,7 +484,6 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -524,7 +520,6 @@ func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalF
 
 		e.SetFields(protocol.BodyTarget, "StructMember", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -661,7 +656,6 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -697,7 +691,6 @@ func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "TimeMember", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -720,7 +713,6 @@ func (s *OutputService3TestShapeTimeContainer) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.BodyTarget, "foo", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -857,7 +849,6 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -880,7 +871,6 @@ func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalF
 
 		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1017,7 +1007,6 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1040,7 +1029,6 @@ func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalF
 
 		e.SetList(protocol.BodyTarget, "ListMember", encodeOutputService5TestShapeSingleStructList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1063,7 +1051,6 @@ func (s *OutputService5TestShapeSingleStruct) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1208,7 +1195,6 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1236,7 +1222,6 @@ func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalF
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1373,7 +1358,6 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1396,7 +1380,6 @@ func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalF
 
 		e.SetMap(protocol.BodyTarget, "MapMember", protocol.EncodeTimeMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1533,7 +1516,6 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1556,7 +1538,6 @@ func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "StrType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1693,7 +1674,6 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1729,7 +1709,6 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalF
 
 		e.SetMap(protocol.HeadersTarget, "X-", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1879,7 +1858,6 @@ func (s *OutputService10TestShapeBodyStructure) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1889,7 +1867,6 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1915,17 +1892,16 @@ func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetHea
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Data != nil {
-		v := s.Data
-
-		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
-	}
 	if s.Header != nil {
 		v := *s.Header
 
 		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Data != nil {
+		v := s.Data
 
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -2062,7 +2038,6 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2085,7 +2060,6 @@ func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) Marsha
 
 		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2358,7 +2332,6 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2368,7 +2341,6 @@ type OutputService12TestShapeOutputService12TestCaseOperation2Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService12TestShapeOutputService12TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2378,7 +2350,6 @@ type OutputService12TestShapeOutputService12TestCaseOperation3Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService12TestShapeOutputService12TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2427,7 +2398,6 @@ func (s *OutputService12TestShapeOutputService12TestCaseOperation3Output) Marsha
 
 		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -175,6 +175,12 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService1TestShapeOutputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -265,6 +271,63 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetStr(v
 func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation1Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.BodyTarget, "Char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.BodyTarget, "Double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.BodyTarget, "FalseBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
+
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.BodyTarget, "Long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Num != nil {
+		v := *s.Num
+
+		e.SetValue(protocol.BodyTarget, "Num", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. Status
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.BodyTarget, "Str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService2ProtocolTest provides the API operation methods for making requests to
@@ -407,8 +470,25 @@ func (s *OutputService2TestShapeBlobContainer) SetFoo(v []byte) *OutputService2T
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeBlobContainer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
@@ -430,6 +510,22 @@ func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlobM
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetStructMember(v *OutputService2TestShapeBlobContainer) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
 	s.StructMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BlobMember != nil {
+		v := s.BlobMember
+
+		e.SetValue(protocol.BodyTarget, "BlobMember", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.StructMember != nil {
+		v := s.StructMember
+
+		e.SetFields(protocol.BodyTarget, "StructMember", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService3ProtocolTest provides the API operation methods for making requests to
@@ -563,6 +659,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -583,6 +685,22 @@ func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetTimeM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StructMember != nil {
+		v := s.StructMember
+
+		e.SetFields(protocol.BodyTarget, "StructMember", v, protocol.Metadata{})
+	}
+	if s.TimeMember != nil {
+		v := *s.TimeMember
+
+		e.SetValue(protocol.BodyTarget, "TimeMember", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService3TestShapeTimeContainer struct {
 	_ struct{} `type:"structure"`
 
@@ -593,6 +711,17 @@ type OutputService3TestShapeTimeContainer struct {
 func (s *OutputService3TestShapeTimeContainer) SetFoo(v time.Time) *OutputService3TestShapeTimeContainer {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeTimeContainer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService4ProtocolTest provides the API operation methods for making requests to
@@ -726,6 +855,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -736,6 +871,17 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService5ProtocolTest provides the API operation methods for making requests to
@@ -869,6 +1015,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -881,6 +1033,17 @@ func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", encodeOutputService5TestShapeSingleStructList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService5TestShapeSingleStruct struct {
 	_ struct{} `type:"structure"`
 
@@ -891,6 +1054,25 @@ type OutputService5TestShapeSingleStruct struct {
 func (s *OutputService5TestShapeSingleStruct) SetFoo(v string) *OutputService5TestShapeSingleStruct {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeSingleStruct) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputService5TestShapeSingleStructList(vs []*OutputService5TestShapeSingleStruct) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // OutputService6ProtocolTest provides the API operation methods for making requests to
@@ -1024,6 +1206,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1034,6 +1222,22 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMapMember(v map[string][]*int64) *OutputService6TestShapeOutputService6TestCaseOperation1Output {
 	s.MapMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.MapMember) > 0 {
+		v := s.MapMember
+
+		e.SetMap(protocol.BodyTarget, "MapMember", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeInt64List(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService7ProtocolTest provides the API operation methods for making requests to
@@ -1167,6 +1371,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1177,6 +1387,17 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMapMember(v map[string]*time.Time) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
 	s.MapMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.MapMember) > 0 {
+		v := s.MapMember
+
+		e.SetMap(protocol.BodyTarget, "MapMember", protocol.EncodeTimeMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService8ProtocolTest provides the API operation methods for making requests to
@@ -1310,6 +1531,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1320,6 +1547,17 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetStrType(v string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
 	s.StrType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StrType != nil {
+		v := *s.StrType
+
+		e.SetValue(protocol.BodyTarget, "StrType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService9ProtocolTest provides the API operation methods for making requests to
@@ -1453,6 +1691,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1471,6 +1715,22 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetAllHe
 func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetPrefixedHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
 	s.PrefixedHeaders = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AllHeaders) > 0 {
+		v := s.AllHeaders
+
+		e.SetMap(protocol.HeadersTarget, "AllHeaders", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.PrefixedHeaders) > 0 {
+		v := s.PrefixedHeaders
+
+		e.SetMap(protocol.HeadersTarget, "X-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService10ProtocolTest provides the API operation methods for making requests to
@@ -1612,8 +1872,25 @@ func (s *OutputService10TestShapeBodyStructure) SetFoo(v string) *OutputService1
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeBodyStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
@@ -1634,6 +1911,22 @@ func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetDat
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetHeader(v string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
 	s.Header = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Data != nil {
+		v := s.Data
+
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
+	if s.Header != nil {
+		v := *s.Header
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService11ProtocolTest provides the API operation methods for making requests to
@@ -1767,6 +2060,12 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
@@ -1777,6 +2076,17 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStream(v []byte) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
 	s.Stream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Stream != nil {
+		v := s.Stream
+
+		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService12ProtocolTest provides the API operation methods for making requests to
@@ -2046,12 +2356,30 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService12TestShapeOutputService12TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService12TestShapeOutputService12TestCaseOperation3Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation3Output struct {
@@ -2080,6 +2408,27 @@ func (s *OutputService12TestShapeOutputService12TestCaseOperation3Output) SetBod
 func (s *OutputService12TestShapeOutputService12TestCaseOperation3Output) SetHeaderField(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation3Output {
 	s.HeaderField = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BodyField != nil {
+		v := s.BodyField
+
+		e.SetValue(protocol.BodyTarget, "BodyField", protocol.JSONValue{V: v}, protocol.Metadata{})
+	}
+	if len(s.BodyListField) > 0 {
+		v := s.BodyListField
+
+		e.SetList(protocol.BodyTarget, "BodyListField", protocol.EncodeJSONValueList(v), protocol.Metadata{})
+	}
+	if s.HeaderField != nil {
+		v := s.HeaderField
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Foo", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -320,6 +320,12 @@ type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation2Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
@@ -340,16 +346,50 @@ func (s *InputService1TestShapeInputService1TestCaseOperation2Input) SetName(v s
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService1TestShapeInputService1TestCaseOperation3Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService1TestShapeInputService1TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService2ProtocolTest provides the API operation methods for making requests to
@@ -518,8 +558,40 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetThird(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.First != nil {
+		v := *s.First
+
+		e.SetValue(protocol.BodyTarget, "First", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Fourth != nil {
+		v := *s.Fourth
+
+		e.SetValue(protocol.BodyTarget, "Fourth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Second != nil {
+		v := *s.Second
+
+		e.SetValue(protocol.BodyTarget, "Second", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Third != nil {
+		v := *s.Third
+
+		e.SetValue(protocol.BodyTarget, "Third", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService3ProtocolTest provides the API operation methods for making requests to
@@ -727,6 +799,12 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation2Input struct {
 	_ struct{} `locationName:"OperationRequest" type:"structure" xmlURI:"https://foo/"`
 
@@ -747,8 +825,30 @@ func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetSubStruc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubStructure != nil {
+		v := s.SubStructure
+
+		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeInputService3TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService3TestShapeSubStructure struct {
@@ -769,6 +869,22 @@ func (s *InputService3TestShapeSubStructure) SetBar(v string) *InputService3Test
 func (s *InputService3TestShapeSubStructure) SetFoo(v string) *InputService3TestShapeSubStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService3TestShapeSubStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := *s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService4ProtocolTest provides the API operation methods for making requests to
@@ -921,8 +1037,30 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetSubStruc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubStructure != nil {
+		v := s.SubStructure
+
+		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService4TestShapeSubStructure struct {
@@ -943,6 +1081,22 @@ func (s *InputService4TestShapeSubStructure) SetBar(v string) *InputService4Test
 func (s *InputService4TestShapeSubStructure) SetFoo(v string) *InputService4TestShapeSubStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService4TestShapeSubStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bar != nil {
+		v := *s.Bar
+
+		e.SetValue(protocol.BodyTarget, "Bar", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService5ProtocolTest provides the API operation methods for making requests to
@@ -1087,8 +1241,25 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService6ProtocolTest provides the API operation methods for making requests to
@@ -1233,8 +1404,25 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "AlternateName", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NotMember"})
+	}
+
+	return nil
+}
+
 type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService7ProtocolTest provides the API operation methods for making requests to
@@ -1379,8 +1567,25 @@ func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService8ProtocolTest provides the API operation methods for making requests to
@@ -1525,8 +1730,25 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService9ProtocolTest provides the API operation methods for making requests to
@@ -1671,8 +1893,25 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetListPara
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListParam) > 0 {
+		v := s.ListParam
+
+		e.SetList(protocol.BodyTarget, "item", encodeInputService9TestShapeSingleFieldStructList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService9TestShapeSingleFieldStruct struct {
@@ -1685,6 +1924,25 @@ type InputService9TestShapeSingleFieldStruct struct {
 func (s *InputService9TestShapeSingleFieldStruct) SetElement(v string) *InputService9TestShapeSingleFieldStruct {
 	s.Element = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService9TestShapeSingleFieldStruct) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Element != nil {
+		v := *s.Element
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService9TestShapeSingleFieldStructList(vs []*InputService9TestShapeSingleFieldStruct) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // InputService10ProtocolTest provides the API operation methods for making requests to
@@ -1829,8 +2087,25 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetStruct
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StructureParam != nil {
+		v := s.StructureParam
+
+		e.SetFields(protocol.BodyTarget, "StructureParam", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService10TestShapeStructureShape struct {
@@ -1852,6 +2127,22 @@ func (s *InputService10TestShapeStructureShape) SetB(v []byte) *InputService10Te
 func (s *InputService10TestShapeStructureShape) SetT(v time.Time) *InputService10TestShapeStructureShape {
 	s.T = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService10TestShapeStructureShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.B != nil {
+		v := s.B
+
+		e.SetValue(protocol.BodyTarget, "b", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.T != nil {
+		v := *s.T
+
+		e.SetValue(protocol.BodyTarget, "t", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // InputService11ProtocolTest provides the API operation methods for making requests to
@@ -1996,8 +2287,25 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Foo) > 0 {
+		v := s.Foo
+
+		e.SetMap(protocol.HeadersTarget, "x-foo-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService12ProtocolTest provides the API operation methods for making requests to
@@ -2142,8 +2450,25 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) SetItems(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService13ProtocolTest provides the API operation methods for making requests to
@@ -2296,8 +2621,30 @@ func (s *InputService13TestShapeInputService13TestCaseOperation1Input) SetQueryD
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService14ProtocolTest provides the API operation methods for making requests to
@@ -2450,8 +2797,35 @@ func (s *InputService14TestShapeInputService14TestCaseOperation1Input) SetQueryD
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryDoc) > 0 {
+		v := s.QueryDoc
+
+		e.SetMap(protocol.QueryTarget, "QueryDoc", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService15ProtocolTest provides the API operation methods for making requests to
@@ -2659,6 +3033,12 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -2671,8 +3051,25 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) SetBoolQu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BoolQuery != nil {
+		v := *s.BoolQuery
+
+		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService16ProtocolTest provides the API operation methods for making requests to
@@ -2817,8 +3214,25 @@ func (s *InputService16TestShapeInputService16TestCaseOperation1Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService17ProtocolTest provides the API operation methods for making requests to
@@ -3026,6 +3440,12 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Input struct {
 	_ struct{} `type:"structure" payload:"Foo"`
 
@@ -3038,8 +3458,25 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService18ProtocolTest provides the API operation methods for making requests to
@@ -3397,16 +3834,45 @@ func (s *InputService18TestShapeFooShape) SetBaz(v string) *InputService18TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Baz != nil {
+		v := *s.Baz
+
+		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService18TestShapeInputService18TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService18TestShapeInputService18TestCaseOperation4Input struct {
@@ -3421,8 +3887,25 @@ func (s *InputService18TestShapeInputService18TestCaseOperation4Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation4Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService18TestShapeInputService18TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService18TestShapeInputService18TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService19ProtocolTest provides the API operation methods for making requests to
@@ -3567,6 +4050,22 @@ func (s *InputService19TestShapeGrant) SetGrantee(v *InputService19TestShapeGran
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeGrant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeGrantee struct {
 	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 
@@ -3587,6 +4086,18 @@ func (s *InputService19TestShapeGrantee) SetType(v string) *InputService19TestSh
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeGrantee) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Type XML Attribute.
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Input struct {
 	_ struct{} `type:"structure" payload:"Grant"`
 
@@ -3599,8 +4110,25 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) SetGrant(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grant != nil {
+		v := s.Grant
+
+		e.SetFields(protocol.PayloadTarget, "Grant", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService20ProtocolTest provides the API operation methods for making requests to
@@ -3753,8 +4281,30 @@ func (s *InputService20TestShapeInputService20TestCaseOperation1Input) SetKey(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService21ProtocolTest provides the API operation methods for making requests to
@@ -3962,6 +4512,12 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -3974,8 +4530,25 @@ func (s *InputService21TestShapeInputService21TestCaseOperation2Input) SetFoo(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService22ProtocolTest provides the API operation methods for making requests to
@@ -4467,20 +5040,50 @@ type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeInputService22TestCaseOperation3Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation4Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation5Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeInputService22TestCaseOperation6Input struct {
@@ -4495,8 +5098,25 @@ func (s *InputService22TestShapeInputService22TestCaseOperation6Input) SetRecurs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation6Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService22TestShapeInputService22TestCaseOperation6Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeInputService22TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type InputService22TestShapeRecursiveStructType struct {
@@ -4533,6 +5153,48 @@ func (s *InputService22TestShapeRecursiveStructType) SetRecursiveMap(v map[strin
 func (s *InputService22TestShapeRecursiveStructType) SetRecursiveStruct(v *InputService22TestShapeRecursiveStructType) *InputService22TestShapeRecursiveStructType {
 	s.RecursiveStruct = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService22TestShapeRecursiveStructType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoRecurse != nil {
+		v := *s.NoRecurse
+
+		e.SetValue(protocol.BodyTarget, "NoRecurse", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveList) > 0 {
+		v := s.RecursiveList
+
+		e.SetList(protocol.BodyTarget, "RecursiveList", encodeInputService22TestShapeRecursiveStructTypeList(v), protocol.Metadata{})
+	}
+	if len(s.RecursiveMap) > 0 {
+		v := s.RecursiveMap
+
+		e.SetMap(protocol.BodyTarget, "RecursiveMap", encodeInputService22TestShapeRecursiveStructTypeMap(v), protocol.Metadata{})
+	}
+	if s.RecursiveStruct != nil {
+		v := s.RecursiveStruct
+
+		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputService22TestShapeRecursiveStructTypeList(vs []*InputService22TestShapeRecursiveStructType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encodeInputService22TestShapeRecursiveStructTypeMap(vs map[string]*InputService22TestShapeRecursiveStructType) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // InputService23ProtocolTest provides the API operation methods for making requests to
@@ -4677,8 +5339,25 @@ func (s *InputService23TestShapeInputService23TestCaseOperation1Input) SetTimeAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService23TestShapeInputService23TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeArgInHeader != nil {
+		v := *s.TimeArgInHeader
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService23TestShapeInputService23TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService23TestShapeInputService23TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // InputService24ProtocolTest provides the API operation methods for making requests to
@@ -4886,6 +5565,12 @@ type InputService24TestShapeInputService24TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type InputService24TestShapeInputService24TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
 
@@ -4898,8 +5583,31 @@ func (s *InputService24TestShapeInputService24TestCaseOperation2Input) SetToken(
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	var Token string
+	if s.Token != nil {
+		Token = *s.Token
+	} else {
+		Token = protocol.GetIdempotencyToken()
+	}
+	{
+		v := Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type InputService24TestShapeInputService24TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService24TestShapeInputService24TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 //

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -322,7 +322,6 @@ type InputService1TestShapeInputService1TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -348,17 +347,19 @@ func (s *InputService1TestShapeInputService1TestCaseOperation2Input) SetName(v s
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Description != nil {
-		v := *s.Description
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Description != nil {
+			v := *s.Description
 
-		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Name != nil {
-		v := *s.Name
+			e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Name != nil {
+			v := *s.Name
 
-		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -368,7 +369,6 @@ type InputService1TestShapeInputService1TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -378,7 +378,6 @@ type InputService1TestShapeInputService1TestCaseOperation3Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation3Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -388,7 +387,6 @@ type InputService1TestShapeInputService1TestCaseOperation3Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService1TestShapeInputService1TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -560,27 +558,29 @@ func (s *InputService2TestShapeInputService2TestCaseOperation1Input) SetThird(v 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService2TestShapeInputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.First != nil {
-		v := *s.First
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.First != nil {
+			v := *s.First
 
-		e.SetValue(protocol.BodyTarget, "First", protocol.BoolValue(v), protocol.Metadata{})
-	}
-	if s.Fourth != nil {
-		v := *s.Fourth
+			e.SetValue(protocol.BodyTarget, "First", protocol.BoolValue(v), protocol.Metadata{})
+		}
+		if s.Fourth != nil {
+			v := *s.Fourth
 
-		e.SetValue(protocol.BodyTarget, "Fourth", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.Second != nil {
-		v := *s.Second
+			e.SetValue(protocol.BodyTarget, "Fourth", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.Second != nil {
+			v := *s.Second
 
-		e.SetValue(protocol.BodyTarget, "Second", protocol.BoolValue(v), protocol.Metadata{})
-	}
-	if s.Third != nil {
-		v := *s.Third
+			e.SetValue(protocol.BodyTarget, "Second", protocol.BoolValue(v), protocol.Metadata{})
+		}
+		if s.Third != nil {
+			v := *s.Third
 
-		e.SetValue(protocol.BodyTarget, "Third", protocol.Float64Value(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "Third", protocol.Float64Value(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -590,7 +590,6 @@ type InputService2TestShapeInputService2TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService2TestShapeInputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -801,7 +800,6 @@ type InputService3TestShapeInputService3TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService3TestShapeInputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -827,17 +825,19 @@ func (s *InputService3TestShapeInputService3TestCaseOperation2Input) SetSubStruc
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService3TestShapeInputService3TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Description != nil {
-		v := *s.Description
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Description != nil {
+			v := *s.Description
 
-		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SubStructure != nil {
-		v := s.SubStructure
+			e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.SubStructure != nil {
+			v := s.SubStructure
 
-		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -847,7 +847,6 @@ type InputService3TestShapeInputService3TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService3TestShapeInputService3TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -883,7 +882,6 @@ func (s *InputService3TestShapeSubStructure) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1039,17 +1037,19 @@ func (s *InputService4TestShapeInputService4TestCaseOperation1Input) SetSubStruc
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService4TestShapeInputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Description != nil {
-		v := *s.Description
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Description != nil {
+			v := *s.Description
 
-		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SubStructure != nil {
-		v := s.SubStructure
+			e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.SubStructure != nil {
+			v := s.SubStructure
 
-		e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "SubStructure", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1059,7 +1059,6 @@ type InputService4TestShapeInputService4TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService4TestShapeInputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1095,7 +1094,6 @@ func (s *InputService4TestShapeSubStructure) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1243,12 +1241,14 @@ func (s *InputService5TestShapeInputService5TestCaseOperation1Input) SetListPara
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService5TestShapeInputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ListParam) > 0 {
-		v := s.ListParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ListParam) > 0 {
+			v := s.ListParam
 
-		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{})
-	}
-
+			e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1258,7 +1258,6 @@ type InputService5TestShapeInputService5TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService5TestShapeInputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1406,12 +1405,14 @@ func (s *InputService6TestShapeInputService6TestCaseOperation1Input) SetListPara
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService6TestShapeInputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ListParam) > 0 {
-		v := s.ListParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ListParam) > 0 {
+			v := s.ListParam
 
-		e.SetList(protocol.BodyTarget, "AlternateName", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NotMember"})
-	}
-
+			e.SetList(protocol.BodyTarget, "AlternateName", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NotMember"})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1421,7 +1422,6 @@ type InputService6TestShapeInputService6TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService6TestShapeInputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1569,12 +1569,14 @@ func (s *InputService7TestShapeInputService7TestCaseOperation1Input) SetListPara
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService7TestShapeInputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ListParam) > 0 {
-		v := s.ListParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ListParam) > 0 {
+			v := s.ListParam
 
-		e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
-	}
-
+			e.SetList(protocol.BodyTarget, "ListParam", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1584,7 +1586,6 @@ type InputService7TestShapeInputService7TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService7TestShapeInputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1732,12 +1733,14 @@ func (s *InputService8TestShapeInputService8TestCaseOperation1Input) SetListPara
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService8TestShapeInputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ListParam) > 0 {
-		v := s.ListParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ListParam) > 0 {
+			v := s.ListParam
 
-		e.SetList(protocol.BodyTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
-	}
-
+			e.SetList(protocol.BodyTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1747,7 +1750,6 @@ type InputService8TestShapeInputService8TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService8TestShapeInputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1895,12 +1897,14 @@ func (s *InputService9TestShapeInputService9TestCaseOperation1Input) SetListPara
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService9TestShapeInputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ListParam) > 0 {
-		v := s.ListParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ListParam) > 0 {
+			v := s.ListParam
 
-		e.SetList(protocol.BodyTarget, "item", encodeInputService9TestShapeSingleFieldStructList(v), protocol.Metadata{Flatten: true})
-	}
-
+			e.SetList(protocol.BodyTarget, "item", encodeInputService9TestShapeSingleFieldStructList(v), protocol.Metadata{Flatten: true})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -1910,7 +1914,6 @@ type InputService9TestShapeInputService9TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService9TestShapeInputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1933,7 +1936,6 @@ func (s *InputService9TestShapeSingleFieldStruct) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2089,12 +2091,14 @@ func (s *InputService10TestShapeInputService10TestCaseOperation1Input) SetStruct
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService10TestShapeInputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.StructureParam != nil {
-		v := s.StructureParam
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.StructureParam != nil {
+			v := s.StructureParam
 
-		e.SetFields(protocol.BodyTarget, "StructureParam", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "StructureParam", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -2104,7 +2108,6 @@ type InputService10TestShapeInputService10TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService10TestShapeInputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2141,7 +2144,6 @@ func (s *InputService10TestShapeStructureShape) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.BodyTarget, "t", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2294,7 +2296,6 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) MarshalFi
 
 		e.SetMap(protocol.HeadersTarget, "x-foo-", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2304,7 +2305,6 @@ type InputService11TestShapeInputService11TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService11TestShapeInputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2457,7 +2457,6 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) MarshalFi
 
 		e.SetList(protocol.QueryTarget, "item", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2467,7 +2466,6 @@ type InputService12TestShapeInputService12TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService12TestShapeInputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2633,7 +2631,6 @@ func (s *InputService13TestShapeInputService13TestCaseOperation1Input) MarshalFi
 
 		e.SetMap(protocol.QueryTarget, "QueryDoc", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2643,7 +2640,6 @@ type InputService13TestShapeInputService13TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService13TestShapeInputService13TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2814,7 +2810,6 @@ func (s *InputService14TestShapeInputService14TestCaseOperation1Input) MarshalFi
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2824,7 +2819,6 @@ type InputService14TestShapeInputService14TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService14TestShapeInputService14TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3035,7 +3029,6 @@ type InputService15TestShapeInputService15TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService15TestShapeInputService15TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3058,7 +3051,6 @@ func (s *InputService15TestShapeInputService15TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.QueryTarget, "bool-query", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3068,7 +3060,6 @@ type InputService15TestShapeInputService15TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService15TestShapeInputService15TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3221,7 +3212,6 @@ func (s *InputService16TestShapeInputService16TestCaseOperation1Input) MarshalFi
 
 		e.SetStream(protocol.PayloadTarget, "foo", protocol.StringStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3231,7 +3221,6 @@ type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService16TestShapeInputService16TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3442,7 +3431,6 @@ type InputService17TestShapeInputService17TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService17TestShapeInputService17TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3465,7 +3453,6 @@ func (s *InputService17TestShapeInputService17TestCaseOperation2Input) MarshalFi
 
 		e.SetStream(protocol.PayloadTarget, "foo", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3475,7 +3462,6 @@ type InputService17TestShapeInputService17TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService17TestShapeInputService17TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3836,12 +3822,14 @@ func (s *InputService18TestShapeFooShape) SetBaz(v string) *InputService18TestSh
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Baz != nil {
-		v := *s.Baz
+	e.SetFields(protocol.BodyTarget, "foo", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Baz != nil {
+			v := *s.Baz
 
-		e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{})
 	return nil
 }
 
@@ -3851,7 +3839,6 @@ type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeInputService18TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3861,7 +3848,6 @@ type InputService18TestShapeInputService18TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeInputService18TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3871,7 +3857,6 @@ type InputService18TestShapeInputService18TestCaseOperation3Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeInputService18TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3894,7 +3879,6 @@ func (s *InputService18TestShapeInputService18TestCaseOperation4Input) MarshalFi
 
 		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3904,7 +3888,6 @@ type InputService18TestShapeInputService18TestCaseOperation4Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService18TestShapeInputService18TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4052,17 +4035,19 @@ func (s *InputService19TestShapeGrant) SetGrantee(v *InputService19TestShapeGran
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService19TestShapeGrant) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Grantee != nil {
-		v := s.Grantee
-		attrs := make([]protocol.Attribute, 0, 1)
+	e.SetFields(protocol.BodyTarget, "Grant", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Grantee != nil {
+			v := s.Grantee
+			attrs := make([]protocol.Attribute, 0, 1)
 
-		if s.Grantee.Type != nil {
-			v := *s.Grantee.Type
-			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+			if s.Grantee.Type != nil {
+				v := *s.Grantee.Type
+				attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+			}
+			e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
 		}
-		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
-	}
-
+		return nil
+	}), protocol.Metadata{})
 	return nil
 }
 
@@ -4094,7 +4079,6 @@ func (s *InputService19TestShapeGrantee) MarshalFields(e protocol.FieldEncoder) 
 		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
 	}
 	// Skipping Type XML Attribute.
-
 	return nil
 }
 
@@ -4117,7 +4101,6 @@ func (s *InputService19TestShapeInputService19TestCaseOperation1Input) MarshalFi
 
 		e.SetFields(protocol.PayloadTarget, "Grant", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4127,7 +4110,6 @@ type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService19TestShapeInputService19TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4293,7 +4275,6 @@ func (s *InputService20TestShapeInputService20TestCaseOperation1Input) MarshalFi
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4303,7 +4284,6 @@ type InputService20TestShapeInputService20TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService20TestShapeInputService20TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4514,7 +4494,6 @@ type InputService21TestShapeInputService21TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4537,7 +4516,6 @@ func (s *InputService21TestShapeInputService21TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.QueryTarget, "param-name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4547,7 +4525,6 @@ type InputService21TestShapeInputService21TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService21TestShapeInputService21TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5042,7 +5019,6 @@ type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5052,7 +5028,6 @@ type InputService22TestShapeInputService22TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5062,7 +5037,6 @@ type InputService22TestShapeInputService22TestCaseOperation3Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation3Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5072,7 +5046,6 @@ type InputService22TestShapeInputService22TestCaseOperation4Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation4Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5082,7 +5055,6 @@ type InputService22TestShapeInputService22TestCaseOperation5Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation5Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5100,12 +5072,14 @@ func (s *InputService22TestShapeInputService22TestCaseOperation6Input) SetRecurs
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation6Input) MarshalFields(e protocol.FieldEncoder) error {
-	if s.RecursiveStruct != nil {
-		v := s.RecursiveStruct
+	e.SetFields(protocol.BodyTarget, "OperationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.RecursiveStruct != nil {
+			v := s.RecursiveStruct
 
-		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://foo/"})
 	return nil
 }
 
@@ -5115,7 +5089,6 @@ type InputService22TestShapeInputService22TestCaseOperation6Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService22TestShapeInputService22TestCaseOperation6Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5177,7 +5150,6 @@ func (s *InputService22TestShapeRecursiveStructType) MarshalFields(e protocol.Fi
 
 		e.SetFields(protocol.BodyTarget, "RecursiveStruct", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5346,7 +5318,6 @@ func (s *InputService23TestShapeInputService23TestCaseOperation1Input) MarshalFi
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-timearg", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5356,7 +5327,6 @@ type InputService23TestShapeInputService23TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService23TestShapeInputService23TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5567,7 +5537,6 @@ type InputService24TestShapeInputService24TestCaseOperation1Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService24TestShapeInputService24TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5596,7 +5565,6 @@ func (s *InputService24TestShapeInputService24TestCaseOperation2Input) MarshalFi
 
 		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5606,7 +5574,272 @@ type InputService24TestShapeInputService24TestCaseOperation2Output struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InputService24TestShapeInputService24TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+	return nil
+}
 
+// InputService25ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// InputService25ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type InputService25ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService25ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService25ProtocolTest client from just a session.
+//     svc := inputservice25protocoltest.New(mySession)
+//
+//     // Create a InputService25ProtocolTest client with additional configuration
+//     svc := inputservice25protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService25ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService25ProtocolTest {
+	c := p.ClientConfig("inputservice25protocoltest", cfgs...)
+	return newInputService25ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService25ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService25ProtocolTest {
+	svc := &InputService25ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "inputservice25protocoltest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService25ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService25ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService25TestCaseOperation1 = "OperationName"
+
+// InputService25TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService25TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See InputService25TestCaseOperation1 for more information on using the InputService25TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the InputService25TestCaseOperation1Request method.
+//    req, resp := client.InputService25TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation1Request(input *InputService25TestShapeInputService25TestCaseOperation2Input) (req *request.Request, output *InputService25TestShapeInputService25TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService25TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService25TestShapeInputService25TestCaseOperation2Input{}
+	}
+
+	output = &InputService25TestShapeInputService25TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService25TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService25TestCaseOperation1 for usage and error information.
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation1(input *InputService25TestShapeInputService25TestCaseOperation2Input) (*InputService25TestShapeInputService25TestCaseOperation1Output, error) {
+	req, out := c.InputService25TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// InputService25TestCaseOperation1WithContext is the same as InputService25TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See InputService25TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation1WithContext(ctx aws.Context, input *InputService25TestShapeInputService25TestCaseOperation2Input, opts ...request.Option) (*InputService25TestShapeInputService25TestCaseOperation1Output, error) {
+	req, out := c.InputService25TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opInputService25TestCaseOperation2 = "OperationName"
+
+// InputService25TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the InputService25TestCaseOperation2 operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See InputService25TestCaseOperation2 for more information on using the InputService25TestCaseOperation2
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the InputService25TestCaseOperation2Request method.
+//    req, resp := client.InputService25TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation2Request(input *InputService25TestShapeInputService25TestCaseOperation2Input) (req *request.Request, output *InputService25TestShapeInputService25TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opInputService25TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService25TestShapeInputService25TestCaseOperation2Input{}
+	}
+
+	output = &InputService25TestShapeInputService25TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService25TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService25TestCaseOperation2 for usage and error information.
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation2(input *InputService25TestShapeInputService25TestCaseOperation2Input) (*InputService25TestShapeInputService25TestCaseOperation2Output, error) {
+	req, out := c.InputService25TestCaseOperation2Request(input)
+	return out, req.Send()
+}
+
+// InputService25TestCaseOperation2WithContext is the same as InputService25TestCaseOperation2 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See InputService25TestCaseOperation2 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *InputService25ProtocolTest) InputService25TestCaseOperation2WithContext(ctx aws.Context, input *InputService25TestShapeInputService25TestCaseOperation2Input, opts ...request.Option) (*InputService25TestShapeInputService25TestCaseOperation2Output, error) {
+	req, out := c.InputService25TestCaseOperation2Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type InputService25TestShapeFooShape struct {
+	_ struct{} `locationName:"foo" type:"structure"`
+
+	Baz *string `locationName:"baz" type:"string"`
+}
+
+// SetBaz sets the Baz field's value.
+func (s *InputService25TestShapeFooShape) SetBaz(v string) *InputService25TestShapeFooShape {
+	s.Baz = &v
+	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService25TestShapeFooShape) MarshalFields(e protocol.FieldEncoder) error {
+	e.SetFields(protocol.BodyTarget, "foo", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Baz != nil {
+			v := *s.Baz
+
+			e.SetValue(protocol.BodyTarget, "baz", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{})
+	return nil
+}
+
+type InputService25TestShapeInputService25TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService25TestShapeInputService25TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	return nil
+}
+
+type InputService25TestShapeInputService25TestCaseOperation2Input struct {
+	_ struct{} `type:"structure" payload:"Foo"`
+
+	Foo *InputService25TestShapeFooShape `locationName:"foo" type:"structure"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *InputService25TestShapeInputService25TestCaseOperation2Input) SetFoo(v *InputService25TestShapeFooShape) *InputService25TestShapeInputService25TestCaseOperation2Input {
+	s.Foo = v
+	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService25TestShapeInputService25TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := s.Foo
+
+		e.SetFields(protocol.PayloadTarget, "foo", v, protocol.Metadata{})
+	}
+	return nil
+}
+
+type InputService25TestShapeInputService25TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputService25TestShapeInputService25TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
 	return nil
 }
 
@@ -6717,6 +6950,55 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService25ProtocolTestStructurePayloadCase1(t *testing.T) {
+	svc := NewInputService25ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService25TestShapeInputService25TestCaseOperation2Input{
+		Foo: &InputService25TestShapeFooShape{
+			Baz: aws.String("bar"),
+		},
+	}
+	req, _ := svc.InputService25TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	if req.Error != nil {
+		t.Errorf("expect no error, got %v", req.Error)
+	}
+
+	// assert body
+	if r.Body == nil {
+		t.Errorf("expect body not to be nil")
+	}
+	body := util.SortXML(r.Body)
+	awstesting.AssertXML(t, `<foo><baz>bar</baz></foo>`, util.Trim(string(body)), InputService25TestShapeInputService25TestCaseOperation2Input{})
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+
+}
+
+func TestInputService25ProtocolTestStructurePayloadCase2(t *testing.T) {
+	svc := NewInputService25ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService25TestShapeInputService25TestCaseOperation2Input{}
+	req, _ := svc.InputService25TestCaseOperation2Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	restxml.Build(req)
+	if req.Error != nil {
+		t.Errorf("expect no error, got %v", req.Error)
+	}
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/restxml/encode.go
+++ b/private/protocol/restxml/encode.go
@@ -1,0 +1,160 @@
+package restxml
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/rest"
+	"github.com/aws/aws-sdk-go/private/protocol/xml"
+)
+
+// An Encoder provides encoding of the AWS RESTXML protocol. This encoder combindes
+// the XML and REST encoders deligating to them for their associated targets.
+//
+// It is invalid to set a XML and stream payload on the same encoder.
+type Encoder struct {
+	method      string
+	reqEncoder  *rest.Encoder
+	bodyEncoder *xml.Encoder
+
+	buf *bytes.Buffer
+	err error
+}
+
+// NewEncoder creates a new encoder for encoding the AWS RESTXML protocol.
+// The request passed in will be the base the path, query, and headers encoded
+// will be set on top of.
+func NewEncoder(req *http.Request) *Encoder {
+	e := &Encoder{
+		method:      req.Method,
+		reqEncoder:  rest.NewEncoder(req),
+		bodyEncoder: xml.NewEncoder(),
+	}
+
+	return e
+}
+
+// Encode returns the encoded request, and body payload. If no payload body was
+// set nil will be returned.  If an error occurred while encoding the API an
+// error will be returned.
+func (e *Encoder) Encode() (*http.Request, io.ReadSeeker, error) {
+	req, payloadBody, err := e.reqEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	xmlBody, err := e.bodyEncoder.Encode()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	havePayload := payloadBody != nil
+	haveXML := xmlBody != nil
+
+	if havePayload == haveXML && haveXML {
+		return nil, nil, fmt.Errorf("unexpected XML body and request payload for AWSMarshaler")
+	}
+
+	body := payloadBody
+	if body == nil {
+		body = xmlBody
+	}
+
+	return req, body, err
+}
+
+// SetValue will set a value to the header, path, query, or body.
+//
+// If the request's method is GET all BodyTarget values will be written to
+// the query string.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PathTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeaderTarget:
+		e.reqEncoder.SetValue(t, k, v, meta)
+	case protocol.BodyTarget:
+		if e.method == "GET" {
+			e.reqEncoder.SetValue(t, k, v, meta)
+		} else {
+			e.bodyEncoder.SetValue(t, k, v, meta)
+		}
+	default:
+		e.err = fmt.Errorf("unknown SetValue restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetStream will set the stream to the payload of the request.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		e.reqEncoder.SetStream(t, k, v, meta)
+	default:
+		e.err = fmt.Errorf("invalid target %s, for SetStream, must be PayloadTarget", t)
+	}
+}
+
+// SetList will set the nested list values to the header, query, or body.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.HeaderTarget:
+		fallthrough
+	case protocol.QueryTarget:
+		e.reqEncoder.SetList(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetList(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetList restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetMap will set the nested map values to the header, query, or body.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.QueryTarget:
+		fallthrough
+	case protocol.HeadersTarget:
+		e.reqEncoder.SetMap(t, k, fn, meta)
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetMap(t, k, fn, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMap restxml encode target, %s, %s", t, k)
+	}
+}
+
+// SetFields will set the nested type's fields to the body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+
+	switch t {
+	case protocol.PayloadTarget:
+		fallthrough
+	case protocol.BodyTarget:
+		e.bodyEncoder.SetFields(t, k, m, meta)
+	default:
+		e.err = fmt.Errorf("unknown SetMarshaler restxml encode target, %s, %s", t, k)
+	}
+}

--- a/private/protocol/restxml/encode_test.go
+++ b/private/protocol/restxml/encode_test.go
@@ -1,0 +1,86 @@
+package restxml
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeNestedShape(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadShape: &nestedShape{
+			Value: aws.String("some value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payloadShape><value>some value</value></payloadShape>`
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNestedStream(t *testing.T) {
+	_, reader, err := encode("PUT", "/path", shape{
+		PayloadStream: strings.NewReader("some value"),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := "some value"
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type shape struct {
+	PayloadShape  *nestedShape
+	PayloadStream io.ReadSeeker
+}
+
+func (s *shape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PayloadShape != nil {
+		e.SetFields(protocol.PayloadTarget, "payloadShape", s.PayloadShape, protocol.Metadata{})
+	}
+	if s.PayloadStream != nil {
+		e.SetStream(protocol.PayloadTarget, "payloadReader", protocol.ReadSeekerStream{V: s.PayloadStream}, protocol.Metadata{})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	return nil
+}
+
+func encode(method, path string, s shape) (*http.Request, io.ReadSeeker, error) {
+	origReq, _ := http.NewRequest(method, "https://service.amazonaws.com"+path, nil)
+
+	e := NewEncoder(origReq)
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -245,7 +245,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -255,7 +254,6 @@ type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService1TestShapeOutputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -373,16 +371,6 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
 	}
-	if s.ImaHeader != nil {
-		v := *s.ImaHeader
-
-		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.ImaHeaderLocation != nil {
-		v := *s.ImaHeaderLocation
-
-		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Long != nil {
 		v := *s.Long
 
@@ -408,7 +396,16 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
 	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
 
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -545,7 +542,6 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -569,7 +565,6 @@ func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalF
 
 		e.SetValue(protocol.BodyTarget, "Blob", protocol.BytesValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -706,7 +701,6 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -729,7 +723,6 @@ func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalF
 
 		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -866,7 +859,6 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -889,7 +881,6 @@ func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalF
 
 		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "item"})
 	}
-
 	return nil
 }
 
@@ -1026,7 +1017,6 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1049,7 +1039,6 @@ func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalF
 
 		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -1186,7 +1175,6 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1209,7 +1197,6 @@ func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalF
 
 		e.SetMap(protocol.BodyTarget, "Map", encodeOutputService6TestShapeSingleStructureMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1232,7 +1219,6 @@ func (s *OutputService6TestShapeSingleStructure) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.BodyTarget, "foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1377,7 +1363,6 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1400,7 +1385,6 @@ func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalF
 
 		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -1537,7 +1521,6 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1560,7 +1543,6 @@ func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalF
 
 		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{MapLocationNameKey: "foo", MapLocationNameValue: "bar"})
 	}
-
 	return nil
 }
 
@@ -1697,7 +1679,6 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1723,17 +1704,16 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetHeade
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Data != nil {
-		v := s.Data
-
-		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
-	}
 	if s.Header != nil {
 		v := *s.Header
 
 		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Data != nil {
+		v := s.Data
 
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -1756,7 +1736,6 @@ func (s *OutputService9TestShapeSingleStructure) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1893,7 +1872,6 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1916,7 +1894,6 @@ func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) Marsha
 
 		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2053,7 +2030,6 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2180,7 +2156,6 @@ func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) Marsha
 
 		e.SetValue(protocol.HeaderTarget, "x-true-bool", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2317,7 +2292,6 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2340,7 +2314,6 @@ func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) Marsha
 
 		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -243,8 +243,20 @@ type OutputService1TestShapeOutputService1TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService1TestShapeOutputService1TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 type OutputService1TestShapeOutputService1TestCaseOperation2Output struct {
@@ -337,6 +349,67 @@ func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTimes
 func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) SetTrueBool(v bool) *OutputService1TestShapeOutputService1TestCaseOperation2Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService1TestShapeOutputService1TestCaseOperation2Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.BodyTarget, "Char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.BodyTarget, "Double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.BodyTarget, "FalseBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.BodyTarget, "Float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.ImaHeader != nil {
+		v := *s.ImaHeader
+
+		e.SetValue(protocol.HeaderTarget, "ImaHeader", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImaHeaderLocation != nil {
+		v := *s.ImaHeaderLocation
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.BodyTarget, "Long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Num != nil {
+		v := *s.Num
+
+		e.SetValue(protocol.BodyTarget, "FooNum", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.BodyTarget, "Str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.BodyTarget, "TrueBool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService2ProtocolTest provides the API operation methods for making requests to
@@ -470,6 +543,12 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -481,6 +560,17 @@ type OutputService2TestShapeOutputService2TestCaseOperation1Output struct {
 func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) SetBlob(v []byte) *OutputService2TestShapeOutputService2TestCaseOperation1Output {
 	s.Blob = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService2TestShapeOutputService2TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Blob != nil {
+		v := s.Blob
+
+		e.SetValue(protocol.BodyTarget, "Blob", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService3ProtocolTest provides the API operation methods for making requests to
@@ -614,6 +704,12 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -624,6 +720,17 @@ type OutputService3TestShapeOutputService3TestCaseOperation1Output struct {
 func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) SetListMember(v []*string) *OutputService3TestShapeOutputService3TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService3TestShapeOutputService3TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService4ProtocolTest provides the API operation methods for making requests to
@@ -757,6 +864,12 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -767,6 +880,17 @@ type OutputService4TestShapeOutputService4TestCaseOperation1Output struct {
 func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) SetListMember(v []*string) *OutputService4TestShapeOutputService4TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService4TestShapeOutputService4TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "item"})
+	}
+
+	return nil
 }
 
 // OutputService5ProtocolTest provides the API operation methods for making requests to
@@ -900,6 +1024,12 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -910,6 +1040,17 @@ type OutputService5TestShapeOutputService5TestCaseOperation1Output struct {
 func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) SetListMember(v []*string) *OutputService5TestShapeOutputService5TestCaseOperation1Output {
 	s.ListMember = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService5TestShapeOutputService5TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ListMember) > 0 {
+		v := s.ListMember
+
+		e.SetList(protocol.BodyTarget, "ListMember", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // OutputService6ProtocolTest provides the API operation methods for making requests to
@@ -1043,6 +1184,12 @@ type OutputService6TestShapeOutputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService6TestShapeOutputService6TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1055,6 +1202,17 @@ func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) SetMap(v
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeOutputService6TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", encodeOutputService6TestShapeSingleStructureMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService6TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
@@ -1065,6 +1223,25 @@ type OutputService6TestShapeSingleStructure struct {
 func (s *OutputService6TestShapeSingleStructure) SetFoo(v string) *OutputService6TestShapeSingleStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService6TestShapeSingleStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputService6TestShapeSingleStructureMap(vs map[string]*OutputService6TestShapeSingleStructure) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // OutputService7ProtocolTest provides the API operation methods for making requests to
@@ -1198,6 +1375,12 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1208,6 +1391,17 @@ type OutputService7TestShapeOutputService7TestCaseOperation1Output struct {
 func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService7TestShapeOutputService7TestCaseOperation1Output {
 	s.Map = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService7TestShapeOutputService7TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // OutputService8ProtocolTest provides the API operation methods for making requests to
@@ -1341,6 +1535,12 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1351,6 +1551,17 @@ type OutputService8TestShapeOutputService8TestCaseOperation1Output struct {
 func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) SetMap(v map[string]*string) *OutputService8TestShapeOutputService8TestCaseOperation1Output {
 	s.Map = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService8TestShapeOutputService8TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Map) > 0 {
+		v := s.Map
+
+		e.SetMap(protocol.BodyTarget, "Map", protocol.EncodeStringMap(v), protocol.Metadata{MapLocationNameKey: "foo", MapLocationNameValue: "bar"})
+	}
+
+	return nil
 }
 
 // OutputService9ProtocolTest provides the API operation methods for making requests to
@@ -1484,6 +1695,12 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Data"`
 
@@ -1504,6 +1721,22 @@ func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetHeade
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Data != nil {
+		v := s.Data
+
+		e.SetFields(protocol.PayloadTarget, "Data", v, protocol.Metadata{})
+	}
+	if s.Header != nil {
+		v := *s.Header
+
+		e.SetValue(protocol.HeaderTarget, "X-Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type OutputService9TestShapeSingleStructure struct {
 	_ struct{} `type:"structure"`
 
@@ -1514,6 +1747,17 @@ type OutputService9TestShapeSingleStructure struct {
 func (s *OutputService9TestShapeSingleStructure) SetFoo(v string) *OutputService9TestShapeSingleStructure {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService9TestShapeSingleStructure) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService10ProtocolTest provides the API operation methods for making requests to
@@ -1647,6 +1891,12 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 	_ struct{} `type:"structure" payload:"Stream"`
 
@@ -1657,6 +1907,17 @@ type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
 func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetStream(v []byte) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
 	s.Stream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Stream != nil {
+		v := s.Stream
+
+		e.SetStream(protocol.PayloadTarget, "Stream", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService11ProtocolTest provides the API operation methods for making requests to
@@ -1790,6 +2051,12 @@ type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -1864,6 +2131,57 @@ func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTim
 func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetTrueBool(v bool) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
 	s.TrueBool = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Char != nil {
+		v := *s.Char
+
+		e.SetValue(protocol.HeaderTarget, "x-char", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Double != nil {
+		v := *s.Double
+
+		e.SetValue(protocol.HeaderTarget, "x-double", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.FalseBool != nil {
+		v := *s.FalseBool
+
+		e.SetValue(protocol.HeaderTarget, "x-false-bool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Float != nil {
+		v := *s.Float
+
+		e.SetValue(protocol.HeaderTarget, "x-float", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Integer != nil {
+		v := *s.Integer
+
+		e.SetValue(protocol.HeaderTarget, "x-int", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Long != nil {
+		v := *s.Long
+
+		e.SetValue(protocol.HeaderTarget, "x-long", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Str != nil {
+		v := *s.Str
+
+		e.SetValue(protocol.HeaderTarget, "x-str", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.HeaderTarget, "x-timestamp", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.TrueBool != nil {
+		v := *s.TrueBool
+
+		e.SetValue(protocol.HeaderTarget, "x-true-bool", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // OutputService12ProtocolTest provides the API operation methods for making requests to
@@ -1997,6 +2315,12 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Input) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
@@ -2007,6 +2331,17 @@ type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
 func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetFoo(v string) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
 	s.Foo = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Foo != nil {
+		v := *s.Foo
+
+		e.SetValue(protocol.BodyTarget, "Foo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 //

--- a/private/protocol/target.go
+++ b/private/protocol/target.go
@@ -1,0 +1,38 @@
+package protocol
+
+import "fmt"
+
+// Target is the encode and decode targets of protocol marshaling.
+type Target int
+
+// The protocol marshaling targets.
+const (
+	PathTarget Target = iota
+	QueryTarget
+	HeaderTarget
+	HeadersTarget
+	StatusCodeTarget
+	BodyTarget
+	PayloadTarget
+)
+
+func (e Target) String() string {
+	switch e {
+	case PathTarget:
+		return "Path"
+	case QueryTarget:
+		return "Query"
+	case HeaderTarget:
+		return "Header"
+	case HeadersTarget:
+		return "Headers"
+	case StatusCodeTarget:
+		return "StatusCode"
+	case BodyTarget:
+		return "Body"
+	case PayloadTarget:
+		return "Payload"
+	default:
+		panic(fmt.Sprintf("// unknown encoding target, %d", e))
+	}
+}

--- a/private/protocol/xml/encode.go
+++ b/private/protocol/xml/encode.go
@@ -1,0 +1,374 @@
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+// An Encoder provides encoding of the AWS XML protocol. This encoder will will
+// write all content to XML. Only supports body and payload targets.
+type Encoder struct {
+	encoder    *xml.Encoder
+	encodedBuf *bytes.Buffer
+	fieldBuf   protocol.FieldBuffer
+	err        error
+}
+
+// NewEncoder creates a new encoder for encoding AWS XML protocol. Only encodes
+// fields into the XML body, and error is returned if target is anything other
+// than Body or Payload.
+func NewEncoder() *Encoder {
+	encodedBuf := bytes.NewBuffer(nil)
+	return &Encoder{
+		encodedBuf: encodedBuf,
+		encoder:    xml.NewEncoder(encodedBuf),
+	}
+}
+
+// Encode returns the encoded XMl reader. An error will be returned if one was
+// encountered while building the XML body.
+func (e *Encoder) Encode() (io.ReadSeeker, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	if err := e.encoder.Flush(); err != nil {
+		return nil, fmt.Errorf("unable to marshal XML, %v", err)
+	}
+
+	if e.encodedBuf.Len() == 0 {
+		return nil, nil
+	}
+
+	return bytes.NewReader(e.encodedBuf.Bytes()), e.err
+}
+
+// SetValue sets an individual value to the XML body.
+func (e *Encoder) SetValue(t protocol.Target, k string, v protocol.ValueMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	e.err = addValueToken(e.encoder, &e.fieldBuf, k, v, meta)
+}
+
+// SetStream is not supported for XML protocol marshaling.
+func (e *Encoder) SetStream(t protocol.Target, k string, v protocol.StreamMarshaler, meta protocol.Metadata) {
+	e.err = fmt.Errorf("xml encoder SetStream not supported, %s, %s", t, k)
+}
+
+// SetList creates an XML list and calls the passed in fn callback with a list encoder.
+func (e *Encoder) SetList(t protocol.Target, k string, fn func(le protocol.ListEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	le := ListEncoder{Base: e,
+		Flatten:  meta.Flatten,
+		ListName: meta.ListLocationName,
+	}
+	if v := meta.ListLocationName; len(v) == 0 {
+		if le.Flatten {
+			le.ListName = k
+		} else {
+			le.ListName = "member"
+		}
+	}
+
+	var tok xml.StartElement
+	if !le.Flatten {
+		tok, e.err = xmlStartElem(k, meta)
+		if e.err != nil {
+			return
+		}
+		e.encoder.EncodeToken(tok)
+	}
+
+	fn(&le)
+
+	if !le.Flatten {
+		e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+// SetMap creates an XML map and calls the passed in fn callback with a map encoder.
+func (e *Encoder) SetMap(t protocol.Target, k string, fn func(me protocol.MapEncoder), meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetValue, %s", t, k)
+		return
+	}
+
+	me := MapEncoder{Base: e,
+		Flatten:   meta.Flatten,
+		KeyName:   meta.MapLocationNameKey,
+		ValueName: meta.MapLocationNameValue,
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	e.encoder.EncodeToken(tok)
+
+	fn(&me)
+
+	e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// SetFields sets the nested fields to the XML body.
+func (e *Encoder) SetFields(t protocol.Target, k string, m protocol.FieldMarshaler, meta protocol.Metadata) {
+	if e.err != nil {
+		return
+	}
+	if t != protocol.BodyTarget && t != protocol.PayloadTarget {
+		e.err = fmt.Errorf(" invalid target %s for xml encoder SetFields, %s", t, k)
+		return
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		e.err = err
+		return
+	}
+
+	e.encoder.EncodeToken(tok)
+	m.MarshalFields(e)
+	e.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// A ListEncoder encodes elements within a list for the XML encoder.
+type ListEncoder struct {
+	Base     *Encoder
+	Flatten  bool
+	ListName string
+	err      error
+}
+
+// ListAddValue will add the value to the list.
+func (e *ListEncoder) ListAddValue(v protocol.ValueMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	e.err = addValueToken(e.Base.encoder, &e.Base.fieldBuf, e.ListName, v, protocol.Metadata{})
+}
+
+// ListAddList is not supported for XML encoder.
+func (e *ListEncoder) ListAddList(fn func(le protocol.ListEncoder)) {
+	e.err = fmt.Errorf("xml encoder ListAddList not supported, %s", e.ListName)
+}
+
+// ListAddMap is not supported for XML encoder.
+func (e *ListEncoder) ListAddMap(fn func(me protocol.MapEncoder)) {
+	e.err = fmt.Errorf("xml encoder ListAddMap not supported, %s", e.ListName)
+}
+
+// ListAddFields will set the nested type's fields to the list.
+func (e *ListEncoder) ListAddFields(m protocol.FieldMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	tok, e.err = xmlStartElem(e.ListName, protocol.Metadata{})
+	if e.err != nil {
+		return
+	}
+
+	e.Base.encoder.EncodeToken(tok)
+	m.MarshalFields(e.Base)
+	e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+}
+
+// A MapEncoder encodes key values pair map values for the XML encoder.
+type MapEncoder struct {
+	Base      *Encoder
+	Flatten   bool
+	KeyName   string
+	ValueName string
+	err       error
+}
+
+// MapSetValue sets a map value.
+func (e *MapEncoder) MapSetValue(k string, v protocol.ValueMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	if !e.Flatten {
+		tok, e.err = xmlStartElem("entry", protocol.Metadata{})
+		if e.err != nil {
+			return
+		}
+		e.Base.encoder.EncodeToken(tok)
+	}
+
+	keyName, valueName := e.KeyName, e.ValueName
+	if len(keyName) == 0 {
+		keyName = "key"
+	}
+	if len(valueName) == 0 {
+		valueName = "value"
+	}
+
+	e.err = addValueToken(e.Base.encoder, &e.Base.fieldBuf, keyName, protocol.StringValue(k), protocol.Metadata{})
+	if e.err != nil {
+		return
+	}
+
+	e.err = addValueToken(e.Base.encoder, &e.Base.fieldBuf, valueName, v, protocol.Metadata{})
+	if e.err != nil {
+		return
+	}
+
+	if !e.Flatten {
+		e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+// MapSetList is not supported.
+func (e *MapEncoder) MapSetList(k string, fn func(le protocol.ListEncoder)) {
+	e.err = fmt.Errorf("xml map encoder MapSetList not supported, %s", k)
+}
+
+// MapSetMap is not supported.
+func (e *MapEncoder) MapSetMap(k string, fn func(me protocol.MapEncoder)) {
+	e.err = fmt.Errorf("xml map encoder MapSetMap not supported, %s", k)
+}
+
+// MapSetFields will set the nested type's fields under the map.
+func (e *MapEncoder) MapSetFields(k string, m protocol.FieldMarshaler) {
+	if e.err != nil {
+		return
+	}
+
+	var tok xml.StartElement
+	if !e.Flatten {
+		tok, e.err = xmlStartElem("entry", protocol.Metadata{})
+		if e.err != nil {
+			return
+		}
+		e.Base.encoder.EncodeToken(tok)
+	}
+
+	keyName, valueName := e.KeyName, e.ValueName
+	if len(keyName) == 0 {
+		keyName = "key"
+	}
+	if len(valueName) == 0 {
+		valueName = "value"
+	}
+
+	e.err = addValueToken(e.Base.encoder, &e.Base.fieldBuf, keyName, protocol.StringValue(k), protocol.Metadata{})
+	if e.err != nil {
+		return
+	}
+
+	valTok, err := xmlStartElem(valueName, protocol.Metadata{})
+	if err != nil {
+		e.err = err
+		return
+	}
+	e.Base.encoder.EncodeToken(valTok)
+
+	m.MarshalFields(e.Base)
+
+	e.Base.encoder.EncodeToken(xml.EndElement{Name: valTok.Name})
+
+	if !e.Flatten {
+		e.Base.encoder.EncodeToken(xml.EndElement{Name: tok.Name})
+	}
+}
+
+func addValueToken(e *xml.Encoder, fieldBuf *protocol.FieldBuffer, k string, v protocol.ValueMarshaler, meta protocol.Metadata) error {
+	b, err := fieldBuf.GetValue(v)
+	if err != nil {
+		return err
+	}
+
+	tok, err := xmlStartElem(k, meta)
+	if err != nil {
+		return err
+	}
+
+	e.EncodeToken(tok)
+	e.EncodeToken(xml.CharData(b))
+	e.EncodeToken(xml.EndElement{Name: tok.Name})
+
+	return nil
+}
+
+func xmlStartElem(k string, meta protocol.Metadata) (xml.StartElement, error) {
+	tok := xml.StartElement{Name: xmlName(k, meta)}
+	attrs, err := buildAttributes(meta)
+	if err != nil {
+		return xml.StartElement{}, err
+	}
+	tok.Attr = attrs
+
+	return tok, nil
+}
+
+func xmlName(k string, meta protocol.Metadata) xml.Name {
+	name := xml.Name{Local: k}
+
+	// TODO need to do something with namespace?
+	//	if len(meta.XMLNamespacePrefix) > 0  && len(meta.XMLNamespaceURI) {
+	//		name.Space = prefix
+	//	}
+
+	return name
+}
+
+func buildAttributes(meta protocol.Metadata) ([]xml.Attr, error) {
+	n := len(meta.Attributes)
+	if len(meta.XMLNamespaceURI) > 0 {
+		n++
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	attrs := make([]xml.Attr, n)
+
+	for _, a := range meta.Attributes {
+		str, err := a.Value.MarshalValue()
+		if err != nil {
+			return nil, err
+		}
+
+		attrs = append(attrs, xml.Attr{Name: xmlName(a.Name, a.Meta), Value: str})
+	}
+
+	if uri := meta.XMLNamespaceURI; len(uri) > 0 {
+		attr := xml.Attr{
+			Name:  xml.Name{Local: "xmlns"},
+			Value: uri,
+		}
+		if p := meta.XMLNamespacePrefix; len(p) > 0 {
+			attr.Name.Local += ":" + p
+		}
+		attrs = append(attrs, attr)
+	}
+
+	return attrs, nil
+}

--- a/private/protocol/xml/encode_test.go
+++ b/private/protocol/xml/encode_test.go
@@ -1,0 +1,549 @@
+package xml
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+)
+
+func TestEncodeAttribute(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			AttrValue: aws.String("value"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload attrkey="value"></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNamespace(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Namespace: &nestedShape{
+				Prefixed: aws.String("abc"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><namespace xmlns:prefix="https://example.com"><prefixed>abc</prefixed></namespace></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+func TestEncodeNestedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			Nested: &nestedShape{
+				Value: aws.String("expected value"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><nested><value>expected value</value></nested></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapStr: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapstr><entry><key>abc</key><value>123</value></entry></mapstr></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapFlatten(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapFlatten: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapFlatten><key>abc</key><value>123</value></mapFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapNamed(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapNamed: map[string]*string{
+				"abc": aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapNamed><entry><namedKey>abc</namedKey><namedValue>123</namedValue></entry></mapNamed></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapShape><entry><key>abc</key><value><value>1</value></value></entry></mapShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapFlattenShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapFlattenShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapFlattenShape><key>abc</key><value><value>1</value></value></mapFlattenShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeMapNamedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			MapNamedShape: map[string]*nestedShape{
+				"abc": {Value: aws.String("1")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><mapNamedShape><entry><namedKey>abc</namedKey><namedValue><value>1</value></namedValue></entry></mapNamedShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListString(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListStr: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><liststr><member>abc</member><member>123</member></liststr></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlatten(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlatten: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlatten>abc</listFlatten><listFlatten>123</listFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlattened(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlatten: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlatten>abc</listFlatten><listFlatten>123</listFlatten></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListNamed(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListNamed: []*string{
+				aws.String("abc"),
+				aws.String("123"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listNamed><namedMember>abc</namedMember><namedMember>123</namedMember></listNamed></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listShape><member><value>abc</value></member><member><value>123</value></member></listShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListFlattenShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListFlattenShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listFlattenShape><value>abc</value></listFlattenShape><listFlattenShape><value>123</value></listFlattenShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+func TestEncodeListNamedShape(t *testing.T) {
+	r, err := encode(baseShape{
+		Payload: &payloadShape{
+			ListNamedShape: []*nestedShape{
+				{Value: aws.String("abc")},
+				{Value: aws.String("123")},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expect no marshal error, %v", err)
+	}
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("expect no read error, %v", err)
+	}
+
+	expect := `<payload><listNamedShape><namedMember><value>abc</value></namedMember><namedMember><value>123</value></namedMember></listNamedShape></payload>`
+
+	if e, a := expect, string(b); e != a {
+		t.Errorf("expect bodies to match, did not.\n,\tExpect:\n%s\n\tActual:\n%s\n", e, a)
+	}
+}
+
+type baseShape struct {
+	Payload *payloadShape
+}
+
+func (s *baseShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		attrs := make([]protocol.Attribute, 0, 1)
+		if s.Payload.AttrValue != nil {
+			attrs = append(attrs, protocol.Attribute{
+				Name:  "attrkey",
+				Value: protocol.StringValue(*s.Payload.AttrValue),
+				Meta:  protocol.Metadata{},
+			})
+		}
+		e.SetFields(protocol.PayloadTarget, "payload", s.Payload, protocol.Metadata{Attributes: attrs})
+	}
+	return nil
+}
+
+type payloadShape struct {
+	AttrValue        *string
+	Namespace        *nestedShape
+	Nested           *nestedShape
+	MapStr           map[string]*string
+	MapFlatten       map[string]*string
+	MapNamed         map[string]*string
+	MapShape         map[string]*nestedShape
+	MapFlattenShape  map[string]*nestedShape
+	MapNamedShape    map[string]*nestedShape
+	ListStr          []*string
+	ListFlatten      []*string
+	ListNamed        []*string
+	ListShape        []*nestedShape
+	ListFlattenShape []*nestedShape
+	ListNamedShape   []*nestedShape
+}
+
+func (s *payloadShape) MarshalFields(e protocol.FieldEncoder) error {
+	// Attribute values are skipped
+	if s.Namespace != nil {
+		e.SetFields(protocol.BodyTarget, "namespace", s.Namespace, protocol.Metadata{
+			XMLNamespaceURI: "https://example.com", XMLNamespacePrefix: "prefix",
+		})
+	}
+	if s.Nested != nil {
+		e.SetFields(protocol.BodyTarget, "nested", s.Nested, protocol.Metadata{})
+	}
+	if len(s.MapStr) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapstr", func(me protocol.MapEncoder) {
+			for k, v := range s.MapStr {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.MapFlatten) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlatten", func(me protocol.MapEncoder) {
+			for k, v := range s.MapFlatten {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamed) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamed", func(me protocol.MapEncoder) {
+			for k, v := range s.MapNamed {
+				me.MapSetValue(k, protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.MapShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapShape", encodeNestedShapeMap(s.MapShape), protocol.Metadata{})
+	}
+	if len(s.MapFlattenShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapFlattenShape", encodeNestedShapeMap(s.MapFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.MapNamedShape) > 0 {
+		e.SetMap(protocol.BodyTarget, "mapNamedShape", encodeNestedShapeMap(s.MapNamedShape), protocol.Metadata{
+			MapLocationNameKey: "namedKey", MapLocationNameValue: "namedValue",
+		})
+	}
+	if len(s.ListStr) > 0 {
+		e.SetList(protocol.BodyTarget, "liststr", func(le protocol.ListEncoder) {
+			for _, v := range s.ListStr {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.ListFlatten) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlatten", func(le protocol.ListEncoder) {
+			for _, v := range s.ListFlatten {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamed) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamed", func(le protocol.ListEncoder) {
+			for _, v := range s.ListNamed {
+				le.ListAddValue(protocol.StringValue(*v))
+			}
+		}, protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	if len(s.ListShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listShape", encodeNestedShapeList(s.ListShape), protocol.Metadata{})
+	}
+	if len(s.ListFlattenShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listFlattenShape", encodeNestedShapeList(s.ListFlattenShape), protocol.Metadata{
+			Flatten: true,
+		})
+	}
+	if len(s.ListNamedShape) > 0 {
+		e.SetList(protocol.BodyTarget, "listNamedShape", encodeNestedShapeList(s.ListNamedShape), protocol.Metadata{
+			ListLocationName: "namedMember",
+		})
+	}
+	return nil
+}
+
+type nestedShape struct {
+	Value    *string
+	Prefixed *string
+}
+
+func (s *nestedShape) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(*s.Value), protocol.Metadata{})
+	}
+	if s.Prefixed != nil {
+		e.SetValue(protocol.BodyTarget, "prefixed", protocol.StringValue(*s.Prefixed), protocol.Metadata{
+			XMLNamespacePrefix: "prefix",
+		})
+	}
+	return nil
+}
+func encodeNestedShapeMap(vs map[string]*nestedShape) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+func encodeNestedShapeList(vs []*nestedShape) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
+func encode(s baseShape) (io.ReadSeeker, error) {
+	e := NewEncoder()
+	s.MarshalFields(e)
+	return e.Encode()
+}

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -10596,6 +10596,22 @@ func (s *AccessLogSettings) SetFormat(v string) *AccessLogSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessLogSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DestinationArn != nil {
+		v := *s.DestinationArn
+
+		e.SetValue(protocol.BodyTarget, "destinationArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "format", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents an AWS account that is associated with Amazon API Gateway.
 //
 // To view the account info, call GET on this resource.
@@ -10681,6 +10697,32 @@ func (s *Account) SetFeatures(v []*string) *Account {
 func (s *Account) SetThrottleSettings(v *ThrottleSettings) *Account {
 	s.ThrottleSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Account) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyVersion != nil {
+		v := *s.ApiKeyVersion
+
+		e.SetValue(protocol.BodyTarget, "apiKeyVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudwatchRoleArn != nil {
+		v := *s.CloudwatchRoleArn
+
+		e.SetValue(protocol.BodyTarget, "cloudwatchRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Features) > 0 {
+		v := s.Features
+
+		e.SetList(protocol.BodyTarget, "features", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ThrottleSettings != nil {
+		v := s.ThrottleSettings
+
+		e.SetFields(protocol.BodyTarget, "throttleSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A resource that can be distributed to callers for executing Method resources
@@ -10785,6 +10827,65 @@ func (s *ApiKey) SetValue(v string) *ApiKey {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApiKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.BodyTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageKeys) > 0 {
+		v := s.StageKeys
+
+		e.SetList(protocol.BodyTarget, "stageKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApiKeyList(vs []*ApiKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // API stage name of the associated API stage in a usage plan.
 type ApiStage struct {
 	_ struct{} `type:"structure"`
@@ -10816,6 +10917,30 @@ func (s *ApiStage) SetApiId(v string) *ApiStage {
 func (s *ApiStage) SetStage(v string) *ApiStage {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApiStage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiId != nil {
+		v := *s.ApiId
+
+		e.SetValue(protocol.BodyTarget, "apiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApiStageList(vs []*ApiStage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents an authorization layer for methods. If enabled on a method, API
@@ -10968,6 +11093,70 @@ func (s *Authorizer) SetType(v string) *Authorizer {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Authorizer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthType != nil {
+		v := *s.AuthType
+
+		e.SetValue(protocol.BodyTarget, "authType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerCredentials != nil {
+		v := *s.AuthorizerCredentials
+
+		e.SetValue(protocol.BodyTarget, "authorizerCredentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerResultTtlInSeconds != nil {
+		v := *s.AuthorizerResultTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "authorizerResultTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AuthorizerUri != nil {
+		v := *s.AuthorizerUri
+
+		e.SetValue(protocol.BodyTarget, "authorizerUri", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentitySource != nil {
+		v := *s.IdentitySource
+
+		e.SetValue(protocol.BodyTarget, "identitySource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityValidationExpression != nil {
+		v := *s.IdentityValidationExpression
+
+		e.SetValue(protocol.BodyTarget, "identityValidationExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ProviderARNs) > 0 {
+		v := s.ProviderARNs
+
+		e.SetList(protocol.BodyTarget, "providerARNs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAuthorizerList(vs []*Authorizer) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the base path that callers of the API must provide as part of
 // the URL after the domain name.
 //
@@ -11014,6 +11203,35 @@ func (s *BasePathMapping) SetRestApiId(v string) *BasePathMapping {
 func (s *BasePathMapping) SetStage(v string) *BasePathMapping {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BasePathMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.BodyTarget, "basePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBasePathMappingList(vs []*BasePathMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a client certificate used to configure client-side SSL authentication
@@ -11081,6 +11299,45 @@ func (s *ClientCertificate) SetExpirationDate(v time.Time) *ClientCertificate {
 func (s *ClientCertificate) SetPemEncodedCertificate(v string) *ClientCertificate {
 	s.PemEncodedCertificate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ClientCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "expirationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.PemEncodedCertificate != nil {
+		v := *s.PemEncodedCertificate
+
+		e.SetValue(protocol.BodyTarget, "pemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeClientCertificateList(vs []*ClientCertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Request to create an ApiKey resource.
@@ -11161,6 +11418,47 @@ func (s *CreateApiKeyInput) SetStageKeys(v []*StageKey) *CreateApiKeyInput {
 func (s *CreateApiKeyInput) SetValue(v string) *CreateApiKeyInput {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.BodyTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.GenerateDistinctId != nil {
+		v := *s.GenerateDistinctId
+
+		e.SetValue(protocol.BodyTarget, "generateDistinctId", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageKeys) > 0 {
+		v := s.StageKeys
+
+		e.SetList(protocol.BodyTarget, "stageKeys", encodeStageKeyList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to add a new Authorizer to an existing RestApi resource.
@@ -11335,6 +11633,62 @@ func (s *CreateAuthorizerInput) SetType(v string) *CreateAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthType != nil {
+		v := *s.AuthType
+
+		e.SetValue(protocol.BodyTarget, "authType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerCredentials != nil {
+		v := *s.AuthorizerCredentials
+
+		e.SetValue(protocol.BodyTarget, "authorizerCredentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerResultTtlInSeconds != nil {
+		v := *s.AuthorizerResultTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "authorizerResultTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AuthorizerUri != nil {
+		v := *s.AuthorizerUri
+
+		e.SetValue(protocol.BodyTarget, "authorizerUri", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentitySource != nil {
+		v := *s.IdentitySource
+
+		e.SetValue(protocol.BodyTarget, "identitySource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityValidationExpression != nil {
+		v := *s.IdentityValidationExpression
+
+		e.SetValue(protocol.BodyTarget, "identityValidationExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ProviderARNs) > 0 {
+		v := s.ProviderARNs
+
+		e.SetList(protocol.BodyTarget, "providerARNs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to create a new BasePathMapping resource.
 type CreateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -11409,6 +11763,32 @@ func (s *CreateBasePathMappingInput) SetRestApiId(v string) *CreateBasePathMappi
 func (s *CreateBasePathMappingInput) SetStage(v string) *CreateBasePathMappingInput {
 	s.Stage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.BodyTarget, "basePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Stage != nil {
+		v := *s.Stage
+
+		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Deployment resource.
@@ -11507,6 +11887,47 @@ func (s *CreateDeploymentInput) SetVariables(v map[string]*string) *CreateDeploy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageDescription != nil {
+		v := *s.StageDescription
+
+		e.SetValue(protocol.BodyTarget, "stageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a new documentation part of a given API.
 type CreateDocumentationPartInput struct {
 	_ struct{} `type:"structure"`
@@ -11582,6 +12003,27 @@ func (s *CreateDocumentationPartInput) SetRestApiId(v string) *CreateDocumentati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "location", v, protocol.Metadata{})
+	}
+	if s.Properties != nil {
+		v := *s.Properties
+
+		e.SetValue(protocol.BodyTarget, "properties", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a new documentation version of a given API.
 type CreateDocumentationVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -11651,6 +12093,32 @@ func (s *CreateDocumentationVersionInput) SetRestApiId(v string) *CreateDocument
 func (s *CreateDocumentationVersionInput) SetStageName(v string) *CreateDocumentationVersionInput {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to create a new domain name.
@@ -11779,6 +12247,57 @@ func (s *CreateDomainNameInput) SetRegionalCertificateName(v string) *CreateDoma
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateBody != nil {
+		v := *s.CertificateBody
+
+		e.SetValue(protocol.BodyTarget, "certificateBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateChain != nil {
+		v := *s.CertificateChain
+
+		e.SetValue(protocol.BodyTarget, "certificateChain", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateName != nil {
+		v := *s.CertificateName
+
+		e.SetValue(protocol.BodyTarget, "certificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePrivateKey != nil {
+		v := *s.CertificatePrivateKey
+
+		e.SetValue(protocol.BodyTarget, "certificatePrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointConfiguration != nil {
+		v := s.EndpointConfiguration
+
+		e.SetFields(protocol.BodyTarget, "endpointConfiguration", v, protocol.Metadata{})
+	}
+	if s.RegionalCertificateArn != nil {
+		v := *s.RegionalCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "regionalCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegionalCertificateName != nil {
+		v := *s.RegionalCertificateName
+
+		e.SetValue(protocol.BodyTarget, "regionalCertificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to add a new Model to an existing RestApi resource.
 type CreateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -11865,6 +12384,37 @@ func (s *CreateModelInput) SetSchema(v string) *CreateModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schema != nil {
+		v := *s.Schema
+
+		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Creates a RequestValidator of a given RestApi.
 type CreateRequestValidatorInput struct {
 	_ struct{} `type:"structure"`
@@ -11933,6 +12483,32 @@ func (s *CreateRequestValidatorInput) SetValidateRequestParameters(v bool) *Crea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestBody != nil {
+		v := *s.ValidateRequestBody
+
+		e.SetValue(protocol.BodyTarget, "validateRequestBody", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestParameters != nil {
+		v := *s.ValidateRequestParameters
+
+		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to create a Resource resource.
 type CreateResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -11998,6 +12574,27 @@ func (s *CreateResourceInput) SetPathPart(v string) *CreateResourceInput {
 func (s *CreateResourceInput) SetRestApiId(v string) *CreateResourceInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.PathTarget, "parent_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathPart != nil {
+		v := *s.PathPart
+
+		e.SetValue(protocol.BodyTarget, "pathPart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The POST Request to add a new RestApi resource to your collection.
@@ -12084,6 +12681,42 @@ func (s *CreateRestApiInput) SetName(v string) *CreateRestApiInput {
 func (s *CreateRestApiInput) SetVersion(v string) *CreateRestApiInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BinaryMediaTypes) > 0 {
+		v := s.BinaryMediaTypes
+
+		e.SetList(protocol.BodyTarget, "binaryMediaTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CloneFrom != nil {
+		v := *s.CloneFrom
+
+		e.SetValue(protocol.BodyTarget, "cloneFrom", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointConfiguration != nil {
+		v := s.EndpointConfiguration
+
+		e.SetFields(protocol.BodyTarget, "endpointConfiguration", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to create a Stage resource.
@@ -12200,6 +12833,52 @@ func (s *CreateStageInput) SetVariables(v map[string]*string) *CreateStageInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The POST request to create a usage plan with the name, description, throttle
 // limits and quota limits, as well as the associated API stages, specified
 // in the payload.
@@ -12277,6 +12956,37 @@ func (s *CreateUsagePlanInput) SetThrottle(v *ThrottleSettings) *CreateUsagePlan
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiStages) > 0 {
+		v := s.ApiStages
+
+		e.SetList(protocol.BodyTarget, "apiStages", encodeApiStageList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quota != nil {
+		v := s.Quota
+
+		e.SetFields(protocol.BodyTarget, "quota", v, protocol.Metadata{})
+	}
+	if s.Throttle != nil {
+		v := s.Throttle
+
+		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The POST request to create a usage plan key for adding an existing API key
 // to a usage plan.
 type CreateUsagePlanKeyInput struct {
@@ -12346,6 +13056,27 @@ func (s *CreateUsagePlanKeyInput) SetUsagePlanId(v string) *CreateUsagePlanKeyIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.BodyTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyType != nil {
+		v := *s.KeyType
+
+		e.SetValue(protocol.BodyTarget, "keyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to delete the ApiKey resource.
 type DeleteApiKeyInput struct {
 	_ struct{} `type:"structure"`
@@ -12385,6 +13116,17 @@ func (s *DeleteApiKeyInput) SetApiKey(v string) *DeleteApiKeyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteApiKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12397,6 +13139,12 @@ func (s DeleteApiKeyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteApiKeyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApiKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing Authorizer resource.
@@ -12452,6 +13200,22 @@ func (s *DeleteAuthorizerInput) SetRestApiId(v string) *DeleteAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12464,6 +13228,12 @@ func (s DeleteAuthorizerOutput) String() string {
 // GoString returns the string representation
 func (s DeleteAuthorizerOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the BasePathMapping resource.
@@ -12519,6 +13289,22 @@ func (s *DeleteBasePathMappingInput) SetDomainName(v string) *DeleteBasePathMapp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteBasePathMappingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12531,6 +13317,12 @@ func (s DeleteBasePathMappingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBasePathMappingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBasePathMappingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the ClientCertificate resource.
@@ -12572,6 +13364,17 @@ func (s *DeleteClientCertificateInput) SetClientCertificateId(v string) *DeleteC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteClientCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12584,6 +13387,12 @@ func (s DeleteClientCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteClientCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteClientCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to delete a Deployment resource.
@@ -12639,6 +13448,22 @@ func (s *DeleteDeploymentInput) SetRestApiId(v string) *DeleteDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDeploymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12651,6 +13476,12 @@ func (s DeleteDeploymentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDeploymentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes an existing documentation part of an API.
@@ -12706,6 +13537,22 @@ func (s *DeleteDocumentationPartInput) SetRestApiId(v string) *DeleteDocumentati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDocumentationPartOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12718,6 +13565,12 @@ func (s DeleteDocumentationPartOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentationPartOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes an existing documentation version of an API.
@@ -12773,6 +13626,22 @@ func (s *DeleteDocumentationVersionInput) SetRestApiId(v string) *DeleteDocument
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDocumentationVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12785,6 +13654,12 @@ func (s DeleteDocumentationVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentationVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentationVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete the DomainName resource.
@@ -12826,6 +13701,17 @@ func (s *DeleteDomainNameInput) SetDomainName(v string) *DeleteDomainNameInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteDomainNameOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12838,6 +13724,12 @@ func (s DeleteDomainNameOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDomainNameOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDomainNameOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Clears any customization of a GatewayResponse of a specified response type
@@ -12914,6 +13806,22 @@ func (s *DeleteGatewayResponseInput) SetRestApiId(v string) *DeleteGatewayRespon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteGatewayResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12926,6 +13834,12 @@ func (s DeleteGatewayResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteGatewayResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents a delete integration request.
@@ -12995,6 +13909,27 @@ func (s *DeleteIntegrationInput) SetRestApiId(v string) *DeleteIntegrationInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteIntegrationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13007,6 +13942,12 @@ func (s DeleteIntegrationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntegrationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents a delete integration response request.
@@ -13090,6 +14031,32 @@ func (s *DeleteIntegrationResponseInput) SetStatusCode(v string) *DeleteIntegrat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteIntegrationResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13102,6 +14069,12 @@ func (s DeleteIntegrationResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntegrationResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntegrationResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing Method resource.
@@ -13171,6 +14144,27 @@ func (s *DeleteMethodInput) SetRestApiId(v string) *DeleteMethodInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteMethodOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13183,6 +14177,12 @@ func (s DeleteMethodOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMethodOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete an existing MethodResponse resource.
@@ -13266,6 +14266,32 @@ func (s *DeleteMethodResponseInput) SetStatusCode(v string) *DeleteMethodRespons
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteMethodResponseOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13278,6 +14304,12 @@ func (s DeleteMethodResponseOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMethodResponseOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMethodResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete an existing model in an existing RestApi resource.
@@ -13333,6 +14365,22 @@ func (s *DeleteModelInput) SetRestApiId(v string) *DeleteModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteModelOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13345,6 +14393,12 @@ func (s DeleteModelOutput) String() string {
 // GoString returns the string representation
 func (s DeleteModelOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteModelOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Deletes a specified RequestValidator of a given RestApi.
@@ -13400,6 +14454,22 @@ func (s *DeleteRequestValidatorInput) SetRestApiId(v string) *DeleteRequestValid
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteRequestValidatorOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13412,6 +14482,12 @@ func (s DeleteRequestValidatorOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRequestValidatorOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete a Resource.
@@ -13467,6 +14543,22 @@ func (s *DeleteResourceInput) SetRestApiId(v string) *DeleteResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13479,6 +14571,12 @@ func (s DeleteResourceOutput) String() string {
 // GoString returns the string representation
 func (s DeleteResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Request to delete the specified API from your collection.
@@ -13520,6 +14618,17 @@ func (s *DeleteRestApiInput) SetRestApiId(v string) *DeleteRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteRestApiOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13532,6 +14641,12 @@ func (s DeleteRestApiOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRestApiOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRestApiOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to delete a Stage resource.
@@ -13587,6 +14702,22 @@ func (s *DeleteStageInput) SetStageName(v string) *DeleteStageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteStageOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13599,6 +14730,12 @@ func (s DeleteStageOutput) String() string {
 // GoString returns the string representation
 func (s DeleteStageOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStageOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The DELETE request to delete a usage plan of a given plan Id.
@@ -13638,6 +14775,17 @@ func (s *DeleteUsagePlanInput) Validate() error {
 func (s *DeleteUsagePlanInput) SetUsagePlanId(v string) *DeleteUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The DELETE request to delete a usage plan key and remove the underlying API
@@ -13695,6 +14843,22 @@ func (s *DeleteUsagePlanKeyInput) SetUsagePlanId(v string) *DeleteUsagePlanKeyIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteUsagePlanKeyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13709,6 +14873,12 @@ func (s DeleteUsagePlanKeyOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type DeleteUsagePlanOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13721,6 +14891,12 @@ func (s DeleteUsagePlanOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUsagePlanOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUsagePlanOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // An immutable representation of a RestApi resource that can be called by users
@@ -13782,6 +14958,45 @@ func (s *Deployment) SetDescription(v string) *Deployment {
 func (s *Deployment) SetId(v string) *Deployment {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiSummary) > 0 {
+		v := s.ApiSummary
+
+		e.SetMap(protocol.BodyTarget, "apiSummary", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetMap(k, encodeMethodSnapshotMap(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeploymentList(vs []*Deployment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A documentation part for a targeted API entity.
@@ -13849,6 +15064,35 @@ func (s *DocumentationPart) SetLocation(v *DocumentationPartLocation) *Documenta
 func (s *DocumentationPart) SetProperties(v string) *DocumentationPart {
 	s.Properties = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationPart) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "location", v, protocol.Metadata{})
+	}
+	if s.Properties != nil {
+		v := *s.Properties
+
+		e.SetValue(protocol.BodyTarget, "properties", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentationPartList(vs []*DocumentationPart) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies the target API entity to which the documentation applies.
@@ -13951,6 +15195,37 @@ func (s *DocumentationPartLocation) SetType(v string) *DocumentationPartLocation
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationPartLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Method != nil {
+		v := *s.Method
+
+		e.SetValue(protocol.BodyTarget, "method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A snapshot of the documentation of an API.
 //
 // Publishing API documentation involves creating a documentation version associated
@@ -13998,6 +15273,35 @@ func (s *DocumentationVersion) SetDescription(v string) *DocumentationVersion {
 func (s *DocumentationVersion) SetVersion(v string) *DocumentationVersion {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentationVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentationVersionList(vs []*DocumentationVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a custom domain name as a user-friendly host name of an API (RestApi).
@@ -14144,6 +15448,75 @@ func (s *DomainName) SetRegionalHostedZoneId(v string) *DomainName {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DomainName) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateName != nil {
+		v := *s.CertificateName
+
+		e.SetValue(protocol.BodyTarget, "certificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateUploadDate != nil {
+		v := *s.CertificateUploadDate
+
+		e.SetValue(protocol.BodyTarget, "certificateUploadDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DistributionDomainName != nil {
+		v := *s.DistributionDomainName
+
+		e.SetValue(protocol.BodyTarget, "distributionDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DistributionHostedZoneId != nil {
+		v := *s.DistributionHostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "distributionHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointConfiguration != nil {
+		v := s.EndpointConfiguration
+
+		e.SetFields(protocol.BodyTarget, "endpointConfiguration", v, protocol.Metadata{})
+	}
+	if s.RegionalCertificateArn != nil {
+		v := *s.RegionalCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "regionalCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegionalCertificateName != nil {
+		v := *s.RegionalCertificateName
+
+		e.SetValue(protocol.BodyTarget, "regionalCertificateName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegionalDomainName != nil {
+		v := *s.RegionalDomainName
+
+		e.SetValue(protocol.BodyTarget, "regionalDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegionalHostedZoneId != nil {
+		v := *s.RegionalHostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "regionalHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDomainNameList(vs []*DomainName) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The endpoint configuration to indicate the types of endpoints an API (RestApi)
 // or its custom domain name (DomainName) has.
 type EndpointConfiguration struct {
@@ -14170,6 +15543,17 @@ func (s EndpointConfiguration) GoString() string {
 func (s *EndpointConfiguration) SetTypes(v []*string) *EndpointConfiguration {
 	s.Types = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Types) > 0 {
+		v := s.Types
+
+		e.SetList(protocol.BodyTarget, "types", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to flush authorizer cache entries on a specified stage.
@@ -14225,6 +15609,22 @@ func (s *FlushStageAuthorizersCacheInput) SetStageName(v string) *FlushStageAuth
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageAuthorizersCacheInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type FlushStageAuthorizersCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -14237,6 +15637,12 @@ func (s FlushStageAuthorizersCacheOutput) String() string {
 // GoString returns the string representation
 func (s FlushStageAuthorizersCacheOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageAuthorizersCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Requests Amazon API Gateway to flush a stage's cache.
@@ -14292,6 +15698,22 @@ func (s *FlushStageCacheInput) SetStageName(v string) *FlushStageCacheInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageCacheInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type FlushStageCacheOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -14304,6 +15726,12 @@ func (s FlushStageCacheOutput) String() string {
 // GoString returns the string representation
 func (s FlushStageCacheOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FlushStageCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to generate a ClientCertificate resource.
@@ -14330,6 +15758,17 @@ func (s *GenerateClientCertificateInput) SetDescription(v string) *GenerateClien
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GenerateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about the current Account
 // resource.
 type GetAccountInput struct {
@@ -14344,6 +15783,12 @@ func (s GetAccountInput) String() string {
 // GoString returns the string representation
 func (s GetAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to get information about the current ApiKey resource.
@@ -14393,6 +15838,22 @@ func (s *GetApiKeyInput) SetApiKey(v string) *GetApiKeyInput {
 func (s *GetApiKeyInput) SetIncludeValue(v bool) *GetApiKeyInput {
 	s.IncludeValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeValue != nil {
+		v := *s.IncludeValue
+
+		e.SetValue(protocol.QueryTarget, "includeValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about the current ApiKeys resource.
@@ -14457,6 +15918,37 @@ func (s *GetApiKeysInput) SetPosition(v string) *GetApiKeysInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomerId != nil {
+		v := *s.CustomerId
+
+		e.SetValue(protocol.QueryTarget, "customerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeValues != nil {
+		v := *s.IncludeValues
+
+		e.SetValue(protocol.QueryTarget, "includeValues", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of API keys as represented by an ApiKeys resource.
 //
 // Use API Keys (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html)
@@ -14499,6 +15991,27 @@ func (s *GetApiKeysOutput) SetPosition(v string) *GetApiKeysOutput {
 func (s *GetApiKeysOutput) SetWarnings(v []*string) *GetApiKeysOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeApiKeyList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe an existing Authorizer resource.
@@ -14552,6 +16065,22 @@ func (s *GetAuthorizerInput) SetAuthorizerId(v string) *GetAuthorizerInput {
 func (s *GetAuthorizerInput) SetRestApiId(v string) *GetAuthorizerInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe an existing Authorizers resource.
@@ -14611,6 +16140,27 @@ func (s *GetAuthorizersInput) SetRestApiId(v string) *GetAuthorizersInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Authorizer resources.
 //
 // Enable custom authorization (http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html)
@@ -14643,6 +16193,22 @@ func (s *GetAuthorizersOutput) SetItems(v []*Authorizer) *GetAuthorizersOutput {
 func (s *GetAuthorizersOutput) SetPosition(v string) *GetAuthorizersOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAuthorizersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeAuthorizerList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe a BasePathMapping resource.
@@ -14699,6 +16265,22 @@ func (s *GetBasePathMappingInput) SetBasePath(v string) *GetBasePathMappingInput
 func (s *GetBasePathMappingInput) SetDomainName(v string) *GetBasePathMappingInput {
 	s.DomainName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a collection of BasePathMapping resources.
@@ -14759,6 +16341,27 @@ func (s *GetBasePathMappingsInput) SetPosition(v string) *GetBasePathMappingsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of BasePathMapping resources.
 //
 // Use Custom Domain Names (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
@@ -14791,6 +16394,22 @@ func (s *GetBasePathMappingsOutput) SetItems(v []*BasePathMapping) *GetBasePathM
 func (s *GetBasePathMappingsOutput) SetPosition(v string) *GetBasePathMappingsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBasePathMappingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeBasePathMappingList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about the current ClientCertificate resource.
@@ -14832,6 +16451,17 @@ func (s *GetClientCertificateInput) SetClientCertificateId(v string) *GetClientC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to get information about a collection of ClientCertificate resources.
 type GetClientCertificatesInput struct {
 	_ struct{} `type:"structure"`
@@ -14866,6 +16496,22 @@ func (s *GetClientCertificatesInput) SetPosition(v string) *GetClientCertificate
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of ClientCertificate resources.
 //
 // Use Client-Side Certificate (http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html)
@@ -14898,6 +16544,22 @@ func (s *GetClientCertificatesOutput) SetItems(v []*ClientCertificate) *GetClien
 func (s *GetClientCertificatesOutput) SetPosition(v string) *GetClientCertificatesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetClientCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeClientCertificateList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to get information about a Deployment resource.
@@ -14968,6 +16630,27 @@ func (s *GetDeploymentInput) SetRestApiId(v string) *GetDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about a Deployments collection.
 type GetDeploymentsInput struct {
 	_ struct{} `type:"structure"`
@@ -15026,6 +16709,27 @@ func (s *GetDeploymentsInput) SetRestApiId(v string) *GetDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection resource that contains zero or more references to
 // your existing deployments, and links that guide you on how to interact with
 // your collection. The collection offers a paginated view of the contained
@@ -15067,6 +16771,22 @@ func (s *GetDeploymentsOutput) SetItems(v []*Deployment) *GetDeploymentsOutput {
 func (s *GetDeploymentsOutput) SetPosition(v string) *GetDeploymentsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDeploymentList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a specified documentation part of a given API.
@@ -15120,6 +16840,22 @@ func (s *GetDocumentationPartInput) SetDocumentationPartId(v string) *GetDocumen
 func (s *GetDocumentationPartInput) SetRestApiId(v string) *GetDocumentationPartInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the documentation parts of an API. The result may be filtered by the
@@ -15218,6 +16954,47 @@ func (s *GetDocumentationPartsInput) SetType(v string) *GetDocumentationPartsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LocationStatus != nil {
+		v := *s.LocationStatus
+
+		e.SetValue(protocol.QueryTarget, "locationStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.QueryTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of documentation parts of an API.
 //
 // Documenting an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html), DocumentationPart
@@ -15250,6 +17027,22 @@ func (s *GetDocumentationPartsOutput) SetItems(v []*DocumentationPart) *GetDocum
 func (s *GetDocumentationPartsOutput) SetPosition(v string) *GetDocumentationPartsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDocumentationPartList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a documentation snapshot of an API.
@@ -15303,6 +17096,22 @@ func (s *GetDocumentationVersionInput) SetDocumentationVersion(v string) *GetDoc
 func (s *GetDocumentationVersionInput) SetRestApiId(v string) *GetDocumentationVersionInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the documentation versions of an API.
@@ -15362,6 +17171,27 @@ func (s *GetDocumentationVersionsInput) SetRestApiId(v string) *GetDocumentation
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of documentation snapshots of an API.
 //
 // Use the DocumentationVersions to manage documentation snapshots associated
@@ -15398,6 +17228,22 @@ func (s *GetDocumentationVersionsOutput) SetItems(v []*DocumentationVersion) *Ge
 func (s *GetDocumentationVersionsOutput) SetPosition(v string) *GetDocumentationVersionsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentationVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDocumentationVersionList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to get the name of a DomainName resource.
@@ -15439,6 +17285,17 @@ func (s *GetDomainNameInput) SetDomainName(v string) *GetDomainNameInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to describe a collection of DomainName resources.
 type GetDomainNamesInput struct {
 	_ struct{} `type:"structure"`
@@ -15473,6 +17330,22 @@ func (s *GetDomainNamesInput) SetPosition(v string) *GetDomainNamesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of DomainName resources.
 //
 // Use Client-Side Certificate (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
@@ -15505,6 +17378,22 @@ func (s *GetDomainNamesOutput) SetItems(v []*DomainName) *GetDomainNamesOutput {
 func (s *GetDomainNamesOutput) SetPosition(v string) *GetDomainNamesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeDomainNameList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request a new export of a RestApi for a particular Stage.
@@ -15600,6 +17489,37 @@ func (s *GetExportInput) SetStageName(v string) *GetExportInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Accepts != nil {
+		v := *s.Accepts
+
+		e.SetValue(protocol.HeaderTarget, "Accept", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.PathTarget, "export_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The binary blob response to GetExport, which contains the generated SDK.
 type GetExportOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -15641,6 +17561,27 @@ func (s *GetExportOutput) SetContentDisposition(v string) *GetExportOutput {
 func (s *GetExportOutput) SetContentType(v string) *GetExportOutput {
 	s.ContentType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a GatewayResponse of a specified response type on the given RestApi.
@@ -15716,6 +17657,22 @@ func (s *GetGatewayResponseInput) SetRestApiId(v string) *GetGatewayResponseInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Gets the GatewayResponses collection on the given RestApi. If an API developer
 // has not added any definitions for gateway responses, the result will be the
 // Amazon API Gateway-generated default GatewayResponses collection for the
@@ -15776,6 +17733,27 @@ func (s *GetGatewayResponsesInput) SetPosition(v string) *GetGatewayResponsesInp
 func (s *GetGatewayResponsesInput) SetRestApiId(v string) *GetGatewayResponsesInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponsesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The collection of the GatewayResponse instances of a RestApi as a responseType-to-GatewayResponse
@@ -15969,6 +17947,22 @@ func (s *GetGatewayResponsesOutput) SetPosition(v string) *GetGatewayResponsesOu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGatewayResponsesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUpdateGatewayResponseOutputList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a request to get the integration configuration.
 type GetIntegrationInput struct {
 	_ struct{} `type:"structure"`
@@ -16034,6 +18028,27 @@ func (s *GetIntegrationInput) SetResourceId(v string) *GetIntegrationInput {
 func (s *GetIntegrationInput) SetRestApiId(v string) *GetIntegrationInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a get integration response request.
@@ -16117,6 +18132,32 @@ func (s *GetIntegrationResponseInput) SetStatusCode(v string) *GetIntegrationRes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to describe an existing Method resource.
 type GetMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -16182,6 +18223,27 @@ func (s *GetMethodInput) SetResourceId(v string) *GetMethodInput {
 func (s *GetMethodInput) SetRestApiId(v string) *GetMethodInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to describe a MethodResponse resource.
@@ -16265,6 +18327,32 @@ func (s *GetMethodResponseInput) SetStatusCode(v string) *GetMethodResponseInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to list information about a model in an existing RestApi resource.
 type GetModelInput struct {
 	_ struct{} `type:"structure"`
@@ -16329,6 +18417,27 @@ func (s *GetModelInput) SetRestApiId(v string) *GetModelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Flatten != nil {
+		v := *s.Flatten
+
+		e.SetValue(protocol.QueryTarget, "flatten", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to generate a sample mapping template used to transform the payload.
 type GetModelTemplateInput struct {
 	_ struct{} `type:"structure"`
@@ -16382,6 +18491,22 @@ func (s *GetModelTemplateInput) SetRestApiId(v string) *GetModelTemplateInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a mapping template used to transform a payload.
 //
 // Mapping Templates (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings)
@@ -16407,6 +18532,17 @@ func (s GetModelTemplateOutput) GoString() string {
 func (s *GetModelTemplateOutput) SetValue(v string) *GetModelTemplateOutput {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list existing Models defined for a RestApi resource.
@@ -16467,6 +18603,27 @@ func (s *GetModelsInput) SetRestApiId(v string) *GetModelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Model resources.
 //
 // Method, MethodResponse, Models and Mappings (http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html)
@@ -16499,6 +18656,22 @@ func (s *GetModelsOutput) SetItems(v []*Model) *GetModelsOutput {
 func (s *GetModelsOutput) SetPosition(v string) *GetModelsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetModelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeModelList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets a RequestValidator of a given RestApi.
@@ -16552,6 +18725,22 @@ func (s *GetRequestValidatorInput) SetRequestValidatorId(v string) *GetRequestVa
 func (s *GetRequestValidatorInput) SetRestApiId(v string) *GetRequestValidatorInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets the RequestValidators collection of a given RestApi.
@@ -16611,6 +18800,27 @@ func (s *GetRequestValidatorsInput) SetRestApiId(v string) *GetRequestValidators
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A collection of RequestValidator resources of a given RestApi.
 //
 // In Swagger, the RequestValidators of an API is defined by the x-amazon-apigateway-request-validators
@@ -16647,6 +18857,22 @@ func (s *GetRequestValidatorsOutput) SetItems(v []*UpdateRequestValidatorOutput)
 func (s *GetRequestValidatorsOutput) SetPosition(v string) *GetRequestValidatorsOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRequestValidatorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUpdateRequestValidatorOutputList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list information about a resource.
@@ -16714,6 +18940,27 @@ func (s *GetResourceInput) SetResourceId(v string) *GetResourceInput {
 func (s *GetResourceInput) SetRestApiId(v string) *GetResourceInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to list information about a collection of resources.
@@ -16788,6 +19035,32 @@ func (s *GetResourcesInput) SetRestApiId(v string) *GetResourcesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Embed) > 0 {
+		v := s.Embed
+
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of Resource resources.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -16820,6 +19093,22 @@ func (s *GetResourcesOutput) SetItems(v []*Resource) *GetResourcesOutput {
 func (s *GetResourcesOutput) SetPosition(v string) *GetResourcesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetResourcesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeResourceList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to list an existing RestApi defined for your collection.
@@ -16861,6 +19150,17 @@ func (s *GetRestApiInput) SetRestApiId(v string) *GetRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The GET request to list existing RestApis defined for your collection.
 type GetRestApisInput struct {
 	_ struct{} `type:"structure"`
@@ -16893,6 +19193,22 @@ func (s *GetRestApisInput) SetLimit(v int64) *GetRestApisInput {
 func (s *GetRestApisInput) SetPosition(v string) *GetRestApisInput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApisInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains references to your APIs and links that guide you in how to interact
@@ -16928,6 +19244,22 @@ func (s *GetRestApisOutput) SetItems(v []*RestApi) *GetRestApisOutput {
 func (s *GetRestApisOutput) SetPosition(v string) *GetRestApisOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRestApisOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeRestApiList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request a new generated client SDK for a RestApi and Stage.
@@ -17011,6 +19343,32 @@ func (s *GetSdkInput) SetStageName(v string) *GetSdkInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SdkType != nil {
+		v := *s.SdkType
+
+		e.SetValue(protocol.PathTarget, "sdk_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The binary blob response to GetSdk, which contains the generated SDK.
 type GetSdkOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -17053,6 +19411,27 @@ func (s *GetSdkOutput) SetContentType(v string) *GetSdkOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get an SdkType instance.
 type GetSdkTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -17092,6 +19471,17 @@ func (s *GetSdkTypeInput) SetId(v string) *GetSdkTypeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "sdktype_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get the SdkTypes collection.
 type GetSdkTypesInput struct {
 	_ struct{} `type:"structure"`
@@ -17125,6 +19515,22 @@ func (s *GetSdkTypesInput) SetPosition(v string) *GetSdkTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The collection of SdkType instances.
 type GetSdkTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -17155,6 +19561,22 @@ func (s *GetSdkTypesOutput) SetItems(v []*SdkType) *GetSdkTypesOutput {
 func (s *GetSdkTypesOutput) SetPosition(v string) *GetSdkTypesOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSdkTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeSdkTypeList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to get information about a Stage resource.
@@ -17210,6 +19632,22 @@ func (s *GetStageInput) SetStageName(v string) *GetStageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to get information about one or more Stage resources.
 type GetStagesInput struct {
 	_ struct{} `type:"structure"`
@@ -17258,6 +19696,22 @@ func (s *GetStagesInput) SetRestApiId(v string) *GetStagesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStagesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.QueryTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of Stage resources that are associated with the ApiKey resource.
 //
 // Deploying API in Stages (http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html)
@@ -17282,6 +19736,17 @@ func (s GetStagesOutput) GoString() string {
 func (s *GetStagesOutput) SetItem(v []*Stage) *GetStagesOutput {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStagesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "item", encodeStageList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get the usage data of a usage plan in a specified time
@@ -17379,6 +19844,42 @@ func (s *GetUsageInput) SetUsagePlanId(v string) *GetUsageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.QueryTarget, "endDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.QueryTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.QueryTarget, "startDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The GET request to get a usage plan of a given plan identifier.
 type GetUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -17416,6 +19917,17 @@ func (s *GetUsagePlanInput) Validate() error {
 func (s *GetUsagePlanInput) SetUsagePlanId(v string) *GetUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get a usage plan key of a given key identifier.
@@ -17471,6 +19983,22 @@ func (s *GetUsagePlanKeyInput) SetKeyId(v string) *GetUsagePlanKeyInput {
 func (s *GetUsagePlanKeyInput) SetUsagePlanId(v string) *GetUsagePlanKeyInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get all the usage plan keys representing the API keys
@@ -17541,6 +20069,32 @@ func (s *GetUsagePlanKeysInput) SetUsagePlanId(v string) *GetUsagePlanKeysInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameQuery != nil {
+		v := *s.NameQuery
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the collection of usage plan keys added to usage plans for the
 // associated API keys and, possibly, other types of keys.
 //
@@ -17574,6 +20128,22 @@ func (s *GetUsagePlanKeysOutput) SetItems(v []*UsagePlanKey) *GetUsagePlanKeysOu
 func (s *GetUsagePlanKeysOutput) SetPosition(v string) *GetUsagePlanKeysOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlanKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUsagePlanKeyList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The GET request to get all the usage plans of the caller's account.
@@ -17618,6 +20188,27 @@ func (s *GetUsagePlansInput) SetPosition(v string) *GetUsagePlansInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlansInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.QueryTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a collection of usage plans for an AWS account.
 //
 // Create and Use Usage Plans (http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html)
@@ -17650,6 +20241,22 @@ func (s *GetUsagePlansOutput) SetItems(v []*UsagePlan) *GetUsagePlansOutput {
 func (s *GetUsagePlansOutput) SetPosition(v string) *GetUsagePlansOutput {
 	s.Position = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUsagePlansOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "item", encodeUsagePlanList(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The POST request to import API keys from an external source, such as a CSV-formatted
@@ -17718,6 +20325,27 @@ func (s *ImportApiKeysInput) SetFormat(v string) *ImportApiKeysInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.QueryTarget, "format", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The identifier of an ApiKey used in a UsagePlan.
 type ImportApiKeysOutput struct {
 	_ struct{} `type:"structure"`
@@ -17749,6 +20377,22 @@ func (s *ImportApiKeysOutput) SetIds(v []*string) *ImportApiKeysOutput {
 func (s *ImportApiKeysOutput) SetWarnings(v []*string) *ImportApiKeysOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Ids) > 0 {
+		v := s.Ids
+
+		e.SetList(protocol.BodyTarget, "ids", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Import documentation parts from an external (e.g., Swagger) definition file.
@@ -17827,6 +20471,32 @@ func (s *ImportDocumentationPartsInput) SetRestApiId(v string) *ImportDocumentat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.QueryTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A collection of the imported DocumentationPart identifiers.
 //
 // This is used to return the result when documentation parts in an external
@@ -17864,6 +20534,22 @@ func (s *ImportDocumentationPartsOutput) SetIds(v []*string) *ImportDocumentatio
 func (s *ImportDocumentationPartsOutput) SetWarnings(v []*string) *ImportDocumentationPartsOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Ids) > 0 {
+		v := s.Ids
+
+		e.SetList(protocol.BodyTarget, "ids", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A POST request to import an API to Amazon API Gateway using an input of an
@@ -17945,6 +20631,27 @@ func (s *ImportRestApiInput) SetFailOnWarnings(v bool) *ImportRestApiInput {
 func (s *ImportRestApiInput) SetParameters(v map[string]*string) *ImportRestApiInput {
 	s.Parameters = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an HTTP, HTTP_PROXY, AWS, AWS_PROXY, or Mock integration.
@@ -18152,6 +20859,72 @@ func (s *Integration) SetUri(v string) *Integration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Integration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CacheKeyParameters) > 0 {
+		v := s.CacheKeyParameters
+
+		e.SetList(protocol.BodyTarget, "cacheKeyParameters", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CacheNamespace != nil {
+		v := *s.CacheNamespace
+
+		e.SetValue(protocol.BodyTarget, "cacheNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credentials != nil {
+		v := *s.Credentials
+
+		e.SetValue(protocol.BodyTarget, "credentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.IntegrationResponses) > 0 {
+		v := s.IntegrationResponses
+
+		e.SetMap(protocol.BodyTarget, "integrationResponses", encodeIntegrationResponseMap(v), protocol.Metadata{})
+	}
+	if s.PassthroughBehavior != nil {
+		v := *s.PassthroughBehavior
+
+		e.SetValue(protocol.BodyTarget, "passthroughBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestTemplates) > 0 {
+		v := s.RequestTemplates
+
+		e.SetMap(protocol.BodyTarget, "requestTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.TimeoutInMillis != nil {
+		v := *s.TimeoutInMillis
+
+		e.SetValue(protocol.BodyTarget, "timeoutInMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents an integration response. The status code must map to an existing
 // MethodResponse, and parameters and templates can be used to transform the
 // back-end response.
@@ -18243,6 +21016,45 @@ func (s *IntegrationResponse) SetSelectionPattern(v string) *IntegrationResponse
 func (s *IntegrationResponse) SetStatusCode(v string) *IntegrationResponse {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IntegrationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SelectionPattern != nil {
+		v := *s.SelectionPattern
+
+		e.SetValue(protocol.BodyTarget, "selectionPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntegrationResponseMap(vs map[string]*IntegrationResponse) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Represents a client-facing interface by which the client calls the API to
@@ -18501,6 +21313,70 @@ func (s *Method) SetRequestValidatorId(v string) *Method {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Method) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.BodyTarget, "authorizerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MethodIntegration != nil {
+		v := s.MethodIntegration
+
+		e.SetFields(protocol.BodyTarget, "methodIntegration", v, protocol.Metadata{})
+	}
+	if len(s.MethodResponses) > 0 {
+		v := s.MethodResponses
+
+		e.SetMap(protocol.BodyTarget, "methodResponses", encodeMethodResponseMap(v), protocol.Metadata{})
+	}
+	if s.OperationName != nil {
+		v := *s.OperationName
+
+		e.SetValue(protocol.BodyTarget, "operationName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestModels) > 0 {
+		v := s.RequestModels
+
+		e.SetMap(protocol.BodyTarget, "requestModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodMap(vs map[string]*Method) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Represents a method response of a given HTTP status code returned to the
 // client. The method response is passed from the back end through the associated
 // integration response that can be transformed using a mapping template.
@@ -18578,6 +21454,35 @@ func (s *MethodResponse) SetResponseParameters(v map[string]*bool) *MethodRespon
 func (s *MethodResponse) SetStatusCode(v string) *MethodResponse {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResponseModels) > 0 {
+		v := s.ResponseModels
+
+		e.SetMap(protocol.BodyTarget, "responseModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodResponseMap(vs map[string]*MethodResponse) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Specifies the method setting properties.
@@ -18706,6 +21611,70 @@ func (s *MethodSetting) SetUnauthorizedCacheControlHeaderStrategy(v string) *Met
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodSetting) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheDataEncrypted != nil {
+		v := *s.CacheDataEncrypted
+
+		e.SetValue(protocol.BodyTarget, "cacheDataEncrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheTtlInSeconds != nil {
+		v := *s.CacheTtlInSeconds
+
+		e.SetValue(protocol.BodyTarget, "cacheTtlInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CachingEnabled != nil {
+		v := *s.CachingEnabled
+
+		e.SetValue(protocol.BodyTarget, "cachingEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DataTraceEnabled != nil {
+		v := *s.DataTraceEnabled
+
+		e.SetValue(protocol.BodyTarget, "dataTraceEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LoggingLevel != nil {
+		v := *s.LoggingLevel
+
+		e.SetValue(protocol.BodyTarget, "loggingLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricsEnabled != nil {
+		v := *s.MetricsEnabled
+
+		e.SetValue(protocol.BodyTarget, "metricsEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RequireAuthorizationForCacheControl != nil {
+		v := *s.RequireAuthorizationForCacheControl
+
+		e.SetValue(protocol.BodyTarget, "requireAuthorizationForCacheControl", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThrottlingBurstLimit != nil {
+		v := *s.ThrottlingBurstLimit
+
+		e.SetValue(protocol.BodyTarget, "throttlingBurstLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThrottlingRateLimit != nil {
+		v := *s.ThrottlingRateLimit
+
+		e.SetValue(protocol.BodyTarget, "throttlingRateLimit", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.UnauthorizedCacheControlHeaderStrategy != nil {
+		v := *s.UnauthorizedCacheControlHeaderStrategy
+
+		e.SetValue(protocol.BodyTarget, "unauthorizedCacheControlHeaderStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodSettingMap(vs map[string]*MethodSetting) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Represents a summary of a Method resource, given a particular date and time.
 type MethodSnapshot struct {
 	_ struct{} `type:"structure"`
@@ -18739,6 +21708,30 @@ func (s *MethodSnapshot) SetApiKeyRequired(v bool) *MethodSnapshot {
 func (s *MethodSnapshot) SetAuthorizationType(v string) *MethodSnapshot {
 	s.AuthorizationType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MethodSnapshot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMethodSnapshotMap(vs map[string]*MethodSnapshot) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Represents the data structure of a method's request or response payload.
@@ -18816,6 +21809,45 @@ func (s *Model) SetSchema(v string) *Model {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Model) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schema != nil {
+		v := *s.Schema
+
+		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeModelList(vs []*Model) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A single patch operation to apply to the specified resource. Please refer
 // to http://tools.ietf.org/html/rfc6902#section-4 for an explanation of how
 // each operation is used.
@@ -18881,6 +21913,40 @@ func (s *PatchOperation) SetPath(v string) *PatchOperation {
 func (s *PatchOperation) SetValue(v string) *PatchOperation {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PatchOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.From != nil {
+		v := *s.From
+
+		e.SetValue(protocol.BodyTarget, "from", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Op != nil {
+		v := *s.Op
+
+		e.SetValue(protocol.BodyTarget, "op", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePatchOperationList(vs []*PatchOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Creates a customization of a GatewayResponse of a specified response type
@@ -18984,6 +22050,37 @@ func (s *PutGatewayResponseInput) SetRestApiId(v string) *PutGatewayResponseInpu
 func (s *PutGatewayResponseInput) SetStatusCode(v string) *PutGatewayResponseInput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Sets up a method's integration.
@@ -19200,6 +22297,82 @@ func (s *PutIntegrationInput) SetUri(v string) *PutIntegrationInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CacheKeyParameters) > 0 {
+		v := s.CacheKeyParameters
+
+		e.SetList(protocol.BodyTarget, "cacheKeyParameters", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CacheNamespace != nil {
+		v := *s.CacheNamespace
+
+		e.SetValue(protocol.BodyTarget, "cacheNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credentials != nil {
+		v := *s.Credentials
+
+		e.SetValue(protocol.BodyTarget, "credentials", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntegrationHttpMethod != nil {
+		v := *s.IntegrationHttpMethod
+
+		e.SetValue(protocol.BodyTarget, "httpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PassthroughBehavior != nil {
+		v := *s.PassthroughBehavior
+
+		e.SetValue(protocol.BodyTarget, "passthroughBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestTemplates) > 0 {
+		v := s.RequestTemplates
+
+		e.SetMap(protocol.BodyTarget, "requestTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeoutInMillis != nil {
+		v := *s.TimeoutInMillis
+
+		e.SetValue(protocol.BodyTarget, "timeoutInMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents a put integration response request.
 type PutIntegrationResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -19335,6 +22508,52 @@ func (s *PutIntegrationResponseInput) SetSelectionPattern(v string) *PutIntegrat
 func (s *PutIntegrationResponseInput) SetStatusCode(v string) *PutIntegrationResponseInput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentHandling != nil {
+		v := *s.ContentHandling
+
+		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SelectionPattern != nil {
+		v := *s.SelectionPattern
+
+		e.SetValue(protocol.BodyTarget, "selectionPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to add a method to an existing Resource resource.
@@ -19486,6 +22705,62 @@ func (s *PutMethodInput) SetRestApiId(v string) *PutMethodInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKeyRequired != nil {
+		v := *s.ApiKeyRequired
+
+		e.SetValue(protocol.BodyTarget, "apiKeyRequired", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizationType != nil {
+		v := *s.AuthorizationType
+
+		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.BodyTarget, "authorizerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OperationName != nil {
+		v := *s.OperationName
+
+		e.SetValue(protocol.BodyTarget, "operationName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestModels) > 0 {
+		v := s.RequestModels
+
+		e.SetMap(protocol.BodyTarget, "requestModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.RequestParameters) > 0 {
+		v := s.RequestParameters
+
+		e.SetMap(protocol.BodyTarget, "requestParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to add a MethodResponse to an existing Method resource.
 type PutMethodResponseInput struct {
 	_ struct{} `type:"structure"`
@@ -19597,6 +22872,42 @@ func (s *PutMethodResponseInput) SetStatusCode(v string) *PutMethodResponseInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseModels) > 0 {
+		v := s.ResponseModels
+
+		e.SetMap(protocol.BodyTarget, "responseModels", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A PUT request to update an existing API, with external API definitions specified
 // as the request body.
 type PutRestApiInput struct {
@@ -19685,6 +22996,37 @@ func (s *PutRestApiInput) SetRestApiId(v string) *PutRestApiInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.FailOnWarnings != nil {
+		v := *s.FailOnWarnings
+
+		e.SetValue(protocol.QueryTarget, "failonwarnings", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.QueryTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Quotas configured for a usage plan.
 type QuotaSettings struct {
 	_ struct{} `type:"structure"`
@@ -19727,6 +23069,27 @@ func (s *QuotaSettings) SetOffset(v int64) *QuotaSettings {
 func (s *QuotaSettings) SetPeriod(v string) *QuotaSettings {
 	s.Period = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QuotaSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Offset != nil {
+		v := *s.Offset
+
+		e.SetValue(protocol.BodyTarget, "offset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Period != nil {
+		v := *s.Period
+
+		e.SetValue(protocol.BodyTarget, "period", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an API resource.
@@ -19847,6 +23210,45 @@ func (s *Resource) SetResourceMethods(v map[string]*Method) *Resource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "parentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathPart != nil {
+		v := *s.PathPart
+
+		e.SetValue(protocol.BodyTarget, "pathPart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceMethods) > 0 {
+		v := s.ResourceMethods
+
+		e.SetMap(protocol.BodyTarget, "resourceMethods", encodeMethodMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceList(vs []*Resource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents a REST API.
 //
 // Create an API (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html)
@@ -19940,6 +23342,60 @@ func (s *RestApi) SetWarnings(v []*string) *RestApi {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestApi) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BinaryMediaTypes) > 0 {
+		v := s.BinaryMediaTypes
+
+		e.SetList(protocol.BodyTarget, "binaryMediaTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointConfiguration != nil {
+		v := s.EndpointConfiguration
+
+		e.SetFields(protocol.BodyTarget, "endpointConfiguration", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRestApiList(vs []*RestApi) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A configuration property of an SDK type.
 type SdkConfigurationProperty struct {
 	_ struct{} `type:"structure"`
@@ -20001,6 +23457,45 @@ func (s *SdkConfigurationProperty) SetRequired(v bool) *SdkConfigurationProperty
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SdkConfigurationProperty) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := *s.DefaultValue
+
+		e.SetValue(protocol.BodyTarget, "defaultValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FriendlyName != nil {
+		v := *s.FriendlyName
+
+		e.SetValue(protocol.BodyTarget, "friendlyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Required != nil {
+		v := *s.Required
+
+		e.SetValue(protocol.BodyTarget, "required", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSdkConfigurationPropertyList(vs []*SdkConfigurationProperty) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A type of SDK that API Gateway can generate.
 type SdkType struct {
 	_ struct{} `type:"structure"`
@@ -20050,6 +23545,40 @@ func (s *SdkType) SetFriendlyName(v string) *SdkType {
 func (s *SdkType) SetId(v string) *SdkType {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SdkType) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConfigurationProperties) > 0 {
+		v := s.ConfigurationProperties
+
+		e.SetList(protocol.BodyTarget, "configurationProperties", encodeSdkConfigurationPropertyList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FriendlyName != nil {
+		v := *s.FriendlyName
+
+		e.SetValue(protocol.BodyTarget, "friendlyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSdkTypeList(vs []*SdkType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents a unique identifier for a version of a deployed RestApi that is
@@ -20193,6 +23722,85 @@ func (s *Stage) SetVariables(v map[string]*string) *Stage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Stage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessLogSettings != nil {
+		v := s.AccessLogSettings
+
+		e.SetFields(protocol.BodyTarget, "accessLogSettings", v, protocol.Metadata{})
+	}
+	if s.CacheClusterEnabled != nil {
+		v := *s.CacheClusterEnabled
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterSize != nil {
+		v := *s.CacheClusterSize
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheClusterStatus != nil {
+		v := *s.CacheClusterStatus
+
+		e.SetValue(protocol.BodyTarget, "cacheClusterStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if len(s.MethodSettings) > 0 {
+		v := s.MethodSettings
+
+		e.SetMap(protocol.BodyTarget, "methodSettings", encodeMethodSettingMap(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStageList(vs []*Stage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A reference to a unique stage identified in the format {restApiId}/{stage}.
 type StageKey struct {
 	_ struct{} `type:"structure"`
@@ -20224,6 +23832,30 @@ func (s *StageKey) SetRestApiId(v string) *StageKey {
 func (s *StageKey) SetStageName(v string) *StageKey {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StageKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.BodyTarget, "restApiId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStageKeyList(vs []*StageKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Make a request to simulate the execution of an Authorizer.
@@ -20328,6 +23960,47 @@ func (s *TestInvokeAuthorizerInput) SetStageVariables(v map[string]*string) *Tes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalContext) > 0 {
+		v := s.AdditionalContext
+
+		e.SetMap(protocol.BodyTarget, "additionalContext", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.PathWithQueryString != nil {
+		v := *s.PathWithQueryString
+
+		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageVariables) > 0 {
+		v := s.StageVariables
+
+		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the response of the test invoke request for a custom Authorizer
 type TestInvokeAuthorizerOutput struct {
 	_ struct{} `type:"structure"`
@@ -20406,6 +24079,52 @@ func (s *TestInvokeAuthorizerOutput) SetPolicy(v string) *TestInvokeAuthorizerOu
 func (s *TestInvokeAuthorizerOutput) SetPrincipalId(v string) *TestInvokeAuthorizerOutput {
 	s.PrincipalId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Authorization) > 0 {
+		v := s.Authorization
+
+		e.SetMap(protocol.BodyTarget, "authorization", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.Claims) > 0 {
+		v := s.Claims
+
+		e.SetMap(protocol.BodyTarget, "claims", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ClientStatus != nil {
+		v := *s.ClientStatus
+
+		e.SetValue(protocol.BodyTarget, "clientStatus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Latency != nil {
+		v := *s.Latency
+
+		e.SetValue(protocol.BodyTarget, "latency", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Log != nil {
+		v := *s.Log
+
+		e.SetValue(protocol.BodyTarget, "log", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.BodyTarget, "principalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Make a request to simulate the execution of a Method.
@@ -20524,6 +24243,52 @@ func (s *TestInvokeMethodInput) SetStageVariables(v map[string]*string) *TestInv
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.BodyTarget, "clientCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PathWithQueryString != nil {
+		v := *s.PathWithQueryString
+
+		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageVariables) > 0 {
+		v := s.StageVariables
+
+		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the response of the test invoke request in the HTTP method.
 //
 // Test API using the API Gateway console (http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console)
@@ -20586,6 +24351,37 @@ func (s *TestInvokeMethodOutput) SetStatus(v int64) *TestInvokeMethodOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestInvokeMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Headers) > 0 {
+		v := s.Headers
+
+		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Latency != nil {
+		v := *s.Latency
+
+		e.SetValue(protocol.BodyTarget, "latency", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Log != nil {
+		v := *s.Log
+
+		e.SetValue(protocol.BodyTarget, "log", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The API request rate limits.
 type ThrottleSettings struct {
 	_ struct{} `type:"structure"`
@@ -20621,6 +24417,22 @@ func (s *ThrottleSettings) SetRateLimit(v float64) *ThrottleSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThrottleSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BurstLimit != nil {
+		v := *s.BurstLimit
+
+		e.SetValue(protocol.BodyTarget, "burstLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RateLimit != nil {
+		v := *s.RateLimit
+
+		e.SetValue(protocol.BodyTarget, "rateLimit", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Requests Amazon API Gateway to change information about the current Account
 // resource.
 type UpdateAccountInput struct {
@@ -20645,6 +24457,17 @@ func (s UpdateAccountInput) GoString() string {
 func (s *UpdateAccountInput) SetPatchOperations(v []*PatchOperation) *UpdateAccountInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to change information about an ApiKey resource.
@@ -20694,6 +24517,22 @@ func (s *UpdateApiKeyInput) SetApiKey(v string) *UpdateApiKeyInput {
 func (s *UpdateApiKeyInput) SetPatchOperations(v []*PatchOperation) *UpdateApiKeyInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request to update an existing Authorizer resource.
@@ -20759,6 +24598,27 @@ func (s *UpdateAuthorizerInput) SetRestApiId(v string) *UpdateAuthorizerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about the BasePathMapping resource.
 type UpdateBasePathMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -20822,6 +24682,27 @@ func (s *UpdateBasePathMappingInput) SetPatchOperations(v []*PatchOperation) *Up
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BasePath != nil {
+		v := *s.BasePath
+
+		e.SetValue(protocol.PathTarget, "base_path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about an ClientCertificate resource.
 type UpdateClientCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -20869,6 +24750,22 @@ func (s *UpdateClientCertificateInput) SetClientCertificateId(v string) *UpdateC
 func (s *UpdateClientCertificateInput) SetPatchOperations(v []*PatchOperation) *UpdateClientCertificateInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
+
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Deployment resource.
@@ -20935,6 +24832,27 @@ func (s *UpdateDeploymentInput) SetRestApiId(v string) *UpdateDeploymentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Updates an existing documentation part of a given API.
 type UpdateDocumentationPartInput struct {
 	_ struct{} `type:"structure"`
@@ -20996,6 +24914,27 @@ func (s *UpdateDocumentationPartInput) SetPatchOperations(v []*PatchOperation) *
 func (s *UpdateDocumentationPartInput) SetRestApiId(v string) *UpdateDocumentationPartInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates an existing documentation version of an API.
@@ -21061,6 +25000,27 @@ func (s *UpdateDocumentationVersionInput) SetRestApiId(v string) *UpdateDocument
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to change information about the DomainName resource.
 type UpdateDomainNameInput struct {
 	_ struct{} `type:"structure"`
@@ -21108,6 +25068,22 @@ func (s *UpdateDomainNameInput) SetDomainName(v string) *UpdateDomainNameInput {
 func (s *UpdateDomainNameInput) SetPatchOperations(v []*PatchOperation) *UpdateDomainNameInput {
 	s.PatchOperations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates a GatewayResponse of a specified response type on the given RestApi.
@@ -21191,6 +25167,27 @@ func (s *UpdateGatewayResponseInput) SetResponseType(v string) *UpdateGatewayRes
 func (s *UpdateGatewayResponseInput) SetRestApiId(v string) *UpdateGatewayResponseInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.PathTarget, "response_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A gateway response of a given response type and status code, with optional
@@ -21317,6 +25314,45 @@ func (s *UpdateGatewayResponseOutput) SetStatusCode(v string) *UpdateGatewayResp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultResponse != nil {
+		v := *s.DefaultResponse
+
+		e.SetValue(protocol.BodyTarget, "defaultResponse", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.ResponseParameters) > 0 {
+		v := s.ResponseParameters
+
+		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTemplates) > 0 {
+		v := s.ResponseTemplates
+
+		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResponseType != nil {
+		v := *s.ResponseType
+
+		e.SetValue(protocol.BodyTarget, "responseType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUpdateGatewayResponseOutputList(vs []*UpdateGatewayResponseOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an update integration request.
 type UpdateIntegrationInput struct {
 	_ struct{} `type:"structure"`
@@ -21392,6 +25428,32 @@ func (s *UpdateIntegrationInput) SetResourceId(v string) *UpdateIntegrationInput
 func (s *UpdateIntegrationInput) SetRestApiId(v string) *UpdateIntegrationInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an update integration response request.
@@ -21485,6 +25547,37 @@ func (s *UpdateIntegrationResponseInput) SetStatusCode(v string) *UpdateIntegrat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing Method resource.
 type UpdateMethodInput struct {
 	_ struct{} `type:"structure"`
@@ -21560,6 +25653,32 @@ func (s *UpdateMethodInput) SetResourceId(v string) *UpdateMethodInput {
 func (s *UpdateMethodInput) SetRestApiId(v string) *UpdateMethodInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateMethodInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to update an existing MethodResponse resource.
@@ -21653,6 +25772,37 @@ func (s *UpdateMethodResponseInput) SetStatusCode(v string) *UpdateMethodRespons
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing model in an existing RestApi resource.
 type UpdateModelInput struct {
 	_ struct{} `type:"structure"`
@@ -21714,6 +25864,27 @@ func (s *UpdateModelInput) SetPatchOperations(v []*PatchOperation) *UpdateModelI
 func (s *UpdateModelInput) SetRestApiId(v string) *UpdateModelInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateModelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Updates a RequestValidator of a given RestApi.
@@ -21779,6 +25950,27 @@ func (s *UpdateRequestValidatorInput) SetRestApiId(v string) *UpdateRequestValid
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RequestValidatorId != nil {
+		v := *s.RequestValidatorId
+
+		e.SetValue(protocol.PathTarget, "requestvalidator_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A set of validation rules for incoming Method requests.
 //
 // In Swagger, a RequestValidator of an API is defined by the x-amazon-apigateway-request-validators.requestValidator
@@ -21838,6 +26030,40 @@ func (s *UpdateRequestValidatorOutput) SetValidateRequestBody(v bool) *UpdateReq
 func (s *UpdateRequestValidatorOutput) SetValidateRequestParameters(v bool) *UpdateRequestValidatorOutput {
 	s.ValidateRequestParameters = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestBody != nil {
+		v := *s.ValidateRequestBody
+
+		e.SetValue(protocol.BodyTarget, "validateRequestBody", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ValidateRequestParameters != nil {
+		v := *s.ValidateRequestParameters
+
+		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUpdateRequestValidatorOutputList(vs []*UpdateRequestValidatorOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Request to change information about a Resource resource.
@@ -21903,6 +26129,27 @@ func (s *UpdateResourceInput) SetRestApiId(v string) *UpdateResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to update an existing RestApi resource in your collection.
 type UpdateRestApiInput struct {
 	_ struct{} `type:"structure"`
@@ -21950,6 +26197,22 @@ func (s *UpdateRestApiInput) SetPatchOperations(v []*PatchOperation) *UpdateRest
 func (s *UpdateRestApiInput) SetRestApiId(v string) *UpdateRestApiInput {
 	s.RestApiId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Requests Amazon API Gateway to change information about a Stage resource.
@@ -22013,6 +26276,27 @@ func (s *UpdateStageInput) SetRestApiId(v string) *UpdateStageInput {
 func (s *UpdateStageInput) SetStageName(v string) *UpdateStageInput {
 	s.StageName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StageName != nil {
+		v := *s.StageName
+
+		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The PATCH request to grant a temporary extension to the remaining quota of
@@ -22080,6 +26364,27 @@ func (s *UpdateUsageInput) SetUsagePlanId(v string) *UpdateUsageInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The PATCH request to update a usage plan of a given plan Id.
 type UpdateUsagePlanInput struct {
 	_ struct{} `type:"structure"`
@@ -22127,6 +26432,22 @@ func (s *UpdateUsagePlanInput) SetPatchOperations(v []*PatchOperation) *UpdateUs
 func (s *UpdateUsagePlanInput) SetUsagePlanId(v string) *UpdateUsagePlanInput {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the usage data of a usage plan.
@@ -22192,6 +26513,47 @@ func (s *Usage) SetStartDate(v string) *Usage {
 func (s *Usage) SetUsagePlanId(v string) *Usage {
 	s.UsagePlanId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Usage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "endDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetMap(protocol.BodyTarget, "values", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, func(le protocol.ListEncoder) {
+					for _, item := range v {
+						v := item
+						le.ListAddList(protocol.EncodeInt64List(v))
+					}
+				})
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "startDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.BodyTarget, "usagePlanId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a usage plan than can specify who can assess associated API stages
@@ -22280,6 +26642,55 @@ func (s *UsagePlan) SetThrottle(v *ThrottleSettings) *UsagePlan {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UsagePlan) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApiStages) > 0 {
+		v := s.ApiStages
+
+		e.SetList(protocol.BodyTarget, "apiStages", encodeApiStageList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProductCode != nil {
+		v := *s.ProductCode
+
+		e.SetValue(protocol.BodyTarget, "productCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quota != nil {
+		v := s.Quota
+
+		e.SetFields(protocol.BodyTarget, "quota", v, protocol.Metadata{})
+	}
+	if s.Throttle != nil {
+		v := s.Throttle
+
+		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUsagePlanList(vs []*UsagePlan) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents a usage plan key to identify a plan customer.
 //
 // To associate an API stage with a selected API key in a usage plan, you must
@@ -22334,6 +26745,40 @@ func (s *UsagePlanKey) SetType(v string) *UsagePlanKey {
 func (s *UsagePlanKey) SetValue(v string) *UsagePlanKey {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UsagePlanKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUsagePlanKeyList(vs []*UsagePlanKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -10608,7 +10608,6 @@ func (s *AccessLogSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "format", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10721,7 +10720,6 @@ func (s *Account) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "throttleSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10874,7 +10872,6 @@ func (s *ApiKey) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10931,7 +10928,6 @@ func (s *ApiStage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11145,7 +11141,6 @@ func (s *Authorizer) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11222,7 +11217,6 @@ func (s *BasePathMapping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11328,7 +11322,6 @@ func (s *ClientCertificate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11457,7 +11450,6 @@ func (s *CreateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11675,17 +11667,16 @@ func (s *CreateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "providerARNs", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Type != nil {
 		v := *s.Type
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11772,11 +11763,6 @@ func (s *CreateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "basePath", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.DomainName != nil {
-		v := *s.DomainName
-
-		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
@@ -11787,7 +11773,11 @@ func (s *CreateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "stage", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DomainName != nil {
+		v := *s.DomainName
 
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11904,11 +11894,6 @@ func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StageDescription != nil {
 		v := *s.StageDescription
 
@@ -11924,7 +11909,11 @@ func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12020,7 +12009,6 @@ func (s *CreateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12107,17 +12095,16 @@ func (s *CreateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StageName != nil {
 		v := *s.StageName
 
 		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12294,7 +12281,6 @@ func (s *CreateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "regionalCertificateName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12401,17 +12387,16 @@ func (s *CreateModelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Schema != nil {
 		v := *s.Schema
 
 		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12490,11 +12475,6 @@ func (s *CreateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ValidateRequestBody != nil {
 		v := *s.ValidateRequestBody
 
@@ -12505,7 +12485,11 @@ func (s *CreateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12578,22 +12562,21 @@ func (s *CreateResourceInput) SetRestApiId(v string) *CreateResourceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ParentId != nil {
-		v := *s.ParentId
-
-		e.SetValue(protocol.PathTarget, "parent_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.PathPart != nil {
 		v := *s.PathPart
 
 		e.SetValue(protocol.BodyTarget, "pathPart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.PathTarget, "parent_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12715,7 +12698,6 @@ func (s *CreateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12860,11 +12842,6 @@ func (s *CreateStageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "documentationVersion", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StageName != nil {
 		v := *s.StageName
 
@@ -12875,7 +12852,11 @@ func (s *CreateStageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
 
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12983,7 +12964,6 @@ func (s *CreateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13073,7 +13053,6 @@ func (s *CreateUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13123,7 +13102,6 @@ func (s *DeleteApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13143,7 +13121,6 @@ func (s DeleteApiKeyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteApiKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13212,7 +13189,6 @@ func (s *DeleteAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13232,7 +13208,6 @@ func (s DeleteAuthorizerOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13301,7 +13276,6 @@ func (s *DeleteBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13321,7 +13295,6 @@ func (s DeleteBasePathMappingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBasePathMappingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13371,7 +13344,6 @@ func (s *DeleteClientCertificateInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13391,7 +13363,6 @@ func (s DeleteClientCertificateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteClientCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13460,7 +13431,6 @@ func (s *DeleteDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13480,7 +13450,6 @@ func (s DeleteDeploymentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13549,7 +13518,6 @@ func (s *DeleteDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13569,7 +13537,6 @@ func (s DeleteDocumentationPartOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDocumentationPartOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13638,7 +13605,6 @@ func (s *DeleteDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13658,7 +13624,6 @@ func (s DeleteDocumentationVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDocumentationVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13708,7 +13673,6 @@ func (s *DeleteDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13728,7 +13692,6 @@ func (s DeleteDomainNameOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDomainNameOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13818,7 +13781,6 @@ func (s *DeleteGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13838,7 +13800,6 @@ func (s DeleteGatewayResponseOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13926,7 +13887,6 @@ func (s *DeleteIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13946,7 +13906,6 @@ func (s DeleteIntegrationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteIntegrationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14053,7 +14012,6 @@ func (s *DeleteIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14073,7 +14031,6 @@ func (s DeleteIntegrationResponseOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteIntegrationResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14161,7 +14118,6 @@ func (s *DeleteMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14181,7 +14137,6 @@ func (s DeleteMethodOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14288,7 +14243,6 @@ func (s *DeleteMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14308,7 +14262,6 @@ func (s DeleteMethodResponseOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteMethodResponseOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14377,7 +14330,6 @@ func (s *DeleteModelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14397,7 +14349,6 @@ func (s DeleteModelOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteModelOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14466,7 +14417,6 @@ func (s *DeleteRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14486,7 +14436,6 @@ func (s DeleteRequestValidatorOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14555,7 +14504,6 @@ func (s *DeleteResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14575,7 +14523,6 @@ func (s DeleteResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14625,7 +14572,6 @@ func (s *DeleteRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14645,7 +14591,6 @@ func (s DeleteRestApiOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteRestApiOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14714,7 +14659,6 @@ func (s *DeleteStageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14734,7 +14678,6 @@ func (s DeleteStageOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteStageOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14784,7 +14727,6 @@ func (s *DeleteUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14855,7 +14797,6 @@ func (s *DeleteUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14875,7 +14816,6 @@ func (s DeleteUsagePlanKeyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteUsagePlanKeyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14895,7 +14835,6 @@ func (s DeleteUsagePlanOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteUsagePlanOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14987,7 +14926,6 @@ func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15083,7 +15021,6 @@ func (s *DocumentationPart) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "properties", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15222,7 +15159,6 @@ func (s *DocumentationPartLocation) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15292,7 +15228,6 @@ func (s *DocumentationVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15505,7 +15440,6 @@ func (s *DomainName) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "regionalHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15552,7 +15486,6 @@ func (s *EndpointConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "types", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15621,7 +15554,6 @@ func (s *FlushStageAuthorizersCacheInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15641,7 +15573,6 @@ func (s FlushStageAuthorizersCacheOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *FlushStageAuthorizersCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -15710,7 +15641,6 @@ func (s *FlushStageCacheInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15730,7 +15660,6 @@ func (s FlushStageCacheOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *FlushStageCacheOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -15765,7 +15694,6 @@ func (s *GenerateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15787,7 +15715,6 @@ func (s GetAccountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetAccountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -15852,7 +15779,6 @@ func (s *GetApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "includeValue", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15945,7 +15871,6 @@ func (s *GetApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16010,7 +15935,6 @@ func (s *GetApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16079,7 +16003,6 @@ func (s *GetAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16142,6 +16065,11 @@ func (s *GetAuthorizersInput) SetRestApiId(v string) *GetAuthorizersInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetAuthorizersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -16152,12 +16080,6 @@ func (s *GetAuthorizersInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -16207,7 +16129,6 @@ func (s *GetAuthorizersOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16279,7 +16200,6 @@ func (s *GetBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16358,7 +16278,6 @@ func (s *GetBasePathMappingsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16408,7 +16327,6 @@ func (s *GetBasePathMappingsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16458,7 +16376,6 @@ func (s *GetClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16508,7 +16425,6 @@ func (s *GetClientCertificatesInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16558,7 +16474,6 @@ func (s *GetClientCertificatesOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16637,17 +16552,16 @@ func (s *GetDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Embed) > 0 {
-		v := s.Embed
-
-		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
-	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Embed) > 0 {
+		v := s.Embed
 
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -16711,6 +16625,11 @@ func (s *GetDeploymentsInput) SetRestApiId(v string) *GetDeploymentsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -16721,12 +16640,6 @@ func (s *GetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -16785,7 +16698,6 @@ func (s *GetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16854,7 +16766,6 @@ func (s *GetDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16956,6 +16867,11 @@ func (s *GetDocumentationPartsInput) SetType(v string) *GetDocumentationPartsInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -16981,17 +16897,11 @@ func (s *GetDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Type != nil {
 		v := *s.Type
 
 		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17041,7 +16951,6 @@ func (s *GetDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17110,7 +17019,6 @@ func (s *GetDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17173,6 +17081,11 @@ func (s *GetDocumentationVersionsInput) SetRestApiId(v string) *GetDocumentation
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetDocumentationVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -17183,12 +17096,6 @@ func (s *GetDocumentationVersionsInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -17242,7 +17149,6 @@ func (s *GetDocumentationVersionsOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17292,7 +17198,6 @@ func (s *GetDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17342,7 +17247,6 @@ func (s *GetDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17392,7 +17296,6 @@ func (s *GetDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17501,11 +17404,6 @@ func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "export_type", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Parameters) > 0 {
-		v := s.Parameters
-
-		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
@@ -17516,7 +17414,11 @@ func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
 
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -17565,11 +17467,6 @@ func (s *GetExportOutput) SetContentType(v string) *GetExportOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
-	}
 	if s.ContentDisposition != nil {
 		v := *s.ContentDisposition
 
@@ -17580,7 +17477,11 @@ func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Body != nil {
+		v := s.Body
 
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -17669,7 +17570,6 @@ func (s *GetGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17737,6 +17637,11 @@ func (s *GetGatewayResponsesInput) SetRestApiId(v string) *GetGatewayResponsesIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetGatewayResponsesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -17747,12 +17652,6 @@ func (s *GetGatewayResponsesInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -17959,7 +17858,6 @@ func (s *GetGatewayResponsesOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18047,7 +17945,6 @@ func (s *GetIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18154,7 +18051,6 @@ func (s *GetIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18242,7 +18138,6 @@ func (s *GetMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18349,7 +18244,6 @@ func (s *GetMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18419,11 +18313,6 @@ func (s *GetModelInput) SetRestApiId(v string) *GetModelInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetModelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Flatten != nil {
-		v := *s.Flatten
-
-		e.SetValue(protocol.QueryTarget, "flatten", protocol.BoolValue(v), protocol.Metadata{})
-	}
 	if s.ModelName != nil {
 		v := *s.ModelName
 
@@ -18434,7 +18323,11 @@ func (s *GetModelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Flatten != nil {
+		v := *s.Flatten
 
+		e.SetValue(protocol.QueryTarget, "flatten", protocol.BoolValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18503,7 +18396,6 @@ func (s *GetModelTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18541,7 +18433,6 @@ func (s *GetModelTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18605,6 +18496,11 @@ func (s *GetModelsInput) SetRestApiId(v string) *GetModelsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetModelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -18615,12 +18511,6 @@ func (s *GetModelsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -18670,7 +18560,6 @@ func (s *GetModelsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18739,7 +18628,6 @@ func (s *GetRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18802,6 +18690,11 @@ func (s *GetRequestValidatorsInput) SetRestApiId(v string) *GetRequestValidators
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetRequestValidatorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -18812,12 +18705,6 @@ func (s *GetRequestValidatorsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -18871,7 +18758,6 @@ func (s *GetRequestValidatorsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18944,11 +18830,6 @@ func (s *GetResourceInput) SetRestApiId(v string) *GetResourceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.Embed) > 0 {
-		v := s.Embed
-
-		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
-	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
@@ -18959,7 +18840,11 @@ func (s *GetResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Embed) > 0 {
+		v := s.Embed
 
+		e.SetList(protocol.QueryTarget, "embed", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19037,6 +18922,11 @@ func (s *GetResourcesInput) SetRestApiId(v string) *GetResourcesInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if len(s.Embed) > 0 {
 		v := s.Embed
 
@@ -19052,12 +18942,6 @@ func (s *GetResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -19107,7 +18991,6 @@ func (s *GetResourcesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19157,7 +19040,6 @@ func (s *GetRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19207,7 +19089,6 @@ func (s *GetRestApisInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19258,7 +19139,6 @@ func (s *GetRestApisOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19345,11 +19225,6 @@ func (s *GetSdkInput) SetStageName(v string) *GetSdkInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetSdkInput) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.Parameters) > 0 {
-		v := s.Parameters
-
-		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
@@ -19365,7 +19240,11 @@ func (s *GetSdkInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
 
+		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19413,11 +19292,6 @@ func (s *GetSdkOutput) SetContentType(v string) *GetSdkOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetSdkOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
-	}
 	if s.ContentDisposition != nil {
 		v := *s.ContentDisposition
 
@@ -19428,7 +19302,11 @@ func (s *GetSdkOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Body != nil {
+		v := s.Body
 
+		e.SetStream(protocol.PayloadTarget, "body", protocol.BytesStream(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19478,7 +19356,6 @@ func (s *GetSdkTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "sdktype_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19527,7 +19404,6 @@ func (s *GetSdkTypesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19575,7 +19451,6 @@ func (s *GetSdkTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19644,7 +19519,6 @@ func (s *GetStageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19698,17 +19572,16 @@ func (s *GetStagesInput) SetRestApiId(v string) *GetStagesInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetStagesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DeploymentId != nil {
-		v := *s.DeploymentId
-
-		e.SetValue(protocol.QueryTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
 
+		e.SetValue(protocol.QueryTarget, "deploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19745,7 +19618,6 @@ func (s *GetStagesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "item", encodeStageList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19846,6 +19718,11 @@ func (s *GetUsageInput) SetUsagePlanId(v string) *GetUsageInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.EndDate != nil {
 		v := *s.EndDate
 
@@ -19871,12 +19748,6 @@ func (s *GetUsageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "startDate", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.UsagePlanId != nil {
-		v := *s.UsagePlanId
-
-		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -19926,7 +19797,6 @@ func (s *GetUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19997,7 +19867,6 @@ func (s *GetUsagePlanKeyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20071,6 +19940,11 @@ func (s *GetUsagePlanKeysInput) SetUsagePlanId(v string) *GetUsagePlanKeysInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetUsagePlanKeysInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UsagePlanId != nil {
+		v := *s.UsagePlanId
+
+		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -20086,12 +19960,6 @@ func (s *GetUsagePlanKeysInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.UsagePlanId != nil {
-		v := *s.UsagePlanId
-
-		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -20142,7 +20010,6 @@ func (s *GetUsagePlanKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20205,7 +20072,6 @@ func (s *GetUsagePlansInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20255,7 +20121,6 @@ func (s *GetUsagePlansOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20342,7 +20207,6 @@ func (s *ImportApiKeysInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "format", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20391,7 +20255,6 @@ func (s *ImportApiKeysOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20473,6 +20336,11 @@ func (s *ImportDocumentationPartsInput) SetRestApiId(v string) *ImportDocumentat
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ImportDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Body != nil {
 		v := s.Body
 
@@ -20488,12 +20356,6 @@ func (s *ImportDocumentationPartsInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -20548,7 +20410,6 @@ func (s *ImportDocumentationPartsOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20650,7 +20511,6 @@ func (s *ImportRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20921,7 +20781,6 @@ func (s *Integration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21045,7 +20904,6 @@ func (s *IntegrationResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21365,7 +21223,6 @@ func (s *Method) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21473,7 +21330,6 @@ func (s *MethodResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21663,7 +21519,6 @@ func (s *MethodSetting) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "unauthorizedCacheControlHeaderStrategy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21722,7 +21577,6 @@ func (s *MethodSnapshot) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "authorizationType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21836,7 +21690,6 @@ func (s *Model) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "schema", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21937,7 +21790,6 @@ func (s *PatchOperation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22064,6 +21916,11 @@ func (s *PutGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.ResponseType != nil {
 		v := *s.ResponseType
 
@@ -22074,12 +21931,6 @@ func (s *PutGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.StatusCode != nil {
-		v := *s.StatusCode
-
-		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -22319,11 +22170,6 @@ func (s *PutIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "credentials", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IntegrationHttpMethod != nil {
 		v := *s.IntegrationHttpMethod
 
@@ -22344,16 +22190,6 @@ func (s *PutIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "requestTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TimeoutInMillis != nil {
 		v := *s.TimeoutInMillis
 
@@ -22369,7 +22205,21 @@ func (s *PutIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
 
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -22517,16 +22367,6 @@ func (s *PutIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "contentHandling", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.ResponseParameters) > 0 {
 		v := s.ResponseParameters
 
@@ -22537,22 +22377,31 @@ func (s *PutIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetMap(protocol.BodyTarget, "responseTemplates", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.SelectionPattern != nil {
 		v := *s.SelectionPattern
 
 		e.SetValue(protocol.BodyTarget, "selectionPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.StatusCode != nil {
 		v := *s.StatusCode
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22722,11 +22571,6 @@ func (s *PutMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "authorizerId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.OperationName != nil {
 		v := *s.OperationName
 
@@ -22747,6 +22591,11 @@ func (s *PutMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "requestValidatorId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
@@ -22757,7 +22606,6 @@ func (s *PutMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22874,16 +22722,6 @@ func (s *PutMethodResponseInput) SetStatusCode(v string) *PutMethodResponseInput
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.ResponseModels) > 0 {
 		v := s.ResponseModels
 
@@ -22893,6 +22731,16 @@ func (s *PutMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := s.ResponseParameters
 
 		e.SetMap(protocol.BodyTarget, "responseParameters", protocol.EncodeBoolMap(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "resource_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
@@ -22904,7 +22752,6 @@ func (s *PutMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22998,6 +22845,11 @@ func (s *PutRestApiInput) SetRestApiId(v string) *PutRestApiInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Body != nil {
 		v := s.Body
 
@@ -23018,12 +22870,6 @@ func (s *PutRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.QueryTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -23088,7 +22934,6 @@ func (s *QuotaSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "period", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23237,7 +23082,6 @@ func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "resourceMethods", encodeMethodMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23384,7 +23228,6 @@ func (s *RestApi) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "warnings", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23484,7 +23327,6 @@ func (s *SdkConfigurationProperty) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "required", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23569,7 +23411,6 @@ func (s *SdkType) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23789,7 +23630,6 @@ func (s *Stage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23846,7 +23686,6 @@ func (s *StageKey) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stageName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23967,11 +23806,6 @@ func (s *TestInvokeAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetMap(protocol.BodyTarget, "additionalContext", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.AuthorizerId != nil {
-		v := *s.AuthorizerId
-
-		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Body != nil {
 		v := *s.Body
 
@@ -23987,17 +23821,21 @@ func (s *TestInvokeAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RestApiId != nil {
-		v := *s.RestApiId
-
-		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.StageVariables) > 0 {
 		v := s.StageVariables
 
 		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
 
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestApiId != nil {
+		v := *s.RestApiId
+
+		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -24123,7 +23961,6 @@ func (s *TestInvokeAuthorizerOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "principalId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24260,15 +24097,20 @@ func (s *TestInvokeMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "headers", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.PathWithQueryString != nil {
 		v := *s.PathWithQueryString
 
 		e.SetValue(protocol.BodyTarget, "pathWithQueryString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StageVariables) > 0 {
+		v := s.StageVariables
+
+		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -24280,12 +24122,6 @@ func (s *TestInvokeMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.StageVariables) > 0 {
-		v := s.StageVariables
-
-		e.SetMap(protocol.BodyTarget, "stageVariables", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -24378,7 +24214,6 @@ func (s *TestInvokeMethodOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24429,7 +24264,6 @@ func (s *ThrottleSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "rateLimit", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24466,7 +24300,6 @@ func (s *UpdateAccountInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24521,17 +24354,16 @@ func (s *UpdateApiKeyInput) SetPatchOperations(v []*PatchOperation) *UpdateApiKe
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateApiKeyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ApiKey != nil {
-		v := *s.ApiKey
-
-		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
 	}
+	if s.ApiKey != nil {
+		v := *s.ApiKey
 
+		e.SetValue(protocol.PathTarget, "api_Key", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -24600,22 +24432,21 @@ func (s *UpdateAuthorizerInput) SetRestApiId(v string) *UpdateAuthorizerInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateAuthorizerInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthorizerId != nil {
-		v := *s.AuthorizerId
-
-		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.AuthorizerId != nil {
+		v := *s.AuthorizerId
+
+		e.SetValue(protocol.PathTarget, "authorizer_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24684,6 +24515,11 @@ func (s *UpdateBasePathMappingInput) SetPatchOperations(v []*PatchOperation) *Up
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PatchOperations) > 0 {
+		v := s.PatchOperations
+
+		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
 	if s.BasePath != nil {
 		v := *s.BasePath
 
@@ -24694,12 +24530,6 @@ func (s *UpdateBasePathMappingInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.PatchOperations) > 0 {
-		v := s.PatchOperations
-
-		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -24754,17 +24584,16 @@ func (s *UpdateClientCertificateInput) SetPatchOperations(v []*PatchOperation) *
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateClientCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ClientCertificateId != nil {
-		v := *s.ClientCertificateId
-
-		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
 	}
+	if s.ClientCertificateId != nil {
+		v := *s.ClientCertificateId
 
+		e.SetValue(protocol.PathTarget, "clientcertificate_id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -24834,22 +24663,21 @@ func (s *UpdateDeploymentInput) SetRestApiId(v string) *UpdateDeploymentInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DeploymentId != nil {
-		v := *s.DeploymentId
-
-		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "deployment_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24918,22 +24746,21 @@ func (s *UpdateDocumentationPartInput) SetRestApiId(v string) *UpdateDocumentati
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentationPartInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DocumentationPartId != nil {
-		v := *s.DocumentationPartId
-
-		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.DocumentationPartId != nil {
+		v := *s.DocumentationPartId
+
+		e.SetValue(protocol.PathTarget, "part_id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25002,22 +24829,21 @@ func (s *UpdateDocumentationVersionInput) SetRestApiId(v string) *UpdateDocument
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentationVersionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DocumentationVersion != nil {
-		v := *s.DocumentationVersion
-
-		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.DocumentationVersion != nil {
+		v := *s.DocumentationVersion
+
+		e.SetValue(protocol.PathTarget, "doc_version", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25072,17 +24898,16 @@ func (s *UpdateDomainNameInput) SetPatchOperations(v []*PatchOperation) *UpdateD
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDomainNameInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DomainName != nil {
-		v := *s.DomainName
-
-		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
 	}
+	if s.DomainName != nil {
+		v := *s.DomainName
 
+		e.SetValue(protocol.PathTarget, "domain_name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -25186,7 +25011,6 @@ func (s *UpdateGatewayResponseInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25341,7 +25165,6 @@ func (s *UpdateGatewayResponseOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "statusCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25432,15 +25255,15 @@ func (s *UpdateIntegrationInput) SetRestApiId(v string) *UpdateIntegrationInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -25452,7 +25275,6 @@ func (s *UpdateIntegrationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25549,15 +25371,15 @@ func (s *UpdateIntegrationResponseInput) SetStatusCode(v string) *UpdateIntegrat
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -25574,7 +25396,6 @@ func (s *UpdateIntegrationResponseInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25657,15 +25478,15 @@ func (s *UpdateMethodInput) SetRestApiId(v string) *UpdateMethodInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateMethodInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -25677,7 +25498,6 @@ func (s *UpdateMethodInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25774,15 +25594,15 @@ func (s *UpdateMethodResponseInput) SetStatusCode(v string) *UpdateMethodRespons
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HttpMethod != nil {
-		v := *s.HttpMethod
-
-		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.PathTarget, "http_method", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -25799,7 +25619,6 @@ func (s *UpdateMethodResponseInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "status_code", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25868,22 +25687,21 @@ func (s *UpdateModelInput) SetRestApiId(v string) *UpdateModelInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateModelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ModelName != nil {
-		v := *s.ModelName
-
-		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.ModelName != nil {
+		v := *s.ModelName
+
+		e.SetValue(protocol.PathTarget, "model_name", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestApiId != nil {
 		v := *s.RestApiId
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25967,7 +25785,6 @@ func (s *UpdateRequestValidatorInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26054,7 +25871,6 @@ func (s *UpdateRequestValidatorOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "validateRequestParameters", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26146,7 +25962,6 @@ func (s *UpdateResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26211,7 +26026,6 @@ func (s *UpdateRestApiInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "restapi_id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26295,7 +26109,6 @@ func (s *UpdateStageInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "stage_name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26366,22 +26179,21 @@ func (s *UpdateUsageInput) SetUsagePlanId(v string) *UpdateUsageInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateUsageInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.KeyId != nil {
-		v := *s.KeyId
-
-		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.PatchOperations) > 0 {
 		v := s.PatchOperations
 
 		e.SetList(protocol.BodyTarget, "patchOperations", encodePatchOperationList(v), protocol.Metadata{})
+	}
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.PathTarget, "keyId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.UsagePlanId != nil {
 		v := *s.UsagePlanId
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26446,7 +26258,6 @@ func (s *UpdateUsagePlanInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "usageplanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26552,7 +26363,6 @@ func (s *Usage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "usagePlanId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26679,7 +26489,6 @@ func (s *UsagePlan) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "throttle", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -26769,7 +26578,6 @@ func (s *UsagePlanKey) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -1501,7 +1501,6 @@ func (s *AttemptContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "taskArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1582,7 +1581,6 @@ func (s *AttemptDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1661,7 +1659,6 @@ func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1682,7 +1679,6 @@ func (s CancelJobOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1841,7 +1837,6 @@ func (s *ComputeEnvironmentDetail) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1922,7 +1917,6 @@ func (s *ComputeEnvironmentOrder) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "order", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2194,7 +2188,6 @@ func (s *ComputeResource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2259,7 +2252,6 @@ func (s *ComputeResourceUpdate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "minvCpus", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2530,7 +2522,6 @@ func (s *ContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2616,7 +2607,6 @@ func (s *ContainerOverrides) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2904,7 +2894,6 @@ func (s *ContainerProperties) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3040,7 +3029,6 @@ func (s *CreateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3089,7 +3077,6 @@ func (s *CreateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3210,7 +3197,6 @@ func (s *CreateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3263,7 +3249,6 @@ func (s *CreateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3313,7 +3298,6 @@ func (s *DeleteComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3334,7 +3318,6 @@ func (s DeleteComputeEnvironmentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3384,7 +3367,6 @@ func (s *DeleteJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3405,7 +3387,6 @@ func (s DeleteJobQueueOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3456,7 +3437,6 @@ func (s *DeregisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3477,7 +3457,6 @@ func (s DeregisterJobDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeregisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3555,7 +3534,6 @@ func (s *DescribeComputeEnvironmentsInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3607,7 +3585,6 @@ func (s *DescribeComputeEnvironmentsOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3712,7 +3689,6 @@ func (s *DescribeJobDefinitionsInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3764,7 +3740,6 @@ func (s *DescribeJobDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3841,7 +3816,6 @@ func (s *DescribeJobQueuesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3893,7 +3867,6 @@ func (s *DescribeJobQueuesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3943,7 +3916,6 @@ func (s *DescribeJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "jobs", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3978,7 +3950,6 @@ func (s *DescribeJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "jobs", encodeJobDetailList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4024,7 +3995,6 @@ func (s *Host) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sourcePath", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4170,7 +4140,6 @@ func (s *JobDefinition) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4214,7 +4183,6 @@ func (s *JobDependency) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4459,7 +4427,6 @@ func (s *JobDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4600,7 +4567,6 @@ func (s *JobQueueDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4662,7 +4628,6 @@ func (s *JobSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4722,7 +4687,6 @@ func (s *KeyValuePair) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4836,7 +4800,6 @@ func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4890,7 +4853,6 @@ func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4956,7 +4918,6 @@ func (s *MountPoint) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sourceVolume", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5086,7 +5047,6 @@ func (s *RegisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5155,7 +5115,6 @@ func (s *RegisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "revision", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5193,7 +5152,6 @@ func (s *RetryStrategy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "attempts", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5353,7 +5311,6 @@ func (s *SubmitJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5406,7 +5363,6 @@ func (s *SubmitJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5477,7 +5433,6 @@ func (s *TerminateJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5498,7 +5453,6 @@ func (s TerminateJobOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TerminateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5587,7 +5541,6 @@ func (s *Ulimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "softLimit", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5702,7 +5655,6 @@ func (s *UpdateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5751,7 +5703,6 @@ func (s *UpdateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5859,7 +5810,6 @@ func (s *UpdateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5908,7 +5858,6 @@ func (s *UpdateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5964,7 +5913,6 @@ func (s *Volume) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/batch/api.go
+++ b/service/batch/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCancelJob = "CancelJob"
@@ -1473,6 +1474,37 @@ func (s *AttemptContainerDetail) SetTaskArn(v string) *AttemptContainerDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttemptContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerInstanceArn != nil {
+		v := *s.ContainerInstanceArn
+
+		e.SetValue(protocol.BodyTarget, "containerInstanceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExitCode != nil {
+		v := *s.ExitCode
+
+		e.SetValue(protocol.BodyTarget, "exitCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LogStreamName != nil {
+		v := *s.LogStreamName
+
+		e.SetValue(protocol.BodyTarget, "logStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaskArn != nil {
+		v := *s.TaskArn
+
+		e.SetValue(protocol.BodyTarget, "taskArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An object representing a job attempt.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/AttemptDetail
 type AttemptDetail struct {
@@ -1526,6 +1558,40 @@ func (s *AttemptDetail) SetStatusReason(v string) *AttemptDetail {
 func (s *AttemptDetail) SetStoppedAt(v int64) *AttemptDetail {
 	s.StoppedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttemptDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Container != nil {
+		v := s.Container
+
+		e.SetFields(protocol.BodyTarget, "container", v, protocol.Metadata{})
+	}
+	if s.StartedAt != nil {
+		v := *s.StartedAt
+
+		e.SetValue(protocol.BodyTarget, "startedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StoppedAt != nil {
+		v := *s.StoppedAt
+
+		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttemptDetailList(vs []*AttemptDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CancelJobRequest
@@ -1583,6 +1649,22 @@ func (s *CancelJobInput) SetReason(v string) *CancelJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CancelJobResponse
 type CancelJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -1596,6 +1678,12 @@ func (s CancelJobOutput) String() string {
 // GoString returns the string representation
 func (s CancelJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // An object representing an AWS Batch compute environment.
@@ -1706,6 +1794,65 @@ func (s *ComputeEnvironmentDetail) SetType(v string) *ComputeEnvironmentDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeEnvironmentDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.EcsClusterArn != nil {
+		v := *s.EcsClusterArn
+
+		e.SetValue(protocol.BodyTarget, "ecsClusterArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeComputeEnvironmentDetailList(vs []*ComputeEnvironmentDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The order in which compute environments are tried for job placement within
 // a queue. Compute environments are tried in ascending order. For example,
 // if two compute environments are associated with a job queue, the compute
@@ -1761,6 +1908,30 @@ func (s *ComputeEnvironmentOrder) SetComputeEnvironment(v string) *ComputeEnviro
 func (s *ComputeEnvironmentOrder) SetOrder(v int64) *ComputeEnvironmentOrder {
 	s.Order = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeEnvironmentOrder) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.BodyTarget, "order", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeComputeEnvironmentOrderList(vs []*ComputeEnvironmentOrder) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An object representing an AWS Batch compute resource.
@@ -1956,6 +2127,77 @@ func (s *ComputeResource) SetType(v string) *ComputeResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BidPercentage != nil {
+		v := *s.BidPercentage
+
+		e.SetValue(protocol.BodyTarget, "bidPercentage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DesiredvCpus != nil {
+		v := *s.DesiredvCpus
+
+		e.SetValue(protocol.BodyTarget, "desiredvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Ec2KeyPair != nil {
+		v := *s.Ec2KeyPair
+
+		e.SetValue(protocol.BodyTarget, "ec2KeyPair", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageId != nil {
+		v := *s.ImageId
+
+		e.SetValue(protocol.BodyTarget, "imageId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceRole != nil {
+		v := *s.InstanceRole
+
+		e.SetValue(protocol.BodyTarget, "instanceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InstanceTypes) > 0 {
+		v := s.InstanceTypes
+
+		e.SetList(protocol.BodyTarget, "instanceTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxvCpus != nil {
+		v := *s.MaxvCpus
+
+		e.SetValue(protocol.BodyTarget, "maxvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinvCpus != nil {
+		v := *s.MinvCpus
+
+		e.SetValue(protocol.BodyTarget, "minvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "securityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SpotIamFleetRole != nil {
+		v := *s.SpotIamFleetRole
+
+		e.SetValue(protocol.BodyTarget, "spotIamFleetRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subnets) > 0 {
+		v := s.Subnets
+
+		e.SetList(protocol.BodyTarget, "subnets", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An object representing the attributes of a compute environment that can be
 // updated.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ComputeResourceUpdate
@@ -1998,6 +2240,27 @@ func (s *ComputeResourceUpdate) SetMaxvCpus(v int64) *ComputeResourceUpdate {
 func (s *ComputeResourceUpdate) SetMinvCpus(v int64) *ComputeResourceUpdate {
 	s.MinvCpus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ComputeResourceUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DesiredvCpus != nil {
+		v := *s.DesiredvCpus
+
+		e.SetValue(protocol.BodyTarget, "desiredvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxvCpus != nil {
+		v := *s.MaxvCpus
+
+		e.SetValue(protocol.BodyTarget, "maxvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinvCpus != nil {
+		v := *s.MinvCpus
+
+		e.SetValue(protocol.BodyTarget, "minvCpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An object representing the details of a container that is part of a job.
@@ -2180,6 +2443,97 @@ func (s *ContainerDetail) SetVolumes(v []*Volume) *ContainerDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ContainerInstanceArn != nil {
+		v := *s.ContainerInstanceArn
+
+		e.SetValue(protocol.BodyTarget, "containerInstanceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.ExitCode != nil {
+		v := *s.ExitCode
+
+		e.SetValue(protocol.BodyTarget, "exitCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Image != nil {
+		v := *s.Image
+
+		e.SetValue(protocol.BodyTarget, "image", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobRoleArn != nil {
+		v := *s.JobRoleArn
+
+		e.SetValue(protocol.BodyTarget, "jobRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogStreamName != nil {
+		v := *s.LogStreamName
+
+		e.SetValue(protocol.BodyTarget, "logStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.MountPoints) > 0 {
+		v := s.MountPoints
+
+		e.SetList(protocol.BodyTarget, "mountPoints", encodeMountPointList(v), protocol.Metadata{})
+	}
+	if s.Privileged != nil {
+		v := *s.Privileged
+
+		e.SetValue(protocol.BodyTarget, "privileged", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ReadonlyRootFilesystem != nil {
+		v := *s.ReadonlyRootFilesystem
+
+		e.SetValue(protocol.BodyTarget, "readonlyRootFilesystem", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaskArn != nil {
+		v := *s.TaskArn
+
+		e.SetValue(protocol.BodyTarget, "taskArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Ulimits) > 0 {
+		v := s.Ulimits
+
+		e.SetList(protocol.BodyTarget, "ulimits", encodeUlimitList(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := *s.User
+
+		e.SetValue(protocol.BodyTarget, "user", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Volumes) > 0 {
+		v := s.Volumes
+
+		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The overrides that should be sent to a container.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ContainerOverrides
 type ContainerOverrides struct {
@@ -2238,6 +2592,32 @@ func (s *ContainerOverrides) SetMemory(v int64) *ContainerOverrides {
 func (s *ContainerOverrides) SetVcpus(v int64) *ContainerOverrides {
 	s.Vcpus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerOverrides) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container properties are used in job definitions to describe the container
@@ -2462,6 +2842,72 @@ func (s *ContainerProperties) SetVolumes(v []*Volume) *ContainerProperties {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Command) > 0 {
+		v := s.Command
+
+		e.SetList(protocol.BodyTarget, "command", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Environment) > 0 {
+		v := s.Environment
+
+		e.SetList(protocol.BodyTarget, "environment", encodeKeyValuePairList(v), protocol.Metadata{})
+	}
+	if s.Image != nil {
+		v := *s.Image
+
+		e.SetValue(protocol.BodyTarget, "image", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobRoleArn != nil {
+		v := *s.JobRoleArn
+
+		e.SetValue(protocol.BodyTarget, "jobRoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Memory != nil {
+		v := *s.Memory
+
+		e.SetValue(protocol.BodyTarget, "memory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.MountPoints) > 0 {
+		v := s.MountPoints
+
+		e.SetList(protocol.BodyTarget, "mountPoints", encodeMountPointList(v), protocol.Metadata{})
+	}
+	if s.Privileged != nil {
+		v := *s.Privileged
+
+		e.SetValue(protocol.BodyTarget, "privileged", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ReadonlyRootFilesystem != nil {
+		v := *s.ReadonlyRootFilesystem
+
+		e.SetValue(protocol.BodyTarget, "readonlyRootFilesystem", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Ulimits) > 0 {
+		v := s.Ulimits
+
+		e.SetList(protocol.BodyTarget, "ulimits", encodeUlimitList(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := *s.User
+
+		e.SetValue(protocol.BodyTarget, "user", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Vcpus != nil {
+		v := *s.Vcpus
+
+		e.SetValue(protocol.BodyTarget, "vcpus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Volumes) > 0 {
+		v := s.Volumes
+
+		e.SetList(protocol.BodyTarget, "volumes", encodeVolumeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateComputeEnvironmentRequest
 type CreateComputeEnvironmentInput struct {
 	_ struct{} `type:"structure"`
@@ -2567,6 +3013,37 @@ func (s *CreateComputeEnvironmentInput) SetType(v string) *CreateComputeEnvironm
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateComputeEnvironmentResponse
 type CreateComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -2598,6 +3075,22 @@ func (s *CreateComputeEnvironmentOutput) SetComputeEnvironmentArn(v string) *Cre
 func (s *CreateComputeEnvironmentOutput) SetComputeEnvironmentName(v string) *CreateComputeEnvironmentOutput {
 	s.ComputeEnvironmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateJobQueueRequest
@@ -2695,6 +3188,32 @@ func (s *CreateJobQueueInput) SetState(v string) *CreateJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/CreateJobQueueResponse
 type CreateJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -2730,6 +3249,22 @@ func (s *CreateJobQueueOutput) SetJobQueueArn(v string) *CreateJobQueueOutput {
 func (s *CreateJobQueueOutput) SetJobQueueName(v string) *CreateJobQueueOutput {
 	s.JobQueueName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteComputeEnvironmentRequest
@@ -2771,6 +3306,17 @@ func (s *DeleteComputeEnvironmentInput) SetComputeEnvironment(v string) *DeleteC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteComputeEnvironmentResponse
 type DeleteComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -2784,6 +3330,12 @@ func (s DeleteComputeEnvironmentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteComputeEnvironmentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteJobQueueRequest
@@ -2825,6 +3377,17 @@ func (s *DeleteJobQueueInput) SetJobQueue(v string) *DeleteJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeleteJobQueueResponse
 type DeleteJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -2838,6 +3401,12 @@ func (s DeleteJobQueueOutput) String() string {
 // GoString returns the string representation
 func (s DeleteJobQueueOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeregisterJobDefinitionRequest
@@ -2880,6 +3449,17 @@ func (s *DeregisterJobDefinitionInput) SetJobDefinition(v string) *DeregisterJob
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeregisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DeregisterJobDefinitionResponse
 type DeregisterJobDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -2893,6 +3473,12 @@ func (s DeregisterJobDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeregisterJobDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeregisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeComputeEnvironmentsRequest
@@ -2952,6 +3538,27 @@ func (s *DescribeComputeEnvironmentsInput) SetNextToken(v string) *DescribeCompu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeComputeEnvironmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironments) > 0 {
+		v := s.ComputeEnvironments
+
+		e.SetList(protocol.BodyTarget, "computeEnvironments", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeComputeEnvironmentsResponse
 type DescribeComputeEnvironmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2986,6 +3593,22 @@ func (s *DescribeComputeEnvironmentsOutput) SetComputeEnvironments(v []*ComputeE
 func (s *DescribeComputeEnvironmentsOutput) SetNextToken(v string) *DescribeComputeEnvironmentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeComputeEnvironmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironments) > 0 {
+		v := s.ComputeEnvironments
+
+		e.SetList(protocol.BodyTarget, "computeEnvironments", encodeComputeEnvironmentDetailList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobDefinitionsRequest
@@ -3062,6 +3685,37 @@ func (s *DescribeJobDefinitionsInput) SetStatus(v string) *DescribeJobDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.JobDefinitions) > 0 {
+		v := s.JobDefinitions
+
+		e.SetList(protocol.BodyTarget, "jobDefinitions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobDefinitionsResponse
 type DescribeJobDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3096,6 +3750,22 @@ func (s *DescribeJobDefinitionsOutput) SetJobDefinitions(v []*JobDefinition) *De
 func (s *DescribeJobDefinitionsOutput) SetNextToken(v string) *DescribeJobDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobDefinitions) > 0 {
+		v := s.JobDefinitions
+
+		e.SetList(protocol.BodyTarget, "jobDefinitions", encodeJobDefinitionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobQueuesRequest
@@ -3154,6 +3824,27 @@ func (s *DescribeJobQueuesInput) SetNextToken(v string) *DescribeJobQueuesInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobQueuesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobQueues) > 0 {
+		v := s.JobQueues
+
+		e.SetList(protocol.BodyTarget, "jobQueues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobQueuesResponse
 type DescribeJobQueuesOutput struct {
 	_ struct{} `type:"structure"`
@@ -3188,6 +3879,22 @@ func (s *DescribeJobQueuesOutput) SetJobQueues(v []*JobQueueDetail) *DescribeJob
 func (s *DescribeJobQueuesOutput) SetNextToken(v string) *DescribeJobQueuesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobQueuesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobQueues) > 0 {
+		v := s.JobQueues
+
+		e.SetList(protocol.BodyTarget, "jobQueues", encodeJobQueueDetailList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobsRequest
@@ -3229,6 +3936,17 @@ func (s *DescribeJobsInput) SetJobs(v []*string) *DescribeJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "jobs", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/DescribeJobsResponse
 type DescribeJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3251,6 +3969,17 @@ func (s DescribeJobsOutput) GoString() string {
 func (s *DescribeJobsOutput) SetJobs(v []*JobDetail) *DescribeJobsOutput {
 	s.Jobs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "jobs", encodeJobDetailList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The contents of the host parameter determine whether your data volume persists
@@ -3286,6 +4015,17 @@ func (s Host) GoString() string {
 func (s *Host) SetSourcePath(v string) *Host {
 	s.SourcePath = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Host) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SourcePath != nil {
+		v := *s.SourcePath
+
+		e.SetValue(protocol.BodyTarget, "sourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An object representing an AWS Batch job definition.
@@ -3388,6 +4128,60 @@ func (s *JobDefinition) SetType(v string) *JobDefinition {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerProperties != nil {
+		v := s.ContainerProperties
+
+		e.SetFields(protocol.BodyTarget, "containerProperties", v, protocol.Metadata{})
+	}
+	if s.JobDefinitionArn != nil {
+		v := *s.JobDefinitionArn
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.Revision != nil {
+		v := *s.Revision
+
+		e.SetValue(protocol.BodyTarget, "revision", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDefinitionList(vs []*JobDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing an AWS Batch job dependency.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobDependency
 type JobDependency struct {
@@ -3411,6 +4205,25 @@ func (s JobDependency) GoString() string {
 func (s *JobDependency) SetJobId(v string) *JobDependency {
 	s.JobId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDependency) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDependencyList(vs []*JobDependency) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An object representing an AWS Batch job.
@@ -3574,6 +4387,90 @@ func (s *JobDetail) SetStoppedAt(v int64) *JobDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attempts) > 0 {
+		v := s.Attempts
+
+		e.SetList(protocol.BodyTarget, "attempts", encodeAttemptDetailList(v), protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := s.Container
+
+		e.SetFields(protocol.BodyTarget, "container", v, protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.DependsOn) > 0 {
+		v := s.DependsOn
+
+		e.SetList(protocol.BodyTarget, "dependsOn", encodeJobDependencyList(v), protocol.Metadata{})
+	}
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.StartedAt != nil {
+		v := *s.StartedAt
+
+		e.SetValue(protocol.BodyTarget, "startedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StoppedAt != nil {
+		v := *s.StoppedAt
+
+		e.SetValue(protocol.BodyTarget, "stoppedAt", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDetailList(vs []*JobDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing the details of an AWS Batch job queue.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobQueueDetail
 type JobQueueDetail struct {
@@ -3666,6 +4563,55 @@ func (s *JobQueueDetail) SetStatusReason(v string) *JobQueueDetail {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobQueueDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReason != nil {
+		v := *s.StatusReason
+
+		e.SetValue(protocol.BodyTarget, "statusReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobQueueDetailList(vs []*JobQueueDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // An object representing summary details of a job.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/JobSummary
 type JobSummary struct {
@@ -3704,6 +4650,30 @@ func (s *JobSummary) SetJobName(v string) *JobSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobSummaryList(vs []*JobSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A key-value pair object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/KeyValuePair
 type KeyValuePair struct {
@@ -3738,6 +4708,30 @@ func (s *KeyValuePair) SetName(v string) *KeyValuePair {
 func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyValuePair) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeKeyValuePairList(vs []*KeyValuePair) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ListJobsRequest
@@ -3820,6 +4814,32 @@ func (s *ListJobsInput) SetNextToken(v string) *ListJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobStatus != nil {
+		v := *s.JobStatus
+
+		e.SetValue(protocol.BodyTarget, "jobStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/ListJobsResponse
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3856,6 +4876,22 @@ func (s *ListJobsOutput) SetJobSummaryList(v []*JobSummary) *ListJobsOutput {
 func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobSummaryList) > 0 {
+		v := s.JobSummaryList
+
+		e.SetList(protocol.BodyTarget, "jobSummaryList", encodeJobSummaryList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Details on a Docker volume mount point that is used in a job's container
@@ -3901,6 +4937,35 @@ func (s *MountPoint) SetReadOnly(v bool) *MountPoint {
 func (s *MountPoint) SetSourceVolume(v string) *MountPoint {
 	s.SourceVolume = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MountPoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerPath != nil {
+		v := *s.ContainerPath
+
+		e.SetValue(protocol.BodyTarget, "containerPath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReadOnly != nil {
+		v := *s.ReadOnly
+
+		e.SetValue(protocol.BodyTarget, "readOnly", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SourceVolume != nil {
+		v := *s.SourceVolume
+
+		e.SetValue(protocol.BodyTarget, "sourceVolume", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMountPointList(vs []*MountPoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RegisterJobDefinitionRequest
@@ -3994,6 +5059,37 @@ func (s *RegisterJobDefinitionInput) SetType(v string) *RegisterJobDefinitionInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterJobDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerProperties != nil {
+		v := s.ContainerProperties
+
+		e.SetFields(protocol.BodyTarget, "containerProperties", v, protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RegisterJobDefinitionResponse
 type RegisterJobDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4042,6 +5138,27 @@ func (s *RegisterJobDefinitionOutput) SetRevision(v int64) *RegisterJobDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterJobDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobDefinitionArn != nil {
+		v := *s.JobDefinitionArn
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobDefinitionName != nil {
+		v := *s.JobDefinitionName
+
+		e.SetValue(protocol.BodyTarget, "jobDefinitionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Revision != nil {
+		v := *s.Revision
+
+		e.SetValue(protocol.BodyTarget, "revision", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The retry strategy associated with a job.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/RetryStrategy
 type RetryStrategy struct {
@@ -4067,6 +5184,17 @@ func (s RetryStrategy) GoString() string {
 func (s *RetryStrategy) SetAttempts(v int64) *RetryStrategy {
 	s.Attempts = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RetryStrategy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attempts != nil {
+		v := *s.Attempts
+
+		e.SetValue(protocol.BodyTarget, "attempts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/SubmitJobRequest
@@ -4188,6 +5316,47 @@ func (s *SubmitJobInput) SetRetryStrategy(v *RetryStrategy) *SubmitJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubmitJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerOverrides != nil {
+		v := s.ContainerOverrides
+
+		e.SetFields(protocol.BodyTarget, "containerOverrides", v, protocol.Metadata{})
+	}
+	if len(s.DependsOn) > 0 {
+		v := s.DependsOn
+
+		e.SetList(protocol.BodyTarget, "dependsOn", encodeJobDependencyList(v), protocol.Metadata{})
+	}
+	if s.JobDefinition != nil {
+		v := *s.JobDefinition
+
+		e.SetValue(protocol.BodyTarget, "jobDefinition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RetryStrategy != nil {
+		v := s.RetryStrategy
+
+		e.SetFields(protocol.BodyTarget, "retryStrategy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/SubmitJobResponse
 type SubmitJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4223,6 +5392,22 @@ func (s *SubmitJobOutput) SetJobId(v string) *SubmitJobOutput {
 func (s *SubmitJobOutput) SetJobName(v string) *SubmitJobOutput {
 	s.JobName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubmitJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobName != nil {
+		v := *s.JobName
+
+		e.SetValue(protocol.BodyTarget, "jobName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/TerminateJobRequest
@@ -4280,6 +5465,22 @@ func (s *TerminateJobInput) SetReason(v string) *TerminateJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TerminateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reason != nil {
+		v := *s.Reason
+
+		e.SetValue(protocol.BodyTarget, "reason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/TerminateJobResponse
 type TerminateJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -4293,6 +5494,12 @@ func (s TerminateJobOutput) String() string {
 // GoString returns the string representation
 func (s TerminateJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TerminateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The ulimit settings to pass to the container.
@@ -4361,6 +5568,35 @@ func (s *Ulimit) SetName(v string) *Ulimit {
 func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
 	s.SoftLimit = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Ulimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HardLimit != nil {
+		v := *s.HardLimit
+
+		e.SetValue(protocol.BodyTarget, "hardLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SoftLimit != nil {
+		v := *s.SoftLimit
+
+		e.SetValue(protocol.BodyTarget, "softLimit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUlimitList(vs []*Ulimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateComputeEnvironmentRequest
@@ -4444,6 +5680,32 @@ func (s *UpdateComputeEnvironmentInput) SetState(v string) *UpdateComputeEnviron
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateComputeEnvironmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironment != nil {
+		v := *s.ComputeEnvironment
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeResources != nil {
+		v := s.ComputeResources
+
+		e.SetFields(protocol.BodyTarget, "computeResources", v, protocol.Metadata{})
+	}
+	if s.ServiceRole != nil {
+		v := *s.ServiceRole
+
+		e.SetValue(protocol.BodyTarget, "serviceRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateComputeEnvironmentResponse
 type UpdateComputeEnvironmentOutput struct {
 	_ struct{} `type:"structure"`
@@ -4475,6 +5737,22 @@ func (s *UpdateComputeEnvironmentOutput) SetComputeEnvironmentArn(v string) *Upd
 func (s *UpdateComputeEnvironmentOutput) SetComputeEnvironmentName(v string) *UpdateComputeEnvironmentOutput {
 	s.ComputeEnvironmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateComputeEnvironmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComputeEnvironmentArn != nil {
+		v := *s.ComputeEnvironmentArn
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ComputeEnvironmentName != nil {
+		v := *s.ComputeEnvironmentName
+
+		e.SetValue(protocol.BodyTarget, "computeEnvironmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateJobQueueRequest
@@ -4559,6 +5837,32 @@ func (s *UpdateJobQueueInput) SetState(v string) *UpdateJobQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ComputeEnvironmentOrder) > 0 {
+		v := s.ComputeEnvironmentOrder
+
+		e.SetList(protocol.BodyTarget, "computeEnvironmentOrder", encodeComputeEnvironmentOrderList(v), protocol.Metadata{})
+	}
+	if s.JobQueue != nil {
+		v := *s.JobQueue
+
+		e.SetValue(protocol.BodyTarget, "jobQueue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/batch-2016-08-10/UpdateJobQueueResponse
 type UpdateJobQueueOutput struct {
 	_ struct{} `type:"structure"`
@@ -4590,6 +5894,22 @@ func (s *UpdateJobQueueOutput) SetJobQueueArn(v string) *UpdateJobQueueOutput {
 func (s *UpdateJobQueueOutput) SetJobQueueName(v string) *UpdateJobQueueOutput {
 	s.JobQueueName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobQueueArn != nil {
+		v := *s.JobQueueArn
+
+		e.SetValue(protocol.BodyTarget, "jobQueueArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobQueueName != nil {
+		v := *s.JobQueueName
+
+		e.SetValue(protocol.BodyTarget, "jobQueueName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A data volume used in a job's container properties.
@@ -4630,6 +5950,30 @@ func (s *Volume) SetHost(v *Host) *Volume {
 func (s *Volume) SetName(v string) *Volume {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Volume) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Host != nil {
+		v := s.Host
+
+		e.SetFields(protocol.BodyTarget, "host", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVolumeList(vs []*Volume) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -7903,6 +7903,32 @@ func (s *AddFacetToObjectInput) SetSchemaFacet(v *SchemaFacet) *AddFacetToObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddFacetToObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AddFacetToObjectResponse
 type AddFacetToObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -7916,6 +7942,12 @@ func (s AddFacetToObjectOutput) String() string {
 // GoString returns the string representation
 func (s AddFacetToObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddFacetToObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ApplySchemaRequest
@@ -7973,6 +8005,22 @@ func (s *ApplySchemaInput) SetPublishedSchemaArn(v string) *ApplySchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplySchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PublishedSchemaArn != nil {
+		v := *s.PublishedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ApplySchemaResponse
 type ApplySchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -8007,6 +8055,22 @@ func (s *ApplySchemaOutput) SetAppliedSchemaArn(v string) *ApplySchemaOutput {
 func (s *ApplySchemaOutput) SetDirectoryArn(v string) *ApplySchemaOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplySchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppliedSchemaArn != nil {
+		v := *s.AppliedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "AppliedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachObjectRequest
@@ -8094,6 +8158,32 @@ func (s *AttachObjectInput) SetParentReference(v *ObjectReference) *AttachObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChildReference != nil {
+		v := s.ChildReference
+
+		e.SetFields(protocol.BodyTarget, "ChildReference", v, protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachObjectResponse
 type AttachObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -8116,6 +8206,17 @@ func (s AttachObjectOutput) GoString() string {
 func (s *AttachObjectOutput) SetAttachedObjectIdentifier(v string) *AttachObjectOutput {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachPolicyRequest
@@ -8181,6 +8282,27 @@ func (s *AttachPolicyInput) SetPolicyReference(v *ObjectReference) *AttachPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachPolicyResponse
 type AttachPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -8194,6 +8316,12 @@ func (s AttachPolicyOutput) String() string {
 // GoString returns the string representation
 func (s AttachPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachToIndexRequest
@@ -8264,6 +8392,27 @@ func (s *AttachToIndexInput) SetTargetReference(v *ObjectReference) *AttachToInd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachToIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachToIndexResponse
 type AttachToIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -8286,6 +8435,17 @@ func (s AttachToIndexOutput) GoString() string {
 func (s *AttachToIndexOutput) SetAttachedObjectIdentifier(v string) *AttachToIndexOutput {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachToIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkRequest
@@ -8399,6 +8559,37 @@ func (s *AttachTypedLinkInput) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttachTypedLinkResponse
 type AttachTypedLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -8421,6 +8612,17 @@ func (s AttachTypedLinkOutput) GoString() string {
 func (s *AttachTypedLinkOutput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *AttachTypedLinkOutput {
 	s.TypedLinkSpecifier = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A unique identifier for an attribute.
@@ -8498,6 +8700,35 @@ func (s *AttributeKey) SetSchemaArn(v string) *AttributeKey {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeKey) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetName != nil {
+		v := *s.FacetName
+
+		e.SetValue(protocol.BodyTarget, "FacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeKeyList(vs []*AttributeKey) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The combination of an attribute key and an attribute value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeKeyAndValue
 type AttributeKeyAndValue struct {
@@ -8557,6 +8788,30 @@ func (s *AttributeKeyAndValue) SetValue(v *TypedAttributeValue) *AttributeKeyAnd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeKeyAndValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := s.Key
+
+		e.SetFields(protocol.BodyTarget, "Key", v, protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := s.Value
+
+		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeKeyAndValueList(vs []*AttributeKeyAndValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the attribute name and value for a typed link.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/AttributeNameAndValue
 type AttributeNameAndValue struct {
@@ -8612,6 +8867,30 @@ func (s *AttributeNameAndValue) SetAttributeName(v string) *AttributeNameAndValu
 func (s *AttributeNameAndValue) SetValue(v *TypedAttributeValue) *AttributeNameAndValue {
 	s.Value = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeNameAndValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.BodyTarget, "AttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := s.Value
+
+		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeNameAndValueList(vs []*AttributeNameAndValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Represents the output of a batch add facet to object operation.
@@ -8697,6 +8976,27 @@ func (s *BatchAddFacetToObject) SetSchemaFacet(v *SchemaFacet) *BatchAddFacetToO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAddFacetToObject) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a batch add facet to object operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAddFacetToObjectResponse
 type BatchAddFacetToObjectResponse struct {
@@ -8711,6 +9011,12 @@ func (s BatchAddFacetToObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchAddFacetToObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAddFacetToObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the output of an AttachObject operation.
@@ -8784,6 +9090,27 @@ func (s *BatchAttachObject) SetParentReference(v *ObjectReference) *BatchAttachO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChildReference != nil {
+		v := s.ChildReference
+
+		e.SetFields(protocol.BodyTarget, "ChildReference", v, protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output batch AttachObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachObjectResponse
 type BatchAttachObjectResponse struct {
@@ -8807,6 +9134,17 @@ func (s BatchAttachObjectResponse) GoString() string {
 func (s *BatchAttachObjectResponse) SetAttachedObjectIdentifier(v string) *BatchAttachObjectResponse {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "attachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Attaches a policy object to a regular object inside a BatchRead operation. For
@@ -8864,6 +9202,22 @@ func (s *BatchAttachPolicy) SetPolicyReference(v *ObjectReference) *BatchAttachP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of an AttachPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachPolicyResponse
 type BatchAttachPolicyResponse struct {
@@ -8878,6 +9232,12 @@ func (s BatchAttachPolicyResponse) String() string {
 // GoString returns the string representation
 func (s BatchAttachPolicyResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Attaches the specified object to the specified index inside a BatchRead operation.
@@ -8935,6 +9295,22 @@ func (s *BatchAttachToIndex) SetTargetReference(v *ObjectReference) *BatchAttach
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachToIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a AttachToIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachToIndexResponse
 type BatchAttachToIndexResponse struct {
@@ -8958,6 +9334,17 @@ func (s BatchAttachToIndexResponse) GoString() string {
 func (s *BatchAttachToIndexResponse) SetAttachedObjectIdentifier(v string) *BatchAttachToIndexResponse {
 	s.AttachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachToIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachedObjectIdentifier != nil {
+		v := *s.AttachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Attaches a typed link to a specified source and target object inside a BatchRead
@@ -9058,6 +9445,32 @@ func (s *BatchAttachTypedLink) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a AttachTypedLink response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchAttachTypedLinkResponse
 type BatchAttachTypedLinkResponse struct {
@@ -9081,6 +9494,17 @@ func (s BatchAttachTypedLinkResponse) GoString() string {
 func (s *BatchAttachTypedLinkResponse) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *BatchAttachTypedLinkResponse {
 	s.TypedLinkSpecifier = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchAttachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Creates an index object inside of a BatchRead operation. For more information,
@@ -9181,6 +9605,37 @@ func (s *BatchCreateIndex) SetParentReference(v *ObjectReference) *BatchCreateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsUnique != nil {
+		v := *s.IsUnique
+
+		e.SetValue(protocol.BodyTarget, "IsUnique", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OrderedIndexedAttributeList) > 0 {
+		v := s.OrderedIndexedAttributeList
+
+		e.SetList(protocol.BodyTarget, "OrderedIndexedAttributeList", encodeAttributeKeyList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a CreateIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchCreateIndexResponse
 type BatchCreateIndexResponse struct {
@@ -9204,6 +9659,17 @@ func (s BatchCreateIndexResponse) GoString() string {
 func (s *BatchCreateIndexResponse) SetObjectIdentifier(v string) *BatchCreateIndexResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a CreateObject operation.
@@ -9328,6 +9794,37 @@ func (s *BatchCreateObject) SetSchemaFacet(v []*SchemaFacet) *BatchCreateObject 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+	if len(s.SchemaFacet) > 0 {
+		v := s.SchemaFacet
+
+		e.SetList(protocol.BodyTarget, "SchemaFacet", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a CreateObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchCreateObjectResponse
 type BatchCreateObjectResponse struct {
@@ -9351,6 +9848,17 @@ func (s BatchCreateObjectResponse) GoString() string {
 func (s *BatchCreateObjectResponse) SetObjectIdentifier(v string) *BatchCreateObjectResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchCreateObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a DeleteObject operation.
@@ -9393,6 +9901,17 @@ func (s *BatchDeleteObject) SetObjectReference(v *ObjectReference) *BatchDeleteO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDeleteObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DeleteObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDeleteObjectResponse
 type BatchDeleteObjectResponse struct {
@@ -9407,6 +9926,12 @@ func (s BatchDeleteObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchDeleteObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDeleteObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Detaches the specified object from the specified index inside a BatchRead
@@ -9464,6 +9989,22 @@ func (s *BatchDetachFromIndex) SetTargetReference(v *ObjectReference) *BatchDeta
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachFromIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachFromIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachFromIndexResponse
 type BatchDetachFromIndexResponse struct {
@@ -9487,6 +10028,17 @@ func (s BatchDetachFromIndexResponse) GoString() string {
 func (s *BatchDetachFromIndexResponse) SetDetachedObjectIdentifier(v string) *BatchDetachFromIndexResponse {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachFromIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a DetachObject operation.
@@ -9561,6 +10113,27 @@ func (s *BatchDetachObject) SetParentReference(v *ObjectReference) *BatchDetachO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchReferenceName != nil {
+		v := *s.BatchReferenceName
+
+		e.SetValue(protocol.BodyTarget, "BatchReferenceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachObject response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachObjectResponse
 type BatchDetachObjectResponse struct {
@@ -9584,6 +10157,17 @@ func (s BatchDetachObjectResponse) GoString() string {
 func (s *BatchDetachObjectResponse) SetDetachedObjectIdentifier(v string) *BatchDetachObjectResponse {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "detachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Detaches the specified policy from the specified directory inside a BatchRead
@@ -9641,6 +10225,22 @@ func (s *BatchDetachPolicy) SetPolicyReference(v *ObjectReference) *BatchDetachP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachPolicyResponse
 type BatchDetachPolicyResponse struct {
@@ -9655,6 +10255,12 @@ func (s BatchDetachPolicyResponse) String() string {
 // GoString returns the string representation
 func (s BatchDetachPolicyResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Detaches a typed link from a specified source and target object inside a
@@ -9703,6 +10309,17 @@ func (s *BatchDetachTypedLink) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a DetachTypedLink response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchDetachTypedLinkResponse
 type BatchDetachTypedLinkResponse struct {
@@ -9717,6 +10334,12 @@ func (s BatchDetachTypedLinkResponse) String() string {
 // GoString returns the string representation
 func (s BatchDetachTypedLinkResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchDetachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Retrieves metadata about an object inside a BatchRead operation. For more
@@ -9760,6 +10383,17 @@ func (s *BatchGetObjectInformation) SetObjectReference(v *ObjectReference) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetObjectInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a GetObjectInformation response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchGetObjectInformationResponse
 type BatchGetObjectInformationResponse struct {
@@ -9792,6 +10426,22 @@ func (s *BatchGetObjectInformationResponse) SetObjectIdentifier(v string) *Batch
 func (s *BatchGetObjectInformationResponse) SetSchemaFacets(v []*SchemaFacet) *BatchGetObjectInformationResponse {
 	s.SchemaFacets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetObjectInformationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists indices attached to an object inside a BatchRead operation. For more
@@ -9856,6 +10506,27 @@ func (s *BatchListAttachedIndices) SetTargetReference(v *ObjectReference) *Batch
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListAttachedIndices) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListAttachedIndices response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListAttachedIndicesResponse
 type BatchListAttachedIndicesResponse struct {
@@ -9888,6 +10559,22 @@ func (s *BatchListAttachedIndicesResponse) SetIndexAttachments(v []*IndexAttachm
 func (s *BatchListAttachedIndicesResponse) SetNextToken(v string) *BatchListAttachedIndicesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListAttachedIndicesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns a paginated list of all the incoming TypedLinkSpecifier information
@@ -9990,6 +10677,37 @@ func (s *BatchListIncomingTypedLinks) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIncomingTypedLinks) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListIncomingTypedLinks response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListIncomingTypedLinksResponse
 type BatchListIncomingTypedLinksResponse struct {
@@ -10022,6 +10740,22 @@ func (s *BatchListIncomingTypedLinksResponse) SetLinkSpecifiers(v []*TypedLinkSp
 func (s *BatchListIncomingTypedLinksResponse) SetNextToken(v string) *BatchListIncomingTypedLinksResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIncomingTypedLinksResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LinkSpecifiers) > 0 {
+		v := s.LinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "LinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists objects attached to the specified index inside a BatchRead operation.
@@ -10105,6 +10839,32 @@ func (s *BatchListIndex) SetRangesOnIndexedValues(v []*ObjectAttributeRange) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIndex) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RangesOnIndexedValues) > 0 {
+		v := s.RangesOnIndexedValues
+
+		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListIndex response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListIndexResponse
 type BatchListIndexResponse struct {
@@ -10137,6 +10897,22 @@ func (s *BatchListIndexResponse) SetIndexAttachments(v []*IndexAttachment) *Batc
 func (s *BatchListIndexResponse) SetNextToken(v string) *BatchListIndexResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a ListObjectAttributes operation.
@@ -10216,6 +10992,32 @@ func (s *BatchListObjectAttributes) SetObjectReference(v *ObjectReference) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetFilter != nil {
+		v := s.FacetFilter
+
+		e.SetFields(protocol.BodyTarget, "FacetFilter", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectAttributes response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectAttributesResponse
 type BatchListObjectAttributesResponse struct {
@@ -10249,6 +11051,22 @@ func (s *BatchListObjectAttributesResponse) SetAttributes(v []*AttributeKeyAndVa
 func (s *BatchListObjectAttributesResponse) SetNextToken(v string) *BatchListObjectAttributesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectAttributesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a ListObjectChildren operation.
@@ -10313,6 +11131,27 @@ func (s *BatchListObjectChildren) SetObjectReference(v *ObjectReference) *BatchL
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectChildren) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectChildren response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectChildrenResponse
 type BatchListObjectChildrenResponse struct {
@@ -10346,6 +11185,22 @@ func (s *BatchListObjectChildrenResponse) SetChildren(v map[string]*string) *Bat
 func (s *BatchListObjectChildrenResponse) SetNextToken(v string) *BatchListObjectChildrenResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectChildrenResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Children) > 0 {
+		v := s.Children
+
+		e.SetMap(protocol.BodyTarget, "Children", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Retrieves all available parent paths for any object type such as node, leaf
@@ -10411,6 +11266,27 @@ func (s *BatchListObjectParentPaths) SetObjectReference(v *ObjectReference) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectParentPaths) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectParentPaths response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectParentPathsResponse
 type BatchListObjectParentPathsResponse struct {
@@ -10443,6 +11319,22 @@ func (s *BatchListObjectParentPathsResponse) SetNextToken(v string) *BatchListOb
 func (s *BatchListObjectParentPathsResponse) SetPathToObjectIdentifiersList(v []*PathToObjectIdentifiers) *BatchListObjectParentPathsResponse {
 	s.PathToObjectIdentifiersList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectParentPathsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PathToObjectIdentifiersList) > 0 {
+		v := s.PathToObjectIdentifiersList
+
+		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns policies attached to an object in pagination fashion inside a BatchRead
@@ -10507,6 +11399,27 @@ func (s *BatchListObjectPolicies) SetObjectReference(v *ObjectReference) *BatchL
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectPolicies) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListObjectPolicies response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListObjectPoliciesResponse
 type BatchListObjectPoliciesResponse struct {
@@ -10539,6 +11452,22 @@ func (s *BatchListObjectPoliciesResponse) SetAttachedPolicyIds(v []*string) *Bat
 func (s *BatchListObjectPoliciesResponse) SetNextToken(v string) *BatchListObjectPoliciesResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListObjectPoliciesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttachedPolicyIds) > 0 {
+		v := s.AttachedPolicyIds
+
+		e.SetList(protocol.BodyTarget, "AttachedPolicyIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns a paginated list of all the outgoing TypedLinkSpecifier information
@@ -10641,6 +11570,37 @@ func (s *BatchListOutgoingTypedLinks) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListOutgoingTypedLinks) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListOutgoingTypedLinks response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListOutgoingTypedLinksResponse
 type BatchListOutgoingTypedLinksResponse struct {
@@ -10673,6 +11633,22 @@ func (s *BatchListOutgoingTypedLinksResponse) SetNextToken(v string) *BatchListO
 func (s *BatchListOutgoingTypedLinksResponse) SetTypedLinkSpecifiers(v []*TypedLinkSpecifier) *BatchListOutgoingTypedLinksResponse {
 	s.TypedLinkSpecifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListOutgoingTypedLinksResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TypedLinkSpecifiers) > 0 {
+		v := s.TypedLinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returns all of the ObjectIdentifiers to which a given policy is attached
@@ -10738,6 +11714,27 @@ func (s *BatchListPolicyAttachments) SetPolicyReference(v *ObjectReference) *Bat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListPolicyAttachments) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a ListPolicyAttachments response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchListPolicyAttachmentsResponse
 type BatchListPolicyAttachmentsResponse struct {
@@ -10770,6 +11767,22 @@ func (s *BatchListPolicyAttachmentsResponse) SetNextToken(v string) *BatchListPo
 func (s *BatchListPolicyAttachmentsResponse) SetObjectIdentifiers(v []*string) *BatchListPolicyAttachmentsResponse {
 	s.ObjectIdentifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchListPolicyAttachmentsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists all policies from the root of the Directory to the object specified
@@ -10835,6 +11848,27 @@ func (s *BatchLookupPolicy) SetObjectReference(v *ObjectReference) *BatchLookupP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchLookupPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a LookupPolicy response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchLookupPolicyResponse
 type BatchLookupPolicyResponse struct {
@@ -10870,6 +11904,22 @@ func (s *BatchLookupPolicyResponse) SetPolicyToPathList(v []*PolicyToPath) *Batc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchLookupPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PolicyToPathList) > 0 {
+		v := s.PolicyToPathList
+
+		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The batch read exception structure, which contains the exception type and
 // message.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadException
@@ -10903,6 +11953,22 @@ func (s *BatchReadException) SetMessage(v string) *BatchReadException {
 func (s *BatchReadException) SetType(v string) *BatchReadException {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadException) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadRequest
@@ -10977,6 +12043,27 @@ func (s *BatchReadInput) SetDirectoryArn(v string) *BatchReadInput {
 func (s *BatchReadInput) SetOperations(v []*BatchReadOperation) *BatchReadInput {
 	s.Operations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Operations) > 0 {
+		v := s.Operations
+
+		e.SetList(protocol.BodyTarget, "Operations", encodeBatchReadOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchRead operation.
@@ -11172,6 +12259,75 @@ func (s *BatchReadOperation) SetLookupPolicy(v *BatchLookupPolicy) *BatchReadOpe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GetObjectInformation != nil {
+		v := s.GetObjectInformation
+
+		e.SetFields(protocol.BodyTarget, "GetObjectInformation", v, protocol.Metadata{})
+	}
+	if s.ListAttachedIndices != nil {
+		v := s.ListAttachedIndices
+
+		e.SetFields(protocol.BodyTarget, "ListAttachedIndices", v, protocol.Metadata{})
+	}
+	if s.ListIncomingTypedLinks != nil {
+		v := s.ListIncomingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListIncomingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListIndex != nil {
+		v := s.ListIndex
+
+		e.SetFields(protocol.BodyTarget, "ListIndex", v, protocol.Metadata{})
+	}
+	if s.ListObjectAttributes != nil {
+		v := s.ListObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "ListObjectAttributes", v, protocol.Metadata{})
+	}
+	if s.ListObjectChildren != nil {
+		v := s.ListObjectChildren
+
+		e.SetFields(protocol.BodyTarget, "ListObjectChildren", v, protocol.Metadata{})
+	}
+	if s.ListObjectParentPaths != nil {
+		v := s.ListObjectParentPaths
+
+		e.SetFields(protocol.BodyTarget, "ListObjectParentPaths", v, protocol.Metadata{})
+	}
+	if s.ListObjectPolicies != nil {
+		v := s.ListObjectPolicies
+
+		e.SetFields(protocol.BodyTarget, "ListObjectPolicies", v, protocol.Metadata{})
+	}
+	if s.ListOutgoingTypedLinks != nil {
+		v := s.ListOutgoingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListOutgoingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListPolicyAttachments != nil {
+		v := s.ListPolicyAttachments
+
+		e.SetFields(protocol.BodyTarget, "ListPolicyAttachments", v, protocol.Metadata{})
+	}
+	if s.LookupPolicy != nil {
+		v := s.LookupPolicy
+
+		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchReadOperationList(vs []*BatchReadOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the output of a BatchRead response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadOperationResponse
 type BatchReadOperationResponse struct {
@@ -11206,6 +12362,30 @@ func (s *BatchReadOperationResponse) SetSuccessfulResponse(v *BatchReadSuccessfu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOperationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExceptionResponse != nil {
+		v := s.ExceptionResponse
+
+		e.SetFields(protocol.BodyTarget, "ExceptionResponse", v, protocol.Metadata{})
+	}
+	if s.SuccessfulResponse != nil {
+		v := s.SuccessfulResponse
+
+		e.SetFields(protocol.BodyTarget, "SuccessfulResponse", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchReadOperationResponseList(vs []*BatchReadOperationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchReadResponse
 type BatchReadOutput struct {
 	_ struct{} `type:"structure"`
@@ -11228,6 +12408,17 @@ func (s BatchReadOutput) GoString() string {
 func (s *BatchReadOutput) SetResponses(v []*BatchReadOperationResponse) *BatchReadOutput {
 	s.Responses = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Responses) > 0 {
+		v := s.Responses
+
+		e.SetList(protocol.BodyTarget, "Responses", encodeBatchReadOperationResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchRead success response operation.
@@ -11358,6 +12549,67 @@ func (s *BatchReadSuccessfulResponse) SetLookupPolicy(v *BatchLookupPolicyRespon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchReadSuccessfulResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GetObjectInformation != nil {
+		v := s.GetObjectInformation
+
+		e.SetFields(protocol.BodyTarget, "GetObjectInformation", v, protocol.Metadata{})
+	}
+	if s.ListAttachedIndices != nil {
+		v := s.ListAttachedIndices
+
+		e.SetFields(protocol.BodyTarget, "ListAttachedIndices", v, protocol.Metadata{})
+	}
+	if s.ListIncomingTypedLinks != nil {
+		v := s.ListIncomingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListIncomingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListIndex != nil {
+		v := s.ListIndex
+
+		e.SetFields(protocol.BodyTarget, "ListIndex", v, protocol.Metadata{})
+	}
+	if s.ListObjectAttributes != nil {
+		v := s.ListObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "ListObjectAttributes", v, protocol.Metadata{})
+	}
+	if s.ListObjectChildren != nil {
+		v := s.ListObjectChildren
+
+		e.SetFields(protocol.BodyTarget, "ListObjectChildren", v, protocol.Metadata{})
+	}
+	if s.ListObjectParentPaths != nil {
+		v := s.ListObjectParentPaths
+
+		e.SetFields(protocol.BodyTarget, "ListObjectParentPaths", v, protocol.Metadata{})
+	}
+	if s.ListObjectPolicies != nil {
+		v := s.ListObjectPolicies
+
+		e.SetFields(protocol.BodyTarget, "ListObjectPolicies", v, protocol.Metadata{})
+	}
+	if s.ListOutgoingTypedLinks != nil {
+		v := s.ListOutgoingTypedLinks
+
+		e.SetFields(protocol.BodyTarget, "ListOutgoingTypedLinks", v, protocol.Metadata{})
+	}
+	if s.ListPolicyAttachments != nil {
+		v := s.ListPolicyAttachments
+
+		e.SetFields(protocol.BodyTarget, "ListPolicyAttachments", v, protocol.Metadata{})
+	}
+	if s.LookupPolicy != nil {
+		v := s.LookupPolicy
+
+		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A batch operation to remove a facet from an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObject
 type BatchRemoveFacetFromObject struct {
@@ -11417,6 +12669,22 @@ func (s *BatchRemoveFacetFromObject) SetSchemaFacet(v *SchemaFacet) *BatchRemove
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchRemoveFacetFromObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty result that represents success.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchRemoveFacetFromObjectResponse
 type BatchRemoveFacetFromObjectResponse struct {
@@ -11431,6 +12699,12 @@ func (s BatchRemoveFacetFromObjectResponse) String() string {
 // GoString returns the string representation
 func (s BatchRemoveFacetFromObjectResponse) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchRemoveFacetFromObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the output of a BatchUpdate operation.
@@ -11497,6 +12771,22 @@ func (s *BatchUpdateObjectAttributes) SetObjectReference(v *ObjectReference) *Ba
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchUpdateObjectAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeObjectAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Represents the output of a BatchUpdate response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchUpdateObjectAttributesResponse
 type BatchUpdateObjectAttributesResponse struct {
@@ -11520,6 +12810,17 @@ func (s BatchUpdateObjectAttributesResponse) GoString() string {
 func (s *BatchUpdateObjectAttributesResponse) SetObjectIdentifier(v string) *BatchUpdateObjectAttributesResponse {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchUpdateObjectAttributesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteRequest
@@ -11584,6 +12885,22 @@ func (s *BatchWriteInput) SetDirectoryArn(v string) *BatchWriteInput {
 func (s *BatchWriteInput) SetOperations(v []*BatchWriteOperation) *BatchWriteInput {
 	s.Operations = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Operations) > 0 {
+		v := s.Operations
+
+		e.SetList(protocol.BodyTarget, "Operations", encodeBatchWriteOperationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents the output of a BatchWrite operation.
@@ -11812,6 +13129,90 @@ func (s *BatchWriteOperation) SetUpdateObjectAttributes(v *BatchUpdateObjectAttr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOperation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AddFacetToObject != nil {
+		v := s.AddFacetToObject
+
+		e.SetFields(protocol.BodyTarget, "AddFacetToObject", v, protocol.Metadata{})
+	}
+	if s.AttachObject != nil {
+		v := s.AttachObject
+
+		e.SetFields(protocol.BodyTarget, "AttachObject", v, protocol.Metadata{})
+	}
+	if s.AttachPolicy != nil {
+		v := s.AttachPolicy
+
+		e.SetFields(protocol.BodyTarget, "AttachPolicy", v, protocol.Metadata{})
+	}
+	if s.AttachToIndex != nil {
+		v := s.AttachToIndex
+
+		e.SetFields(protocol.BodyTarget, "AttachToIndex", v, protocol.Metadata{})
+	}
+	if s.AttachTypedLink != nil {
+		v := s.AttachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "AttachTypedLink", v, protocol.Metadata{})
+	}
+	if s.CreateIndex != nil {
+		v := s.CreateIndex
+
+		e.SetFields(protocol.BodyTarget, "CreateIndex", v, protocol.Metadata{})
+	}
+	if s.CreateObject != nil {
+		v := s.CreateObject
+
+		e.SetFields(protocol.BodyTarget, "CreateObject", v, protocol.Metadata{})
+	}
+	if s.DeleteObject != nil {
+		v := s.DeleteObject
+
+		e.SetFields(protocol.BodyTarget, "DeleteObject", v, protocol.Metadata{})
+	}
+	if s.DetachFromIndex != nil {
+		v := s.DetachFromIndex
+
+		e.SetFields(protocol.BodyTarget, "DetachFromIndex", v, protocol.Metadata{})
+	}
+	if s.DetachObject != nil {
+		v := s.DetachObject
+
+		e.SetFields(protocol.BodyTarget, "DetachObject", v, protocol.Metadata{})
+	}
+	if s.DetachPolicy != nil {
+		v := s.DetachPolicy
+
+		e.SetFields(protocol.BodyTarget, "DetachPolicy", v, protocol.Metadata{})
+	}
+	if s.DetachTypedLink != nil {
+		v := s.DetachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "DetachTypedLink", v, protocol.Metadata{})
+	}
+	if s.RemoveFacetFromObject != nil {
+		v := s.RemoveFacetFromObject
+
+		e.SetFields(protocol.BodyTarget, "RemoveFacetFromObject", v, protocol.Metadata{})
+	}
+	if s.UpdateObjectAttributes != nil {
+		v := s.UpdateObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchWriteOperationList(vs []*BatchWriteOperation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents the output of a BatchWrite response operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteOperationResponse
 type BatchWriteOperationResponse struct {
@@ -11958,6 +13359,90 @@ func (s *BatchWriteOperationResponse) SetUpdateObjectAttributes(v *BatchUpdateOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOperationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AddFacetToObject != nil {
+		v := s.AddFacetToObject
+
+		e.SetFields(protocol.BodyTarget, "AddFacetToObject", v, protocol.Metadata{})
+	}
+	if s.AttachObject != nil {
+		v := s.AttachObject
+
+		e.SetFields(protocol.BodyTarget, "AttachObject", v, protocol.Metadata{})
+	}
+	if s.AttachPolicy != nil {
+		v := s.AttachPolicy
+
+		e.SetFields(protocol.BodyTarget, "AttachPolicy", v, protocol.Metadata{})
+	}
+	if s.AttachToIndex != nil {
+		v := s.AttachToIndex
+
+		e.SetFields(protocol.BodyTarget, "AttachToIndex", v, protocol.Metadata{})
+	}
+	if s.AttachTypedLink != nil {
+		v := s.AttachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "AttachTypedLink", v, protocol.Metadata{})
+	}
+	if s.CreateIndex != nil {
+		v := s.CreateIndex
+
+		e.SetFields(protocol.BodyTarget, "CreateIndex", v, protocol.Metadata{})
+	}
+	if s.CreateObject != nil {
+		v := s.CreateObject
+
+		e.SetFields(protocol.BodyTarget, "CreateObject", v, protocol.Metadata{})
+	}
+	if s.DeleteObject != nil {
+		v := s.DeleteObject
+
+		e.SetFields(protocol.BodyTarget, "DeleteObject", v, protocol.Metadata{})
+	}
+	if s.DetachFromIndex != nil {
+		v := s.DetachFromIndex
+
+		e.SetFields(protocol.BodyTarget, "DetachFromIndex", v, protocol.Metadata{})
+	}
+	if s.DetachObject != nil {
+		v := s.DetachObject
+
+		e.SetFields(protocol.BodyTarget, "DetachObject", v, protocol.Metadata{})
+	}
+	if s.DetachPolicy != nil {
+		v := s.DetachPolicy
+
+		e.SetFields(protocol.BodyTarget, "DetachPolicy", v, protocol.Metadata{})
+	}
+	if s.DetachTypedLink != nil {
+		v := s.DetachTypedLink
+
+		e.SetFields(protocol.BodyTarget, "DetachTypedLink", v, protocol.Metadata{})
+	}
+	if s.RemoveFacetFromObject != nil {
+		v := s.RemoveFacetFromObject
+
+		e.SetFields(protocol.BodyTarget, "RemoveFacetFromObject", v, protocol.Metadata{})
+	}
+	if s.UpdateObjectAttributes != nil {
+		v := s.UpdateObjectAttributes
+
+		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBatchWriteOperationResponseList(vs []*BatchWriteOperationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/BatchWriteResponse
 type BatchWriteOutput struct {
 	_ struct{} `type:"structure"`
@@ -11980,6 +13465,17 @@ func (s BatchWriteOutput) GoString() string {
 func (s *BatchWriteOutput) SetResponses(v []*BatchWriteOperationResponse) *BatchWriteOutput {
 	s.Responses = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchWriteOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Responses) > 0 {
+		v := s.Responses
+
+		e.SetList(protocol.BodyTarget, "Responses", encodeBatchWriteOperationResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateDirectoryRequest
@@ -12037,6 +13533,22 @@ func (s *CreateDirectoryInput) SetName(v string) *CreateDirectoryInput {
 func (s *CreateDirectoryInput) SetSchemaArn(v string) *CreateDirectoryInput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateDirectoryResponse
@@ -12099,6 +13611,32 @@ func (s *CreateDirectoryOutput) SetName(v string) *CreateDirectoryOutput {
 func (s *CreateDirectoryOutput) SetObjectIdentifier(v string) *CreateDirectoryOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppliedSchemaArn != nil {
+		v := *s.AppliedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "AppliedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateFacetRequest
@@ -12201,6 +13739,32 @@ func (s *CreateFacetInput) SetSchemaArn(v string) *CreateFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeFacetAttributeList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateFacetResponse
 type CreateFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12214,6 +13778,12 @@ func (s CreateFacetOutput) String() string {
 // GoString returns the string representation
 func (s CreateFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateIndexRequest
@@ -12316,6 +13886,37 @@ func (s *CreateIndexInput) SetParentReference(v *ObjectReference) *CreateIndexIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsUnique != nil {
+		v := *s.IsUnique
+
+		e.SetValue(protocol.BodyTarget, "IsUnique", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OrderedIndexedAttributeList) > 0 {
+		v := s.OrderedIndexedAttributeList
+
+		e.SetList(protocol.BodyTarget, "OrderedIndexedAttributeList", encodeAttributeKeyList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateIndexResponse
 type CreateIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -12338,6 +13939,17 @@ func (s CreateIndexOutput) GoString() string {
 func (s *CreateIndexOutput) SetObjectIdentifier(v string) *CreateIndexOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateObjectRequest
@@ -12446,6 +14058,37 @@ func (s *CreateObjectInput) SetSchemaFacets(v []*SchemaFacet) *CreateObjectInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectAttributeList) > 0 {
+		v := s.ObjectAttributeList
+
+		e.SetList(protocol.BodyTarget, "ObjectAttributeList", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateObjectResponse
 type CreateObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -12468,6 +14111,17 @@ func (s CreateObjectOutput) GoString() string {
 func (s *CreateObjectOutput) SetObjectIdentifier(v string) *CreateObjectOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateSchemaRequest
@@ -12513,6 +14167,17 @@ func (s *CreateSchemaInput) SetName(v string) *CreateSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateSchemaResponse
 type CreateSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -12536,6 +14201,17 @@ func (s CreateSchemaOutput) GoString() string {
 func (s *CreateSchemaOutput) SetSchemaArn(v string) *CreateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetRequest
@@ -12597,6 +14273,22 @@ func (s *CreateTypedLinkFacetInput) SetSchemaArn(v string) *CreateTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Facet != nil {
+		v := s.Facet
+
+		e.SetFields(protocol.BodyTarget, "Facet", v, protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/CreateTypedLinkFacetResponse
 type CreateTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12610,6 +14302,12 @@ func (s CreateTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s CreateTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectoryRequest
@@ -12651,6 +14349,17 @@ func (s *DeleteDirectoryInput) SetDirectoryArn(v string) *DeleteDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteDirectoryResponse
 type DeleteDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -12675,6 +14384,17 @@ func (s DeleteDirectoryOutput) GoString() string {
 func (s *DeleteDirectoryOutput) SetDirectoryArn(v string) *DeleteDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteFacetRequest
@@ -12734,6 +14454,22 @@ func (s *DeleteFacetInput) SetSchemaArn(v string) *DeleteFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteFacetResponse
 type DeleteFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12747,6 +14483,12 @@ func (s DeleteFacetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteObjectRequest
@@ -12803,6 +14545,22 @@ func (s *DeleteObjectInput) SetObjectReference(v *ObjectReference) *DeleteObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteObjectResponse
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -12816,6 +14574,12 @@ func (s DeleteObjectOutput) String() string {
 // GoString returns the string representation
 func (s DeleteObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteSchemaRequest
@@ -12858,6 +14622,17 @@ func (s *DeleteSchemaInput) SetSchemaArn(v string) *DeleteSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteSchemaResponse
 type DeleteSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -12881,6 +14656,17 @@ func (s DeleteSchemaOutput) GoString() string {
 func (s *DeleteSchemaOutput) SetSchemaArn(v string) *DeleteSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetRequest
@@ -12937,6 +14723,22 @@ func (s *DeleteTypedLinkFacetInput) SetSchemaArn(v string) *DeleteTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DeleteTypedLinkFacetResponse
 type DeleteTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -12950,6 +14752,12 @@ func (s DeleteTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndexRequest
@@ -13020,6 +14828,27 @@ func (s *DetachFromIndexInput) SetTargetReference(v *ObjectReference) *DetachFro
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachFromIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachFromIndexResponse
 type DetachFromIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -13042,6 +14871,17 @@ func (s DetachFromIndexOutput) GoString() string {
 func (s *DetachFromIndexOutput) SetDetachedObjectIdentifier(v string) *DetachFromIndexOutput {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachFromIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachObjectRequest
@@ -13116,6 +14956,27 @@ func (s *DetachObjectInput) SetParentReference(v *ObjectReference) *DetachObject
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkName != nil {
+		v := *s.LinkName
+
+		e.SetValue(protocol.BodyTarget, "LinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentReference != nil {
+		v := s.ParentReference
+
+		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachObjectResponse
 type DetachObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -13138,6 +14999,17 @@ func (s DetachObjectOutput) GoString() string {
 func (s *DetachObjectOutput) SetDetachedObjectIdentifier(v string) *DetachObjectOutput {
 	s.DetachedObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetachedObjectIdentifier != nil {
+		v := *s.DetachedObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachPolicyRequest
@@ -13208,6 +15080,27 @@ func (s *DetachPolicyInput) SetPolicyReference(v *ObjectReference) *DetachPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachPolicyResponse
 type DetachPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -13221,6 +15114,12 @@ func (s DetachPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DetachPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkRequest
@@ -13282,6 +15181,22 @@ func (s *DetachTypedLinkInput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *Det
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TypedLinkSpecifier != nil {
+		v := s.TypedLinkSpecifier
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DetachTypedLinkOutput
 type DetachTypedLinkOutput struct {
 	_ struct{} `type:"structure"`
@@ -13295,6 +15210,12 @@ func (s DetachTypedLinkOutput) String() string {
 // GoString returns the string representation
 func (s DetachTypedLinkOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Directory structure that includes the directory name and directory ARN.
@@ -13350,6 +15271,40 @@ func (s *Directory) SetState(v string) *Directory {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Directory) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDateTime != nil {
+		v := *s.CreationDateTime
+
+		e.SetValue(protocol.BodyTarget, "CreationDateTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDirectoryList(vs []*Directory) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DisableDirectoryRequest
 type DisableDirectoryInput struct {
 	_ struct{} `type:"structure"`
@@ -13389,6 +15344,17 @@ func (s *DisableDirectoryInput) SetDirectoryArn(v string) *DisableDirectoryInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/DisableDirectoryResponse
 type DisableDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13413,6 +15379,17 @@ func (s DisableDirectoryOutput) GoString() string {
 func (s *DisableDirectoryOutput) SetDirectoryArn(v string) *DisableDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/EnableDirectoryRequest
@@ -13454,6 +15431,17 @@ func (s *EnableDirectoryInput) SetDirectoryArn(v string) *EnableDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/EnableDirectoryResponse
 type EnableDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13478,6 +15466,17 @@ func (s EnableDirectoryOutput) GoString() string {
 func (s *EnableDirectoryOutput) SetDirectoryArn(v string) *EnableDirectoryOutput {
 	s.DirectoryArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A structure that contains Name, ARN, Attributes, Rules, and ObjectTypes.
@@ -13513,6 +15512,22 @@ func (s *Facet) SetName(v string) *Facet {
 func (s *Facet) SetObjectType(v string) *Facet {
 	s.ObjectType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Facet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An attribute that is associated with the Facet.
@@ -13599,6 +15614,40 @@ func (s *FacetAttribute) SetRequiredBehavior(v string) *FacetAttribute {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttribute) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeDefinition != nil {
+		v := s.AttributeDefinition
+
+		e.SetFields(protocol.BodyTarget, "AttributeDefinition", v, protocol.Metadata{})
+	}
+	if s.AttributeReference != nil {
+		v := s.AttributeReference
+
+		e.SetFields(protocol.BodyTarget, "AttributeReference", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequiredBehavior != nil {
+		v := *s.RequiredBehavior
+
+		e.SetValue(protocol.BodyTarget, "RequiredBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFacetAttributeList(vs []*FacetAttribute) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A facet attribute definition. See Attribute References (http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_advanced.html#attributereferences)
 // for more information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeDefinition
@@ -13667,6 +15716,32 @@ func (s *FacetAttributeDefinition) SetType(v string) *FacetAttributeDefinition {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := s.DefaultValue
+
+		e.SetFields(protocol.BodyTarget, "DefaultValue", v, protocol.Metadata{})
+	}
+	if s.IsImmutable != nil {
+		v := *s.IsImmutable
+
+		e.SetValue(protocol.BodyTarget, "IsImmutable", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetMap(protocol.BodyTarget, "Rules", encodeRuleMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The facet attribute reference that specifies the attribute definition that
 // contains the attribute facet name and attribute name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeReference
@@ -13732,6 +15807,22 @@ func (s *FacetAttributeReference) SetTargetFacetName(v string) *FacetAttributeRe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetAttributeName != nil {
+		v := *s.TargetAttributeName
+
+		e.SetValue(protocol.BodyTarget, "TargetAttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetFacetName != nil {
+		v := *s.TargetFacetName
+
+		e.SetValue(protocol.BodyTarget, "TargetFacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A structure that contains information used to update an attribute.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/FacetAttributeUpdate
 type FacetAttributeUpdate struct {
@@ -13781,6 +15872,30 @@ func (s *FacetAttributeUpdate) SetAttribute(v *FacetAttribute) *FacetAttributeUp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Attribute != nil {
+		v := s.Attribute
+
+		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFacetAttributeUpdateList(vs []*FacetAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetDirectoryRequest
 type GetDirectoryInput struct {
 	_ struct{} `type:"structure"`
@@ -13820,6 +15935,17 @@ func (s *GetDirectoryInput) SetDirectoryArn(v string) *GetDirectoryInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetDirectoryResponse
 type GetDirectoryOutput struct {
 	_ struct{} `type:"structure"`
@@ -13844,6 +15970,17 @@ func (s GetDirectoryOutput) GoString() string {
 func (s *GetDirectoryOutput) SetDirectory(v *Directory) *GetDirectoryOutput {
 	s.Directory = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Directory != nil {
+		v := s.Directory
+
+		e.SetFields(protocol.BodyTarget, "Directory", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetFacetRequest
@@ -13903,6 +16040,22 @@ func (s *GetFacetInput) SetSchemaArn(v string) *GetFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetFacetResponse
 type GetFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -13925,6 +16078,17 @@ func (s GetFacetOutput) GoString() string {
 func (s *GetFacetOutput) SetFacet(v *Facet) *GetFacetOutput {
 	s.Facet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Facet != nil {
+		v := s.Facet
+
+		e.SetFields(protocol.BodyTarget, "Facet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetObjectInformationRequest
@@ -13989,6 +16153,27 @@ func (s *GetObjectInformationInput) SetObjectReference(v *ObjectReference) *GetO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInformationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetObjectInformationResponse
 type GetObjectInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -14020,6 +16205,22 @@ func (s *GetObjectInformationOutput) SetObjectIdentifier(v string) *GetObjectInf
 func (s *GetObjectInformationOutput) SetSchemaFacets(v []*SchemaFacet) *GetObjectInformationOutput {
 	s.SchemaFacets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInformationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaFacets) > 0 {
+		v := s.SchemaFacets
+
+		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetSchemaAsJsonRequest
@@ -14061,6 +16262,17 @@ func (s *GetSchemaAsJsonInput) SetSchemaArn(v string) *GetSchemaAsJsonInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSchemaAsJsonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetSchemaAsJsonResponse
 type GetSchemaAsJsonOutput struct {
 	_ struct{} `type:"structure"`
@@ -14092,6 +16304,22 @@ func (s *GetSchemaAsJsonOutput) SetDocument(v string) *GetSchemaAsJsonOutput {
 func (s *GetSchemaAsJsonOutput) SetName(v string) *GetSchemaAsJsonOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSchemaAsJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationRequest
@@ -14148,6 +16376,22 @@ func (s *GetTypedLinkFacetInformationInput) SetSchemaArn(v string) *GetTypedLink
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTypedLinkFacetInformationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/GetTypedLinkFacetInformationResponse
 type GetTypedLinkFacetInformationOutput struct {
 	_ struct{} `type:"structure"`
@@ -14177,6 +16421,17 @@ func (s GetTypedLinkFacetInformationOutput) GoString() string {
 func (s *GetTypedLinkFacetInformationOutput) SetIdentityAttributeOrder(v []*string) *GetTypedLinkFacetInformationOutput {
 	s.IdentityAttributeOrder = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTypedLinkFacetInformationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents an index and an attached object.
@@ -14211,6 +16466,30 @@ func (s *IndexAttachment) SetIndexedAttributes(v []*AttributeKeyAndValue) *Index
 func (s *IndexAttachment) SetObjectIdentifier(v string) *IndexAttachment {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IndexAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexedAttributes) > 0 {
+		v := s.IndexedAttributes
+
+		e.SetList(protocol.BodyTarget, "IndexedAttributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIndexAttachmentList(vs []*IndexAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAppliedSchemaArnsRequest
@@ -14273,6 +16552,27 @@ func (s *ListAppliedSchemaArnsInput) SetNextToken(v string) *ListAppliedSchemaAr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAppliedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAppliedSchemaArnsResponse
 type ListAppliedSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14304,6 +16604,22 @@ func (s *ListAppliedSchemaArnsOutput) SetNextToken(v string) *ListAppliedSchemaA
 func (s *ListAppliedSchemaArnsOutput) SetSchemaArns(v []*string) *ListAppliedSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAppliedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAttachedIndicesRequest
@@ -14389,6 +16705,37 @@ func (s *ListAttachedIndicesInput) SetTargetReference(v *ObjectReference) *ListA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAttachedIndicesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetReference != nil {
+		v := s.TargetReference
+
+		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListAttachedIndicesResponse
 type ListAttachedIndicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14420,6 +16767,22 @@ func (s *ListAttachedIndicesOutput) SetIndexAttachments(v []*IndexAttachment) *L
 func (s *ListAttachedIndicesOutput) SetNextToken(v string) *ListAttachedIndicesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAttachedIndicesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDevelopmentSchemaArnsRequest
@@ -14468,6 +16831,22 @@ func (s *ListDevelopmentSchemaArnsInput) SetNextToken(v string) *ListDevelopment
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDevelopmentSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDevelopmentSchemaArnsResponse
 type ListDevelopmentSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14499,6 +16878,22 @@ func (s *ListDevelopmentSchemaArnsOutput) SetNextToken(v string) *ListDevelopmen
 func (s *ListDevelopmentSchemaArnsOutput) SetSchemaArns(v []*string) *ListDevelopmentSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDevelopmentSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDirectoriesRequest
@@ -14557,6 +16952,27 @@ func (s *ListDirectoriesInput) SetState(v string) *ListDirectoriesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDirectoriesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListDirectoriesResponse
 type ListDirectoriesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14591,6 +17007,22 @@ func (s *ListDirectoriesOutput) SetDirectories(v []*Directory) *ListDirectoriesO
 func (s *ListDirectoriesOutput) SetNextToken(v string) *ListDirectoriesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDirectoriesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Directories) > 0 {
+		v := s.Directories
+
+		e.SetList(protocol.BodyTarget, "Directories", encodeDirectoryList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetAttributesRequest
@@ -14670,6 +17102,32 @@ func (s *ListFacetAttributesInput) SetSchemaArn(v string) *ListFacetAttributesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetAttributesResponse
 type ListFacetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14701,6 +17159,22 @@ func (s *ListFacetAttributesOutput) SetAttributes(v []*FacetAttribute) *ListFace
 func (s *ListFacetAttributesOutput) SetNextToken(v string) *ListFacetAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeFacetAttributeList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetNamesRequest
@@ -14763,6 +17237,27 @@ func (s *ListFacetNamesInput) SetSchemaArn(v string) *ListFacetNamesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListFacetNamesResponse
 type ListFacetNamesOutput struct {
 	_ struct{} `type:"structure"`
@@ -14794,6 +17289,22 @@ func (s *ListFacetNamesOutput) SetFacetNames(v []*string) *ListFacetNamesOutput 
 func (s *ListFacetNamesOutput) SetNextToken(v string) *ListFacetNamesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FacetNames) > 0 {
+		v := s.FacetNames
+
+		e.SetList(protocol.BodyTarget, "FacetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksRequest
@@ -14917,6 +17428,47 @@ func (s *ListIncomingTypedLinksInput) SetObjectReference(v *ObjectReference) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIncomingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIncomingTypedLinksResponse
 type ListIncomingTypedLinksOutput struct {
 	_ struct{} `type:"structure"`
@@ -14948,6 +17500,22 @@ func (s *ListIncomingTypedLinksOutput) SetLinkSpecifiers(v []*TypedLinkSpecifier
 func (s *ListIncomingTypedLinksOutput) SetNextToken(v string) *ListIncomingTypedLinksOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIncomingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LinkSpecifiers) > 0 {
+		v := s.LinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "LinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIndexRequest
@@ -15052,6 +17620,42 @@ func (s *ListIndexInput) SetRangesOnIndexedValues(v []*ObjectAttributeRange) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIndexInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IndexReference != nil {
+		v := s.IndexReference
+
+		e.SetFields(protocol.BodyTarget, "IndexReference", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RangesOnIndexedValues) > 0 {
+		v := s.RangesOnIndexedValues
+
+		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListIndexResponse
 type ListIndexOutput struct {
 	_ struct{} `type:"structure"`
@@ -15083,6 +17687,22 @@ func (s *ListIndexOutput) SetIndexAttachments(v []*IndexAttachment) *ListIndexOu
 func (s *ListIndexOutput) SetNextToken(v string) *ListIndexOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IndexAttachments) > 0 {
+		v := s.IndexAttachments
+
+		e.SetList(protocol.BodyTarget, "IndexAttachments", encodeIndexAttachmentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectAttributesRequest
@@ -15186,6 +17806,42 @@ func (s *ListObjectAttributesInput) SetObjectReference(v *ObjectReference) *List
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FacetFilter != nil {
+		v := s.FacetFilter
+
+		e.SetFields(protocol.BodyTarget, "FacetFilter", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectAttributesResponse
 type ListObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15218,6 +17874,22 @@ func (s *ListObjectAttributesOutput) SetAttributes(v []*AttributeKeyAndValue) *L
 func (s *ListObjectAttributesOutput) SetNextToken(v string) *ListObjectAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeKeyAndValueList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectChildrenRequest
@@ -15307,6 +17979,37 @@ func (s *ListObjectChildrenInput) SetObjectReference(v *ObjectReference) *ListOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectChildrenInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectChildrenResponse
 type ListObjectChildrenOutput struct {
 	_ struct{} `type:"structure"`
@@ -15339,6 +18042,22 @@ func (s *ListObjectChildrenOutput) SetChildren(v map[string]*string) *ListObject
 func (s *ListObjectChildrenOutput) SetNextToken(v string) *ListObjectChildrenOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectChildrenOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Children) > 0 {
+		v := s.Children
+
+		e.SetMap(protocol.BodyTarget, "Children", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentPathsRequest
@@ -15416,6 +18135,32 @@ func (s *ListObjectParentPathsInput) SetObjectReference(v *ObjectReference) *Lis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentPathsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentPathsResponse
 type ListObjectParentPathsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15447,6 +18192,22 @@ func (s *ListObjectParentPathsOutput) SetNextToken(v string) *ListObjectParentPa
 func (s *ListObjectParentPathsOutput) SetPathToObjectIdentifiersList(v []*PathToObjectIdentifiers) *ListObjectParentPathsOutput {
 	s.PathToObjectIdentifiersList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentPathsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PathToObjectIdentifiersList) > 0 {
+		v := s.PathToObjectIdentifiersList
+
+		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentsRequest
@@ -15536,6 +18297,37 @@ func (s *ListObjectParentsInput) SetObjectReference(v *ObjectReference) *ListObj
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectParentsResponse
 type ListObjectParentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15568,6 +18360,22 @@ func (s *ListObjectParentsOutput) SetNextToken(v string) *ListObjectParentsOutpu
 func (s *ListObjectParentsOutput) SetParents(v map[string]*string) *ListObjectParentsOutput {
 	s.Parents = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectParentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Parents) > 0 {
+		v := s.Parents
+
+		e.SetMap(protocol.BodyTarget, "Parents", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectPoliciesRequest
@@ -15656,6 +18464,37 @@ func (s *ListObjectPoliciesInput) SetObjectReference(v *ObjectReference) *ListOb
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListObjectPoliciesResponse
 type ListObjectPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -15687,6 +18526,22 @@ func (s *ListObjectPoliciesOutput) SetAttachedPolicyIds(v []*string) *ListObject
 func (s *ListObjectPoliciesOutput) SetNextToken(v string) *ListObjectPoliciesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttachedPolicyIds) > 0 {
+		v := s.AttachedPolicyIds
+
+		e.SetList(protocol.BodyTarget, "AttachedPolicyIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksRequest
@@ -15810,6 +18665,47 @@ func (s *ListOutgoingTypedLinksInput) SetObjectReference(v *ObjectReference) *Li
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.FilterAttributeRanges) > 0 {
+		v := s.FilterAttributeRanges
+
+		e.SetList(protocol.BodyTarget, "FilterAttributeRanges", encodeTypedLinkAttributeRangeList(v), protocol.Metadata{})
+	}
+	if s.FilterTypedLink != nil {
+		v := s.FilterTypedLink
+
+		e.SetFields(protocol.BodyTarget, "FilterTypedLink", v, protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListOutgoingTypedLinksResponse
 type ListOutgoingTypedLinksOutput struct {
 	_ struct{} `type:"structure"`
@@ -15841,6 +18737,22 @@ func (s *ListOutgoingTypedLinksOutput) SetNextToken(v string) *ListOutgoingTyped
 func (s *ListOutgoingTypedLinksOutput) SetTypedLinkSpecifiers(v []*TypedLinkSpecifier) *ListOutgoingTypedLinksOutput {
 	s.TypedLinkSpecifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TypedLinkSpecifiers) > 0 {
+		v := s.TypedLinkSpecifiers
+
+		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachmentsRequest
@@ -15929,6 +18841,37 @@ func (s *ListPolicyAttachmentsInput) SetPolicyReference(v *ObjectReference) *Lis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyAttachmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyReference != nil {
+		v := s.PolicyReference
+
+		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPolicyAttachmentsResponse
 type ListPolicyAttachmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -15960,6 +18903,22 @@ func (s *ListPolicyAttachmentsOutput) SetNextToken(v string) *ListPolicyAttachme
 func (s *ListPolicyAttachmentsOutput) SetObjectIdentifiers(v []*string) *ListPolicyAttachmentsOutput {
 	s.ObjectIdentifiers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyAttachmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPublishedSchemaArnsRequest
@@ -16008,6 +18967,22 @@ func (s *ListPublishedSchemaArnsInput) SetNextToken(v string) *ListPublishedSche
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPublishedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListPublishedSchemaArnsResponse
 type ListPublishedSchemaArnsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16039,6 +19014,22 @@ func (s *ListPublishedSchemaArnsOutput) SetNextToken(v string) *ListPublishedSch
 func (s *ListPublishedSchemaArnsOutput) SetSchemaArns(v []*string) *ListPublishedSchemaArnsOutput {
 	s.SchemaArns = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPublishedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SchemaArns) > 0 {
+		v := s.SchemaArns
+
+		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTagsForResourceRequest
@@ -16104,6 +19095,27 @@ func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResource
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTagsForResourceResponse
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -16136,6 +19148,22 @@ func (s *ListTagsForResourceOutput) SetNextToken(v string) *ListTagsForResourceO
 func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesRequest
@@ -16213,6 +19241,32 @@ func (s *ListTypedLinkFacetAttributesInput) SetSchemaArn(v string) *ListTypedLin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetAttributesResponse
 type ListTypedLinkFacetAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16244,6 +19298,22 @@ func (s *ListTypedLinkFacetAttributesOutput) SetAttributes(v []*TypedLinkAttribu
 func (s *ListTypedLinkFacetAttributesOutput) SetNextToken(v string) *ListTypedLinkFacetAttributesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeTypedLinkAttributeDefinitionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesRequest
@@ -16307,6 +19377,27 @@ func (s *ListTypedLinkFacetNamesInput) SetSchemaArn(v string) *ListTypedLinkFace
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ListTypedLinkFacetNamesResponse
 type ListTypedLinkFacetNamesOutput struct {
 	_ struct{} `type:"structure"`
@@ -16338,6 +19429,22 @@ func (s *ListTypedLinkFacetNamesOutput) SetFacetNames(v []*string) *ListTypedLin
 func (s *ListTypedLinkFacetNamesOutput) SetNextToken(v string) *ListTypedLinkFacetNamesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTypedLinkFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FacetNames) > 0 {
+		v := s.FacetNames
+
+		e.SetList(protocol.BodyTarget, "FacetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/LookupPolicyRequest
@@ -16416,6 +19523,32 @@ func (s *LookupPolicyInput) SetObjectReference(v *ObjectReference) *LookupPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LookupPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/LookupPolicyResponse
 type LookupPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -16450,6 +19583,22 @@ func (s *LookupPolicyOutput) SetPolicyToPathList(v []*PolicyToPath) *LookupPolic
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LookupPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.PolicyToPathList) > 0 {
+		v := s.PolicyToPathList
+
+		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The action to take on the object attribute.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectAttributeAction
 type ObjectAttributeAction struct {
@@ -16482,6 +19631,22 @@ func (s *ObjectAttributeAction) SetObjectAttributeActionType(v string) *ObjectAt
 func (s *ObjectAttributeAction) SetObjectAttributeUpdateValue(v *TypedAttributeValue) *ObjectAttributeAction {
 	s.ObjectAttributeUpdateValue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectAttributeActionType != nil {
+		v := *s.ObjectAttributeActionType
+
+		e.SetValue(protocol.BodyTarget, "ObjectAttributeActionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectAttributeUpdateValue != nil {
+		v := s.ObjectAttributeUpdateValue
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeUpdateValue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A range of attributes.
@@ -16538,6 +19703,30 @@ func (s *ObjectAttributeRange) SetRange(v *TypedAttributeValueRange) *ObjectAttr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeKey != nil {
+		v := s.AttributeKey
+
+		e.SetFields(protocol.BodyTarget, "AttributeKey", v, protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := s.Range
+
+		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectAttributeRangeList(vs []*ObjectAttributeRange) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Structure that contains attribute update information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectAttributeUpdate
 type ObjectAttributeUpdate struct {
@@ -16587,6 +19776,30 @@ func (s *ObjectAttributeUpdate) SetObjectAttributeKey(v *AttributeKey) *ObjectAt
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectAttributeAction != nil {
+		v := s.ObjectAttributeAction
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeAction", v, protocol.Metadata{})
+	}
+	if s.ObjectAttributeKey != nil {
+		v := s.ObjectAttributeKey
+
+		e.SetFields(protocol.BodyTarget, "ObjectAttributeKey", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectAttributeUpdateList(vs []*ObjectAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The reference that identifies an object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/ObjectReference
 type ObjectReference struct {
@@ -16626,6 +19839,17 @@ func (s *ObjectReference) SetSelector(v string) *ObjectReference {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Selector != nil {
+		v := *s.Selector
+
+		e.SetValue(protocol.BodyTarget, "Selector", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returns the path to the ObjectIdentifiers that is associated with the directory.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PathToObjectIdentifiers
 type PathToObjectIdentifiers struct {
@@ -16659,6 +19883,30 @@ func (s *PathToObjectIdentifiers) SetObjectIdentifiers(v []*string) *PathToObjec
 func (s *PathToObjectIdentifiers) SetPath(v string) *PathToObjectIdentifiers {
 	s.Path = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PathToObjectIdentifiers) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ObjectIdentifiers) > 0 {
+		v := s.ObjectIdentifiers
+
+		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePathToObjectIdentifiersList(vs []*PathToObjectIdentifiers) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Contains the PolicyType, PolicyId, and the ObjectIdentifier to which it is
@@ -16705,6 +19953,35 @@ func (s *PolicyAttachment) SetPolicyType(v string) *PolicyAttachment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyId != nil {
+		v := *s.PolicyId
+
+		e.SetValue(protocol.BodyTarget, "PolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyType != nil {
+		v := *s.PolicyType
+
+		e.SetValue(protocol.BodyTarget, "PolicyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyAttachmentList(vs []*PolicyAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Used when a regular object exists in a Directory and you want to find all
 // of the policies that are associated with that object and the parent to that
 // object.
@@ -16739,6 +20016,30 @@ func (s *PolicyToPath) SetPath(v string) *PolicyToPath {
 func (s *PolicyToPath) SetPolicies(v []*PolicyAttachment) *PolicyToPath {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyToPath) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.BodyTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "Policies", encodePolicyAttachmentList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyToPathList(vs []*PolicyToPath) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PublishSchemaRequest
@@ -16811,6 +20112,27 @@ func (s *PublishSchemaInput) SetVersion(v string) *PublishSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DevelopmentSchemaArn != nil {
+		v := *s.DevelopmentSchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PublishSchemaResponse
 type PublishSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -16834,6 +20156,17 @@ func (s PublishSchemaOutput) GoString() string {
 func (s *PublishSchemaOutput) SetPublishedSchemaArn(v string) *PublishSchemaOutput {
 	s.PublishedSchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PublishedSchemaArn != nil {
+		v := *s.PublishedSchemaArn
+
+		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PutSchemaFromJsonRequest
@@ -16889,6 +20222,22 @@ func (s *PutSchemaFromJsonInput) SetSchemaArn(v string) *PutSchemaFromJsonInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSchemaFromJsonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/PutSchemaFromJsonResponse
 type PutSchemaFromJsonOutput struct {
 	_ struct{} `type:"structure"`
@@ -16911,6 +20260,17 @@ func (s PutSchemaFromJsonOutput) GoString() string {
 func (s *PutSchemaFromJsonOutput) SetArn(v string) *PutSchemaFromJsonOutput {
 	s.Arn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSchemaFromJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/RemoveFacetFromObjectRequest
@@ -16985,6 +20345,27 @@ func (s *RemoveFacetFromObjectInput) SetSchemaFacet(v *SchemaFacet) *RemoveFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveFacetFromObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+	if s.SchemaFacet != nil {
+		v := s.SchemaFacet
+
+		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/RemoveFacetFromObjectResponse
 type RemoveFacetFromObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -16998,6 +20379,12 @@ func (s RemoveFacetFromObjectOutput) String() string {
 // GoString returns the string representation
 func (s RemoveFacetFromObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveFacetFromObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Contains an Amazon Resource Name (ARN) and parameters that are associated
@@ -17033,6 +20420,30 @@ func (s *Rule) SetParameters(v map[string]*string) *Rule {
 func (s *Rule) SetType(v string) *Rule {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parameters) > 0 {
+		v := s.Parameters
+
+		e.SetMap(protocol.BodyTarget, "Parameters", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRuleMap(vs map[string]*Rule) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // A facet.
@@ -17082,6 +20493,30 @@ func (s *SchemaFacet) SetSchemaArn(v string) *SchemaFacet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SchemaFacet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FacetName != nil {
+		v := *s.FacetName
+
+		e.SetValue(protocol.BodyTarget, "FacetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSchemaFacetList(vs []*SchemaFacet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The tag structure that contains a tag key and value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/Tag
 type Tag struct {
@@ -17114,6 +20549,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TagResourceRequest
@@ -17170,6 +20629,22 @@ func (s *TagResourceInput) SetTags(v []*Tag) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TagResourceResponse
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -17183,6 +20658,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Represents the data for a typed attribute. You can set one, and only one,
@@ -17248,6 +20729,37 @@ func (s *TypedAttributeValue) SetNumberValue(v string) *TypedAttributeValue {
 func (s *TypedAttributeValue) SetStringValue(v string) *TypedAttributeValue {
 	s.StringValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedAttributeValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BinaryValue != nil {
+		v := s.BinaryValue
+
+		e.SetValue(protocol.BodyTarget, "BinaryValue", protocol.BytesValue(v), protocol.Metadata{})
+	}
+	if s.BooleanValue != nil {
+		v := *s.BooleanValue
+
+		e.SetValue(protocol.BodyTarget, "BooleanValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatetimeValue != nil {
+		v := *s.DatetimeValue
+
+		e.SetValue(protocol.BodyTarget, "DatetimeValue", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NumberValue != nil {
+		v := *s.NumberValue
+
+		e.SetValue(protocol.BodyTarget, "NumberValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StringValue != nil {
+		v := *s.StringValue
+
+		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A range of attribute values.
@@ -17320,6 +20832,32 @@ func (s *TypedAttributeValueRange) SetStartMode(v string) *TypedAttributeValueRa
 func (s *TypedAttributeValueRange) SetStartValue(v *TypedAttributeValue) *TypedAttributeValueRange {
 	s.StartValue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedAttributeValueRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndMode != nil {
+		v := *s.EndMode
+
+		e.SetValue(protocol.BodyTarget, "EndMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndValue != nil {
+		v := s.EndValue
+
+		e.SetFields(protocol.BodyTarget, "EndValue", v, protocol.Metadata{})
+	}
+	if s.StartMode != nil {
+		v := *s.StartMode
+
+		e.SetValue(protocol.BodyTarget, "StartMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartValue != nil {
+		v := s.StartValue
+
+		e.SetFields(protocol.BodyTarget, "StartValue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A typed link attribute definition.
@@ -17420,6 +20958,50 @@ func (s *TypedLinkAttributeDefinition) SetType(v string) *TypedLinkAttributeDefi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkAttributeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultValue != nil {
+		v := s.DefaultValue
+
+		e.SetFields(protocol.BodyTarget, "DefaultValue", v, protocol.Metadata{})
+	}
+	if s.IsImmutable != nil {
+		v := *s.IsImmutable
+
+		e.SetValue(protocol.BodyTarget, "IsImmutable", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequiredBehavior != nil {
+		v := *s.RequiredBehavior
+
+		e.SetValue(protocol.BodyTarget, "RequiredBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetMap(protocol.BodyTarget, "Rules", encodeRuleMap(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkAttributeDefinitionList(vs []*TypedLinkAttributeDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the range of attributes that are used by a specified filter.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkAttributeRange
 type TypedLinkAttributeRange struct {
@@ -17475,6 +21057,30 @@ func (s *TypedLinkAttributeRange) SetAttributeName(v string) *TypedLinkAttribute
 func (s *TypedLinkAttributeRange) SetRange(v *TypedAttributeValueRange) *TypedLinkAttributeRange {
 	s.Range = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.BodyTarget, "AttributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := s.Range
+
+		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkAttributeRangeList(vs []*TypedLinkAttributeRange) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Defines the typed links structure and its attributes. To create a typed link
@@ -17562,6 +21168,27 @@ func (s *TypedLinkFacet) SetName(v string) *TypedLinkFacet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkFacet) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetList(protocol.BodyTarget, "Attributes", encodeTypedLinkAttributeDefinitionList(v), protocol.Metadata{})
+	}
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A typed link facet attribute update.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkFacetAttributeUpdate
 type TypedLinkFacetAttributeUpdate struct {
@@ -17621,6 +21248,30 @@ func (s *TypedLinkFacetAttributeUpdate) SetAttribute(v *TypedLinkAttributeDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkFacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Attribute != nil {
+		v := s.Attribute
+
+		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkFacetAttributeUpdateList(vs []*TypedLinkFacetAttributeUpdate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Identifies the schema Amazon Resource Name (ARN) and facet name for the typed
 // link.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/TypedLinkSchemaAndFacetName
@@ -17675,6 +21326,22 @@ func (s *TypedLinkSchemaAndFacetName) SetSchemaArn(v string) *TypedLinkSchemaAnd
 func (s *TypedLinkSchemaAndFacetName) SetTypedLinkName(v string) *TypedLinkSchemaAndFacetName {
 	s.TypedLinkName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkSchemaAndFacetName) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TypedLinkName != nil {
+		v := *s.TypedLinkName
+
+		e.SetValue(protocol.BodyTarget, "TypedLinkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains all the information that is used to uniquely identify a typed link.
@@ -17779,6 +21446,40 @@ func (s *TypedLinkSpecifier) SetTypedLinkFacet(v *TypedLinkSchemaAndFacetName) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TypedLinkSpecifier) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IdentityAttributeValues) > 0 {
+		v := s.IdentityAttributeValues
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeValues", encodeAttributeNameAndValueList(v), protocol.Metadata{})
+	}
+	if s.SourceObjectReference != nil {
+		v := s.SourceObjectReference
+
+		e.SetFields(protocol.BodyTarget, "SourceObjectReference", v, protocol.Metadata{})
+	}
+	if s.TargetObjectReference != nil {
+		v := s.TargetObjectReference
+
+		e.SetFields(protocol.BodyTarget, "TargetObjectReference", v, protocol.Metadata{})
+	}
+	if s.TypedLinkFacet != nil {
+		v := s.TypedLinkFacet
+
+		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTypedLinkSpecifierList(vs []*TypedLinkSpecifier) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UntagResourceRequest
 type UntagResourceInput struct {
 	_ struct{} `type:"structure"`
@@ -17833,6 +21534,22 @@ func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceArn != nil {
+		v := *s.ResourceArn
+
+		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UntagResourceResponse
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -17846,6 +21563,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateFacetRequest
@@ -17936,6 +21659,32 @@ func (s *UpdateFacetInput) SetSchemaArn(v string) *UpdateFacetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeFacetAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectType != nil {
+		v := *s.ObjectType
+
+		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateFacetResponse
 type UpdateFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -17949,6 +21698,12 @@ func (s UpdateFacetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateObjectAttributesRequest
@@ -18029,6 +21784,27 @@ func (s *UpdateObjectAttributesInput) SetObjectReference(v *ObjectReference) *Up
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeObjectAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateObjectAttributesResponse
 type UpdateObjectAttributesOutput struct {
 	_ struct{} `type:"structure"`
@@ -18051,6 +21827,17 @@ func (s UpdateObjectAttributesOutput) GoString() string {
 func (s *UpdateObjectAttributesOutput) SetObjectIdentifier(v string) *UpdateObjectAttributesOutput {
 	s.ObjectIdentifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectIdentifier != nil {
+		v := *s.ObjectIdentifier
+
+		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateSchemaRequest
@@ -18110,6 +21897,22 @@ func (s *UpdateSchemaInput) SetSchemaArn(v string) *UpdateSchemaInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateSchemaResponse
 type UpdateSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -18133,6 +21936,17 @@ func (s UpdateSchemaOutput) GoString() string {
 func (s *UpdateSchemaOutput) SetSchemaArn(v string) *UpdateSchemaOutput {
 	s.SchemaArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetRequest
@@ -18234,6 +22048,32 @@ func (s *UpdateTypedLinkFacetInput) SetSchemaArn(v string) *UpdateTypedLinkFacet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AttributeUpdates) > 0 {
+		v := s.AttributeUpdates
+
+		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeTypedLinkFacetAttributeUpdateList(v), protocol.Metadata{})
+	}
+	if len(s.IdentityAttributeOrder) > 0 {
+		v := s.IdentityAttributeOrder
+
+		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SchemaArn != nil {
+		v := *s.SchemaArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/clouddirectory-2016-05-10/UpdateTypedLinkFacetResponse
 type UpdateTypedLinkFacetOutput struct {
 	_ struct{} `type:"structure"`
@@ -18247,6 +22087,12 @@ func (s UpdateTypedLinkFacetOutput) String() string {
 // GoString returns the string representation
 func (s UpdateTypedLinkFacetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 const (

--- a/service/clouddirectory/api.go
+++ b/service/clouddirectory/api.go
@@ -7905,11 +7905,6 @@ func (s *AddFacetToObjectInput) SetSchemaFacet(v *SchemaFacet) *AddFacetToObject
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddFacetToObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.ObjectAttributeList) > 0 {
 		v := s.ObjectAttributeList
 
@@ -7925,7 +7920,11 @@ func (s *AddFacetToObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7946,7 +7945,6 @@ func (s AddFacetToObjectOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddFacetToObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8007,17 +8005,16 @@ func (s *ApplySchemaInput) SetPublishedSchemaArn(v string) *ApplySchemaInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ApplySchemaInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.PublishedSchemaArn != nil {
 		v := *s.PublishedSchemaArn
 
 		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8069,7 +8066,6 @@ func (s *ApplySchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8165,11 +8161,6 @@ func (s *AttachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ChildReference", v, protocol.Metadata{})
 	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.LinkName != nil {
 		v := *s.LinkName
 
@@ -8180,7 +8171,11 @@ func (s *AttachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8215,7 +8210,6 @@ func (s *AttachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8284,11 +8278,6 @@ func (s *AttachPolicyInput) SetPolicyReference(v *ObjectReference) *AttachPolicy
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ObjectReference != nil {
 		v := s.ObjectReference
 
@@ -8299,7 +8288,11 @@ func (s *AttachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8320,7 +8313,6 @@ func (s AttachPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8394,11 +8386,6 @@ func (s *AttachToIndexInput) SetTargetReference(v *ObjectReference) *AttachToInd
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachToIndexInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IndexReference != nil {
 		v := s.IndexReference
 
@@ -8409,7 +8396,11 @@ func (s *AttachToIndexInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8444,7 +8435,6 @@ func (s *AttachToIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8566,11 +8556,6 @@ func (s *AttachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Attributes", encodeAttributeNameAndValueList(v), protocol.Metadata{})
 	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.SourceObjectReference != nil {
 		v := s.SourceObjectReference
 
@@ -8586,7 +8571,11 @@ func (s *AttachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8621,7 +8610,6 @@ func (s *AttachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8717,7 +8705,6 @@ func (s *AttributeKey) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8800,7 +8787,6 @@ func (s *AttributeKeyAndValue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8881,7 +8867,6 @@ func (s *AttributeNameAndValue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Value", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8993,7 +8978,6 @@ func (s *BatchAddFacetToObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9015,7 +8999,6 @@ func (s BatchAddFacetToObjectResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchAddFacetToObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9107,7 +9090,6 @@ func (s *BatchAttachObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9143,7 +9125,6 @@ func (s *BatchAttachObjectResponse) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "attachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9214,7 +9195,6 @@ func (s *BatchAttachPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9236,7 +9216,6 @@ func (s BatchAttachPolicyResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchAttachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9307,7 +9286,6 @@ func (s *BatchAttachToIndex) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9343,7 +9321,6 @@ func (s *BatchAttachToIndexResponse) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "AttachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9467,7 +9444,6 @@ func (s *BatchAttachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9503,7 +9479,6 @@ func (s *BatchAttachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9632,7 +9607,6 @@ func (s *BatchCreateIndex) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9668,7 +9642,6 @@ func (s *BatchCreateIndexResponse) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9821,7 +9794,6 @@ func (s *BatchCreateObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "SchemaFacet", encodeSchemaFacetList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9857,7 +9829,6 @@ func (s *BatchCreateObjectResponse) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9908,7 +9879,6 @@ func (s *BatchDeleteObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9930,7 +9900,6 @@ func (s BatchDeleteObjectResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchDeleteObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10001,7 +9970,6 @@ func (s *BatchDetachFromIndex) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10037,7 +10005,6 @@ func (s *BatchDetachFromIndexResponse) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10130,7 +10097,6 @@ func (s *BatchDetachObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10166,7 +10132,6 @@ func (s *BatchDetachObjectResponse) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "detachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10237,7 +10202,6 @@ func (s *BatchDetachPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10259,7 +10223,6 @@ func (s BatchDetachPolicyResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchDetachPolicyResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10316,7 +10279,6 @@ func (s *BatchDetachTypedLink) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10338,7 +10300,6 @@ func (s BatchDetachTypedLinkResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchDetachTypedLinkResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10390,7 +10351,6 @@ func (s *BatchGetObjectInformation) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10440,7 +10400,6 @@ func (s *BatchGetObjectInformationResponse) MarshalFields(e protocol.FieldEncode
 
 		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10523,7 +10482,6 @@ func (s *BatchListAttachedIndices) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10573,7 +10531,6 @@ func (s *BatchListAttachedIndicesResponse) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10704,7 +10661,6 @@ func (s *BatchListIncomingTypedLinks) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10754,7 +10710,6 @@ func (s *BatchListIncomingTypedLinksResponse) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10861,7 +10816,6 @@ func (s *BatchListIndex) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10911,7 +10865,6 @@ func (s *BatchListIndexResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11014,7 +10967,6 @@ func (s *BatchListObjectAttributes) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11065,7 +11017,6 @@ func (s *BatchListObjectAttributesResponse) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11148,7 +11099,6 @@ func (s *BatchListObjectChildren) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11199,7 +11149,6 @@ func (s *BatchListObjectChildrenResponse) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11283,7 +11232,6 @@ func (s *BatchListObjectParentPaths) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11333,7 +11281,6 @@ func (s *BatchListObjectParentPathsResponse) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11416,7 +11363,6 @@ func (s *BatchListObjectPolicies) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11466,7 +11412,6 @@ func (s *BatchListObjectPoliciesResponse) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11597,7 +11542,6 @@ func (s *BatchListOutgoingTypedLinks) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11647,7 +11591,6 @@ func (s *BatchListOutgoingTypedLinksResponse) MarshalFields(e protocol.FieldEnco
 
 		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11731,7 +11674,6 @@ func (s *BatchListPolicyAttachments) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11781,7 +11723,6 @@ func (s *BatchListPolicyAttachmentsResponse) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11865,7 +11806,6 @@ func (s *BatchLookupPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11916,7 +11856,6 @@ func (s *BatchLookupPolicyResponse) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11967,7 +11906,6 @@ func (s *BatchReadException) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12047,6 +11985,11 @@ func (s *BatchReadInput) SetOperations(v []*BatchReadOperation) *BatchReadInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchReadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Operations) > 0 {
+		v := s.Operations
+
+		e.SetList(protocol.BodyTarget, "Operations", encodeBatchReadOperationList(v), protocol.Metadata{})
+	}
 	if s.ConsistencyLevel != nil {
 		v := *s.ConsistencyLevel
 
@@ -12057,12 +12000,6 @@ func (s *BatchReadInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Operations) > 0 {
-		v := s.Operations
-
-		e.SetList(protocol.BodyTarget, "Operations", encodeBatchReadOperationList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -12316,7 +12253,6 @@ func (s *BatchReadOperation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12374,7 +12310,6 @@ func (s *BatchReadOperationResponse) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "SuccessfulResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12417,7 +12352,6 @@ func (s *BatchReadOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Responses", encodeBatchReadOperationResponseList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12606,7 +12540,6 @@ func (s *BatchReadSuccessfulResponse) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "LookupPolicy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12681,7 +12614,6 @@ func (s *BatchRemoveFacetFromObject) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12703,7 +12635,6 @@ func (s BatchRemoveFacetFromObjectResponse) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchRemoveFacetFromObjectResponse) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12783,7 +12714,6 @@ func (s *BatchUpdateObjectAttributes) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12819,7 +12749,6 @@ func (s *BatchUpdateObjectAttributesResponse) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12889,17 +12818,16 @@ func (s *BatchWriteInput) SetOperations(v []*BatchWriteOperation) *BatchWriteInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *BatchWriteInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.Operations) > 0 {
 		v := s.Operations
 
 		e.SetList(protocol.BodyTarget, "Operations", encodeBatchWriteOperationList(v), protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -13201,7 +13129,6 @@ func (s *BatchWriteOperation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13431,7 +13358,6 @@ func (s *BatchWriteOperationResponse) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "UpdateObjectAttributes", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13474,7 +13400,6 @@ func (s *BatchWriteOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Responses", encodeBatchWriteOperationResponseList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13547,7 +13472,6 @@ func (s *CreateDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13635,7 +13559,6 @@ func (s *CreateDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13761,7 +13684,6 @@ func (s *CreateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13782,7 +13704,6 @@ func (s CreateFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13888,11 +13809,6 @@ func (s *CreateIndexInput) SetParentReference(v *ObjectReference) *CreateIndexIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateIndexInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IsUnique != nil {
 		v := *s.IsUnique
 
@@ -13913,7 +13829,11 @@ func (s *CreateIndexInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -13948,7 +13868,6 @@ func (s *CreateIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14060,11 +13979,6 @@ func (s *CreateObjectInput) SetSchemaFacets(v []*SchemaFacet) *CreateObjectInput
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.LinkName != nil {
 		v := *s.LinkName
 
@@ -14085,7 +13999,11 @@ func (s *CreateObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14120,7 +14038,6 @@ func (s *CreateObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14174,7 +14091,6 @@ func (s *CreateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14210,7 +14126,6 @@ func (s *CreateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14285,7 +14200,6 @@ func (s *CreateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14306,7 +14220,6 @@ func (s CreateTypedLinkFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14356,7 +14269,6 @@ func (s *DeleteDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14393,7 +14305,6 @@ func (s *DeleteDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14466,7 +14377,6 @@ func (s *DeleteFacetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14487,7 +14397,6 @@ func (s DeleteFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14547,17 +14456,16 @@ func (s *DeleteObjectInput) SetObjectReference(v *ObjectReference) *DeleteObject
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ObjectReference != nil {
 		v := s.ObjectReference
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14578,7 +14486,6 @@ func (s DeleteObjectOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14629,7 +14536,6 @@ func (s *DeleteSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14665,7 +14571,6 @@ func (s *DeleteSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14735,7 +14640,6 @@ func (s *DeleteTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14756,7 +14660,6 @@ func (s DeleteTypedLinkFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14830,11 +14733,6 @@ func (s *DetachFromIndexInput) SetTargetReference(v *ObjectReference) *DetachFro
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachFromIndexInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IndexReference != nil {
 		v := s.IndexReference
 
@@ -14845,7 +14743,11 @@ func (s *DetachFromIndexInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14880,7 +14782,6 @@ func (s *DetachFromIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14958,11 +14859,6 @@ func (s *DetachObjectInput) SetParentReference(v *ObjectReference) *DetachObject
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.LinkName != nil {
 		v := *s.LinkName
 
@@ -14973,7 +14869,11 @@ func (s *DetachObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ParentReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -15008,7 +14908,6 @@ func (s *DetachObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DetachedObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15082,11 +14981,6 @@ func (s *DetachPolicyInput) SetPolicyReference(v *ObjectReference) *DetachPolicy
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ObjectReference != nil {
 		v := s.ObjectReference
 
@@ -15097,7 +14991,11 @@ func (s *DetachPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -15118,7 +15016,6 @@ func (s DetachPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -15183,17 +15080,16 @@ func (s *DetachTypedLinkInput) SetTypedLinkSpecifier(v *TypedLinkSpecifier) *Det
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachTypedLinkInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TypedLinkSpecifier != nil {
 		v := s.TypedLinkSpecifier
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkSpecifier", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -15214,7 +15110,6 @@ func (s DetachTypedLinkOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachTypedLinkOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -15293,7 +15188,6 @@ func (s *Directory) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15351,7 +15245,6 @@ func (s *DisableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15388,7 +15281,6 @@ func (s *DisableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15438,7 +15330,6 @@ func (s *EnableDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15475,7 +15366,6 @@ func (s *EnableDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DirectoryArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15526,7 +15416,6 @@ func (s *Facet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ObjectType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15636,7 +15525,6 @@ func (s *FacetAttribute) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RequiredBehavior", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15738,7 +15626,6 @@ func (s *FacetAttributeDefinition) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15819,7 +15706,6 @@ func (s *FacetAttributeReference) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TargetFacetName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15884,7 +15770,6 @@ func (s *FacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15942,7 +15827,6 @@ func (s *GetDirectoryInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15979,7 +15863,6 @@ func (s *GetDirectoryOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Directory", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16052,7 +15935,6 @@ func (s *GetFacetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16087,7 +15969,6 @@ func (s *GetFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Facet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16155,6 +16036,11 @@ func (s *GetObjectInformationInput) SetObjectReference(v *ObjectReference) *GetO
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectInformationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ObjectReference != nil {
+		v := s.ObjectReference
+
+		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
+	}
 	if s.ConsistencyLevel != nil {
 		v := *s.ConsistencyLevel
 
@@ -16165,12 +16051,6 @@ func (s *GetObjectInformationInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.ObjectReference != nil {
-		v := s.ObjectReference
-
-		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -16219,7 +16099,6 @@ func (s *GetObjectInformationOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "SchemaFacets", encodeSchemaFacetList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16269,7 +16148,6 @@ func (s *GetSchemaAsJsonInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16318,7 +16196,6 @@ func (s *GetSchemaAsJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16388,7 +16265,6 @@ func (s *GetTypedLinkFacetInformationInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16430,7 +16306,6 @@ func (s *GetTypedLinkFacetInformationOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "IdentityAttributeOrder", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16480,7 +16355,6 @@ func (s *IndexAttachment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16569,7 +16443,6 @@ func (s *ListAppliedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16618,7 +16491,6 @@ func (s *ListAppliedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16707,16 +16579,6 @@ func (s *ListAttachedIndicesInput) SetTargetReference(v *ObjectReference) *ListA
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListAttachedIndicesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -16732,7 +16594,16 @@ func (s *ListAttachedIndicesInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "TargetReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -16781,7 +16652,6 @@ func (s *ListAttachedIndicesOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16843,7 +16713,6 @@ func (s *ListDevelopmentSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16892,7 +16761,6 @@ func (s *ListDevelopmentSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16969,7 +16837,6 @@ func (s *ListDirectoriesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17021,7 +16888,6 @@ func (s *ListDirectoriesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17124,7 +16990,6 @@ func (s *ListFacetAttributesInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17173,7 +17038,6 @@ func (s *ListFacetAttributesOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17254,7 +17118,6 @@ func (s *ListFacetNamesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17303,7 +17166,6 @@ func (s *ListFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17435,11 +17297,6 @@ func (s *ListIncomingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.FilterAttributeRanges) > 0 {
 		v := s.FilterAttributeRanges
 
@@ -17465,7 +17322,11 @@ func (s *ListIncomingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -17514,7 +17375,6 @@ func (s *ListIncomingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17622,16 +17482,6 @@ func (s *ListIndexInput) SetRangesOnIndexedValues(v []*ObjectAttributeRange) *Li
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListIndexInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IndexReference != nil {
 		v := s.IndexReference
 
@@ -17652,7 +17502,16 @@ func (s *ListIndexInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "RangesOnIndexedValues", encodeObjectAttributeRangeList(v), protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -17701,7 +17560,6 @@ func (s *ListIndexOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17808,16 +17666,6 @@ func (s *ListObjectAttributesInput) SetObjectReference(v *ObjectReference) *List
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.FacetFilter != nil {
 		v := s.FacetFilter
 
@@ -17838,7 +17686,16 @@ func (s *ListObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -17888,7 +17745,6 @@ func (s *ListObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17981,16 +17837,6 @@ func (s *ListObjectChildrenInput) SetObjectReference(v *ObjectReference) *ListOb
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectChildrenInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -18006,7 +17852,16 @@ func (s *ListObjectChildrenInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18056,7 +17911,6 @@ func (s *ListObjectChildrenOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18137,11 +17991,6 @@ func (s *ListObjectParentPathsInput) SetObjectReference(v *ObjectReference) *Lis
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectParentPathsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -18157,7 +18006,11 @@ func (s *ListObjectParentPathsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18206,7 +18059,6 @@ func (s *ListObjectParentPathsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "PathToObjectIdentifiersList", encodePathToObjectIdentifiersList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18299,16 +18151,6 @@ func (s *ListObjectParentsInput) SetObjectReference(v *ObjectReference) *ListObj
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectParentsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -18324,7 +18166,16 @@ func (s *ListObjectParentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18374,7 +18225,6 @@ func (s *ListObjectParentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Parents", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18466,16 +18316,6 @@ func (s *ListObjectPoliciesInput) SetObjectReference(v *ObjectReference) *ListOb
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -18491,7 +18331,16 @@ func (s *ListObjectPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18540,7 +18389,6 @@ func (s *ListObjectPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18672,11 +18520,6 @@ func (s *ListOutgoingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "ConsistencyLevel", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.FilterAttributeRanges) > 0 {
 		v := s.FilterAttributeRanges
 
@@ -18702,7 +18545,11 @@ func (s *ListOutgoingTypedLinksInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18751,7 +18598,6 @@ func (s *ListOutgoingTypedLinksOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "TypedLinkSpecifiers", encodeTypedLinkSpecifierList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18843,16 +18689,6 @@ func (s *ListPolicyAttachmentsInput) SetPolicyReference(v *ObjectReference) *Lis
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPolicyAttachmentsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ConsistencyLevel != nil {
-		v := *s.ConsistencyLevel
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -18868,7 +18704,16 @@ func (s *ListPolicyAttachmentsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "PolicyReference", v, protocol.Metadata{})
 	}
+	if s.ConsistencyLevel != nil {
+		v := *s.ConsistencyLevel
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-consistency-level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18917,7 +18762,6 @@ func (s *ListPolicyAttachmentsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "ObjectIdentifiers", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18979,7 +18823,6 @@ func (s *ListPublishedSchemaArnsInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19028,7 +18871,6 @@ func (s *ListPublishedSchemaArnsOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetList(protocol.BodyTarget, "SchemaArns", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19112,7 +18954,6 @@ func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "ResourceArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19162,7 +19003,6 @@ func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19263,7 +19103,6 @@ func (s *ListTypedLinkFacetAttributesInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19312,7 +19151,6 @@ func (s *ListTypedLinkFacetAttributesOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19394,7 +19232,6 @@ func (s *ListTypedLinkFacetNamesInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19443,7 +19280,6 @@ func (s *ListTypedLinkFacetNamesOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19525,11 +19361,6 @@ func (s *LookupPolicyInput) SetObjectReference(v *ObjectReference) *LookupPolicy
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *LookupPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -19545,7 +19376,11 @@ func (s *LookupPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19595,7 +19430,6 @@ func (s *LookupPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "PolicyToPathList", encodePolicyToPathList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19645,7 +19479,6 @@ func (s *ObjectAttributeAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectAttributeUpdateValue", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19715,7 +19548,6 @@ func (s *ObjectAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19788,7 +19620,6 @@ func (s *ObjectAttributeUpdate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ObjectAttributeKey", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19846,7 +19677,6 @@ func (s *ObjectReference) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Selector", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19897,7 +19727,6 @@ func (s *PathToObjectIdentifiers) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19970,7 +19799,6 @@ func (s *PolicyAttachment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PolicyType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20030,7 +19858,6 @@ func (s *PolicyToPath) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Policies", encodePolicyAttachmentList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20114,11 +19941,6 @@ func (s *PublishSchemaInput) SetVersion(v string) *PublishSchemaInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PublishSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DevelopmentSchemaArn != nil {
-		v := *s.DevelopmentSchemaArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
@@ -20129,7 +19951,11 @@ func (s *PublishSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DevelopmentSchemaArn != nil {
+		v := *s.DevelopmentSchemaArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -20165,7 +19991,6 @@ func (s *PublishSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PublishedSchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20234,7 +20059,6 @@ func (s *PutSchemaFromJsonInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20269,7 +20093,6 @@ func (s *PutSchemaFromJsonOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20347,11 +20170,6 @@ func (s *RemoveFacetFromObjectInput) SetSchemaFacet(v *SchemaFacet) *RemoveFacet
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveFacetFromObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ObjectReference != nil {
 		v := s.ObjectReference
 
@@ -20362,7 +20180,11 @@ func (s *RemoveFacetFromObjectInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "SchemaFacet", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -20383,7 +20205,6 @@ func (s RemoveFacetFromObjectOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveFacetFromObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20434,7 +20255,6 @@ func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20505,7 +20325,6 @@ func (s *SchemaFacet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20563,7 +20382,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20641,7 +20459,6 @@ func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20662,7 +20479,6 @@ func (s TagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20758,7 +20574,6 @@ func (s *TypedAttributeValue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20856,7 +20671,6 @@ func (s *TypedAttributeValueRange) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "StartValue", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20990,7 +20804,6 @@ func (s *TypedLinkAttributeDefinition) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21071,7 +20884,6 @@ func (s *TypedLinkAttributeRange) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Range", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21185,7 +20997,6 @@ func (s *TypedLinkFacet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21260,7 +21071,6 @@ func (s *TypedLinkFacetAttributeUpdate) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetFields(protocol.BodyTarget, "Attribute", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21340,7 +21150,6 @@ func (s *TypedLinkSchemaAndFacetName) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "TypedLinkName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21468,7 +21277,6 @@ func (s *TypedLinkSpecifier) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TypedLinkFacet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21546,7 +21354,6 @@ func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21567,7 +21374,6 @@ func (s UntagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21681,7 +21487,6 @@ func (s *UpdateFacetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21702,7 +21507,6 @@ func (s UpdateFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21791,17 +21595,16 @@ func (s *UpdateObjectAttributesInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "AttributeUpdates", encodeObjectAttributeUpdateList(v), protocol.Metadata{})
 	}
-	if s.DirectoryArn != nil {
-		v := *s.DirectoryArn
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ObjectReference != nil {
 		v := s.ObjectReference
 
 		e.SetFields(protocol.BodyTarget, "ObjectReference", v, protocol.Metadata{})
 	}
+	if s.DirectoryArn != nil {
+		v := *s.DirectoryArn
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -21836,7 +21639,6 @@ func (s *UpdateObjectAttributesOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "ObjectIdentifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21909,7 +21711,6 @@ func (s *UpdateSchemaInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21945,7 +21746,6 @@ func (s *UpdateSchemaOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SchemaArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22070,7 +21870,6 @@ func (s *UpdateTypedLinkFacetInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-data-partition", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22091,7 +21890,6 @@ func (s UpdateTypedLinkFacetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateTypedLinkFacetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -3248,6 +3248,27 @@ func (s *ActiveTrustedSigners) SetQuantity(v int64) *ActiveTrustedSigners {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActiveTrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeSignerList(v), protocol.Metadata{ListLocationName: "Signer"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about CNAMEs (alternate domain names),
 // if any, for this distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Aliases
@@ -3298,6 +3319,22 @@ func (s *Aliases) SetItems(v []*string) *Aliases {
 func (s *Aliases) SetQuantity(v int64) *Aliases {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Aliases) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "CNAME"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls which HTTP methods CloudFront processes and
@@ -3392,6 +3429,27 @@ func (s *AllowedMethods) SetItems(v []*string) *AllowedMethods {
 func (s *AllowedMethods) SetQuantity(v int64) *AllowedMethods {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AllowedMethods) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CachedMethods != nil {
+		v := s.CachedMethods
+
+		e.SetFields(protocol.BodyTarget, "CachedMethods", v, protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Method"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes how CloudFront processes requests.
@@ -3701,6 +3759,80 @@ func (s *CacheBehavior) SetViewerProtocolPolicy(v string) *CacheBehavior {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowedMethods != nil {
+		v := s.AllowedMethods
+
+		e.SetFields(protocol.BodyTarget, "AllowedMethods", v, protocol.Metadata{})
+	}
+	if s.Compress != nil {
+		v := *s.Compress
+
+		e.SetValue(protocol.BodyTarget, "Compress", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DefaultTTL != nil {
+		v := *s.DefaultTTL
+
+		e.SetValue(protocol.BodyTarget, "DefaultTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ForwardedValues != nil {
+		v := s.ForwardedValues
+
+		e.SetFields(protocol.BodyTarget, "ForwardedValues", v, protocol.Metadata{})
+	}
+	if s.LambdaFunctionAssociations != nil {
+		v := s.LambdaFunctionAssociations
+
+		e.SetFields(protocol.BodyTarget, "LambdaFunctionAssociations", v, protocol.Metadata{})
+	}
+	if s.MaxTTL != nil {
+		v := *s.MaxTTL
+
+		e.SetValue(protocol.BodyTarget, "MaxTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinTTL != nil {
+		v := *s.MinTTL
+
+		e.SetValue(protocol.BodyTarget, "MinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PathPattern != nil {
+		v := *s.PathPattern
+
+		e.SetValue(protocol.BodyTarget, "PathPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SmoothStreaming != nil {
+		v := *s.SmoothStreaming
+
+		e.SetValue(protocol.BodyTarget, "SmoothStreaming", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.TargetOriginId != nil {
+		v := *s.TargetOriginId
+
+		e.SetValue(protocol.BodyTarget, "TargetOriginId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+	if s.ViewerProtocolPolicy != nil {
+		v := *s.ViewerProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCacheBehaviorList(vs []*CacheBehavior) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains zero or more CacheBehavior elements.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CacheBehaviors
 type CacheBehaviors struct {
@@ -3759,6 +3891,22 @@ func (s *CacheBehaviors) SetItems(v []*CacheBehavior) *CacheBehaviors {
 func (s *CacheBehaviors) SetQuantity(v int64) *CacheBehaviors {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CacheBehaviors) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeCacheBehaviorList(v), protocol.Metadata{ListLocationName: "CacheBehavior"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls whether CloudFront caches the response to requests
@@ -3827,6 +3975,22 @@ func (s *CachedMethods) SetQuantity(v int64) *CachedMethods {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CachedMethods) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Method"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that specifies whether you want CloudFront to forward cookies
 // to the origin and, if so, which ones. For more information about forwarding
 // cookies to the origin, see How CloudFront Forwards, Caches, and Logs Cookies
@@ -3880,6 +4044,22 @@ func (s *CookieNames) SetItems(v []*string) *CookieNames {
 func (s *CookieNames) SetQuantity(v int64) *CookieNames {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CookieNames) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies whether you want CloudFront to forward cookies
@@ -3957,6 +4137,22 @@ func (s *CookiePreference) SetWhitelistedNames(v *CookieNames) *CookiePreference
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CookiePreference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Forward != nil {
+		v := *s.Forward
+
+		e.SetValue(protocol.BodyTarget, "Forward", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WhitelistedNames != nil {
+		v := s.WhitelistedNames
+
+		e.SetFields(protocol.BodyTarget, "WhitelistedNames", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to create a new origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateCloudFrontOriginAccessIdentityRequest
 type CreateCloudFrontOriginAccessIdentityInput struct {
@@ -4002,6 +4198,17 @@ func (s *CreateCloudFrontOriginAccessIdentityInput) SetCloudFrontOriginAccessIde
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateCloudFrontOriginAccessIdentityResult
 type CreateCloudFrontOriginAccessIdentityOutput struct {
@@ -4044,6 +4251,27 @@ func (s *CreateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *CreateCl
 func (s *CreateCloudFrontOriginAccessIdentityOutput) SetLocation(v string) *CreateCloudFrontOriginAccessIdentityOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new distribution.
@@ -4091,6 +4319,17 @@ func (s *CreateDistributionInput) SetDistributionConfig(v *DistributionConfig) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateDistributionResult
 type CreateDistributionOutput struct {
@@ -4133,6 +4372,27 @@ func (s *CreateDistributionOutput) SetETag(v string) *CreateDistributionOutput {
 func (s *CreateDistributionOutput) SetLocation(v string) *CreateDistributionOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new distribution with tags.
@@ -4180,6 +4440,17 @@ func (s *CreateDistributionWithTagsInput) SetDistributionConfigWithTags(v *Distr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionWithTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfigWithTags != nil {
+		v := s.DistributionConfigWithTags
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateDistributionWithTagsResult
 type CreateDistributionWithTagsOutput struct {
@@ -4222,6 +4493,27 @@ func (s *CreateDistributionWithTagsOutput) SetETag(v string) *CreateDistribution
 func (s *CreateDistributionWithTagsOutput) SetLocation(v string) *CreateDistributionWithTagsOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create an invalidation.
@@ -4283,6 +4575,22 @@ func (s *CreateInvalidationInput) SetInvalidationBatch(v *InvalidationBatch) *Cr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvalidationBatch != nil {
+		v := s.InvalidationBatch
+
+		e.SetFields(protocol.PayloadTarget, "InvalidationBatch", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateInvalidationResult
 type CreateInvalidationOutput struct {
@@ -4316,6 +4624,22 @@ func (s *CreateInvalidationOutput) SetInvalidation(v *Invalidation) *CreateInval
 func (s *CreateInvalidationOutput) SetLocation(v string) *CreateInvalidationOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Invalidation != nil {
+		v := s.Invalidation
+
+		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new streaming distribution.
@@ -4363,6 +4687,17 @@ func (s *CreateStreamingDistributionInput) SetStreamingDistributionConfig(v *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateStreamingDistributionResult
 type CreateStreamingDistributionOutput struct {
@@ -4405,6 +4740,27 @@ func (s *CreateStreamingDistributionOutput) SetLocation(v string) *CreateStreami
 func (s *CreateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to create a new streaming distribution with tags.
@@ -4452,6 +4808,17 @@ func (s *CreateStreamingDistributionWithTagsInput) SetStreamingDistributionConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionWithTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfigWithTags != nil {
+		v := s.StreamingDistributionConfigWithTags
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CreateStreamingDistributionWithTagsResult
 type CreateStreamingDistributionWithTagsOutput struct {
@@ -4493,6 +4860,27 @@ func (s *CreateStreamingDistributionWithTagsOutput) SetLocation(v string) *Creat
 func (s *CreateStreamingDistributionWithTagsOutput) SetStreamingDistribution(v *StreamingDistribution) *CreateStreamingDistributionWithTagsOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateStreamingDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls:
@@ -4624,6 +5012,40 @@ func (s *CustomErrorResponse) SetResponsePagePath(v string) *CustomErrorResponse
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomErrorResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCachingMinTTL != nil {
+		v := *s.ErrorCachingMinTTL
+
+		e.SetValue(protocol.BodyTarget, "ErrorCachingMinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResponseCode != nil {
+		v := *s.ResponseCode
+
+		e.SetValue(protocol.BodyTarget, "ResponseCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponsePagePath != nil {
+		v := *s.ResponsePagePath
+
+		e.SetValue(protocol.BodyTarget, "ResponsePagePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCustomErrorResponseList(vs []*CustomErrorResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that controls:
 //
 //    * Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range
@@ -4695,6 +5117,22 @@ func (s *CustomErrorResponses) SetQuantity(v int64) *CustomErrorResponses {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomErrorResponses) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeCustomErrorResponseList(v), protocol.Metadata{ListLocationName: "CustomErrorResponse"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the list of Custom Headers for each origin.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CustomHeaders
 type CustomHeaders struct {
@@ -4754,6 +5192,22 @@ func (s *CustomHeaders) SetItems(v []*OriginCustomHeader) *CustomHeaders {
 func (s *CustomHeaders) SetQuantity(v int64) *CustomHeaders {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomHeaders) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginCustomHeaderList(v), protocol.Metadata{ListLocationName: "OriginCustomHeader"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A customer origin.
@@ -4867,6 +5321,42 @@ func (s *CustomOriginConfig) SetOriginReadTimeout(v int64) *CustomOriginConfig {
 func (s *CustomOriginConfig) SetOriginSslProtocols(v *OriginSslProtocols) *CustomOriginConfig {
 	s.OriginSslProtocols = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CustomOriginConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HTTPPort != nil {
+		v := *s.HTTPPort
+
+		e.SetValue(protocol.BodyTarget, "HTTPPort", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPSPort != nil {
+		v := *s.HTTPSPort
+
+		e.SetValue(protocol.BodyTarget, "HTTPSPort", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginKeepaliveTimeout != nil {
+		v := *s.OriginKeepaliveTimeout
+
+		e.SetValue(protocol.BodyTarget, "OriginKeepaliveTimeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginProtocolPolicy != nil {
+		v := *s.OriginProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "OriginProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginReadTimeout != nil {
+		v := *s.OriginReadTimeout
+
+		e.SetValue(protocol.BodyTarget, "OriginReadTimeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OriginSslProtocols != nil {
+		v := s.OriginSslProtocols
+
+		e.SetFields(protocol.BodyTarget, "OriginSslProtocols", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes the default cache behavior if you don't specify
@@ -5117,6 +5607,67 @@ func (s *DefaultCacheBehavior) SetViewerProtocolPolicy(v string) *DefaultCacheBe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultCacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowedMethods != nil {
+		v := s.AllowedMethods
+
+		e.SetFields(protocol.BodyTarget, "AllowedMethods", v, protocol.Metadata{})
+	}
+	if s.Compress != nil {
+		v := *s.Compress
+
+		e.SetValue(protocol.BodyTarget, "Compress", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DefaultTTL != nil {
+		v := *s.DefaultTTL
+
+		e.SetValue(protocol.BodyTarget, "DefaultTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ForwardedValues != nil {
+		v := s.ForwardedValues
+
+		e.SetFields(protocol.BodyTarget, "ForwardedValues", v, protocol.Metadata{})
+	}
+	if s.LambdaFunctionAssociations != nil {
+		v := s.LambdaFunctionAssociations
+
+		e.SetFields(protocol.BodyTarget, "LambdaFunctionAssociations", v, protocol.Metadata{})
+	}
+	if s.MaxTTL != nil {
+		v := *s.MaxTTL
+
+		e.SetValue(protocol.BodyTarget, "MaxTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinTTL != nil {
+		v := *s.MinTTL
+
+		e.SetValue(protocol.BodyTarget, "MinTTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SmoothStreaming != nil {
+		v := *s.SmoothStreaming
+
+		e.SetValue(protocol.BodyTarget, "SmoothStreaming", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.TargetOriginId != nil {
+		v := *s.TargetOriginId
+
+		e.SetValue(protocol.BodyTarget, "TargetOriginId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+	if s.ViewerProtocolPolicy != nil {
+		v := *s.ViewerProtocolPolicy
+
+		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Deletes a origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteCloudFrontOriginAccessIdentityRequest
 type DeleteCloudFrontOriginAccessIdentityInput struct {
@@ -5167,6 +5718,22 @@ func (s *DeleteCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Delete
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteCloudFrontOriginAccessIdentityOutput
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
 	_ struct{} `type:"structure"`
@@ -5180,6 +5747,12 @@ func (s DeleteCloudFrontOriginAccessIdentityOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // This action deletes a web distribution. To delete a web distribution using
@@ -5266,6 +5839,22 @@ func (s *DeleteDistributionInput) SetIfMatch(v string) *DeleteDistributionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteDistributionOutput
 type DeleteDistributionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5279,6 +5868,12 @@ func (s DeleteDistributionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRoleRequest
@@ -5318,6 +5913,17 @@ func (s *DeleteServiceLinkedRoleInput) SetRoleName(v string) *DeleteServiceLinke
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteServiceLinkedRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleName != nil {
+		v := *s.RoleName
+
+		e.SetValue(protocol.PathTarget, "RoleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteServiceLinkedRoleOutput
 type DeleteServiceLinkedRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -5331,6 +5937,12 @@ func (s DeleteServiceLinkedRoleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteServiceLinkedRoleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteServiceLinkedRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The request to delete a streaming distribution.
@@ -5383,6 +5995,22 @@ func (s *DeleteStreamingDistributionInput) SetIfMatch(v string) *DeleteStreaming
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DeleteStreamingDistributionOutput
 type DeleteStreamingDistributionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5396,6 +6024,12 @@ func (s DeleteStreamingDistributionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteStreamingDistributionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The distribution's information.
@@ -5511,6 +6145,52 @@ func (s *Distribution) SetLastModifiedTime(v time.Time) *Distribution {
 func (s *Distribution) SetStatus(v string) *Distribution {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Distribution) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ActiveTrustedSigners != nil {
+		v := s.ActiveTrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "ActiveTrustedSigners", v, protocol.Metadata{})
+	}
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InProgressInvalidationBatches != nil {
+		v := *s.InProgressInvalidationBatches
+
+		e.SetValue(protocol.BodyTarget, "InProgressInvalidationBatches", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A distribution configuration.
@@ -5952,6 +6632,92 @@ func (s *DistributionConfig) SetWebACLId(v string) *DistributionConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CacheBehaviors != nil {
+		v := s.CacheBehaviors
+
+		e.SetFields(protocol.BodyTarget, "CacheBehaviors", v, protocol.Metadata{})
+	}
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CustomErrorResponses != nil {
+		v := s.CustomErrorResponses
+
+		e.SetFields(protocol.BodyTarget, "CustomErrorResponses", v, protocol.Metadata{})
+	}
+	if s.DefaultCacheBehavior != nil {
+		v := s.DefaultCacheBehavior
+
+		e.SetFields(protocol.BodyTarget, "DefaultCacheBehavior", v, protocol.Metadata{})
+	}
+	if s.DefaultRootObject != nil {
+		v := *s.DefaultRootObject
+
+		e.SetValue(protocol.BodyTarget, "DefaultRootObject", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HttpVersion != nil {
+		v := *s.HttpVersion
+
+		e.SetValue(protocol.BodyTarget, "HttpVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsIPV6Enabled != nil {
+		v := *s.IsIPV6Enabled
+
+		e.SetValue(protocol.BodyTarget, "IsIPV6Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Logging != nil {
+		v := s.Logging
+
+		e.SetFields(protocol.BodyTarget, "Logging", v, protocol.Metadata{})
+	}
+	if s.Origins != nil {
+		v := s.Origins
+
+		e.SetFields(protocol.BodyTarget, "Origins", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restrictions != nil {
+		v := s.Restrictions
+
+		e.SetFields(protocol.BodyTarget, "Restrictions", v, protocol.Metadata{})
+	}
+	if s.ViewerCertificate != nil {
+		v := s.ViewerCertificate
+
+		e.SetFields(protocol.BodyTarget, "ViewerCertificate", v, protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A distribution Configuration and a list of tags to be associated with the
 // distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/DistributionConfigWithTags
@@ -6015,6 +6781,22 @@ func (s *DistributionConfigWithTags) SetDistributionConfig(v *DistributionConfig
 func (s *DistributionConfigWithTags) SetTags(v *Tags) *DistributionConfigWithTags {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionConfigWithTags) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A distribution list.
@@ -6099,6 +6881,42 @@ func (s *DistributionList) SetNextMarker(v string) *DistributionList {
 func (s *DistributionList) SetQuantity(v int64) *DistributionList {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeDistributionSummaryList(v), protocol.Metadata{ListLocationName: "DistributionSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A summary of the information about a CloudFront distribution.
@@ -6407,6 +7225,110 @@ func (s *DistributionSummary) SetWebACLId(v string) *DistributionSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DistributionSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CacheBehaviors != nil {
+		v := s.CacheBehaviors
+
+		e.SetFields(protocol.BodyTarget, "CacheBehaviors", v, protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CustomErrorResponses != nil {
+		v := s.CustomErrorResponses
+
+		e.SetFields(protocol.BodyTarget, "CustomErrorResponses", v, protocol.Metadata{})
+	}
+	if s.DefaultCacheBehavior != nil {
+		v := s.DefaultCacheBehavior
+
+		e.SetFields(protocol.BodyTarget, "DefaultCacheBehavior", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HttpVersion != nil {
+		v := *s.HttpVersion
+
+		e.SetValue(protocol.BodyTarget, "HttpVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsIPV6Enabled != nil {
+		v := *s.IsIPV6Enabled
+
+		e.SetValue(protocol.BodyTarget, "IsIPV6Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Origins != nil {
+		v := s.Origins
+
+		e.SetFields(protocol.BodyTarget, "Origins", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restrictions != nil {
+		v := s.Restrictions
+
+		e.SetFields(protocol.BodyTarget, "Restrictions", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ViewerCertificate != nil {
+		v := s.ViewerCertificate
+
+		e.SetFields(protocol.BodyTarget, "ViewerCertificate", v, protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDistributionSummaryList(vs []*DistributionSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that specifies how CloudFront handles query strings and cookies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ForwardedValues
 type ForwardedValues struct {
@@ -6522,6 +7444,32 @@ func (s *ForwardedValues) SetQueryStringCacheKeys(v *QueryStringCacheKeys) *Forw
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ForwardedValues) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cookies != nil {
+		v := s.Cookies
+
+		e.SetFields(protocol.BodyTarget, "Cookies", v, protocol.Metadata{})
+	}
+	if s.Headers != nil {
+		v := s.Headers
+
+		e.SetFields(protocol.BodyTarget, "Headers", v, protocol.Metadata{})
+	}
+	if s.QueryString != nil {
+		v := *s.QueryString
+
+		e.SetValue(protocol.BodyTarget, "QueryString", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.QueryStringCacheKeys != nil {
+		v := s.QueryStringCacheKeys
+
+		e.SetFields(protocol.BodyTarget, "QueryStringCacheKeys", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that controls the countries in which your content is distributed.
 // CloudFront determines the location of your users using MaxMind GeoIP databases.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GeoRestriction
@@ -6610,6 +7558,27 @@ func (s *GeoRestriction) SetRestrictionType(v string) *GeoRestriction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoRestriction) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Location"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestrictionType != nil {
+		v := *s.RestrictionType
+
+		e.SetValue(protocol.BodyTarget, "RestrictionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The origin access identity's configuration information. For more information,
 // see CloudFrontOriginAccessIdentityConfigComplexType.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityConfigRequest
@@ -6651,6 +7620,17 @@ func (s *GetCloudFrontOriginAccessIdentityConfigInput) SetId(v string) *GetCloud
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityConfigResult
 type GetCloudFrontOriginAccessIdentityConfigOutput struct {
@@ -6683,6 +7663,22 @@ func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetCloudFrontOriginAcces
 func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityConfigOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get an origin access identity's information.
@@ -6725,6 +7721,17 @@ func (s *GetCloudFrontOriginAccessIdentityInput) SetId(v string) *GetCloudFrontO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetCloudFrontOriginAccessIdentityResult
 type GetCloudFrontOriginAccessIdentityOutput struct {
@@ -6758,6 +7765,22 @@ func (s *GetCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessIdent
 func (s *GetCloudFrontOriginAccessIdentityOutput) SetETag(v string) *GetCloudFrontOriginAccessIdentityOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a distribution configuration.
@@ -6800,6 +7823,17 @@ func (s *GetDistributionConfigInput) SetId(v string) *GetDistributionConfigInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetDistributionConfigResult
 type GetDistributionConfigOutput struct {
@@ -6832,6 +7866,22 @@ func (s *GetDistributionConfigOutput) SetDistributionConfig(v *DistributionConfi
 func (s *GetDistributionConfigOutput) SetETag(v string) *GetDistributionConfigOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a distribution's information.
@@ -6874,6 +7924,17 @@ func (s *GetDistributionInput) SetId(v string) *GetDistributionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetDistributionResult
 type GetDistributionOutput struct {
@@ -6906,6 +7967,22 @@ func (s *GetDistributionOutput) SetDistribution(v *Distribution) *GetDistributio
 func (s *GetDistributionOutput) SetETag(v string) *GetDistributionOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get an invalidation's information.
@@ -6962,6 +8039,22 @@ func (s *GetInvalidationInput) SetId(v string) *GetInvalidationInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetInvalidationResult
 type GetInvalidationOutput struct {
@@ -6986,6 +8079,17 @@ func (s GetInvalidationOutput) GoString() string {
 func (s *GetInvalidationOutput) SetInvalidation(v *Invalidation) *GetInvalidationOutput {
 	s.Invalidation = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Invalidation != nil {
+		v := s.Invalidation
+
+		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // To request to get a streaming distribution configuration.
@@ -7028,6 +8132,17 @@ func (s *GetStreamingDistributionConfigInput) SetId(v string) *GetStreamingDistr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetStreamingDistributionConfigResult
 type GetStreamingDistributionConfigOutput struct {
@@ -7060,6 +8175,22 @@ func (s *GetStreamingDistributionConfigOutput) SetETag(v string) *GetStreamingDi
 func (s *GetStreamingDistributionConfigOutput) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *GetStreamingDistributionConfigOutput {
 	s.StreamingDistributionConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to get a streaming distribution's information.
@@ -7102,6 +8233,17 @@ func (s *GetStreamingDistributionInput) SetId(v string) *GetStreamingDistributio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/GetStreamingDistributionResult
 type GetStreamingDistributionOutput struct {
@@ -7135,6 +8277,22 @@ func (s *GetStreamingDistributionOutput) SetETag(v string) *GetStreamingDistribu
 func (s *GetStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *GetStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the request headers, if any, that you want
@@ -7224,6 +8382,22 @@ func (s *Headers) SetQuantity(v int64) *Headers {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Headers) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An invalidation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Invalidation
 type Invalidation struct {
@@ -7283,6 +8457,32 @@ func (s *Invalidation) SetInvalidationBatch(v *InvalidationBatch) *Invalidation 
 func (s *Invalidation) SetStatus(v string) *Invalidation {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Invalidation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateTime != nil {
+		v := *s.CreateTime
+
+		e.SetValue(protocol.BodyTarget, "CreateTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvalidationBatch != nil {
+		v := s.InvalidationBatch
+
+		e.SetFields(protocol.BodyTarget, "InvalidationBatch", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An invalidation batch.
@@ -7359,6 +8559,22 @@ func (s *InvalidationBatch) SetCallerReference(v string) *InvalidationBatch {
 func (s *InvalidationBatch) SetPaths(v *Paths) *InvalidationBatch {
 	s.Paths = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationBatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Paths != nil {
+		v := s.Paths
+
+		e.SetFields(protocol.BodyTarget, "Paths", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The InvalidationList complex type describes the list of invalidation objects.
@@ -7448,6 +8664,42 @@ func (s *InvalidationList) SetQuantity(v int64) *InvalidationList {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeInvalidationSummaryList(v), protocol.Metadata{ListLocationName: "InvalidationSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A summary of an invalidation request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/InvalidationSummary
 type InvalidationSummary struct {
@@ -7495,6 +8747,35 @@ func (s *InvalidationSummary) SetStatus(v string) *InvalidationSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvalidationSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateTime != nil {
+		v := *s.CreateTime
+
+		e.SetValue(protocol.BodyTarget, "CreateTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInvalidationSummaryList(vs []*InvalidationSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that lists the active CloudFront key pairs, if any, that are
 // associated with AwsAccountNumber.
 //
@@ -7537,6 +8818,22 @@ func (s *KeyPairIds) SetItems(v []*string) *KeyPairIds {
 func (s *KeyPairIds) SetQuantity(v int64) *KeyPairIds {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyPairIds) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "KeyPairId"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains a Lambda function association.
@@ -7595,6 +8892,30 @@ func (s *LambdaFunctionAssociation) SetEventType(v string) *LambdaFunctionAssoci
 func (s *LambdaFunctionAssociation) SetLambdaFunctionARN(v string) *LambdaFunctionAssociation {
 	s.LambdaFunctionARN = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionAssociation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventType != nil {
+		v := *s.EventType
+
+		e.SetValue(protocol.BodyTarget, "EventType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LambdaFunctionARN != nil {
+		v := *s.LambdaFunctionARN
+
+		e.SetValue(protocol.BodyTarget, "LambdaFunctionARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLambdaFunctionAssociationList(vs []*LambdaFunctionAssociation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that specifies a list of Lambda functions associations for
@@ -7657,6 +8978,22 @@ func (s *LambdaFunctionAssociations) SetQuantity(v int64) *LambdaFunctionAssocia
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionAssociations) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeLambdaFunctionAssociationList(v), protocol.Metadata{ListLocationName: "LambdaFunctionAssociation"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to list origin access identities.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListCloudFrontOriginAccessIdentitiesRequest
 type ListCloudFrontOriginAccessIdentitiesInput struct {
@@ -7695,6 +9032,22 @@ func (s *ListCloudFrontOriginAccessIdentitiesInput) SetMaxItems(v int64) *ListCl
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCloudFrontOriginAccessIdentitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListCloudFrontOriginAccessIdentitiesResult
 type ListCloudFrontOriginAccessIdentitiesOutput struct {
@@ -7718,6 +9071,17 @@ func (s ListCloudFrontOriginAccessIdentitiesOutput) GoString() string {
 func (s *ListCloudFrontOriginAccessIdentitiesOutput) SetCloudFrontOriginAccessIdentityList(v *OriginAccessIdentityList) *ListCloudFrontOriginAccessIdentitiesOutput {
 	s.CloudFrontOriginAccessIdentityList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCloudFrontOriginAccessIdentitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityList != nil {
+		v := s.CloudFrontOriginAccessIdentityList
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list distributions that are associated with a specified AWS
@@ -7786,6 +9150,27 @@ func (s *ListDistributionsByWebACLIdInput) SetWebACLId(v string) *ListDistributi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsByWebACLIdInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.PathTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response to a request to list the distributions that are associated with
 // a specified AWS WAF web ACL.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListDistributionsByWebACLIdResult
@@ -7810,6 +9195,17 @@ func (s ListDistributionsByWebACLIdOutput) GoString() string {
 func (s *ListDistributionsByWebACLIdOutput) SetDistributionList(v *DistributionList) *ListDistributionsByWebACLIdOutput {
 	s.DistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsByWebACLIdOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionList != nil {
+		v := s.DistributionList
+
+		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list your distributions.
@@ -7850,6 +9246,22 @@ func (s *ListDistributionsInput) SetMaxItems(v int64) *ListDistributionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListDistributionsResult
 type ListDistributionsOutput struct {
@@ -7873,6 +9285,17 @@ func (s ListDistributionsOutput) GoString() string {
 func (s *ListDistributionsOutput) SetDistributionList(v *DistributionList) *ListDistributionsOutput {
 	s.DistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDistributionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionList != nil {
+		v := s.DistributionList
+
+		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list invalidations.
@@ -7940,6 +9363,27 @@ func (s *ListInvalidationsInput) SetMaxItems(v int64) *ListInvalidationsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInvalidationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionId != nil {
+		v := *s.DistributionId
+
+		e.SetValue(protocol.PathTarget, "DistributionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListInvalidationsResult
 type ListInvalidationsOutput struct {
@@ -7963,6 +9407,17 @@ func (s ListInvalidationsOutput) GoString() string {
 func (s *ListInvalidationsOutput) SetInvalidationList(v *InvalidationList) *ListInvalidationsOutput {
 	s.InvalidationList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInvalidationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InvalidationList != nil {
+		v := s.InvalidationList
+
+		e.SetFields(protocol.PayloadTarget, "InvalidationList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list your streaming distributions.
@@ -7999,6 +9454,22 @@ func (s *ListStreamingDistributionsInput) SetMaxItems(v int64) *ListStreamingDis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListStreamingDistributionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListStreamingDistributionsResult
 type ListStreamingDistributionsOutput struct {
@@ -8022,6 +9493,17 @@ func (s ListStreamingDistributionsOutput) GoString() string {
 func (s *ListStreamingDistributionsOutput) SetStreamingDistributionList(v *StreamingDistributionList) *ListStreamingDistributionsOutput {
 	s.StreamingDistributionList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListStreamingDistributionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionList != nil {
+		v := s.StreamingDistributionList
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionList", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to list tags for a CloudFront resource.
@@ -8064,6 +9546,17 @@ func (s *ListTagsForResourceInput) SetResource(v string) *ListTagsForResourceInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/ListTagsForResourceResult
 type ListTagsForResourceOutput struct {
@@ -8089,6 +9582,17 @@ func (s ListTagsForResourceOutput) GoString() string {
 func (s *ListTagsForResourceOutput) SetTags(v *Tags) *ListTagsForResourceOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that controls whether access logs are written for the distribution.
@@ -8184,6 +9688,32 @@ func (s *LoggingConfig) SetIncludeCookies(v bool) *LoggingConfig {
 func (s *LoggingConfig) SetPrefix(v string) *LoggingConfig {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCookies != nil {
+		v := *s.IncludeCookies
+
+		e.SetValue(protocol.BodyTarget, "IncludeCookies", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes the Amazon S3 bucket or the HTTP server (for
@@ -8350,6 +9880,50 @@ func (s *Origin) SetS3OriginConfig(v *S3OriginConfig) *Origin {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Origin) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomHeaders != nil {
+		v := s.CustomHeaders
+
+		e.SetFields(protocol.BodyTarget, "CustomHeaders", v, protocol.Metadata{})
+	}
+	if s.CustomOriginConfig != nil {
+		v := s.CustomOriginConfig
+
+		e.SetFields(protocol.BodyTarget, "CustomOriginConfig", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginPath != nil {
+		v := *s.OriginPath
+
+		e.SetValue(protocol.BodyTarget, "OriginPath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3OriginConfig != nil {
+		v := s.S3OriginConfig
+
+		e.SetFields(protocol.BodyTarget, "S3OriginConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginList(vs []*Origin) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // CloudFront origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CloudFrontOriginAccessIdentity
 type OriginAccessIdentity struct {
@@ -8397,6 +9971,27 @@ func (s *OriginAccessIdentity) SetId(v string) *OriginAccessIdentity {
 func (s *OriginAccessIdentity) SetS3CanonicalUserId(v string) *OriginAccessIdentity {
 	s.S3CanonicalUserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.BodyTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3CanonicalUserId != nil {
+		v := *s.S3CanonicalUserId
+
+		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Origin access identity configuration. Send a GET request to the /CloudFront
@@ -8465,6 +10060,22 @@ func (s *OriginAccessIdentityConfig) SetCallerReference(v string) *OriginAccessI
 func (s *OriginAccessIdentityConfig) SetComment(v string) *OriginAccessIdentityConfig {
 	s.Comment = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentityConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Lists the origin access identities for CloudFront.Send a GET request to the
@@ -8561,6 +10172,42 @@ func (s *OriginAccessIdentityList) SetQuantity(v int64) *OriginAccessIdentityLis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentityList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginAccessIdentitySummaryList(v), protocol.Metadata{ListLocationName: "CloudFrontOriginAccessIdentitySummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Summary of the information about a CloudFront origin access identity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/CloudFrontOriginAccessIdentitySummary
 type OriginAccessIdentitySummary struct {
@@ -8611,6 +10258,35 @@ func (s *OriginAccessIdentitySummary) SetId(v string) *OriginAccessIdentitySumma
 func (s *OriginAccessIdentitySummary) SetS3CanonicalUserId(v string) *OriginAccessIdentitySummary {
 	s.S3CanonicalUserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginAccessIdentitySummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3CanonicalUserId != nil {
+		v := *s.S3CanonicalUserId
+
+		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginAccessIdentitySummaryList(vs []*OriginAccessIdentitySummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains HeaderName and HeaderValue elements, if any,
@@ -8671,6 +10347,30 @@ func (s *OriginCustomHeader) SetHeaderValue(v string) *OriginCustomHeader {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginCustomHeader) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HeaderName != nil {
+		v := *s.HeaderName
+
+		e.SetValue(protocol.BodyTarget, "HeaderName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HeaderValue != nil {
+		v := *s.HeaderValue
+
+		e.SetValue(protocol.BodyTarget, "HeaderValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginCustomHeaderList(vs []*OriginCustomHeader) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains information about the SSL/TLS protocols that
 // CloudFront can use when establishing an HTTPS connection with your origin.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/OriginSslProtocols
@@ -8725,6 +10425,22 @@ func (s *OriginSslProtocols) SetItems(v []*string) *OriginSslProtocols {
 func (s *OriginSslProtocols) SetQuantity(v int64) *OriginSslProtocols {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginSslProtocols) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "SslProtocol"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about origins for this distribution.
@@ -8789,6 +10505,22 @@ func (s *Origins) SetQuantity(v int64) *Origins {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Origins) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeOriginList(v), protocol.Metadata{ListLocationName: "Origin"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the objects that you want
 // to invalidate. For more information, see Specifying the Objects to Invalidate
 // (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects)
@@ -8841,6 +10573,22 @@ func (s *Paths) SetQuantity(v int64) *Paths {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Paths) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Path"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/QueryStringCacheKeys
 type QueryStringCacheKeys struct {
 	_ struct{} `type:"structure"`
@@ -8891,6 +10639,22 @@ func (s *QueryStringCacheKeys) SetQuantity(v int64) *QueryStringCacheKeys {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueryStringCacheKeys) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Name"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that identifies ways in which you want to restrict distribution
 // of your content.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Restrictions
@@ -8936,6 +10700,17 @@ func (s *Restrictions) Validate() error {
 func (s *Restrictions) SetGeoRestriction(v *GeoRestriction) *Restrictions {
 	s.GeoRestriction = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Restrictions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GeoRestriction != nil {
+		v := s.GeoRestriction
+
+		e.SetFields(protocol.BodyTarget, "GeoRestriction", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the Amazon S3 bucket from
@@ -9009,6 +10784,22 @@ func (s *S3Origin) SetOriginAccessIdentity(v string) *S3Origin {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3Origin) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginAccessIdentity != nil {
+		v := *s.OriginAccessIdentity
+
+		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the Amazon S3 origin. If the
 // origin is a custom origin, use the CustomOriginConfig element instead.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/S3OriginConfig
@@ -9072,6 +10863,17 @@ func (s *S3OriginConfig) SetOriginAccessIdentity(v string) *S3OriginConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3OriginConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OriginAccessIdentity != nil {
+		v := *s.OriginAccessIdentity
+
+		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
 // complex type, as well as their active CloudFront key pair IDs, if any.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Signer
@@ -9111,6 +10913,30 @@ func (s *Signer) SetAwsAccountNumber(v string) *Signer {
 func (s *Signer) SetKeyPairIds(v *KeyPairIds) *Signer {
 	s.KeyPairIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Signer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsAccountNumber != nil {
+		v := *s.AwsAccountNumber
+
+		e.SetValue(protocol.BodyTarget, "AwsAccountNumber", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPairIds != nil {
+		v := s.KeyPairIds
+
+		e.SetFields(protocol.BodyTarget, "KeyPairIds", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSignerList(vs []*Signer) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A streaming distribution.
@@ -9213,6 +11039,47 @@ func (s *StreamingDistribution) SetStatus(v string) *StreamingDistribution {
 func (s *StreamingDistribution) SetStreamingDistributionConfig(v *StreamingDistributionConfig) *StreamingDistribution {
 	s.StreamingDistributionConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistribution) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ActiveTrustedSigners != nil {
+		v := s.ActiveTrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "ActiveTrustedSigners", v, protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The RTMP distribution's configuration information.
@@ -9377,6 +11244,52 @@ func (s *StreamingDistributionConfig) SetTrustedSigners(v *TrustedSigners) *Stre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Logging != nil {
+		v := s.Logging
+
+		e.SetFields(protocol.BodyTarget, "Logging", v, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Origin != nil {
+		v := s.S3Origin
+
+		e.SetFields(protocol.BodyTarget, "S3Origin", v, protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A streaming distribution Configuration and a list of tags to be associated
 // with the streaming distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/StreamingDistributionConfigWithTags
@@ -9440,6 +11353,22 @@ func (s *StreamingDistributionConfigWithTags) SetStreamingDistributionConfig(v *
 func (s *StreamingDistributionConfigWithTags) SetTags(v *Tags) *StreamingDistributionConfigWithTags {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionConfigWithTags) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.BodyTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A streaming distribution list.
@@ -9525,6 +11454,42 @@ func (s *StreamingDistributionList) SetNextMarker(v string) *StreamingDistributi
 func (s *StreamingDistributionList) SetQuantity(v int64) *StreamingDistributionList {
 	s.Quantity = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeStreamingDistributionSummaryList(v), protocol.Metadata{ListLocationName: "StreamingDistributionSummary"})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A summary of the information for an Amazon CloudFront streaming distribution.
@@ -9677,6 +11642,75 @@ func (s *StreamingDistributionSummary) SetTrustedSigners(v *TrustedSigners) *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingDistributionSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Aliases != nil {
+		v := s.Aliases
+
+		e.SetFields(protocol.BodyTarget, "Aliases", v, protocol.Metadata{})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedTime != nil {
+		v := *s.LastModifiedTime
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.PriceClass != nil {
+		v := *s.PriceClass
+
+		e.SetValue(protocol.BodyTarget, "PriceClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Origin != nil {
+		v := s.S3Origin
+
+		e.SetFields(protocol.BodyTarget, "S3Origin", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrustedSigners != nil {
+		v := s.TrustedSigners
+
+		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStreamingDistributionSummaryList(vs []*StreamingDistributionSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that controls whether access logs are written for this streaming
 // distribution.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/StreamingLoggingConfig
@@ -9754,6 +11788,27 @@ func (s *StreamingLoggingConfig) SetPrefix(v string) *StreamingLoggingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamingLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains Tag key and Tag value.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/Tag
 type Tag struct {
@@ -9812,6 +11867,30 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains zero or more Tag elements.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/TagKeys
 type TagKeys struct {
@@ -9835,6 +11914,17 @@ func (s TagKeys) GoString() string {
 func (s *TagKeys) SetItems(v []*string) *TagKeys {
 	s.Items = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagKeys) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
+	}
+
+	return nil
 }
 
 // The request to add tags to a CloudFront resource.
@@ -9896,6 +11986,22 @@ func (s *TagResourceInput) SetTags(v *Tags) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tags != nil {
+		v := s.Tags
+
+		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/TagResourceOutput
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -9909,6 +12015,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains zero or more Tag elements.
@@ -9954,6 +12066,17 @@ func (s *Tags) Validate() error {
 func (s *Tags) SetItems(v []*Tag) *Tags {
 	s.Items = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tags) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the AWS accounts, if any, that you want to
@@ -10038,6 +12161,27 @@ func (s *TrustedSigners) SetQuantity(v int64) *TrustedSigners {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "AwsAccountNumber"})
+	}
+	if s.Quantity != nil {
+		v := *s.Quantity
+
+		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The request to remove tags from a CloudFront resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UntagResourceRequest
 type UntagResourceInput struct {
@@ -10092,6 +12236,22 @@ func (s *UntagResourceInput) SetTagKeys(v *TagKeys) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TagKeys != nil {
+		v := s.TagKeys
+
+		e.SetFields(protocol.PayloadTarget, "TagKeys", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UntagResourceOutput
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -10105,6 +12265,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The request to update an origin access identity.
@@ -10176,6 +12342,27 @@ func (s *UpdateCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Update
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateCloudFrontOriginAccessIdentityResult
 type UpdateCloudFrontOriginAccessIdentityOutput struct {
@@ -10208,6 +12395,22 @@ func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetCloudFrontOriginAccessId
 func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *UpdateCloudFrontOriginAccessIdentityOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
+
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to update a distribution.
@@ -10279,6 +12482,27 @@ func (s *UpdateDistributionInput) SetIfMatch(v string) *UpdateDistributionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateDistributionResult
 type UpdateDistributionOutput struct {
@@ -10311,6 +12535,22 @@ func (s *UpdateDistributionOutput) SetDistribution(v *Distribution) *UpdateDistr
 func (s *UpdateDistributionOutput) SetETag(v string) *UpdateDistributionOutput {
 	s.ETag = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Distribution != nil {
+		v := s.Distribution
+
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The request to update a streaming distribution.
@@ -10382,6 +12622,27 @@ func (s *UpdateStreamingDistributionInput) SetStreamingDistributionConfig(v *Str
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistributionConfig != nil {
+		v := s.StreamingDistributionConfig
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+	}
+
+	return nil
+}
+
 // The returned result of the corresponding request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-03-25/UpdateStreamingDistributionResult
 type UpdateStreamingDistributionOutput struct {
@@ -10414,6 +12675,22 @@ func (s *UpdateStreamingDistributionOutput) SetETag(v string) *UpdateStreamingDi
 func (s *UpdateStreamingDistributionOutput) SetStreamingDistribution(v *StreamingDistribution) *UpdateStreamingDistributionOutput {
 	s.StreamingDistribution = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingDistribution != nil {
+		v := s.StreamingDistribution
+
+		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that specifies the following:
@@ -10648,6 +12925,47 @@ func (s *ViewerCertificate) SetMinimumProtocolVersion(v string) *ViewerCertifica
 func (s *ViewerCertificate) SetSSLSupportMethod(v string) *ViewerCertificate {
 	s.SSLSupportMethod = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ViewerCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACMCertificateArn != nil {
+		v := *s.ACMCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "ACMCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateSource != nil {
+		v := *s.CertificateSource
+
+		e.SetValue(protocol.BodyTarget, "CertificateSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudFrontDefaultCertificate != nil {
+		v := *s.CloudFrontDefaultCertificate
+
+		e.SetValue(protocol.BodyTarget, "CloudFrontDefaultCertificate", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.IAMCertificateId != nil {
+		v := *s.IAMCertificateId
+
+		e.SetValue(protocol.BodyTarget, "IAMCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MinimumProtocolVersion != nil {
+		v := *s.MinimumProtocolVersion
+
+		e.SetValue(protocol.BodyTarget, "MinimumProtocolVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSLSupportMethod != nil {
+		v := *s.SSLSupportMethod
+
+		e.SetValue(protocol.BodyTarget, "SSLSupportMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -3265,7 +3265,6 @@ func (s *ActiveTrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3333,7 +3332,6 @@ func (s *Aliases) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3448,7 +3446,6 @@ func (s *AllowedMethods) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3821,7 +3818,6 @@ func (s *CacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3905,7 +3901,6 @@ func (s *CacheBehaviors) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3987,7 +3982,6 @@ func (s *CachedMethods) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4058,7 +4052,6 @@ func (s *CookieNames) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4149,7 +4142,6 @@ func (s *CookiePreference) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "WhitelistedNames", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4205,7 +4197,6 @@ func (s *CreateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.Fie
 
 		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4255,11 +4246,6 @@ func (s *CreateCloudFrontOriginAccessIdentityOutput) SetLocation(v string) *Crea
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudFrontOriginAccessIdentity != nil {
-		v := s.CloudFrontOriginAccessIdentity
-
-		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
@@ -4270,7 +4256,11 @@ func (s *CreateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.Fi
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
 
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4326,7 +4316,6 @@ func (s *CreateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4376,11 +4365,6 @@ func (s *CreateDistributionOutput) SetLocation(v string) *CreateDistributionOutp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Distribution != nil {
-		v := s.Distribution
-
-		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
@@ -4391,7 +4375,11 @@ func (s *CreateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Distribution != nil {
+		v := s.Distribution
 
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4447,7 +4435,6 @@ func (s *CreateDistributionWithTagsInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.PayloadTarget, "DistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4497,11 +4484,6 @@ func (s *CreateDistributionWithTagsOutput) SetLocation(v string) *CreateDistribu
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Distribution != nil {
-		v := s.Distribution
-
-		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
@@ -4512,7 +4494,11 @@ func (s *CreateDistributionWithTagsOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Distribution != nil {
+		v := s.Distribution
 
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4587,7 +4573,6 @@ func (s *CreateInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "InvalidationBatch", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4628,17 +4613,16 @@ func (s *CreateInvalidationOutput) SetLocation(v string) *CreateInvalidationOutp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Invalidation != nil {
-		v := s.Invalidation
-
-		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
-	}
 	if s.Location != nil {
 		v := *s.Location
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Invalidation != nil {
+		v := s.Invalidation
 
+		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4694,7 +4678,6 @@ func (s *CreateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4759,7 +4742,6 @@ func (s *CreateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4815,7 +4797,6 @@ func (s *CreateStreamingDistributionWithTagsInput) MarshalFields(e protocol.Fiel
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfigWithTags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -4879,7 +4860,6 @@ func (s *CreateStreamingDistributionWithTagsOutput) MarshalFields(e protocol.Fie
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5034,7 +5014,6 @@ func (s *CustomErrorResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResponsePagePath", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5129,7 +5108,6 @@ func (s *CustomErrorResponses) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5206,7 +5184,6 @@ func (s *CustomHeaders) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5355,7 +5332,6 @@ func (s *CustomOriginConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "OriginSslProtocols", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5664,7 +5640,6 @@ func (s *DefaultCacheBehavior) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ViewerProtocolPolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5720,17 +5695,16 @@ func (s *DeleteCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Delete
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
 		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5751,7 +5725,6 @@ func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5841,17 +5814,16 @@ func (s *DeleteDistributionInput) SetIfMatch(v string) *DeleteDistributionInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
 		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5872,7 +5844,6 @@ func (s DeleteDistributionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5920,7 +5891,6 @@ func (s *DeleteServiceLinkedRoleInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "RoleName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5941,7 +5911,6 @@ func (s DeleteServiceLinkedRoleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteServiceLinkedRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5997,17 +5966,16 @@ func (s *DeleteStreamingDistributionInput) SetIfMatch(v string) *DeleteStreaming
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
 		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6028,7 +5996,6 @@ func (s DeleteStreamingDistributionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6189,7 +6156,6 @@ func (s *Distribution) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6714,7 +6680,6 @@ func (s *DistributionConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6795,7 +6760,6 @@ func (s *DistributionConfigWithTags) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6915,7 +6879,6 @@ func (s *DistributionList) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7317,7 +7280,6 @@ func (s *DistributionSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7466,7 +7428,6 @@ func (s *ForwardedValues) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "QueryStringCacheKeys", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7575,7 +7536,6 @@ func (s *GeoRestriction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RestrictionType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7627,7 +7587,6 @@ func (s *GetCloudFrontOriginAccessIdentityConfigInput) MarshalFields(e protocol.
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7667,17 +7626,16 @@ func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetETag(v string) *GetCl
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetCloudFrontOriginAccessIdentityConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudFrontOriginAccessIdentityConfig != nil {
-		v := s.CloudFrontOriginAccessIdentityConfig
-
-		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
 
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7728,7 +7686,6 @@ func (s *GetCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7769,17 +7726,16 @@ func (s *GetCloudFrontOriginAccessIdentityOutput) SetETag(v string) *GetCloudFro
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudFrontOriginAccessIdentity != nil {
-		v := s.CloudFrontOriginAccessIdentity
-
-		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
 
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7830,7 +7786,6 @@ func (s *GetDistributionConfigInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7870,17 +7825,16 @@ func (s *GetDistributionConfigOutput) SetETag(v string) *GetDistributionConfigOu
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetDistributionConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DistributionConfig != nil {
-		v := s.DistributionConfig
-
-		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
 
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7931,7 +7885,6 @@ func (s *GetDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7971,17 +7924,16 @@ func (s *GetDistributionOutput) SetETag(v string) *GetDistributionOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Distribution != nil {
-		v := s.Distribution
-
-		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Distribution != nil {
+		v := s.Distribution
 
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8051,7 +8003,6 @@ func (s *GetInvalidationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8088,7 +8039,6 @@ func (s *GetInvalidationOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "Invalidation", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8139,7 +8089,6 @@ func (s *GetStreamingDistributionConfigInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8189,7 +8138,6 @@ func (s *GetStreamingDistributionConfigOutput) MarshalFields(e protocol.FieldEnc
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8240,7 +8188,6 @@ func (s *GetStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8291,7 +8238,6 @@ func (s *GetStreamingDistributionOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8394,7 +8340,6 @@ func (s *Headers) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8481,7 +8426,6 @@ func (s *Invalidation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8573,7 +8517,6 @@ func (s *InvalidationBatch) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Paths", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8696,7 +8639,6 @@ func (s *InvalidationList) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8764,7 +8706,6 @@ func (s *InvalidationSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8832,7 +8773,6 @@ func (s *KeyPairIds) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8906,7 +8846,6 @@ func (s *LambdaFunctionAssociation) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "LambdaFunctionARN", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8990,7 +8929,6 @@ func (s *LambdaFunctionAssociations) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9044,7 +8982,6 @@ func (s *ListCloudFrontOriginAccessIdentitiesInput) MarshalFields(e protocol.Fie
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9080,7 +9017,6 @@ func (s *ListCloudFrontOriginAccessIdentitiesOutput) MarshalFields(e protocol.Fi
 
 		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityList", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9152,6 +9088,11 @@ func (s *ListDistributionsByWebACLIdInput) SetWebACLId(v string) *ListDistributi
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListDistributionsByWebACLIdInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.WebACLId != nil {
+		v := *s.WebACLId
+
+		e.SetValue(protocol.PathTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Marker != nil {
 		v := *s.Marker
 
@@ -9162,12 +9103,6 @@ func (s *ListDistributionsByWebACLIdInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	if s.WebACLId != nil {
-		v := *s.WebACLId
-
-		e.SetValue(protocol.PathTarget, "WebACLId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -9204,7 +9139,6 @@ func (s *ListDistributionsByWebACLIdOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9258,7 +9192,6 @@ func (s *ListDistributionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9294,7 +9227,6 @@ func (s *ListDistributionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "DistributionList", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9380,7 +9312,6 @@ func (s *ListInvalidationsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9416,7 +9347,6 @@ func (s *ListInvalidationsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "InvalidationList", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9466,7 +9396,6 @@ func (s *ListStreamingDistributionsInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9502,7 +9431,6 @@ func (s *ListStreamingDistributionsOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistributionList", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9553,7 +9481,6 @@ func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9591,7 +9518,6 @@ func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9712,7 +9638,6 @@ func (s *LoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9912,7 +9837,6 @@ func (s *Origin) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "S3OriginConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9990,7 +9914,6 @@ func (s *OriginAccessIdentity) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10074,7 +9997,6 @@ func (s *OriginAccessIdentityConfig) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10204,7 +10126,6 @@ func (s *OriginAccessIdentityList) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10277,7 +10198,6 @@ func (s *OriginAccessIdentitySummary) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "S3CanonicalUserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10359,7 +10279,6 @@ func (s *OriginCustomHeader) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "HeaderValue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10439,7 +10358,6 @@ func (s *OriginSslProtocols) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10517,7 +10435,6 @@ func (s *Origins) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10585,7 +10502,6 @@ func (s *Paths) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10651,7 +10567,6 @@ func (s *QueryStringCacheKeys) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10709,7 +10624,6 @@ func (s *Restrictions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "GeoRestriction", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10796,7 +10710,6 @@ func (s *S3Origin) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10870,7 +10783,6 @@ func (s *S3OriginConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "OriginAccessIdentity", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10927,7 +10839,6 @@ func (s *Signer) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "KeyPairIds", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11078,7 +10989,6 @@ func (s *StreamingDistribution) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "StreamingDistributionConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11286,7 +11196,6 @@ func (s *StreamingDistributionConfig) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11367,7 +11276,6 @@ func (s *StreamingDistributionConfigWithTags) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.BodyTarget, "Tags", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11488,7 +11396,6 @@ func (s *StreamingDistributionList) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11699,7 +11606,6 @@ func (s *StreamingDistributionSummary) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.BodyTarget, "TrustedSigners", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11805,7 +11711,6 @@ func (s *StreamingLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11879,7 +11784,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11923,7 +11827,6 @@ func (s *TagKeys) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Items", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
 	}
-
 	return nil
 }
 
@@ -11988,17 +11891,16 @@ func (s *TagResourceInput) SetTags(v *Tags) *TagResourceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Resource != nil {
-		v := *s.Resource
-
-		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Tags != nil {
 		v := s.Tags
 
 		e.SetFields(protocol.PayloadTarget, "Tags", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
+	if s.Resource != nil {
+		v := *s.Resource
 
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12019,7 +11921,6 @@ func (s TagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12075,7 +11976,6 @@ func (s *Tags) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Items", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
 	}
-
 	return nil
 }
 
@@ -12178,7 +12078,6 @@ func (s *TrustedSigners) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quantity", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12238,17 +12137,16 @@ func (s *UntagResourceInput) SetTagKeys(v *TagKeys) *UntagResourceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Resource != nil {
-		v := *s.Resource
-
-		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TagKeys != nil {
 		v := s.TagKeys
 
 		e.SetFields(protocol.PayloadTarget, "TagKeys", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
+	if s.Resource != nil {
+		v := *s.Resource
 
+		e.SetValue(protocol.QueryTarget, "Resource", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12269,7 +12167,6 @@ func (s UntagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12344,22 +12241,21 @@ func (s *UpdateCloudFrontOriginAccessIdentityInput) SetIfMatch(v string) *Update
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCloudFrontOriginAccessIdentityInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudFrontOriginAccessIdentityConfig != nil {
-		v := s.CloudFrontOriginAccessIdentityConfig
+	if s.IfMatch != nil {
+		v := *s.IfMatch
 
-		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.IfMatch != nil {
-		v := *s.IfMatch
+	if s.CloudFrontOriginAccessIdentityConfig != nil {
+		v := s.CloudFrontOriginAccessIdentityConfig
 
-		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentityConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -12399,17 +12295,16 @@ func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *UpdateCl
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCloudFrontOriginAccessIdentityOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudFrontOriginAccessIdentity != nil {
-		v := s.CloudFrontOriginAccessIdentity
-
-		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CloudFrontOriginAccessIdentity != nil {
+		v := s.CloudFrontOriginAccessIdentity
 
+		e.SetFields(protocol.PayloadTarget, "CloudFrontOriginAccessIdentity", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12484,22 +12379,21 @@ func (s *UpdateDistributionInput) SetIfMatch(v string) *UpdateDistributionInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DistributionConfig != nil {
-		v := s.DistributionConfig
+	if s.IfMatch != nil {
+		v := *s.IfMatch
 
-		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.IfMatch != nil {
-		v := *s.IfMatch
+	if s.DistributionConfig != nil {
+		v := s.DistributionConfig
 
-		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+		e.SetFields(protocol.PayloadTarget, "DistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -12539,17 +12433,16 @@ func (s *UpdateDistributionOutput) SetETag(v string) *UpdateDistributionOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDistributionOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Distribution != nil {
-		v := s.Distribution
-
-		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
-	}
 	if s.ETag != nil {
 		v := *s.ETag
 
 		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Distribution != nil {
+		v := s.Distribution
 
+		e.SetFields(protocol.PayloadTarget, "Distribution", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12624,22 +12517,21 @@ func (s *UpdateStreamingDistributionInput) SetStreamingDistributionConfig(v *Str
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateStreamingDistributionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
 		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.StreamingDistributionConfig != nil {
 		v := s.StreamingDistributionConfig
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistributionConfig", v, protocol.Metadata{XMLNamespaceURI: "http://cloudfront.amazonaws.com/doc/2017-03-25/"})
 	}
-
 	return nil
 }
 
@@ -12689,7 +12581,6 @@ func (s *UpdateStreamingDistributionOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.PayloadTarget, "StreamingDistribution", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12964,7 +12855,6 @@ func (s *ViewerCertificate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SSLSupportMethod", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opSearch = "Search"
@@ -328,6 +329,30 @@ func (s *Bucket) SetValue(v string) *Bucket {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketList(vs []*Bucket) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A container for the calculated facet values and counts.
 type BucketInfo struct {
 	_ struct{} `type:"structure"`
@@ -350,6 +375,25 @@ func (s BucketInfo) GoString() string {
 func (s *BucketInfo) SetBuckets(v []*Bucket) *BucketInfo {
 	s.Buckets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Buckets) > 0 {
+		v := s.Buckets
+
+		e.SetList(protocol.BodyTarget, "buckets", encodeBucketList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketInfoMap(vs map[string]*BucketInfo) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // A warning returned by the document service when an issue is discovered while
@@ -375,6 +419,25 @@ func (s DocumentServiceWarning) GoString() string {
 func (s *DocumentServiceWarning) SetMessage(v string) *DocumentServiceWarning {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentServiceWarning) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentServiceWarningList(vs []*DocumentServiceWarning) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The statistics for a field calculated in the request.
@@ -486,6 +549,60 @@ func (s *FieldStats) SetSumOfSquares(v float64) *FieldStats {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FieldStats) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Max != nil {
+		v := *s.Max
+
+		e.SetValue(protocol.BodyTarget, "max", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mean != nil {
+		v := *s.Mean
+
+		e.SetValue(protocol.BodyTarget, "mean", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Min != nil {
+		v := *s.Min
+
+		e.SetValue(protocol.BodyTarget, "min", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Missing != nil {
+		v := *s.Missing
+
+		e.SetValue(protocol.BodyTarget, "missing", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Stddev != nil {
+		v := *s.Stddev
+
+		e.SetValue(protocol.BodyTarget, "stddev", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Sum != nil {
+		v := *s.Sum
+
+		e.SetValue(protocol.BodyTarget, "sum", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.SumOfSquares != nil {
+		v := *s.SumOfSquares
+
+		e.SetValue(protocol.BodyTarget, "sumOfSquares", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFieldStatsMap(vs map[string]*FieldStats) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Information about a document that matches the search request.
 type Hit struct {
 	_ struct{} `type:"structure"`
@@ -535,6 +652,45 @@ func (s *Hit) SetHighlights(v map[string]*string) *Hit {
 func (s *Hit) SetId(v string) *Hit {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Hit) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Exprs) > 0 {
+		v := s.Exprs
+
+		e.SetMap(protocol.BodyTarget, "exprs", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.Fields) > 0 {
+		v := s.Fields
+
+		e.SetMap(protocol.BodyTarget, "fields", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if len(s.Highlights) > 0 {
+		v := s.Highlights
+
+		e.SetMap(protocol.BodyTarget, "highlights", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHitList(vs []*Hit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The collection of documents that match the search request.
@@ -587,6 +743,32 @@ func (s *Hits) SetHit(v []*Hit) *Hits {
 func (s *Hits) SetStart(v int64) *Hits {
 	s.Start = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Hits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cursor != nil {
+		v := *s.Cursor
+
+		e.SetValue(protocol.BodyTarget, "cursor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Found != nil {
+		v := *s.Found
+
+		e.SetValue(protocol.BodyTarget, "found", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Hit) > 0 {
+		v := s.Hit
+
+		e.SetList(protocol.BodyTarget, "hit", encodeHitList(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "start", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the Search request.
@@ -1000,6 +1182,82 @@ func (s *SearchInput) SetStats(v string) *SearchInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cursor != nil {
+		v := *s.Cursor
+
+		e.SetValue(protocol.QueryTarget, "cursor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expr != nil {
+		v := *s.Expr
+
+		e.SetValue(protocol.QueryTarget, "expr", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Facet != nil {
+		v := *s.Facet
+
+		e.SetValue(protocol.QueryTarget, "facet", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterQuery != nil {
+		v := *s.FilterQuery
+
+		e.SetValue(protocol.QueryTarget, "fq", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Highlight != nil {
+		v := *s.Highlight
+
+		e.SetValue(protocol.QueryTarget, "highlight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Partial != nil {
+		v := *s.Partial
+
+		e.SetValue(protocol.QueryTarget, "partial", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "q", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryOptions != nil {
+		v := *s.QueryOptions
+
+		e.SetValue(protocol.QueryTarget, "q.options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryParser != nil {
+		v := *s.QueryParser
+
+		e.SetValue(protocol.QueryTarget, "q.parser", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Return != nil {
+		v := *s.Return
+
+		e.SetValue(protocol.QueryTarget, "return", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.QueryTarget, "size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.QueryTarget, "start", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Stats != nil {
+		v := *s.Stats
+
+		e.SetValue(protocol.QueryTarget, "stats", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
@@ -1052,6 +1310,32 @@ func (s *SearchOutput) SetStatus(v *SearchStatus) *SearchOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Facets) > 0 {
+		v := s.Facets
+
+		e.SetMap(protocol.BodyTarget, "facets", encodeBucketInfoMap(v), protocol.Metadata{})
+	}
+	if s.Hits != nil {
+		v := s.Hits
+
+		e.SetFields(protocol.BodyTarget, "hits", v, protocol.Metadata{})
+	}
+	if len(s.Stats) > 0 {
+		v := s.Stats
+
+		e.SetMap(protocol.BodyTarget, "stats", encodeFieldStatsMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SearchStatus struct {
@@ -1084,6 +1368,22 @@ func (s *SearchStatus) SetRid(v string) *SearchStatus {
 func (s *SearchStatus) SetTimems(v int64) *SearchStatus {
 	s.Timems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SearchStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rid != nil {
+		v := *s.Rid
+
+		e.SetValue(protocol.BodyTarget, "rid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timems != nil {
+		v := *s.Timems
+
+		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the Suggest request.
@@ -1148,6 +1448,27 @@ func (s *SuggestInput) SetSuggester(v string) *SuggestInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "q", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.QueryTarget, "size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Suggester != nil {
+		v := *s.Suggester
+
+		e.SetValue(protocol.QueryTarget, "suggester", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the suggestion information returned in a SuggestResponse.
 type SuggestModel struct {
 	_ struct{} `type:"structure"`
@@ -1190,6 +1511,27 @@ func (s *SuggestModel) SetSuggestions(v []*SuggestionMatch) *SuggestModel {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestModel) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Found != nil {
+		v := *s.Found
+
+		e.SetValue(protocol.BodyTarget, "found", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.BodyTarget, "query", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Suggestions) > 0 {
+		v := s.Suggestions
+
+		e.SetList(protocol.BodyTarget, "suggestions", encodeSuggestionMatchList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the response to a Suggest request.
 type SuggestOutput struct {
 	_ struct{} `type:"structure"`
@@ -1224,6 +1566,22 @@ func (s *SuggestOutput) SetSuggest(v *SuggestModel) *SuggestOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "status", v, protocol.Metadata{})
+	}
+	if s.Suggest != nil {
+		v := s.Suggest
+
+		e.SetFields(protocol.BodyTarget, "suggest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SuggestStatus struct {
@@ -1256,6 +1614,22 @@ func (s *SuggestStatus) SetRid(v string) *SuggestStatus {
 func (s *SuggestStatus) SetTimems(v int64) *SuggestStatus {
 	s.Timems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rid != nil {
+		v := *s.Rid
+
+		e.SetValue(protocol.BodyTarget, "rid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timems != nil {
+		v := *s.Timems
+
+		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An autocomplete suggestion that matches the query string specified in a SuggestRequest.
@@ -1298,6 +1672,35 @@ func (s *SuggestionMatch) SetScore(v int64) *SuggestionMatch {
 func (s *SuggestionMatch) SetSuggestion(v string) *SuggestionMatch {
 	s.Suggestion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SuggestionMatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Score != nil {
+		v := *s.Score
+
+		e.SetValue(protocol.BodyTarget, "score", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Suggestion != nil {
+		v := *s.Suggestion
+
+		e.SetValue(protocol.BodyTarget, "suggestion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSuggestionMatchList(vs []*SuggestionMatch) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for the parameters to the UploadDocuments request.
@@ -1357,6 +1760,22 @@ func (s *UploadDocumentsInput) SetDocuments(v io.ReadSeeker) *UploadDocumentsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadDocumentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Documents != nil {
+		v := s.Documents
+
+		e.SetStream(protocol.PayloadTarget, "documents", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the response to an UploadDocuments request.
 type UploadDocumentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1406,6 +1825,32 @@ func (s *UploadDocumentsOutput) SetStatus(v string) *UploadDocumentsOutput {
 func (s *UploadDocumentsOutput) SetWarnings(v []*DocumentServiceWarning) *UploadDocumentsOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadDocumentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Adds != nil {
+		v := *s.Adds
+
+		e.SetValue(protocol.BodyTarget, "adds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Deletes != nil {
+		v := *s.Deletes
+
+		e.SetValue(protocol.BodyTarget, "deletes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "warnings", encodeDocumentServiceWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -341,7 +341,6 @@ func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -384,7 +383,6 @@ func (s *BucketInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "buckets", encodeBucketList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -428,7 +426,6 @@ func (s *DocumentServiceWarning) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -591,7 +588,6 @@ func (s *FieldStats) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sumOfSquares", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -681,7 +677,6 @@ func (s *Hit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -767,7 +762,6 @@ func (s *Hits) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "start", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1254,7 +1248,6 @@ func (s *SearchInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "stats", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1332,7 +1325,6 @@ func (s *SearchOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1382,7 +1374,6 @@ func (s *SearchStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1465,7 +1456,6 @@ func (s *SuggestInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "suggester", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1528,7 +1518,6 @@ func (s *SuggestModel) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "suggestions", encodeSuggestionMatchList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1578,7 +1567,6 @@ func (s *SuggestOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "suggest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1628,7 +1616,6 @@ func (s *SuggestStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1691,7 +1678,6 @@ func (s *SuggestionMatch) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "suggestion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1772,7 +1758,6 @@ func (s *UploadDocumentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "documents", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1849,7 +1834,6 @@ func (s *UploadDocumentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "warnings", encodeDocumentServiceWarningList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1713,6 +1713,17 @@ func (s *BulkPublishInput) SetIdentityPoolId(v string) *BulkPublishInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BulkPublishInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the BulkPublish operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/BulkPublishResponse
 type BulkPublishOutput struct {
@@ -1737,6 +1748,17 @@ func (s BulkPublishOutput) GoString() string {
 func (s *BulkPublishOutput) SetIdentityPoolId(v string) *BulkPublishOutput {
 	s.IdentityPoolId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BulkPublishOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Configuration options for configure Cognito streams.
@@ -1803,6 +1825,27 @@ func (s *CognitoStreams) SetStreamName(v string) *CognitoStreams {
 func (s *CognitoStreams) SetStreamingStatus(v string) *CognitoStreams {
 	s.StreamingStatus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CognitoStreams) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "StreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamingStatus != nil {
+		v := *s.StreamingStatus
+
+		e.SetValue(protocol.BodyTarget, "StreamingStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A collection of data for an identity pool. An identity pool can have multiple
@@ -1890,6 +1933,55 @@ func (s *Dataset) SetNumRecords(v int64) *Dataset {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Dataset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.BodyTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.BodyTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NumRecords != nil {
+		v := *s.NumRecords
+
+		e.SetValue(protocol.BodyTarget, "NumRecords", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDatasetList(vs []*Dataset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A request to delete the specific dataset.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DeleteDatasetRequest
 type DeleteDatasetInput struct {
@@ -1970,6 +2062,27 @@ func (s *DeleteDatasetInput) SetIdentityPoolId(v string) *DeleteDatasetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DeleteDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DeleteDatasetResponse
 type DeleteDatasetOutput struct {
@@ -1997,6 +2110,17 @@ func (s DeleteDatasetOutput) GoString() string {
 func (s *DeleteDatasetOutput) SetDataset(v *Dataset) *DeleteDatasetOutput {
 	s.Dataset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dataset != nil {
+		v := s.Dataset
+
+		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for meta data about a dataset (creation date, number of records,
@@ -2080,6 +2204,27 @@ func (s *DescribeDatasetInput) SetIdentityPoolId(v string) *DescribeDatasetInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DescribeDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeDatasetResponse
 type DescribeDatasetOutput struct {
@@ -2107,6 +2252,17 @@ func (s DescribeDatasetOutput) GoString() string {
 func (s *DescribeDatasetOutput) SetDataset(v *Dataset) *DescribeDatasetOutput {
 	s.Dataset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dataset != nil {
+		v := s.Dataset
+
+		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for usage information about the identity pool.
@@ -2153,6 +2309,17 @@ func (s *DescribeIdentityPoolUsageInput) SetIdentityPoolId(v string) *DescribeId
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a successful DescribeIdentityPoolUsage request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeIdentityPoolUsageResponse
 type DescribeIdentityPoolUsageOutput struct {
@@ -2176,6 +2343,17 @@ func (s DescribeIdentityPoolUsageOutput) GoString() string {
 func (s *DescribeIdentityPoolUsageOutput) SetIdentityPoolUsage(v *IdentityPoolUsage) *DescribeIdentityPoolUsageOutput {
 	s.IdentityPoolUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolUsage != nil {
+		v := s.IdentityPoolUsage
+
+		e.SetFields(protocol.BodyTarget, "IdentityPoolUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for information about the usage of an identity pool.
@@ -2240,6 +2418,22 @@ func (s *DescribeIdentityUsageInput) SetIdentityPoolId(v string) *DescribeIdenti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response to a successful DescribeIdentityUsage request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/DescribeIdentityUsageResponse
 type DescribeIdentityUsageOutput struct {
@@ -2263,6 +2457,17 @@ func (s DescribeIdentityUsageOutput) GoString() string {
 func (s *DescribeIdentityUsageOutput) SetIdentityUsage(v *IdentityUsage) *DescribeIdentityUsageOutput {
 	s.IdentityUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeIdentityUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityUsage != nil {
+		v := s.IdentityUsage
+
+		e.SetFields(protocol.BodyTarget, "IdentityUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetBulkPublishDetails operation.
@@ -2307,6 +2512,17 @@ func (s *GetBulkPublishDetailsInput) Validate() error {
 func (s *GetBulkPublishDetailsInput) SetIdentityPoolId(v string) *GetBulkPublishDetailsInput {
 	s.IdentityPoolId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBulkPublishDetailsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output for the GetBulkPublishDetails operation.
@@ -2382,6 +2598,37 @@ func (s *GetBulkPublishDetailsOutput) SetIdentityPoolId(v string) *GetBulkPublis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBulkPublishDetailsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BulkPublishCompleteTime != nil {
+		v := *s.BulkPublishCompleteTime
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishCompleteTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.BulkPublishStartTime != nil {
+		v := *s.BulkPublishStartTime
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishStartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.BulkPublishStatus != nil {
+		v := *s.BulkPublishStatus
+
+		e.SetValue(protocol.BodyTarget, "BulkPublishStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureMessage != nil {
+		v := *s.FailureMessage
+
+		e.SetValue(protocol.BodyTarget, "FailureMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for a list of the configured Cognito Events
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetCognitoEventsRequest
 type GetCognitoEventsInput struct {
@@ -2425,6 +2672,17 @@ func (s *GetCognitoEventsInput) SetIdentityPoolId(v string) *GetCognitoEventsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response from the GetCognitoEvents request
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetCognitoEventsResponse
 type GetCognitoEventsOutput struct {
@@ -2448,6 +2706,17 @@ func (s GetCognitoEventsOutput) GoString() string {
 func (s *GetCognitoEventsOutput) SetEvents(v map[string]*string) *GetCognitoEventsOutput {
 	s.Events = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetMap(protocol.BodyTarget, "Events", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetIdentityPoolConfiguration operation.
@@ -2495,6 +2764,17 @@ func (s *GetIdentityPoolConfigurationInput) SetIdentityPoolId(v string) *GetIden
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the GetIdentityPoolConfiguration operation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/GetIdentityPoolConfigurationResponse
 type GetIdentityPoolConfigurationOutput struct {
@@ -2537,6 +2817,27 @@ func (s *GetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *GetIde
 func (s *GetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *GetIdentityPoolConfigurationOutput {
 	s.PushSync = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Usage information for the identity pool.
@@ -2590,6 +2891,40 @@ func (s *IdentityPoolUsage) SetLastModifiedDate(v time.Time) *IdentityPoolUsage 
 func (s *IdentityPoolUsage) SetSyncSessionsCount(v int64) *IdentityPoolUsage {
 	s.SyncSessionsCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IdentityPoolUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SyncSessionsCount != nil {
+		v := *s.SyncSessionsCount
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionsCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIdentityPoolUsageList(vs []*IdentityPoolUsage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Usage information for the identity.
@@ -2653,6 +2988,37 @@ func (s *IdentityUsage) SetIdentityPoolId(v string) *IdentityUsage {
 func (s *IdentityUsage) SetLastModifiedDate(v time.Time) *IdentityUsage {
 	s.LastModifiedDate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IdentityUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataStorage != nil {
+		v := *s.DataStorage
+
+		e.SetValue(protocol.BodyTarget, "DataStorage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetCount != nil {
+		v := *s.DatasetCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.BodyTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request for a list of datasets for an identity.
@@ -2735,6 +3101,32 @@ func (s *ListDatasetsInput) SetNextToken(v string) *ListDatasetsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDatasetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful ListDatasets request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListDatasetsResponse
 type ListDatasetsOutput struct {
@@ -2778,6 +3170,27 @@ func (s *ListDatasetsOutput) SetNextToken(v string) *ListDatasetsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDatasetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Datasets) > 0 {
+		v := s.Datasets
+
+		e.SetList(protocol.BodyTarget, "Datasets", encodeDatasetList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for usage information on an identity pool.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListIdentityPoolUsageRequest
 type ListIdentityPoolUsageInput struct {
@@ -2810,6 +3223,22 @@ func (s *ListIdentityPoolUsageInput) SetMaxResults(v int64) *ListIdentityPoolUsa
 func (s *ListIdentityPoolUsageInput) SetNextToken(v string) *ListIdentityPoolUsageInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Returned for a successful ListIdentityPoolUsage request.
@@ -2862,6 +3291,32 @@ func (s *ListIdentityPoolUsageOutput) SetMaxResults(v int64) *ListIdentityPoolUs
 func (s *ListIdentityPoolUsageOutput) SetNextToken(v string) *ListIdentityPoolUsageOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.IdentityPoolUsages) > 0 {
+		v := s.IdentityPoolUsages
+
+		e.SetList(protocol.BodyTarget, "IdentityPoolUsages", encodeIdentityPoolUsageList(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for a list of records.
@@ -2980,6 +3435,47 @@ func (s *ListRecordsInput) SetSyncSessionToken(v string) *ListRecordsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastSyncCount != nil {
+		v := *s.LastSyncCount
+
+		e.SetValue(protocol.QueryTarget, "lastSyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.QueryTarget, "syncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful ListRecordsRequest.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/ListRecordsResponse
 type ListRecordsOutput struct {
@@ -3077,6 +3573,57 @@ func (s *ListRecordsOutput) SetSyncSessionToken(v string) *ListRecordsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DatasetDeletedAfterRequestedSyncCount != nil {
+		v := *s.DatasetDeletedAfterRequestedSyncCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetDeletedAfterRequestedSyncCount", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatasetExists != nil {
+		v := *s.DatasetExists
+
+		e.SetValue(protocol.BodyTarget, "DatasetExists", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DatasetSyncCount != nil {
+		v := *s.DatasetSyncCount
+
+		e.SetValue(protocol.BodyTarget, "DatasetSyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.MergedDatasetNames) > 0 {
+		v := s.MergedDatasetNames
+
+		e.SetList(protocol.BodyTarget, "MergedDatasetNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Records) > 0 {
+		v := s.Records
+
+		e.SetList(protocol.BodyTarget, "Records", encodeRecordList(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Configuration options to be applied to the identity pool.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/PushSync
 type PushSync struct {
@@ -3122,6 +3669,22 @@ func (s *PushSync) SetApplicationArns(v []*string) *PushSync {
 func (s *PushSync) SetRoleArn(v string) *PushSync {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PushSync) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ApplicationArns) > 0 {
+		v := s.ApplicationArns
+
+		e.SetList(protocol.BodyTarget, "ApplicationArns", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The basic data structure of a dataset.
@@ -3192,6 +3755,50 @@ func (s *Record) SetSyncCount(v int64) *Record {
 func (s *Record) SetValue(v string) *Record {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Record) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceLastModifiedDate != nil {
+		v := *s.DeviceLastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "DeviceLastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SyncCount != nil {
+		v := *s.SyncCount
+
+		e.SetValue(protocol.BodyTarget, "SyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRecordList(vs []*Record) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An update operation for a record.
@@ -3281,6 +3888,45 @@ func (s *RecordPatch) SetSyncCount(v int64) *RecordPatch {
 func (s *RecordPatch) SetValue(v string) *RecordPatch {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RecordPatch) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceLastModifiedDate != nil {
+		v := *s.DeviceLastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "DeviceLastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Op != nil {
+		v := *s.Op
+
+		e.SetValue(protocol.BodyTarget, "Op", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncCount != nil {
+		v := *s.SyncCount
+
+		e.SetValue(protocol.BodyTarget, "SyncCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRecordPatchList(vs []*RecordPatch) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A request to RegisterDevice.
@@ -3373,6 +4019,32 @@ func (s *RegisterDeviceInput) SetToken(v string) *RegisterDeviceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterDeviceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a RegisterDevice request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/RegisterDeviceResponse
 type RegisterDeviceOutput struct {
@@ -3396,6 +4068,17 @@ func (s RegisterDeviceOutput) GoString() string {
 func (s *RegisterDeviceOutput) SetDeviceId(v string) *RegisterDeviceOutput {
 	s.DeviceId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterDeviceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to configure Cognito Events"
@@ -3455,6 +4138,22 @@ func (s *SetCognitoEventsInput) SetIdentityPoolId(v string) *SetCognitoEventsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetMap(protocol.BodyTarget, "Events", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SetCognitoEventsOutput
 type SetCognitoEventsOutput struct {
 	_ struct{} `type:"structure"`
@@ -3468,6 +4167,12 @@ func (s SetCognitoEventsOutput) String() string {
 // GoString returns the string representation
 func (s SetCognitoEventsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the SetIdentityPoolConfiguration operation.
@@ -3542,6 +4247,27 @@ func (s *SetIdentityPoolConfigurationInput) SetPushSync(v *PushSync) *SetIdentit
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the SetIdentityPoolConfiguration operation
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SetIdentityPoolConfigurationResponse
 type SetIdentityPoolConfigurationOutput struct {
@@ -3584,6 +4310,27 @@ func (s *SetIdentityPoolConfigurationOutput) SetIdentityPoolId(v string) *SetIde
 func (s *SetIdentityPoolConfigurationOutput) SetPushSync(v *PushSync) *SetIdentityPoolConfigurationOutput {
 	s.PushSync = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CognitoStreams != nil {
+		v := s.CognitoStreams
+
+		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PushSync != nil {
+		v := s.PushSync
+
+		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to SubscribeToDatasetRequest.
@@ -3681,6 +4428,32 @@ func (s *SubscribeToDatasetInput) SetIdentityPoolId(v string) *SubscribeToDatase
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscribeToDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.PathTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to a SubscribeToDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/SubscribeToDatasetResponse
 type SubscribeToDatasetOutput struct {
@@ -3695,6 +4468,12 @@ func (s SubscribeToDatasetOutput) String() string {
 // GoString returns the string representation
 func (s SubscribeToDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscribeToDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to UnsubscribeFromDataset.
@@ -3792,6 +4571,32 @@ func (s *UnsubscribeFromDatasetInput) SetIdentityPoolId(v string) *UnsubscribeFr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnsubscribeFromDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.PathTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Response to an UnsubscribeFromDataset request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/UnsubscribeFromDatasetResponse
 type UnsubscribeFromDatasetOutput struct {
@@ -3806,6 +4611,12 @@ func (s UnsubscribeFromDatasetOutput) String() string {
 // GoString returns the string representation
 func (s UnsubscribeFromDatasetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnsubscribeFromDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to post updates to records or add and delete records for a dataset
@@ -3945,6 +4756,47 @@ func (s *UpdateRecordsInput) SetSyncSessionToken(v string) *UpdateRecordsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceId != nil {
+		v := *s.DeviceId
+
+		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecordPatches) > 0 {
+		v := s.RecordPatches
+
+		e.SetList(protocol.BodyTarget, "RecordPatches", encodeRecordPatchList(v), protocol.Metadata{})
+	}
+	if s.SyncSessionToken != nil {
+		v := *s.SyncSessionToken
+
+		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Returned for a successful UpdateRecordsRequest.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/cognito-sync-2014-06-30/UpdateRecordsResponse
 type UpdateRecordsOutput struct {
@@ -3968,6 +4820,17 @@ func (s UpdateRecordsOutput) GoString() string {
 func (s *UpdateRecordsOutput) SetRecords(v []*Record) *UpdateRecordsOutput {
 	s.Records = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Records) > 0 {
+		v := s.Records
+
+		e.SetList(protocol.BodyTarget, "Records", encodeRecordList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -1720,7 +1720,6 @@ func (s *BulkPublishInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1757,7 +1756,6 @@ func (s *BulkPublishOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1844,7 +1842,6 @@ func (s *CognitoStreams) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StreamingStatus", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1970,7 +1967,6 @@ func (s *Dataset) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NumRecords", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2079,7 +2075,6 @@ func (s *DeleteDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2119,7 +2114,6 @@ func (s *DeleteDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2221,7 +2215,6 @@ func (s *DescribeDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2261,7 +2254,6 @@ func (s *DescribeDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Dataset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2316,7 +2308,6 @@ func (s *DescribeIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2352,7 +2343,6 @@ func (s *DescribeIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.BodyTarget, "IdentityPoolUsage", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2430,7 +2420,6 @@ func (s *DescribeIdentityUsageInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2466,7 +2455,6 @@ func (s *DescribeIdentityUsageOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "IdentityUsage", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2521,7 +2509,6 @@ func (s *GetBulkPublishDetailsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2625,7 +2612,6 @@ func (s *GetBulkPublishDetailsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2679,7 +2665,6 @@ func (s *GetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2715,7 +2700,6 @@ func (s *GetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Events", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2771,7 +2755,6 @@ func (s *GetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2836,7 +2819,6 @@ func (s *GetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2915,7 +2897,6 @@ func (s *IdentityPoolUsage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SyncSessionsCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3017,7 +2998,6 @@ func (s *IdentityUsage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3123,7 +3103,6 @@ func (s *ListDatasetsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3187,7 +3166,6 @@ func (s *ListDatasetsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3237,7 +3215,6 @@ func (s *ListIdentityPoolUsageInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3315,7 +3292,6 @@ func (s *ListIdentityPoolUsageOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3472,7 +3448,6 @@ func (s *ListRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "syncSessionToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3620,7 +3595,6 @@ func (s *ListRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3683,7 +3657,6 @@ func (s *PushSync) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3789,7 +3762,6 @@ func (s *Record) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3917,7 +3889,6 @@ func (s *RecordPatch) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4021,16 +3992,6 @@ func (s *RegisterDeviceInput) SetToken(v string) *RegisterDeviceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RegisterDeviceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.IdentityId != nil {
-		v := *s.IdentityId
-
-		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.IdentityPoolId != nil {
-		v := *s.IdentityPoolId
-
-		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Platform != nil {
 		v := *s.Platform
 
@@ -4041,7 +4002,16 @@ func (s *RegisterDeviceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Token", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
 
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4077,7 +4047,6 @@ func (s *RegisterDeviceOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4150,7 +4119,6 @@ func (s *SetCognitoEventsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4171,7 +4139,6 @@ func (s SetCognitoEventsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetCognitoEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4254,17 +4221,16 @@ func (s *SetIdentityPoolConfigurationInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.BodyTarget, "CognitoStreams", v, protocol.Metadata{})
 	}
-	if s.IdentityPoolId != nil {
-		v := *s.IdentityPoolId
-
-		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.PushSync != nil {
 		v := s.PushSync
 
 		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
 	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
 
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4329,7 +4295,6 @@ func (s *SetIdentityPoolConfigurationOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetFields(protocol.BodyTarget, "PushSync", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4450,7 +4415,6 @@ func (s *SubscribeToDatasetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4472,7 +4436,6 @@ func (s SubscribeToDatasetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SubscribeToDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4593,7 +4556,6 @@ func (s *UnsubscribeFromDatasetInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4615,7 +4577,6 @@ func (s UnsubscribeFromDatasetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UnsubscribeFromDatasetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4758,30 +4719,10 @@ func (s *UpdateRecordsInput) SetSyncSessionToken(v string) *UpdateRecordsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ClientContext != nil {
-		v := *s.ClientContext
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DatasetName != nil {
-		v := *s.DatasetName
-
-		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.DeviceId != nil {
 		v := *s.DeviceId
 
 		e.SetValue(protocol.BodyTarget, "DeviceId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.IdentityId != nil {
-		v := *s.IdentityId
-
-		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.IdentityPoolId != nil {
-		v := *s.IdentityPoolId
-
-		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if len(s.RecordPatches) > 0 {
 		v := s.RecordPatches
@@ -4793,7 +4734,26 @@ func (s *UpdateRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SyncSessionToken", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ClientContext != nil {
+		v := *s.ClientContext
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DatasetName != nil {
+		v := *s.DatasetName
+
+		e.SetValue(protocol.PathTarget, "DatasetName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityId != nil {
+		v := *s.IdentityId
+
+		e.SetValue(protocol.PathTarget, "IdentityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdentityPoolId != nil {
+		v := *s.IdentityPoolId
+
+		e.SetValue(protocol.PathTarget, "IdentityPoolId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4829,7 +4789,6 @@ func (s *UpdateRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Records", encodeRecordList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -1393,6 +1393,32 @@ func (s *CreateFileSystemInput) SetPerformanceMode(v string) *CreateFileSystemIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.BodyTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encrypted != nil {
+		v := *s.Encrypted
+
+		e.SetValue(protocol.BodyTarget, "Encrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KmsKeyId != nil {
+		v := *s.KmsKeyId
+
+		e.SetValue(protocol.BodyTarget, "KmsKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PerformanceMode != nil {
+		v := *s.PerformanceMode
+
+		e.SetValue(protocol.BodyTarget, "PerformanceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateMountTargetRequest
 type CreateMountTargetInput struct {
 	_ struct{} `type:"structure"`
@@ -1465,6 +1491,32 @@ func (s *CreateMountTargetInput) SetSubnetId(v string) *CreateMountTargetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IpAddress != nil {
+		v := *s.IpAddress
+
+		e.SetValue(protocol.BodyTarget, "IpAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SubnetId != nil {
+		v := *s.SubnetId
+
+		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateTagsRequest
 type CreateTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -1529,6 +1581,22 @@ func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/CreateTagsOutput
 type CreateTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1542,6 +1610,12 @@ func (s CreateTagsOutput) String() string {
 // GoString returns the string representation
 func (s CreateTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteFileSystemRequest
@@ -1583,6 +1657,17 @@ func (s *DeleteFileSystemInput) SetFileSystemId(v string) *DeleteFileSystemInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteFileSystemOutput
 type DeleteFileSystemOutput struct {
 	_ struct{} `type:"structure"`
@@ -1596,6 +1681,12 @@ func (s DeleteFileSystemOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFileSystemOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFileSystemOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteMountTargetRequest
@@ -1637,6 +1728,17 @@ func (s *DeleteMountTargetInput) SetMountTargetId(v string) *DeleteMountTargetIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteMountTargetOutput
 type DeleteMountTargetOutput struct {
 	_ struct{} `type:"structure"`
@@ -1650,6 +1752,12 @@ func (s DeleteMountTargetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteMountTargetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMountTargetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteTagsRequest
@@ -1705,6 +1813,22 @@ func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DeleteTagsOutput
 type DeleteTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1718,6 +1842,12 @@ func (s DeleteTagsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeFileSystemsRequest
@@ -1795,6 +1925,32 @@ func (s *DescribeFileSystemsInput) SetMaxItems(v int64) *DescribeFileSystemsInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFileSystemsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.QueryTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.QueryTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeFileSystemsResponse
 type DescribeFileSystemsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1838,6 +1994,27 @@ func (s *DescribeFileSystemsOutput) SetNextMarker(v string) *DescribeFileSystems
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFileSystemsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FileSystems) > 0 {
+		v := s.FileSystems
+
+		e.SetList(protocol.BodyTarget, "FileSystems", encodeFileSystemDescriptionList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetSecurityGroupsRequest
 type DescribeMountTargetSecurityGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -1877,6 +2054,17 @@ func (s *DescribeMountTargetSecurityGroupsInput) SetMountTargetId(v string) *Des
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetSecurityGroupsResponse
 type DescribeMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1901,6 +2089,17 @@ func (s DescribeMountTargetSecurityGroupsOutput) GoString() string {
 func (s *DescribeMountTargetSecurityGroupsOutput) SetSecurityGroups(v []*string) *DescribeMountTargetSecurityGroupsOutput {
 	s.SecurityGroups = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetsRequest
@@ -1972,6 +2171,32 @@ func (s *DescribeMountTargetsInput) SetMountTargetId(v string) *DescribeMountTar
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.QueryTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.QueryTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeMountTargetsResponse
 type DescribeMountTargetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2016,6 +2241,27 @@ func (s *DescribeMountTargetsOutput) SetMountTargets(v []*MountTargetDescription
 func (s *DescribeMountTargetsOutput) SetNextMarker(v string) *DescribeMountTargetsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeMountTargetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.MountTargets) > 0 {
+		v := s.MountTargets
+
+		e.SetList(protocol.BodyTarget, "MountTargets", encodeMountTargetDescriptionList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeTagsRequest
@@ -2081,6 +2327,27 @@ func (s *DescribeTagsInput) SetMaxItems(v int64) *DescribeTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeTagsResponse
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2126,6 +2393,27 @@ func (s *DescribeTagsOutput) SetNextMarker(v string) *DescribeTagsOutput {
 func (s *DescribeTagsOutput) SetTags(v []*Tag) *DescribeTagsOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Description of the file system.
@@ -2272,6 +2560,75 @@ func (s *FileSystemDescription) SetSizeInBytes(v *FileSystemSize) *FileSystemDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileSystemDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationTime != nil {
+		v := *s.CreationTime
+
+		e.SetValue(protocol.BodyTarget, "CreationTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreationToken != nil {
+		v := *s.CreationToken
+
+		e.SetValue(protocol.BodyTarget, "CreationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encrypted != nil {
+		v := *s.Encrypted
+
+		e.SetValue(protocol.BodyTarget, "Encrypted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KmsKeyId != nil {
+		v := *s.KmsKeyId
+
+		e.SetValue(protocol.BodyTarget, "KmsKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifeCycleState != nil {
+		v := *s.LifeCycleState
+
+		e.SetValue(protocol.BodyTarget, "LifeCycleState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumberOfMountTargets != nil {
+		v := *s.NumberOfMountTargets
+
+		e.SetValue(protocol.BodyTarget, "NumberOfMountTargets", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OwnerId != nil {
+		v := *s.OwnerId
+
+		e.SetValue(protocol.BodyTarget, "OwnerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PerformanceMode != nil {
+		v := *s.PerformanceMode
+
+		e.SetValue(protocol.BodyTarget, "PerformanceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizeInBytes != nil {
+		v := s.SizeInBytes
+
+		e.SetFields(protocol.BodyTarget, "SizeInBytes", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFileSystemDescriptionList(vs []*FileSystemDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Latest known metered size (in bytes) of data stored in the file system, in
 // its Value field, and the time at which that size was determined in its Timestamp
 // field. Note that the value does not represent the size of a consistent snapshot
@@ -2314,6 +2671,22 @@ func (s *FileSystemSize) SetTimestamp(v time.Time) *FileSystemSize {
 func (s *FileSystemSize) SetValue(v int64) *FileSystemSize {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileSystemSize) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/ModifyMountTargetSecurityGroupsRequest
@@ -2364,6 +2737,22 @@ func (s *ModifyMountTargetSecurityGroupsInput) SetSecurityGroups(v []*string) *M
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ModifyMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/ModifyMountTargetSecurityGroupsOutput
 type ModifyMountTargetSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2377,6 +2766,12 @@ func (s ModifyMountTargetSecurityGroupsOutput) String() string {
 // GoString returns the string representation
 func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ModifyMountTargetSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides a description of a mount target.
@@ -2467,6 +2862,55 @@ func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MountTargetDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
+
+		e.SetValue(protocol.BodyTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IpAddress != nil {
+		v := *s.IpAddress
+
+		e.SetValue(protocol.BodyTarget, "IpAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifeCycleState != nil {
+		v := *s.LifeCycleState
+
+		e.SetValue(protocol.BodyTarget, "LifeCycleState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
+
+		e.SetValue(protocol.BodyTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NetworkInterfaceId != nil {
+		v := *s.NetworkInterfaceId
+
+		e.SetValue(protocol.BodyTarget, "NetworkInterfaceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OwnerId != nil {
+		v := *s.OwnerId
+
+		e.SetValue(protocol.BodyTarget, "OwnerId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubnetId != nil {
+		v := *s.SubnetId
+
+		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMountTargetDescriptionList(vs []*MountTargetDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers,
 // representable in UTF-8, and the following characters: + - = . _ : /
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/Tag
@@ -2523,6 +2967,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -1415,7 +1415,6 @@ func (s *CreateFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PerformanceMode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1513,7 +1512,6 @@ func (s *CreateMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1583,17 +1581,16 @@ func (s *CreateTagsInput) SetTags(v []*Tag) *CreateTagsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTagsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.FileSystemId != nil {
-		v := *s.FileSystemId
-
-		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.Tags) > 0 {
 		v := s.Tags
 
 		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
 	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
 
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -1614,7 +1611,6 @@ func (s CreateTagsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1664,7 +1660,6 @@ func (s *DeleteFileSystemInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1685,7 +1680,6 @@ func (s DeleteFileSystemOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFileSystemOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1735,7 +1729,6 @@ func (s *DeleteMountTargetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1756,7 +1749,6 @@ func (s DeleteMountTargetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteMountTargetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1815,17 +1807,16 @@ func (s *DeleteTagsInput) SetTagKeys(v []*string) *DeleteTagsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTagsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.FileSystemId != nil {
-		v := *s.FileSystemId
-
-		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.TagKeys) > 0 {
 		v := s.TagKeys
 
 		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
+	if s.FileSystemId != nil {
+		v := *s.FileSystemId
 
+		e.SetValue(protocol.PathTarget, "FileSystemId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -1846,7 +1837,6 @@ func (s DeleteTagsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1947,7 +1937,6 @@ func (s *DescribeFileSystemsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2011,7 +2000,6 @@ func (s *DescribeFileSystemsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2061,7 +2049,6 @@ func (s *DescribeMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2098,7 +2085,6 @@ func (s *DescribeMountTargetSecurityGroupsOutput) MarshalFields(e protocol.Field
 
 		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2193,7 +2179,6 @@ func (s *DescribeMountTargetsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2260,7 +2245,6 @@ func (s *DescribeMountTargetsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2344,7 +2328,6 @@ func (s *DescribeTagsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2412,7 +2395,6 @@ func (s *DescribeTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2617,7 +2599,6 @@ func (s *FileSystemDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SizeInBytes", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2685,7 +2666,6 @@ func (s *FileSystemSize) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2739,17 +2719,16 @@ func (s *ModifyMountTargetSecurityGroupsInput) SetSecurityGroups(v []*string) *M
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ModifyMountTargetSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.MountTargetId != nil {
-		v := *s.MountTargetId
-
-		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.SecurityGroups) > 0 {
 		v := s.SecurityGroups
 
 		e.SetList(protocol.BodyTarget, "SecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
+	if s.MountTargetId != nil {
+		v := *s.MountTargetId
 
+		e.SetValue(protocol.PathTarget, "MountTargetId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -2770,7 +2749,6 @@ func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ModifyMountTargetSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2899,7 +2877,6 @@ func (s *MountTargetDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubnetId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2981,7 +2958,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -1455,7 +1455,6 @@ func (s *AccessPoliciesStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1535,7 +1534,6 @@ func (s *AddTagsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1555,7 +1553,6 @@ func (s AddTagsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1610,7 +1607,6 @@ func (s *AdditionalLimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1682,7 +1678,6 @@ func (s *AdvancedOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1860,7 +1855,6 @@ func (s *CreateElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1896,7 +1890,6 @@ func (s *CreateElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1950,7 +1943,6 @@ func (s *DeleteElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1987,7 +1979,6 @@ func (s *DeleteElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2007,7 +1998,6 @@ func (s DeleteElasticsearchServiceRoleInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteElasticsearchServiceRoleInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2027,7 +2017,6 @@ func (s DeleteElasticsearchServiceRoleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteElasticsearchServiceRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2081,7 +2070,6 @@ func (s *DescribeElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2120,7 +2108,6 @@ func (s *DescribeElasticsearchDomainConfigOutput) MarshalFields(e protocol.Field
 
 		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2173,7 +2160,6 @@ func (s *DescribeElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2211,7 +2197,6 @@ func (s *DescribeElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2262,7 +2247,6 @@ func (s *DescribeElasticsearchDomainsInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetList(protocol.BodyTarget, "DomainNames", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2300,7 +2284,6 @@ func (s *DescribeElasticsearchDomainsOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "DomainStatusList", encodeElasticsearchDomainStatusList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2374,11 +2357,6 @@ func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetInstanceType(v string)
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DescribeElasticsearchInstanceTypeLimitsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DomainName != nil {
-		v := *s.DomainName
-
-		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ElasticsearchVersion != nil {
 		v := *s.ElasticsearchVersion
 
@@ -2389,7 +2367,11 @@ func (s *DescribeElasticsearchInstanceTypeLimitsInput) MarshalFields(e protocol.
 
 		e.SetValue(protocol.PathTarget, "InstanceType", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DomainName != nil {
+		v := *s.DomainName
 
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -2428,7 +2410,6 @@ func (s *DescribeElasticsearchInstanceTypeLimitsOutput) MarshalFields(e protocol
 
 		e.SetMap(protocol.BodyTarget, "LimitsByRole", encodeLimitsMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2462,7 +2443,6 @@ func (s *DomainInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2548,7 +2528,6 @@ func (s *EBSOptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VolumeType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2601,7 +2580,6 @@ func (s *EBSOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2711,7 +2689,6 @@ func (s *ElasticsearchClusterConfig) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "ZoneAwarenessEnabled", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2765,7 +2742,6 @@ func (s *ElasticsearchClusterConfigStatus) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2901,7 +2877,6 @@ func (s *ElasticsearchDomainConfig) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3169,7 +3144,6 @@ func (s *ElasticsearchDomainStatus) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3232,7 +3206,6 @@ func (s *ElasticsearchVersionStatus) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3282,7 +3255,6 @@ func (s *InstanceCountLimits) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "MinimumInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3319,7 +3291,6 @@ func (s *InstanceLimits) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "InstanceCountLimits", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3385,7 +3356,6 @@ func (s *Limits) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "StorageTypes", encodeStorageTypeList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3413,7 +3383,6 @@ func (s ListDomainNamesInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3449,7 +3418,6 @@ func (s *ListDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "DomainNames", encodeDomainInfoList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3529,15 +3497,15 @@ func (s *ListElasticsearchInstanceTypesInput) SetNextToken(v string) *ListElasti
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListElasticsearchInstanceTypesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DomainName != nil {
-		v := *s.DomainName
-
-		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ElasticsearchVersion != nil {
 		v := *s.ElasticsearchVersion
 
 		e.SetValue(protocol.PathTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
@@ -3549,7 +3517,6 @@ func (s *ListElasticsearchInstanceTypesInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3601,7 +3568,6 @@ func (s *ListElasticsearchInstanceTypesOutput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3658,7 +3624,6 @@ func (s *ListElasticsearchVersionsInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3710,7 +3675,6 @@ func (s *ListElasticsearchVersionsOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3763,7 +3727,6 @@ func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3799,7 +3762,6 @@ func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3850,7 +3812,6 @@ func (s *LogPublishingOption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3908,7 +3869,6 @@ func (s *LogPublishingOptionsStatus) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4005,7 +3965,6 @@ func (s *OptionStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UpdateVersion", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4078,7 +4037,6 @@ func (s *RemoveTagsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4098,7 +4056,6 @@ func (s RemoveTagsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4135,7 +4092,6 @@ func (s *SnapshotOptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "AutomatedSnapshotStartHour", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4188,7 +4144,6 @@ func (s *SnapshotOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4259,7 +4214,6 @@ func (s *StorageType) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4325,7 +4279,6 @@ func (s *StorageTypeLimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4409,7 +4362,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4546,11 +4498,6 @@ func (s *UpdateElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-	if s.DomainName != nil {
-		v := *s.DomainName
-
-		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.EBSOptions != nil {
 		v := s.EBSOptions
 
@@ -4576,7 +4523,11 @@ func (s *UpdateElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
 	}
+	if s.DomainName != nil {
+		v := *s.DomainName
 
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4614,7 +4565,6 @@ func (s *UpdateElasticsearchDomainConfigOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4695,7 +4645,6 @@ func (s *VPCDerivedInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VPCId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4748,7 +4697,6 @@ func (s *VPCDerivedInfoStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4799,7 +4747,6 @@ func (s *VPCOptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -1443,6 +1443,22 @@ func (s *AccessPoliciesStatus) SetStatus(v *OptionStatus) *AccessPoliciesStatus 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessPoliciesStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := *s.Options
+
+		e.SetValue(protocol.BodyTarget, "Options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters to the AddTags operation. Specify the tags that
 // you want to attach to the Elasticsearch domain.
 type AddTagsInput struct {
@@ -1507,6 +1523,22 @@ func (s *AddTagsInput) SetTagList(v []*Tag) *AddTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagList) > 0 {
+		v := s.TagList
+
+		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AddTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1519,6 +1551,12 @@ func (s AddTagsOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // List of limits that are specific to a given InstanceType and for each of
@@ -1558,6 +1596,30 @@ func (s *AdditionalLimit) SetLimitName(v string) *AdditionalLimit {
 func (s *AdditionalLimit) SetLimitValues(v []*string) *AdditionalLimit {
 	s.LimitValues = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AdditionalLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LimitName != nil {
+		v := *s.LimitName
+
+		e.SetValue(protocol.BodyTarget, "LimitName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.LimitValues) > 0 {
+		v := s.LimitValues
+
+		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAdditionalLimitList(vs []*AdditionalLimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Status of the advanced options for the specified Elasticsearch domain. Currently,
@@ -1606,6 +1668,22 @@ func (s *AdvancedOptionsStatus) SetOptions(v map[string]*string) *AdvancedOption
 func (s *AdvancedOptionsStatus) SetStatus(v *OptionStatus) *AdvancedOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AdvancedOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Options) > 0 {
+		v := s.Options
+
+		e.SetMap(protocol.BodyTarget, "Options", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 type CreateElasticsearchDomainInput struct {
@@ -1735,6 +1813,57 @@ func (s *CreateElasticsearchDomainInput) SetVPCOptions(v *VPCOptions) *CreateEla
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.BodyTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.LogPublishingOptions) > 0 {
+		v := s.LogPublishingOptions
+
+		e.SetMap(protocol.BodyTarget, "LogPublishingOptions", encodeLogPublishingOptionMap(v), protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+	if s.VPCOptions != nil {
+		v := s.VPCOptions
+
+		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a CreateElasticsearchDomain operation. Contains the status
 // of the newly created Elasticsearch domain.
 type CreateElasticsearchDomainOutput struct {
@@ -1758,6 +1887,17 @@ func (s CreateElasticsearchDomainOutput) GoString() string {
 func (s *CreateElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *CreateElasticsearchDomainOutput {
 	s.DomainStatus = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DeleteElasticsearchDomain operation.
@@ -1803,6 +1943,17 @@ func (s *DeleteElasticsearchDomainInput) SetDomainName(v string) *DeleteElastics
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DeleteElasticsearchDomain request. Contains the status of
 // the pending deletion, or no status if the domain and all of its resources
 // have been deleted.
@@ -1829,6 +1980,17 @@ func (s *DeleteElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomain
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteElasticsearchServiceRoleInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1843,6 +2005,12 @@ func (s DeleteElasticsearchServiceRoleInput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchServiceRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type DeleteElasticsearchServiceRoleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -1855,6 +2023,12 @@ func (s DeleteElasticsearchServiceRoleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteElasticsearchServiceRoleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteElasticsearchServiceRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomainConfig operation.
@@ -1900,6 +2074,17 @@ func (s *DescribeElasticsearchDomainConfigInput) SetDomainName(v string) *Descri
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomainConfig request. Contains the configuration
 // information of the requested domain.
 type DescribeElasticsearchDomainConfigOutput struct {
@@ -1926,6 +2111,17 @@ func (s DescribeElasticsearchDomainConfigOutput) GoString() string {
 func (s *DescribeElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *DescribeElasticsearchDomainConfigOutput {
 	s.DomainConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainConfig != nil {
+		v := s.DomainConfig
+
+		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomain operation.
@@ -1970,6 +2166,17 @@ func (s *DescribeElasticsearchDomainInput) SetDomainName(v string) *DescribeElas
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomain request. Contains the status
 // of the domain specified in the request.
 type DescribeElasticsearchDomainOutput struct {
@@ -1995,6 +2202,17 @@ func (s DescribeElasticsearchDomainOutput) GoString() string {
 func (s *DescribeElasticsearchDomainOutput) SetDomainStatus(v *ElasticsearchDomainStatus) *DescribeElasticsearchDomainOutput {
 	s.DomainStatus = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainStatus != nil {
+		v := s.DomainStatus
+
+		e.SetFields(protocol.BodyTarget, "DomainStatus", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the DescribeElasticsearchDomains operation.
@@ -2037,6 +2255,17 @@ func (s *DescribeElasticsearchDomainsInput) SetDomainNames(v []*string) *Describ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainNames) > 0 {
+		v := s.DomainNames
+
+		e.SetList(protocol.BodyTarget, "DomainNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a DescribeElasticsearchDomains request. Contains the status
 // of the specified domains or all domains owned by the account.
 type DescribeElasticsearchDomainsOutput struct {
@@ -2062,6 +2291,17 @@ func (s DescribeElasticsearchDomainsOutput) GoString() string {
 func (s *DescribeElasticsearchDomainsOutput) SetDomainStatusList(v []*ElasticsearchDomainStatus) *DescribeElasticsearchDomainsOutput {
 	s.DomainStatusList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchDomainsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainStatusList) > 0 {
+		v := s.DomainStatusList
+
+		e.SetList(protocol.BodyTarget, "DomainStatusList", encodeElasticsearchDomainStatusList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to DescribeElasticsearchInstanceTypeLimits operation.
@@ -2132,6 +2372,27 @@ func (s *DescribeElasticsearchInstanceTypeLimitsInput) SetInstanceType(v string)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchInstanceTypeLimitsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.PathTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceType != nil {
+		v := *s.InstanceType
+
+		e.SetValue(protocol.PathTarget, "InstanceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters received from DescribeElasticsearchInstanceTypeLimits
 // operation.
 type DescribeElasticsearchInstanceTypeLimitsOutput struct {
@@ -2160,6 +2421,17 @@ func (s *DescribeElasticsearchInstanceTypeLimitsOutput) SetLimitsByRole(v map[st
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeElasticsearchInstanceTypeLimitsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LimitsByRole) > 0 {
+		v := s.LimitsByRole
+
+		e.SetMap(protocol.BodyTarget, "LimitsByRole", encodeLimitsMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DomainInfo struct {
 	_ struct{} `type:"structure"`
 
@@ -2181,6 +2453,25 @@ func (s DomainInfo) GoString() string {
 func (s *DomainInfo) SetDomainName(v string) *DomainInfo {
 	s.DomainName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DomainInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDomainInfoList(vs []*DomainInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Options to enable, disable, and specify the properties of EBS storage volumes.
@@ -2235,6 +2526,32 @@ func (s *EBSOptions) SetVolumeType(v string) *EBSOptions {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EBSOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EBSEnabled != nil {
+		v := *s.EBSEnabled
+
+		e.SetValue(protocol.BodyTarget, "EBSEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Iops != nil {
+		v := *s.Iops
+
+		e.SetValue(protocol.BodyTarget, "Iops", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VolumeSize != nil {
+		v := *s.VolumeSize
+
+		e.SetValue(protocol.BodyTarget, "VolumeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VolumeType != nil {
+		v := *s.VolumeType
+
+		e.SetValue(protocol.BodyTarget, "VolumeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Status of the EBS options for the specified Elasticsearch domain.
 type EBSOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -2270,6 +2587,22 @@ func (s *EBSOptionsStatus) SetOptions(v *EBSOptions) *EBSOptionsStatus {
 func (s *EBSOptionsStatus) SetStatus(v *OptionStatus) *EBSOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EBSOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Specifies the configuration for the domain cluster, such as the type and
@@ -2346,6 +2679,42 @@ func (s *ElasticsearchClusterConfig) SetZoneAwarenessEnabled(v bool) *Elasticsea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchClusterConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DedicatedMasterCount != nil {
+		v := *s.DedicatedMasterCount
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DedicatedMasterEnabled != nil {
+		v := *s.DedicatedMasterEnabled
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DedicatedMasterType != nil {
+		v := *s.DedicatedMasterType
+
+		e.SetValue(protocol.BodyTarget, "DedicatedMasterType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InstanceCount != nil {
+		v := *s.InstanceCount
+
+		e.SetValue(protocol.BodyTarget, "InstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InstanceType != nil {
+		v := *s.InstanceType
+
+		e.SetValue(protocol.BodyTarget, "InstanceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZoneAwarenessEnabled != nil {
+		v := *s.ZoneAwarenessEnabled
+
+		e.SetValue(protocol.BodyTarget, "ZoneAwarenessEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Specifies the configuration status for the specified Elasticsearch domain.
 type ElasticsearchClusterConfigStatus struct {
 	_ struct{} `type:"structure"`
@@ -2382,6 +2751,22 @@ func (s *ElasticsearchClusterConfigStatus) SetOptions(v *ElasticsearchClusterCon
 func (s *ElasticsearchClusterConfigStatus) SetStatus(v *OptionStatus) *ElasticsearchClusterConfigStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchClusterConfigStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The configuration of an Elasticsearch domain.
@@ -2472,6 +2857,52 @@ func (s *ElasticsearchDomainConfig) SetSnapshotOptions(v *SnapshotOptionsStatus)
 func (s *ElasticsearchDomainConfig) SetVPCOptions(v *VPCDerivedInfoStatus) *ElasticsearchDomainConfig {
 	s.VPCOptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchDomainConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := s.AccessPolicies
+
+		e.SetFields(protocol.BodyTarget, "AccessPolicies", v, protocol.Metadata{})
+	}
+	if s.AdvancedOptions != nil {
+		v := s.AdvancedOptions
+
+		e.SetFields(protocol.BodyTarget, "AdvancedOptions", v, protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := s.ElasticsearchVersion
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchVersion", v, protocol.Metadata{})
+	}
+	if s.LogPublishingOptions != nil {
+		v := s.LogPublishingOptions
+
+		e.SetFields(protocol.BodyTarget, "LogPublishingOptions", v, protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+	if s.VPCOptions != nil {
+		v := s.VPCOptions
+
+		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The current status of an Elasticsearch domain.
@@ -2656,6 +3087,100 @@ func (s *ElasticsearchDomainStatus) SetVPCOptions(v *VPCDerivedInfo) *Elasticsea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchDomainStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Created != nil {
+		v := *s.Created
+
+		e.SetValue(protocol.BodyTarget, "Created", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Deleted != nil {
+		v := *s.Deleted
+
+		e.SetValue(protocol.BodyTarget, "Deleted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DomainId != nil {
+		v := *s.DomainId
+
+		e.SetValue(protocol.BodyTarget, "DomainId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.BodyTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.BodyTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "Endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Endpoints) > 0 {
+		v := s.Endpoints
+
+		e.SetMap(protocol.BodyTarget, "Endpoints", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.LogPublishingOptions) > 0 {
+		v := s.LogPublishingOptions
+
+		e.SetMap(protocol.BodyTarget, "LogPublishingOptions", encodeLogPublishingOptionMap(v), protocol.Metadata{})
+	}
+	if s.Processing != nil {
+		v := *s.Processing
+
+		e.SetValue(protocol.BodyTarget, "Processing", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+	if s.VPCOptions != nil {
+		v := s.VPCOptions
+
+		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeElasticsearchDomainStatusList(vs []*ElasticsearchDomainStatus) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Status of the Elasticsearch version options for the specified Elasticsearch
 // domain.
 type ElasticsearchVersionStatus struct {
@@ -2695,6 +3220,22 @@ func (s *ElasticsearchVersionStatus) SetStatus(v *OptionStatus) *ElasticsearchVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchVersionStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := *s.Options
+
+		e.SetValue(protocol.BodyTarget, "Options", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // InstanceCountLimits represents the limits on number of instances that be
 // created in Amazon Elasticsearch for given InstanceType.
 type InstanceCountLimits struct {
@@ -2729,6 +3270,22 @@ func (s *InstanceCountLimits) SetMinimumInstanceCount(v int64) *InstanceCountLim
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InstanceCountLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaximumInstanceCount != nil {
+		v := *s.MaximumInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "MaximumInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinimumInstanceCount != nil {
+		v := *s.MinimumInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "MinimumInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // InstanceLimits represents the list of instance related attributes that are
 // available for given InstanceType.
 type InstanceLimits struct {
@@ -2753,6 +3310,17 @@ func (s InstanceLimits) GoString() string {
 func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *InstanceLimits {
 	s.InstanceCountLimits = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InstanceLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InstanceCountLimits != nil {
+		v := s.InstanceCountLimits
+
+		e.SetFields(protocol.BodyTarget, "InstanceCountLimits", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Limits for given InstanceType and for each of it's role. Limits contains following StorageTypes,   InstanceLimitsand AdditionalLimits
@@ -2800,6 +3368,35 @@ func (s *Limits) SetStorageTypes(v []*StorageType) *Limits {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Limits) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalLimits) > 0 {
+		v := s.AdditionalLimits
+
+		e.SetList(protocol.BodyTarget, "AdditionalLimits", encodeAdditionalLimitList(v), protocol.Metadata{})
+	}
+	if s.InstanceLimits != nil {
+		v := s.InstanceLimits
+
+		e.SetFields(protocol.BodyTarget, "InstanceLimits", v, protocol.Metadata{})
+	}
+	if len(s.StorageTypes) > 0 {
+		v := s.StorageTypes
+
+		e.SetList(protocol.BodyTarget, "StorageTypes", encodeStorageTypeList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLimitsMap(vs map[string]*Limits) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 type ListDomainNamesInput struct {
 	_ struct{} `type:"structure"`
 }
@@ -2812,6 +3409,12 @@ func (s ListDomainNamesInput) String() string {
 // GoString returns the string representation
 func (s ListDomainNamesInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDomainNamesInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The result of a ListDomainNames operation. Contains the names of all Elasticsearch
@@ -2837,6 +3440,17 @@ func (s ListDomainNamesOutput) GoString() string {
 func (s *ListDomainNamesOutput) SetDomainNames(v []*DomainInfo) *ListDomainNamesOutput {
 	s.DomainNames = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDomainNamesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DomainNames) > 0 {
+		v := s.DomainNames
+
+		e.SetList(protocol.BodyTarget, "DomainNames", encodeDomainInfoList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListElasticsearchInstanceTypes operation.
@@ -2913,6 +3527,32 @@ func (s *ListElasticsearchInstanceTypesInput) SetNextToken(v string) *ListElasti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchInstanceTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.QueryTarget, "domainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ElasticsearchVersion != nil {
+		v := *s.ElasticsearchVersion
+
+		e.SetValue(protocol.PathTarget, "ElasticsearchVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters returned by ListElasticsearchInstanceTypes operation.
 type ListElasticsearchInstanceTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -2947,6 +3587,22 @@ func (s *ListElasticsearchInstanceTypesOutput) SetElasticsearchInstanceTypes(v [
 func (s *ListElasticsearchInstanceTypesOutput) SetNextToken(v string) *ListElasticsearchInstanceTypesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchInstanceTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ElasticsearchInstanceTypes) > 0 {
+		v := s.ElasticsearchInstanceTypes
+
+		e.SetList(protocol.BodyTarget, "ElasticsearchInstanceTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListElasticsearchVersions operation.
@@ -2990,6 +3646,22 @@ func (s *ListElasticsearchVersionsInput) SetNextToken(v string) *ListElasticsear
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters for response received from ListElasticsearchVersions
 // operation.
 type ListElasticsearchVersionsOutput struct {
@@ -3024,6 +3696,22 @@ func (s *ListElasticsearchVersionsOutput) SetElasticsearchVersions(v []*string) 
 func (s *ListElasticsearchVersionsOutput) SetNextToken(v string) *ListElasticsearchVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListElasticsearchVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ElasticsearchVersions) > 0 {
+		v := s.ElasticsearchVersions
+
+		e.SetList(protocol.BodyTarget, "ElasticsearchVersions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the parameters to the ListTags operation. Specify the ARN for
@@ -3068,6 +3756,17 @@ func (s *ListTagsInput) SetARN(v string) *ListTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.QueryTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of a ListTags operation. Contains tags for all requested Elasticsearch
 // domains.
 type ListTagsOutput struct {
@@ -3091,6 +3790,17 @@ func (s ListTagsOutput) GoString() string {
 func (s *ListTagsOutput) SetTagList(v []*Tag) *ListTagsOutput {
 	s.TagList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagList) > 0 {
+		v := s.TagList
+
+		e.SetList(protocol.BodyTarget, "TagList", encodeTagList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Log Publishing option that is set for given domain. Attributes and their details: CloudWatchLogsLogGroupArn: ARN of the Cloudwatch
@@ -3128,6 +3838,30 @@ func (s *LogPublishingOption) SetEnabled(v bool) *LogPublishingOption {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LogPublishingOption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudWatchLogsLogGroupArn != nil {
+		v := *s.CloudWatchLogsLogGroupArn
+
+		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLogPublishingOptionMap(vs map[string]*LogPublishingOption) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // The configured log publishing options for the domain and their current status.
 type LogPublishingOptionsStatus struct {
 	_ struct{} `type:"structure"`
@@ -3160,6 +3894,22 @@ func (s *LogPublishingOptionsStatus) SetOptions(v map[string]*LogPublishingOptio
 func (s *LogPublishingOptionsStatus) SetStatus(v *OptionStatus) *LogPublishingOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LogPublishingOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Options) > 0 {
+		v := s.Options
+
+		e.SetMap(protocol.BodyTarget, "Options", encodeLogPublishingOptionMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides the current status of the entity.
@@ -3228,6 +3978,37 @@ func (s *OptionStatus) SetUpdateVersion(v int64) *OptionStatus {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OptionStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.PendingDeletion != nil {
+		v := *s.PendingDeletion
+
+		e.SetValue(protocol.BodyTarget, "PendingDeletion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdateDate != nil {
+		v := *s.UpdateDate
+
+		e.SetValue(protocol.BodyTarget, "UpdateDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UpdateVersion != nil {
+		v := *s.UpdateVersion
+
+		e.SetValue(protocol.BodyTarget, "UpdateVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for the parameters to the RemoveTags operation. Specify the ARN
 // for the Elasticsearch domain from which you want to remove the specified
 // TagKey.
@@ -3285,6 +4066,22 @@ func (s *RemoveTagsInput) SetTagKeys(v []*string) *RemoveTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ARN != nil {
+		v := *s.ARN
+
+		e.SetValue(protocol.BodyTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RemoveTagsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3297,6 +4094,12 @@ func (s RemoveTagsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Specifies the time, in UTC format, when the service takes a daily automated
@@ -3323,6 +4126,17 @@ func (s SnapshotOptions) GoString() string {
 func (s *SnapshotOptions) SetAutomatedSnapshotStartHour(v int64) *SnapshotOptions {
 	s.AutomatedSnapshotStartHour = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnapshotOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AutomatedSnapshotStartHour != nil {
+		v := *s.AutomatedSnapshotStartHour
+
+		e.SetValue(protocol.BodyTarget, "AutomatedSnapshotStartHour", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Status of a daily automated snapshot.
@@ -3360,6 +4174,22 @@ func (s *SnapshotOptionsStatus) SetOptions(v *SnapshotOptions) *SnapshotOptionsS
 func (s *SnapshotOptionsStatus) SetStatus(v *OptionStatus) *SnapshotOptionsStatus {
 	s.Status = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnapshotOptionsStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // StorageTypes represents the list of storage related types and their attributes
@@ -3412,6 +4242,35 @@ func (s *StorageType) SetStorageTypeName(v string) *StorageType {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageSubTypeName != nil {
+		v := *s.StorageSubTypeName
+
+		e.SetValue(protocol.BodyTarget, "StorageSubTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.StorageTypeLimits) > 0 {
+		v := s.StorageTypeLimits
+
+		e.SetList(protocol.BodyTarget, "StorageTypeLimits", encodeStorageTypeLimitList(v), protocol.Metadata{})
+	}
+	if s.StorageTypeName != nil {
+		v := *s.StorageTypeName
+
+		e.SetValue(protocol.BodyTarget, "StorageTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStorageTypeList(vs []*StorageType) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Limits that are applicable for given storage type.
 type StorageTypeLimit struct {
 	_ struct{} `type:"structure"`
@@ -3452,6 +4311,30 @@ func (s *StorageTypeLimit) SetLimitName(v string) *StorageTypeLimit {
 func (s *StorageTypeLimit) SetLimitValues(v []*string) *StorageTypeLimit {
 	s.LimitValues = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageTypeLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LimitName != nil {
+		v := *s.LimitName
+
+		e.SetValue(protocol.BodyTarget, "LimitName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.LimitValues) > 0 {
+		v := s.LimitValues
+
+		e.SetList(protocol.BodyTarget, "LimitValues", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeStorageTypeLimitList(vs []*StorageTypeLimit) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies a key value pair for a resource tag.
@@ -3512,6 +4395,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for the parameters to the UpdateElasticsearchDomain operation.
@@ -3627,6 +4534,52 @@ func (s *UpdateElasticsearchDomainConfigInput) SetVPCOptions(v *VPCOptions) *Upd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateElasticsearchDomainConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessPolicies != nil {
+		v := *s.AccessPolicies
+
+		e.SetValue(protocol.BodyTarget, "AccessPolicies", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AdvancedOptions) > 0 {
+		v := s.AdvancedOptions
+
+		e.SetMap(protocol.BodyTarget, "AdvancedOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DomainName != nil {
+		v := *s.DomainName
+
+		e.SetValue(protocol.PathTarget, "DomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EBSOptions != nil {
+		v := s.EBSOptions
+
+		e.SetFields(protocol.BodyTarget, "EBSOptions", v, protocol.Metadata{})
+	}
+	if s.ElasticsearchClusterConfig != nil {
+		v := s.ElasticsearchClusterConfig
+
+		e.SetFields(protocol.BodyTarget, "ElasticsearchClusterConfig", v, protocol.Metadata{})
+	}
+	if len(s.LogPublishingOptions) > 0 {
+		v := s.LogPublishingOptions
+
+		e.SetMap(protocol.BodyTarget, "LogPublishingOptions", encodeLogPublishingOptionMap(v), protocol.Metadata{})
+	}
+	if s.SnapshotOptions != nil {
+		v := s.SnapshotOptions
+
+		e.SetFields(protocol.BodyTarget, "SnapshotOptions", v, protocol.Metadata{})
+	}
+	if s.VPCOptions != nil {
+		v := s.VPCOptions
+
+		e.SetFields(protocol.BodyTarget, "VPCOptions", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result of an UpdateElasticsearchDomain request. Contains the status of
 // the Elasticsearch domain being updated.
 type UpdateElasticsearchDomainConfigOutput struct {
@@ -3652,6 +4605,17 @@ func (s UpdateElasticsearchDomainConfigOutput) GoString() string {
 func (s *UpdateElasticsearchDomainConfigOutput) SetDomainConfig(v *ElasticsearchDomainConfig) *UpdateElasticsearchDomainConfigOutput {
 	s.DomainConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateElasticsearchDomainConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DomainConfig != nil {
+		v := s.DomainConfig
+
+		e.SetFields(protocol.BodyTarget, "DomainConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Options to specify the subnets and security groups for VPC endpoint. For
@@ -3709,6 +4673,32 @@ func (s *VPCDerivedInfo) SetVPCId(v string) *VPCDerivedInfo {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VPCDerivedInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AvailabilityZones) > 0 {
+		v := s.AvailabilityZones
+
+		e.SetList(protocol.BodyTarget, "AvailabilityZones", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.VPCId != nil {
+		v := *s.VPCId
+
+		e.SetValue(protocol.BodyTarget, "VPCId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Status of the VPC options for the specified Elasticsearch domain.
 type VPCDerivedInfoStatus struct {
 	_ struct{} `type:"structure"`
@@ -3746,6 +4736,22 @@ func (s *VPCDerivedInfoStatus) SetStatus(v *OptionStatus) *VPCDerivedInfoStatus 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VPCDerivedInfoStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Options != nil {
+		v := s.Options
+
+		e.SetFields(protocol.BodyTarget, "Options", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := s.Status
+
+		e.SetFields(protocol.BodyTarget, "Status", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Options to specify the subnets and security groups for VPC endpoint. For
 // more information, see  VPC Endpoints for Amazon Elasticsearch Service Domains
 // (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html).
@@ -3779,6 +4785,22 @@ func (s *VPCOptions) SetSecurityGroupIds(v []*string) *VPCOptions {
 func (s *VPCOptions) SetSubnetIds(v []*string) *VPCOptions {
 	s.SubnetIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VPCOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCancelJob = "CancelJob"
@@ -1986,6 +1987,55 @@ func (s *Artwork) SetSizingPolicy(v string) *Artwork {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Artwork) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArtFormat != nil {
+		v := *s.AlbumArtFormat
+
+		e.SetValue(protocol.BodyTarget, "AlbumArtFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.InputKey != nil {
+		v := *s.InputKey
+
+		e.SetValue(protocol.BodyTarget, "InputKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeArtworkList(vs []*Artwork) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
 	_ struct{} `type:"structure"`
@@ -2077,6 +2127,32 @@ func (s *AudioCodecOptions) SetProfile(v string) *AudioCodecOptions {
 func (s *AudioCodecOptions) SetSigned(v string) *AudioCodecOptions {
 	s.Signed = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioCodecOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BitDepth != nil {
+		v := *s.BitDepth
+
+		e.SetValue(protocol.BodyTarget, "BitDepth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitOrder != nil {
+		v := *s.BitOrder
+
+		e.SetValue(protocol.BodyTarget, "BitOrder", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Profile != nil {
+		v := *s.Profile
+
+		e.SetValue(protocol.BodyTarget, "Profile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signed != nil {
+		v := *s.Signed
+
+		e.SetValue(protocol.BodyTarget, "Signed", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Parameters required for transcoding audio.
@@ -2289,6 +2365,42 @@ func (s *AudioParameters) SetSampleRate(v string) *AudioParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioPackingMode != nil {
+		v := *s.AudioPackingMode
+
+		e.SetValue(protocol.BodyTarget, "AudioPackingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitRate != nil {
+		v := *s.BitRate
+
+		e.SetValue(protocol.BodyTarget, "BitRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Channels != nil {
+		v := *s.Channels
+
+		e.SetValue(protocol.BodyTarget, "Channels", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "Codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecOptions != nil {
+		v := s.CodecOptions
+
+		e.SetFields(protocol.BodyTarget, "CodecOptions", v, protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "SampleRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The CancelJobRequest structure.
 type CancelJobInput struct {
 	_ struct{} `type:"structure"`
@@ -2331,6 +2443,17 @@ func (s *CancelJobInput) SetId(v string) *CancelJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
@@ -2345,6 +2468,12 @@ func (s CancelJobOutput) String() string {
 // GoString returns the string representation
 func (s CancelJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The file format of the output captions. If you leave this value blank, Elastic
@@ -2429,6 +2558,35 @@ func (s *CaptionFormat) SetFormat(v string) *CaptionFormat {
 func (s *CaptionFormat) SetPattern(v string) *CaptionFormat {
 	s.Pattern = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionFormat) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Pattern != nil {
+		v := *s.Pattern
+
+		e.SetValue(protocol.BodyTarget, "Pattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionFormatList(vs []*CaptionFormat) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A source file for the input sidecar captions used during the transcoding
@@ -2529,6 +2687,45 @@ func (s *CaptionSource) SetTimeOffset(v string) *CaptionSource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Label != nil {
+		v := *s.Label
+
+		e.SetValue(protocol.BodyTarget, "Label", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Language != nil {
+		v := *s.Language
+
+		e.SetValue(protocol.BodyTarget, "Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeOffset != nil {
+		v := *s.TimeOffset
+
+		e.SetValue(protocol.BodyTarget, "TimeOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionSourceList(vs []*CaptionSource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The captions to be created, if any.
 type Captions struct {
 	_ struct{} `type:"structure"`
@@ -2611,6 +2808,27 @@ func (s *Captions) SetMergePolicy(v string) *Captions {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Captions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CaptionFormats) > 0 {
+		v := s.CaptionFormats
+
+		e.SetList(protocol.BodyTarget, "CaptionFormats", encodeCaptionFormatList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionSources) > 0 {
+		v := s.CaptionSources
+
+		e.SetList(protocol.BodyTarget, "CaptionSources", encodeCaptionSourceList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for one clip in a composition. All jobs in a playlist must have
 // the same clip settings.
 type Clip struct {
@@ -2634,6 +2852,25 @@ func (s Clip) GoString() string {
 func (s *Clip) SetTimeSpan(v *TimeSpan) *Clip {
 	s.TimeSpan = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Clip) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TimeSpan != nil {
+		v := s.TimeSpan
+
+		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeClipList(vs []*Clip) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The CreateJobRequest structure.
@@ -2797,6 +3034,52 @@ func (s *CreateJobInput) SetPlaylists(v []*CreateJobPlaylist) *CreateJobInput {
 func (s *CreateJobInput) SetUserMetadata(v map[string]*string) *CreateJobInput {
 	s.UserMetadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Input != nil {
+		v := s.Input
+
+		e.SetFields(protocol.BodyTarget, "Input", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "Inputs", encodeJobInputList(v), protocol.Metadata{})
+	}
+	if s.Output != nil {
+		v := s.Output
+
+		e.SetFields(protocol.BodyTarget, "Output", v, protocol.Metadata{})
+	}
+	if s.OutputKeyPrefix != nil {
+		v := *s.OutputKeyPrefix
+
+		e.SetValue(protocol.BodyTarget, "OutputKeyPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "Outputs", encodeCreateJobOutputList(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.BodyTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Playlists) > 0 {
+		v := s.Playlists
+
+		e.SetList(protocol.BodyTarget, "Playlists", encodeCreateJobPlaylistList(v), protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreateJobOutput structure.
@@ -3054,6 +3337,75 @@ func (s *CreateJobOutput) SetWatermarks(v []*JobWatermark) *CreateJobOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArt != nil {
+		v := s.AlbumArt
+
+		e.SetFields(protocol.BodyTarget, "AlbumArt", v, protocol.Metadata{})
+	}
+	if s.Captions != nil {
+		v := s.Captions
+
+		e.SetFields(protocol.BodyTarget, "Captions", v, protocol.Metadata{})
+	}
+	if len(s.Composition) > 0 {
+		v := s.Composition
+
+		e.SetList(protocol.BodyTarget, "Composition", encodeClipList(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetId != nil {
+		v := *s.PresetId
+
+		e.SetValue(protocol.BodyTarget, "PresetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Rotate != nil {
+		v := *s.Rotate
+
+		e.SetValue(protocol.BodyTarget, "Rotate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentDuration != nil {
+		v := *s.SegmentDuration
+
+		e.SetValue(protocol.BodyTarget, "SegmentDuration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailEncryption != nil {
+		v := s.ThumbnailEncryption
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailEncryption", v, protocol.Metadata{})
+	}
+	if s.ThumbnailPattern != nil {
+		v := *s.ThumbnailPattern
+
+		e.SetValue(protocol.BodyTarget, "ThumbnailPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodeJobWatermarkList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCreateJobOutputList(vs []*CreateJobOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about the master playlist.
 type CreateJobPlaylist struct {
 	_ struct{} `type:"structure"`
@@ -3179,6 +3531,45 @@ func (s *CreateJobPlaylist) SetPlayReadyDrm(v *PlayReadyDrm) *CreateJobPlaylist 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobPlaylist) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsContentProtection != nil {
+		v := s.HlsContentProtection
+
+		e.SetFields(protocol.BodyTarget, "HlsContentProtection", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutputKeys) > 0 {
+		v := s.OutputKeys
+
+		e.SetList(protocol.BodyTarget, "OutputKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.PlayReadyDrm != nil {
+		v := s.PlayReadyDrm
+
+		e.SetFields(protocol.BodyTarget, "PlayReadyDrm", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCreateJobPlaylistList(vs []*CreateJobPlaylist) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The CreateJobResponse structure.
 type CreateJobResponse struct {
 	_ struct{} `type:"structure"`
@@ -3202,6 +3593,17 @@ func (s CreateJobResponse) GoString() string {
 func (s *CreateJobResponse) SetJob(v *Job) *CreateJobResponse {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreatePipelineRequest structure.
@@ -3511,6 +3913,52 @@ func (s *CreatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *Creat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
@@ -3549,6 +3997,22 @@ func (s *CreatePipelineOutput) SetPipeline(v *Pipeline) *CreatePipelineOutput {
 func (s *CreatePipelineOutput) SetWarnings(v []*Warning) *CreatePipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The CreatePresetRequest structure.
@@ -3651,6 +4115,42 @@ func (s *CreatePresetInput) SetVideo(v *VideoParameters) *CreatePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Audio != nil {
+		v := s.Audio
+
+		e.SetFields(protocol.BodyTarget, "Audio", v, protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Thumbnails != nil {
+		v := s.Thumbnails
+
+		e.SetFields(protocol.BodyTarget, "Thumbnails", v, protocol.Metadata{})
+	}
+	if s.Video != nil {
+		v := s.Video
+
+		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3686,6 +4186,22 @@ func (s *CreatePresetOutput) SetPreset(v *Preset) *CreatePresetOutput {
 func (s *CreatePresetOutput) SetWarning(v string) *CreatePresetOutput {
 	s.Warning = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "Preset", v, protocol.Metadata{})
+	}
+	if s.Warning != nil {
+		v := *s.Warning
+
+		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The DeletePipelineRequest structure.
@@ -3727,6 +4243,17 @@ func (s *DeletePipelineInput) SetId(v string) *DeletePipelineInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -3740,6 +4267,12 @@ func (s DeletePipelineOutput) String() string {
 // GoString returns the string representation
 func (s DeletePipelineOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The DeletePresetRequest structure.
@@ -3781,6 +4314,17 @@ func (s *DeletePresetInput) SetId(v string) *DeletePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -3794,6 +4338,12 @@ func (s DeletePresetOutput) String() string {
 // GoString returns the string representation
 func (s DeletePresetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The detected properties of the input file. Elastic Transcoder identifies
@@ -3855,6 +4405,37 @@ func (s *DetectedProperties) SetHeight(v int64) *DetectedProperties {
 func (s *DetectedProperties) SetWidth(v int64) *DetectedProperties {
 	s.Width = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetectedProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DurationMillis != nil {
+		v := *s.DurationMillis
+
+		e.SetValue(protocol.BodyTarget, "DurationMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FileSize != nil {
+		v := *s.FileSize
+
+		e.SetValue(protocol.BodyTarget, "FileSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "Height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The encryption settings, if any, that are used for decrypting your input
@@ -3960,6 +4541,32 @@ func (s *Encryption) SetMode(v string) *Encryption {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Encryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The HLS content protection settings, if any, that you want Elastic Transcoder
 // to apply to your output files.
 type HlsContentProtection struct {
@@ -4057,6 +4664,42 @@ func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsContentProtection) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyStoragePolicy != nil {
+		v := *s.KeyStoragePolicy
+
+		e.SetValue(protocol.BodyTarget, "KeyStoragePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LicenseAcquisitionUrl != nil {
+		v := *s.LicenseAcquisitionUrl
+
+		e.SetValue(protocol.BodyTarget, "LicenseAcquisitionUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Method != nil {
+		v := *s.Method
+
+		e.SetValue(protocol.BodyTarget, "Method", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The captions to be created, if any.
 type InputCaptions struct {
 	_ struct{} `type:"structure"`
@@ -4127,6 +4770,22 @@ func (s *InputCaptions) SetCaptionSources(v []*CaptionSource) *InputCaptions {
 func (s *InputCaptions) SetMergePolicy(v string) *InputCaptions {
 	s.MergePolicy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputCaptions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CaptionSources) > 0 {
+		v := s.CaptionSources
+
+		e.SetList(protocol.BodyTarget, "CaptionSources", encodeCaptionSourceList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A section of the response body that provides information about the job that
@@ -4296,6 +4955,80 @@ func (s *Job) SetUserMetadata(v map[string]*string) *Job {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Job) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Input != nil {
+		v := s.Input
+
+		e.SetFields(protocol.BodyTarget, "Input", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "Inputs", encodeJobInputList(v), protocol.Metadata{})
+	}
+	if s.Output != nil {
+		v := s.Output
+
+		e.SetFields(protocol.BodyTarget, "Output", v, protocol.Metadata{})
+	}
+	if s.OutputKeyPrefix != nil {
+		v := *s.OutputKeyPrefix
+
+		e.SetValue(protocol.BodyTarget, "OutputKeyPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "Outputs", encodeJobOutputList(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.BodyTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Playlists) > 0 {
+		v := s.Playlists
+
+		e.SetList(protocol.BodyTarget, "Playlists", encodePlaylistList(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timing != nil {
+		v := s.Timing
+
+		e.SetFields(protocol.BodyTarget, "Timing", v, protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobList(vs []*Job) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The .jpg or .png file associated with an audio file.
 type JobAlbumArt struct {
 	_ struct{} `type:"structure"`
@@ -4360,6 +5093,22 @@ func (s *JobAlbumArt) SetArtwork(v []*Artwork) *JobAlbumArt {
 func (s *JobAlbumArt) SetMergePolicy(v string) *JobAlbumArt {
 	s.MergePolicy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobAlbumArt) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Artwork) > 0 {
+		v := s.Artwork
+
+		e.SetList(protocol.BodyTarget, "Artwork", encodeArtworkList(v), protocol.Metadata{})
+	}
+	if s.MergePolicy != nil {
+		v := *s.MergePolicy
+
+		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information about the file that you're transcoding.
@@ -4562,6 +5311,70 @@ func (s *JobInput) SetResolution(v string) *JobInput {
 func (s *JobInput) SetTimeSpan(v *TimeSpan) *JobInput {
 	s.TimeSpan = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DetectedProperties != nil {
+		v := s.DetectedProperties
+
+		e.SetFields(protocol.BodyTarget, "DetectedProperties", v, protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputCaptions != nil {
+		v := s.InputCaptions
+
+		e.SetFields(protocol.BodyTarget, "InputCaptions", v, protocol.Metadata{})
+	}
+	if s.Interlaced != nil {
+		v := *s.Interlaced
+
+		e.SetValue(protocol.BodyTarget, "Interlaced", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeSpan != nil {
+		v := s.TimeSpan
+
+		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobInputList(vs []*JobInput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Outputs recommended instead.
@@ -4918,6 +5731,125 @@ func (s *JobOutput) SetWidth(v int64) *JobOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlbumArt != nil {
+		v := s.AlbumArt
+
+		e.SetFields(protocol.BodyTarget, "AlbumArt", v, protocol.Metadata{})
+	}
+	if s.AppliedColorSpaceConversion != nil {
+		v := *s.AppliedColorSpaceConversion
+
+		e.SetValue(protocol.BodyTarget, "AppliedColorSpaceConversion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Captions != nil {
+		v := s.Captions
+
+		e.SetFields(protocol.BodyTarget, "Captions", v, protocol.Metadata{})
+	}
+	if len(s.Composition) > 0 {
+		v := s.Composition
+
+		e.SetList(protocol.BodyTarget, "Composition", encodeClipList(v), protocol.Metadata{})
+	}
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DurationMillis != nil {
+		v := *s.DurationMillis
+
+		e.SetValue(protocol.BodyTarget, "DurationMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.FileSize != nil {
+		v := *s.FileSize
+
+		e.SetValue(protocol.BodyTarget, "FileSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "Height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetId != nil {
+		v := *s.PresetId
+
+		e.SetValue(protocol.BodyTarget, "PresetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Rotate != nil {
+		v := *s.Rotate
+
+		e.SetValue(protocol.BodyTarget, "Rotate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentDuration != nil {
+		v := *s.SegmentDuration
+
+		e.SetValue(protocol.BodyTarget, "SegmentDuration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusDetail != nil {
+		v := *s.StatusDetail
+
+		e.SetValue(protocol.BodyTarget, "StatusDetail", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailEncryption != nil {
+		v := s.ThumbnailEncryption
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailEncryption", v, protocol.Metadata{})
+	}
+	if s.ThumbnailPattern != nil {
+		v := *s.ThumbnailPattern
+
+		e.SetValue(protocol.BodyTarget, "ThumbnailPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodeJobWatermarkList(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobOutputList(vs []*JobOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Watermarks can be in .png or .jpg format. If you want to display a watermark
 // that is not rectangular, use the .png format, which supports transparency.
 type JobWatermark struct {
@@ -4988,6 +5920,35 @@ func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobWatermark) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.InputKey != nil {
+		v := *s.InputKey
+
+		e.SetValue(protocol.BodyTarget, "InputKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PresetWatermarkId != nil {
+		v := *s.PresetWatermarkId
+
+		e.SetValue(protocol.BodyTarget, "PresetWatermarkId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobWatermarkList(vs []*JobWatermark) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
 	_ struct{} `type:"structure"`
@@ -5047,6 +6008,27 @@ func (s *ListJobsByPipelineInput) SetPipelineId(v string) *ListJobsByPipelineInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListJobsByPipelineResponse structure.
 type ListJobsByPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -5080,6 +6062,22 @@ func (s *ListJobsByPipelineOutput) SetJobs(v []*Job) *ListJobsByPipelineOutput {
 func (s *ListJobsByPipelineOutput) SetNextPageToken(v string) *ListJobsByPipelineOutput {
 	s.NextPageToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByPipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "Jobs", encodeJobList(v), protocol.Metadata{})
+	}
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListJobsByStatusRequest structure.
@@ -5143,6 +6141,27 @@ func (s *ListJobsByStatusInput) SetStatus(v string) *ListJobsByStatusInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.PathTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListJobsByStatusResponse structure.
 type ListJobsByStatusOutput struct {
 	_ struct{} `type:"structure"`
@@ -5176,6 +6195,22 @@ func (s *ListJobsByStatusOutput) SetJobs(v []*Job) *ListJobsByStatusOutput {
 func (s *ListJobsByStatusOutput) SetNextPageToken(v string) *ListJobsByStatusOutput {
 	s.NextPageToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsByStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "Jobs", encodeJobList(v), protocol.Metadata{})
+	}
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListPipelineRequest structure.
@@ -5214,6 +6249,22 @@ func (s *ListPipelinesInput) SetPageToken(v string) *ListPipelinesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPipelinesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of the pipelines associated with the current AWS account.
 type ListPipelinesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5247,6 +6298,22 @@ func (s *ListPipelinesOutput) SetNextPageToken(v string) *ListPipelinesOutput {
 func (s *ListPipelinesOutput) SetPipelines(v []*Pipeline) *ListPipelinesOutput {
 	s.Pipelines = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPipelinesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Pipelines) > 0 {
+		v := s.Pipelines
+
+		e.SetList(protocol.BodyTarget, "Pipelines", encodePipelineList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ListPresetsRequest structure.
@@ -5285,6 +6352,22 @@ func (s *ListPresetsInput) SetPageToken(v string) *ListPresetsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ascending != nil {
+		v := *s.Ascending
+
+		e.SetValue(protocol.QueryTarget, "Ascending", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageToken != nil {
+		v := *s.PageToken
+
+		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ListPresetsResponse structure.
 type ListPresetsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5318,6 +6401,22 @@ func (s *ListPresetsOutput) SetNextPageToken(v string) *ListPresetsOutput {
 func (s *ListPresetsOutput) SetPresets(v []*Preset) *ListPresetsOutput {
 	s.Presets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextPageToken != nil {
+		v := *s.NextPageToken
+
+		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Presets) > 0 {
+		v := s.Presets
+
+		e.SetList(protocol.BodyTarget, "Presets", encodePresetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify
@@ -5377,6 +6476,32 @@ func (s *Notifications) SetProgressing(v string) *Notifications {
 func (s *Notifications) SetWarning(v string) *Notifications {
 	s.Warning = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Notifications) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.BodyTarget, "Completed", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Error != nil {
+		v := *s.Error
+
+		e.SetValue(protocol.BodyTarget, "Error", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Progressing != nil {
+		v := *s.Progressing
+
+		e.SetValue(protocol.BodyTarget, "Progressing", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Warning != nil {
+		v := *s.Warning
+
+		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The Permission structure.
@@ -5459,6 +6584,35 @@ func (s *Permission) SetGrantee(v string) *Permission {
 func (s *Permission) SetGranteeType(v string) *Permission {
 	s.GranteeType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Permission) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Access) > 0 {
+		v := s.Access
+
+		e.SetList(protocol.BodyTarget, "Access", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Grantee != nil {
+		v := *s.Grantee
+
+		e.SetValue(protocol.BodyTarget, "Grantee", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GranteeType != nil {
+		v := *s.GranteeType
+
+		e.SetValue(protocol.BodyTarget, "GranteeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePermissionList(vs []*Permission) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The pipeline (queue) that is used to manage jobs.
@@ -5696,6 +6850,75 @@ func (s *Pipeline) SetThumbnailConfig(v *PipelineOutputConfig) *Pipeline {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Pipeline) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePipelineList(vs []*Pipeline) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The PipelineOutputConfig structure.
 type PipelineOutputConfig struct {
 	_ struct{} `type:"structure"`
@@ -5788,6 +7011,27 @@ func (s *PipelineOutputConfig) SetPermissions(v []*Permission) *PipelineOutputCo
 func (s *PipelineOutputConfig) SetStorageClass(v string) *PipelineOutputConfig {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PipelineOutputConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Permissions) > 0 {
+		v := s.Permissions
+
+		e.SetList(protocol.BodyTarget, "Permissions", encodePermissionList(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply
@@ -5899,6 +7143,42 @@ func (s *PlayReadyDrm) SetKeyMd5(v string) *PlayReadyDrm {
 func (s *PlayReadyDrm) SetLicenseAcquisitionUrl(v string) *PlayReadyDrm {
 	s.LicenseAcquisitionUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PlayReadyDrm) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitializationVector != nil {
+		v := *s.InitializationVector
+
+		e.SetValue(protocol.BodyTarget, "InitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.BodyTarget, "KeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMd5 != nil {
+		v := *s.KeyMd5
+
+		e.SetValue(protocol.BodyTarget, "KeyMd5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LicenseAcquisitionUrl != nil {
+		v := *s.LicenseAcquisitionUrl
+
+		e.SetValue(protocol.BodyTarget, "LicenseAcquisitionUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for
@@ -6030,6 +7310,55 @@ func (s *Playlist) SetStatusDetail(v string) *Playlist {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Playlist) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsContentProtection != nil {
+		v := s.HlsContentProtection
+
+		e.SetFields(protocol.BodyTarget, "HlsContentProtection", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutputKeys) > 0 {
+		v := s.OutputKeys
+
+		e.SetList(protocol.BodyTarget, "OutputKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.PlayReadyDrm != nil {
+		v := s.PlayReadyDrm
+
+		e.SetFields(protocol.BodyTarget, "PlayReadyDrm", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusDetail != nil {
+		v := *s.StatusDetail
+
+		e.SetValue(protocol.BodyTarget, "StatusDetail", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePlaylistList(vs []*Playlist) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Presets are templates that contain most of the settings for transcoding media
 // files from one format to another. Elastic Transcoder includes some default
 // presets for common formats, for example, several iPod and iPhone versions.
@@ -6135,6 +7464,65 @@ func (s *Preset) SetType(v string) *Preset {
 func (s *Preset) SetVideo(v *VideoParameters) *Preset {
 	s.Video = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Preset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Audio != nil {
+		v := s.Audio
+
+		e.SetFields(protocol.BodyTarget, "Audio", v, protocol.Metadata{})
+	}
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "Container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Thumbnails != nil {
+		v := s.Thumbnails
+
+		e.SetFields(protocol.BodyTarget, "Thumbnails", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Video != nil {
+		v := s.Video
+
+		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePresetList(vs []*Preset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for the size, location, and opacity of graphics that you want Elastic
@@ -6385,6 +7773,70 @@ func (s *PresetWatermark) SetVerticalOffset(v string) *PresetWatermark {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PresetWatermark) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HorizontalAlign != nil {
+		v := *s.HorizontalAlign
+
+		e.SetValue(protocol.BodyTarget, "HorizontalAlign", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HorizontalOffset != nil {
+		v := *s.HorizontalOffset
+
+		e.SetValue(protocol.BodyTarget, "HorizontalOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Opacity != nil {
+		v := *s.Opacity
+
+		e.SetValue(protocol.BodyTarget, "Opacity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Target != nil {
+		v := *s.Target
+
+		e.SetValue(protocol.BodyTarget, "Target", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VerticalAlign != nil {
+		v := *s.VerticalAlign
+
+		e.SetValue(protocol.BodyTarget, "VerticalAlign", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VerticalOffset != nil {
+		v := *s.VerticalOffset
+
+		e.SetValue(protocol.BodyTarget, "VerticalOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePresetWatermarkList(vs []*PresetWatermark) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The ReadJobRequest structure.
 type ReadJobInput struct {
 	_ struct{} `type:"structure"`
@@ -6424,6 +7876,17 @@ func (s *ReadJobInput) SetId(v string) *ReadJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadJobResponse structure.
 type ReadJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -6446,6 +7909,17 @@ func (s ReadJobOutput) GoString() string {
 func (s *ReadJobOutput) SetJob(v *Job) *ReadJobOutput {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ReadPipelineRequest structure.
@@ -6487,6 +7961,17 @@ func (s *ReadPipelineInput) SetId(v string) *ReadPipelineInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadPipelineResponse structure.
 type ReadPipelineOutput struct {
 	_ struct{} `type:"structure"`
@@ -6523,6 +8008,22 @@ func (s *ReadPipelineOutput) SetPipeline(v *Pipeline) *ReadPipelineOutput {
 func (s *ReadPipelineOutput) SetWarnings(v []*Warning) *ReadPipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The ReadPresetRequest structure.
@@ -6564,6 +8065,17 @@ func (s *ReadPresetInput) SetId(v string) *ReadPresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ReadPresetResponse structure.
 type ReadPresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -6586,6 +8098,17 @@ func (s ReadPresetOutput) GoString() string {
 func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
 	s.Preset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReadPresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "Preset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The TestRoleRequest structure.
@@ -6673,6 +8196,32 @@ func (s *TestRoleInput) SetTopics(v []*string) *TestRoleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputBucket != nil {
+		v := *s.OutputBucket
+
+		e.SetValue(protocol.BodyTarget, "OutputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Topics) > 0 {
+		v := s.Topics
+
+		e.SetList(protocol.BodyTarget, "Topics", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The TestRoleResponse structure.
 type TestRoleOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
@@ -6706,6 +8255,22 @@ func (s *TestRoleOutput) SetMessages(v []*string) *TestRoleOutput {
 func (s *TestRoleOutput) SetSuccess(v string) *TestRoleOutput {
 	s.Success = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "Messages", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Success != nil {
+		v := *s.Success
+
+		e.SetValue(protocol.BodyTarget, "Success", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Thumbnails for videos.
@@ -6851,6 +8416,52 @@ func (s *Thumbnails) SetSizingPolicy(v string) *Thumbnails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Thumbnails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Interval != nil {
+		v := *s.Interval
+
+		e.SetValue(protocol.BodyTarget, "Interval", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings that determine when a clip begins and how long it lasts.
 type TimeSpan struct {
 	_ struct{} `type:"structure"`
@@ -6893,6 +8504,22 @@ func (s *TimeSpan) SetStartTime(v string) *TimeSpan {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimeSpan) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Details about the timing of a job.
 type Timing struct {
 	_ struct{} `type:"structure"`
@@ -6933,6 +8560,27 @@ func (s *Timing) SetStartTimeMillis(v int64) *Timing {
 func (s *Timing) SetSubmitTimeMillis(v int64) *Timing {
 	s.SubmitTimeMillis = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Timing) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FinishTimeMillis != nil {
+		v := *s.FinishTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "FinishTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StartTimeMillis != nil {
+		v := *s.StartTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "StartTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SubmitTimeMillis != nil {
+		v := *s.SubmitTimeMillis
+
+		e.SetValue(protocol.BodyTarget, "SubmitTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The UpdatePipelineRequest structure.
@@ -7204,6 +8852,52 @@ func (s *UpdatePipelineInput) SetThumbnailConfig(v *PipelineOutputConfig) *Updat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AwsKmsKeyArn != nil {
+		v := *s.AwsKmsKeyArn
+
+		e.SetValue(protocol.BodyTarget, "AwsKmsKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentConfig != nil {
+		v := s.ContentConfig
+
+		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputBucket != nil {
+		v := *s.InputBucket
+
+		e.SetValue(protocol.BodyTarget, "InputBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThumbnailConfig != nil {
+		v := s.ThumbnailConfig
+
+		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
 	_ struct{} `type:"structure"`
@@ -7279,6 +8973,22 @@ func (s *UpdatePipelineNotificationsInput) SetNotifications(v *Notifications) *U
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Notifications != nil {
+		v := s.Notifications
+
+		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The UpdatePipelineNotificationsResponse structure.
 type UpdatePipelineNotificationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7302,6 +9012,17 @@ func (s UpdatePipelineNotificationsOutput) GoString() string {
 func (s *UpdatePipelineNotificationsOutput) SetPipeline(v *Pipeline) *UpdatePipelineNotificationsOutput {
 	s.Pipeline = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // When you update a pipeline, Elastic Transcoder returns the values that you
@@ -7341,6 +9062,22 @@ func (s *UpdatePipelineOutput) SetPipeline(v *Pipeline) *UpdatePipelineOutput {
 func (s *UpdatePipelineOutput) SetWarnings(v []*Warning) *UpdatePipelineOutput {
 	s.Warnings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+	if len(s.Warnings) > 0 {
+		v := s.Warnings
+
+		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The UpdatePipelineStatusRequest structure.
@@ -7400,6 +9137,22 @@ func (s *UpdatePipelineStatusInput) SetStatus(v string) *UpdatePipelineStatusInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // When you update status for a pipeline, Elastic Transcoder returns the values
 // that you specified in the request.
 type UpdatePipelineStatusOutput struct {
@@ -7423,6 +9176,17 @@ func (s UpdatePipelineStatusOutput) GoString() string {
 func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineStatusOutput {
 	s.Pipeline = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePipelineStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pipeline != nil {
+		v := s.Pipeline
+
+		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The VideoParameters structure.
@@ -7962,6 +9726,87 @@ func (s *VideoParameters) SetWatermarks(v []*PresetWatermark) *VideoParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AspectRatio != nil {
+		v := *s.AspectRatio
+
+		e.SetValue(protocol.BodyTarget, "AspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BitRate != nil {
+		v := *s.BitRate
+
+		e.SetValue(protocol.BodyTarget, "BitRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "Codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CodecOptions) > 0 {
+		v := s.CodecOptions
+
+		e.SetMap(protocol.BodyTarget, "CodecOptions", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DisplayAspectRatio != nil {
+		v := *s.DisplayAspectRatio
+
+		e.SetValue(protocol.BodyTarget, "DisplayAspectRatio", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FixedGOP != nil {
+		v := *s.FixedGOP
+
+		e.SetValue(protocol.BodyTarget, "FixedGOP", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FrameRate != nil {
+		v := *s.FrameRate
+
+		e.SetValue(protocol.BodyTarget, "FrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyframesMaxDist != nil {
+		v := *s.KeyframesMaxDist
+
+		e.SetValue(protocol.BodyTarget, "KeyframesMaxDist", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxFrameRate != nil {
+		v := *s.MaxFrameRate
+
+		e.SetValue(protocol.BodyTarget, "MaxFrameRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxHeight != nil {
+		v := *s.MaxHeight
+
+		e.SetValue(protocol.BodyTarget, "MaxHeight", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxWidth != nil {
+		v := *s.MaxWidth
+
+		e.SetValue(protocol.BodyTarget, "MaxWidth", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingPolicy != nil {
+		v := *s.PaddingPolicy
+
+		e.SetValue(protocol.BodyTarget, "PaddingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Resolution != nil {
+		v := *s.Resolution
+
+		e.SetValue(protocol.BodyTarget, "Resolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SizingPolicy != nil {
+		v := *s.SizingPolicy
+
+		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Watermarks) > 0 {
+		v := s.Watermarks
+
+		e.SetList(protocol.BodyTarget, "Watermarks", encodePresetWatermarkList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Elastic Transcoder returns a warning if the resources used by your pipeline
 // are not in the same region as the pipeline.
 //
@@ -8001,4 +9846,28 @@ func (s *Warning) SetCode(v string) *Warning {
 func (s *Warning) SetMessage(v string) *Warning {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Warning) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := *s.Code
+
+		e.SetValue(protocol.BodyTarget, "Code", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeWarningList(vs []*Warning) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -2024,7 +2024,6 @@ func (s *Artwork) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2151,7 +2150,6 @@ func (s *AudioCodecOptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Signed", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2397,7 +2395,6 @@ func (s *AudioParameters) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SampleRate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2450,7 +2447,6 @@ func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2472,7 +2468,6 @@ func (s CancelJobOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2577,7 +2572,6 @@ func (s *CaptionFormat) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Pattern", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2714,7 +2708,6 @@ func (s *CaptionSource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TimeOffset", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2825,7 +2818,6 @@ func (s *Captions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2861,7 +2853,6 @@ func (s *Clip) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3078,7 +3069,6 @@ func (s *CreateJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3394,7 +3384,6 @@ func (s *CreateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Watermarks", encodeJobWatermarkList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3558,7 +3547,6 @@ func (s *CreateJobPlaylist) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "PlayReadyDrm", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3602,7 +3590,6 @@ func (s *CreateJobResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3955,7 +3942,6 @@ func (s *CreatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4011,7 +3997,6 @@ func (s *CreatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4147,7 +4132,6 @@ func (s *CreatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4200,7 +4184,6 @@ func (s *CreatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4250,7 +4233,6 @@ func (s *DeletePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4271,7 +4253,6 @@ func (s DeletePipelineOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeletePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4321,7 +4302,6 @@ func (s *DeletePresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4342,7 +4322,6 @@ func (s DeletePresetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeletePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4434,7 +4413,6 @@ func (s *DetectedProperties) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4563,7 +4541,6 @@ func (s *Encryption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4696,7 +4673,6 @@ func (s *HlsContentProtection) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Method", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4784,7 +4760,6 @@ func (s *InputCaptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5017,7 +4992,6 @@ func (s *Job) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "UserMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5107,7 +5081,6 @@ func (s *JobAlbumArt) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "MergePolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5365,7 +5338,6 @@ func (s *JobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TimeSpan", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5838,7 +5810,6 @@ func (s *JobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Width", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5937,7 +5908,6 @@ func (s *JobWatermark) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PresetWatermarkId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6010,6 +5980,11 @@ func (s *ListJobsByPipelineInput) SetPipelineId(v string) *ListJobsByPipelineInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListJobsByPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PipelineId != nil {
+		v := *s.PipelineId
+
+		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Ascending != nil {
 		v := *s.Ascending
 
@@ -6020,12 +5995,6 @@ func (s *ListJobsByPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PipelineId != nil {
-		v := *s.PipelineId
-
-		e.SetValue(protocol.PathTarget, "PipelineId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6076,7 +6045,6 @@ func (s *ListJobsByPipelineOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6143,6 +6111,11 @@ func (s *ListJobsByStatusInput) SetStatus(v string) *ListJobsByStatusInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListJobsByStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.PathTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Ascending != nil {
 		v := *s.Ascending
 
@@ -6153,12 +6126,6 @@ func (s *ListJobsByStatusInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Status != nil {
-		v := *s.Status
-
-		e.SetValue(protocol.PathTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6209,7 +6176,6 @@ func (s *ListJobsByStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextPageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6261,7 +6227,6 @@ func (s *ListPipelinesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6312,7 +6277,6 @@ func (s *ListPipelinesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Pipelines", encodePipelineList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6364,7 +6328,6 @@ func (s *ListPresetsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "PageToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6415,7 +6378,6 @@ func (s *ListPresetsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Presets", encodePresetList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6500,7 +6462,6 @@ func (s *Notifications) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Warning", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6603,7 +6564,6 @@ func (s *Permission) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "GranteeType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6907,7 +6867,6 @@ func (s *Pipeline) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7030,7 +6989,6 @@ func (s *PipelineOutputConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7177,7 +7135,6 @@ func (s *PlayReadyDrm) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "LicenseAcquisitionUrl", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7347,7 +7304,6 @@ func (s *Playlist) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StatusDetail", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7513,7 +7469,6 @@ func (s *Preset) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Video", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7825,7 +7780,6 @@ func (s *PresetWatermark) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VerticalOffset", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7883,7 +7837,6 @@ func (s *ReadJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7918,7 +7871,6 @@ func (s *ReadJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Job", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7968,7 +7920,6 @@ func (s *ReadPipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8022,7 +7973,6 @@ func (s *ReadPipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8072,7 +8022,6 @@ func (s *ReadPresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8107,7 +8056,6 @@ func (s *ReadPresetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Preset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8218,7 +8166,6 @@ func (s *TestRoleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Topics", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8269,7 +8216,6 @@ func (s *TestRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Success", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8458,7 +8404,6 @@ func (s *Thumbnails) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SizingPolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8516,7 +8461,6 @@ func (s *TimeSpan) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StartTime", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8579,7 +8523,6 @@ func (s *Timing) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubmitTimeMillis", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8864,11 +8807,6 @@ func (s *UpdatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ContentConfig", v, protocol.Metadata{})
 	}
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InputBucket != nil {
 		v := *s.InputBucket
 
@@ -8894,7 +8832,11 @@ func (s *UpdatePipelineInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ThumbnailConfig", v, protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8975,17 +8917,16 @@ func (s *UpdatePipelineNotificationsInput) SetNotifications(v *Notifications) *U
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdatePipelineNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Notifications != nil {
 		v := s.Notifications
 
 		e.SetFields(protocol.BodyTarget, "Notifications", v, protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -9021,7 +8962,6 @@ func (s *UpdatePipelineNotificationsOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9076,7 +9016,6 @@ func (s *UpdatePipelineOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Warnings", encodeWarningList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9139,17 +9078,16 @@ func (s *UpdatePipelineStatusInput) SetStatus(v string) *UpdatePipelineStatusInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdatePipelineStatusInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Status != nil {
 		v := *s.Status
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -9185,7 +9123,6 @@ func (s *UpdatePipelineStatusOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "Pipeline", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9803,7 +9740,6 @@ func (s *VideoParameters) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Watermarks", encodePresetWatermarkList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9860,7 +9796,6 @@ func (s *Warning) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -3931,6 +3931,27 @@ func (s *AbortMultipartUploadInput) SetVaultName(v string) *AbortMultipartUpload
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -3943,6 +3964,12 @@ func (s AbortMultipartUploadOutput) String() string {
 // GoString returns the string representation
 func (s AbortMultipartUploadOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input values for AbortVaultLock.
@@ -4003,6 +4030,22 @@ func (s *AbortVaultLockInput) SetVaultName(v string) *AbortVaultLockInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AbortVaultLockOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4015,6 +4058,12 @@ func (s AbortVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s AbortVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input values for AddTagsToVault.
@@ -4084,6 +4133,27 @@ func (s *AddTagsToVaultInput) SetVaultName(v string) *AddTagsToVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsToVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AddTagsToVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4096,6 +4166,12 @@ func (s AddTagsToVaultOutput) String() string {
 // GoString returns the string representation
 func (s AddTagsToVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddTagsToVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -4141,6 +4217,27 @@ func (s *ArchiveCreationOutput) SetChecksum(v string) *ArchiveCreationOutput {
 func (s *ArchiveCreationOutput) SetLocation(v string) *ArchiveCreationOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ArchiveCreationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options to complete a multipart upload operation. This informs Amazon
@@ -4240,6 +4337,37 @@ func (s *CompleteMultipartUploadInput) SetVaultName(v string) *CompleteMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSize != nil {
+		v := *s.ArchiveSize
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input values for CompleteVaultLock.
 type CompleteVaultLockInput struct {
 	_ struct{} `type:"structure"`
@@ -4312,6 +4440,27 @@ func (s *CompleteVaultLockInput) SetVaultName(v string) *CompleteVaultLockInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LockId != nil {
+		v := *s.LockId
+
+		e.SetValue(protocol.PathTarget, "lockId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CompleteVaultLockOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4324,6 +4473,12 @@ func (s CompleteVaultLockOutput) String() string {
 // GoString returns the string representation
 func (s CompleteVaultLockOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to create a vault.
@@ -4384,6 +4539,22 @@ func (s *CreateVaultInput) SetVaultName(v string) *CreateVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type CreateVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -4406,6 +4577,17 @@ func (s CreateVaultOutput) GoString() string {
 func (s *CreateVaultOutput) SetLocation(v string) *CreateVaultOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data retrieval policy.
@@ -4431,6 +4613,17 @@ func (s DataRetrievalPolicy) GoString() string {
 func (s *DataRetrievalPolicy) SetRules(v []*DataRetrievalRule) *DataRetrievalPolicy {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DataRetrievalPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rules", encodeDataRetrievalRuleList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data retrieval policy rule.
@@ -4470,6 +4663,30 @@ func (s *DataRetrievalRule) SetBytesPerHour(v int64) *DataRetrievalRule {
 func (s *DataRetrievalRule) SetStrategy(v string) *DataRetrievalRule {
 	s.Strategy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DataRetrievalRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BytesPerHour != nil {
+		v := *s.BytesPerHour
+
+		e.SetValue(protocol.BodyTarget, "BytesPerHour", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Strategy != nil {
+		v := *s.Strategy
+
+		e.SetValue(protocol.BodyTarget, "Strategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDataRetrievalRuleList(vs []*DataRetrievalRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides options for deleting an archive from an Amazon Glacier vault.
@@ -4543,6 +4760,27 @@ func (s *DeleteArchiveInput) SetVaultName(v string) *DeleteArchiveInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.PathTarget, "archiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteArchiveOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4555,6 +4793,12 @@ func (s DeleteArchiveOutput) String() string {
 // GoString returns the string representation
 func (s DeleteArchiveOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteArchiveOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // DeleteVaultAccessPolicy input.
@@ -4614,6 +4858,22 @@ func (s *DeleteVaultAccessPolicyInput) SetVaultName(v string) *DeleteVaultAccess
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4626,6 +4886,12 @@ func (s DeleteVaultAccessPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultAccessPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options for deleting a vault from Amazon Glacier.
@@ -4683,6 +4949,22 @@ func (s *DeleteVaultInput) SetAccountId(v string) *DeleteVaultInput {
 func (s *DeleteVaultInput) SetVaultName(v string) *DeleteVaultInput {
 	s.VaultName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for deleting a vault notification configuration from an
@@ -4743,6 +5025,22 @@ func (s *DeleteVaultNotificationsInput) SetVaultName(v string) *DeleteVaultNotif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteVaultNotificationsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4757,6 +5055,12 @@ func (s DeleteVaultNotificationsOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 type DeleteVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -4769,6 +5073,12 @@ func (s DeleteVaultOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options for retrieving a job description.
@@ -4842,6 +5152,27 @@ func (s *DescribeJobInput) SetVaultName(v string) *DescribeJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
 	_ struct{} `type:"structure"`
@@ -4897,6 +5228,22 @@ func (s *DescribeVaultInput) SetAccountId(v string) *DescribeVaultInput {
 func (s *DescribeVaultInput) SetVaultName(v string) *DescribeVaultInput {
 	s.VaultName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -4975,6 +5322,50 @@ func (s *DescribeVaultOutput) SetVaultName(v string) *DescribeVaultOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastInventoryDate != nil {
+		v := *s.LastInventoryDate
+
+		e.SetValue(protocol.BodyTarget, "LastInventoryDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumberOfArchives != nil {
+		v := *s.NumberOfArchives
+
+		e.SetValue(protocol.BodyTarget, "NumberOfArchives", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SizeInBytes != nil {
+		v := *s.SizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "SizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.BodyTarget, "VaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDescribeVaultOutputList(vs []*DescribeVaultOutput) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Input for GetDataRetrievalPolicy.
 type GetDataRetrievalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5019,6 +5410,17 @@ func (s *GetDataRetrievalPolicyInput) SetAccountId(v string) *GetDataRetrievalPo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -5041,6 +5443,17 @@ func (s GetDataRetrievalPolicyOutput) GoString() string {
 func (s *GetDataRetrievalPolicyOutput) SetPolicy(v *DataRetrievalPolicy) *GetDataRetrievalPolicyOutput {
 	s.Policy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for downloading output of an Amazon Glacier job.
@@ -5151,6 +5564,32 @@ func (s *GetJobOutputInput) SetVaultName(v string) *GetJobOutputInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobOutputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetJobOutputOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -5251,6 +5690,39 @@ func (s *GetJobOutputOutput) SetStatus(v int64) *GetJobOutputOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobOutputOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "Accept-Ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Body Output type's body not valid.
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentRange != nil {
+		v := *s.ContentRange
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. Status
+
+	return nil
+}
+
 // Input for GetVaultAccessPolicy.
 type GetVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5308,6 +5780,22 @@ func (s *GetVaultAccessPolicyInput) SetVaultName(v string) *GetVaultAccessPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -5330,6 +5818,17 @@ func (s GetVaultAccessPolicyOutput) GoString() string {
 func (s *GetVaultAccessPolicyOutput) SetPolicy(v *VaultAccessPolicy) *GetVaultAccessPolicyOutput {
 	s.Policy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input values for GetVaultLock.
@@ -5389,6 +5888,22 @@ func (s *GetVaultLockInput) SetVaultName(v string) *GetVaultLockInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -5440,6 +5955,32 @@ func (s *GetVaultLockOutput) SetPolicy(v string) *GetVaultLockOutput {
 func (s *GetVaultLockOutput) SetState(v string) *GetVaultLockOutput {
 	s.State = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "ExpirationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving the notification configuration set on an
@@ -5500,6 +6041,22 @@ func (s *GetVaultNotificationsInput) SetVaultName(v string) *GetVaultNotificatio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
@@ -5522,6 +6079,17 @@ func (s GetVaultNotificationsOutput) GoString() string {
 func (s *GetVaultNotificationsOutput) SetVaultNotificationConfig(v *VaultNotificationConfig) *GetVaultNotificationsOutput {
 	s.VaultNotificationConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VaultNotificationConfig != nil {
+		v := s.VaultNotificationConfig
+
+		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for initiating an Amazon Glacier job.
@@ -5590,6 +6158,27 @@ func (s *InitiateJobInput) SetVaultName(v string) *InitiateJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobParameters != nil {
+		v := s.JobParameters
+
+		e.SetFields(protocol.PayloadTarget, "jobParameters", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateJobOutput struct {
 	_ struct{} `type:"structure"`
@@ -5621,6 +6210,22 @@ func (s *InitiateJobOutput) SetJobId(v string) *InitiateJobOutput {
 func (s *InitiateJobOutput) SetLocation(v string) *InitiateJobOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-job-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for initiating a multipart upload to an Amazon Glacier vault.
@@ -5704,6 +6309,32 @@ func (s *InitiateMultipartUploadInput) SetVaultName(v string) *InitiateMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSize != nil {
+		v := *s.PartSize
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-part-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -5736,6 +6367,22 @@ func (s *InitiateMultipartUploadOutput) SetLocation(v string) *InitiateMultipart
 func (s *InitiateMultipartUploadOutput) SetUploadId(v string) *InitiateMultipartUploadOutput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-multipart-upload-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input values for InitiateVaultLock.
@@ -5805,6 +6452,27 @@ func (s *InitiateVaultLockInput) SetVaultName(v string) *InitiateVaultLockInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateVaultLockOutput struct {
 	_ struct{} `type:"structure"`
@@ -5827,6 +6495,17 @@ func (s InitiateVaultLockOutput) GoString() string {
 func (s *InitiateVaultLockOutput) SetLockId(v string) *InitiateVaultLockOutput {
 	s.LockId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LockId != nil {
+		v := *s.LockId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lock-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the options for a range inventory retrieval job.
@@ -5901,6 +6580,37 @@ func (s *InventoryRetrievalJobDescription) SetStartDate(v string) *InventoryRetr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryRetrievalJobDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "EndDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "Limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for specifying a range inventory retrieval job.
 type InventoryRetrievalJobInput struct {
 	_ struct{} `type:"structure"`
@@ -5958,6 +6668,32 @@ func (s *InventoryRetrievalJobInput) SetMarker(v string) *InventoryRetrievalJobI
 func (s *InventoryRetrievalJobInput) SetStartDate(v string) *InventoryRetrievalJobInput {
 	s.StartDate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryRetrievalJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndDate != nil {
+		v := *s.EndDate
+
+		e.SetValue(protocol.BodyTarget, "EndDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.BodyTarget, "Limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an Amazon Glacier job.
@@ -6166,6 +6902,110 @@ func (s *JobDescription) SetVaultARN(v string) *JobDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.BodyTarget, "ArchiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSHA256TreeHash != nil {
+		v := *s.ArchiveSHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "ArchiveSHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveSizeInBytes != nil {
+		v := *s.ArchiveSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "ArchiveSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.BodyTarget, "Completed", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CompletionDate != nil {
+		v := *s.CompletionDate
+
+		e.SetValue(protocol.BodyTarget, "CompletionDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryRetrievalParameters != nil {
+		v := s.InventoryRetrievalParameters
+
+		e.SetFields(protocol.BodyTarget, "InventoryRetrievalParameters", v, protocol.Metadata{})
+	}
+	if s.InventorySizeInBytes != nil {
+		v := *s.InventorySizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "InventorySizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.JobDescription != nil {
+		v := *s.JobDescription
+
+		e.SetValue(protocol.BodyTarget, "JobDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.BodyTarget, "JobId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RetrievalByteRange != nil {
+		v := *s.RetrievalByteRange
+
+		e.SetValue(protocol.BodyTarget, "RetrievalByteRange", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SHA256TreeHash != nil {
+		v := *s.SHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "SHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "StatusCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobDescriptionList(vs []*JobDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides options for defining a job.
 type JobParameters struct {
 	_ struct{} `type:"structure"`
@@ -6273,6 +7113,52 @@ func (s *JobParameters) SetType(v string) *JobParameters {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveId != nil {
+		v := *s.ArchiveId
+
+		e.SetValue(protocol.BodyTarget, "ArchiveId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryRetrievalParameters != nil {
+		v := s.InventoryRetrievalParameters
+
+		e.SetFields(protocol.BodyTarget, "InventoryRetrievalParameters", v, protocol.Metadata{})
+	}
+	if s.RetrievalByteRange != nil {
+		v := *s.RetrievalByteRange
+
+		e.SetValue(protocol.BodyTarget, "RetrievalByteRange", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides options for retrieving a job list for an Amazon Glacier vault.
 type ListJobsInput struct {
 	_ struct{} `type:"structure"`
@@ -6372,6 +7258,42 @@ func (s *ListJobsInput) SetVaultName(v string) *ListJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Completed != nil {
+		v := *s.Completed
+
+		e.SetValue(protocol.QueryTarget, "completed", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Statuscode != nil {
+		v := *s.Statuscode
+
+		e.SetValue(protocol.QueryTarget, "statuscode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6406,6 +7328,22 @@ func (s *ListJobsOutput) SetJobList(v []*JobDescription) *ListJobsOutput {
 func (s *ListJobsOutput) SetMarker(v string) *ListJobsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobList) > 0 {
+		v := s.JobList
+
+		e.SetList(protocol.BodyTarget, "JobList", encodeJobDescriptionList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving list of in-progress multipart uploads for
@@ -6489,6 +7427,32 @@ func (s *ListMultipartUploadsInput) SetVaultName(v string) *ListMultipartUploads
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListMultipartUploadsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6522,6 +7486,22 @@ func (s *ListMultipartUploadsOutput) SetMarker(v string) *ListMultipartUploadsOu
 func (s *ListMultipartUploadsOutput) SetUploadsList(v []*UploadListElement) *ListMultipartUploadsOutput {
 	s.UploadsList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.UploadsList) > 0 {
+		v := s.UploadsList
+
+		e.SetList(protocol.BodyTarget, "UploadsList", encodeUploadListElementList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options for retrieving a list of parts of an archive that have been
@@ -6620,6 +7600,37 @@ func (s *ListPartsInput) SetVaultName(v string) *ListPartsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListPartsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6704,6 +7715,47 @@ func (s *ListPartsOutput) SetVaultARN(v string) *ListPartsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.BodyTarget, "ArchiveDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUploadId != nil {
+		v := *s.MultipartUploadId
+
+		e.SetValue(protocol.BodyTarget, "MultipartUploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSizeInBytes != nil {
+		v := *s.PartSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "PartSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Parts", encodePartListElementList(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ListProvisionedCapacityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6746,6 +7798,17 @@ func (s *ListProvisionedCapacityInput) SetAccountId(v string) *ListProvisionedCa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ListProvisionedCapacityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6767,6 +7830,17 @@ func (s ListProvisionedCapacityOutput) GoString() string {
 func (s *ListProvisionedCapacityOutput) SetProvisionedCapacityList(v []*ProvisionedCapacityDescription) *ListProvisionedCapacityOutput {
 	s.ProvisionedCapacityList = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ProvisionedCapacityList) > 0 {
+		v := s.ProvisionedCapacityList
+
+		e.SetList(protocol.BodyTarget, "ProvisionedCapacityList", encodeProvisionedCapacityDescriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input value for ListTagsForVaultInput.
@@ -6826,6 +7900,22 @@ func (s *ListTagsForVaultInput) SetVaultName(v string) *ListTagsForVaultInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
 	_ struct{} `type:"structure"`
@@ -6848,6 +7938,17 @@ func (s ListTagsForVaultOutput) GoString() string {
 func (s *ListTagsForVaultOutput) SetTags(v map[string]*string) *ListTagsForVaultOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides options to retrieve the vault list owned by the calling user's account.
@@ -6916,6 +8017,27 @@ func (s *ListVaultsInput) SetMarker(v string) *ListVaultsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVaultsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListVaultsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6950,6 +8072,22 @@ func (s *ListVaultsOutput) SetVaultList(v []*DescribeVaultOutput) *ListVaultsOut
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVaultsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.VaultList) > 0 {
+		v := s.VaultList
+
+		e.SetList(protocol.BodyTarget, "VaultList", encodeDescribeVaultOutputList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
 	_ struct{} `type:"structure"`
@@ -6982,6 +8120,30 @@ func (s *PartListElement) SetRangeInBytes(v string) *PartListElement {
 func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
 	s.SHA256TreeHash = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PartListElement) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RangeInBytes != nil {
+		v := *s.RangeInBytes
+
+		e.SetValue(protocol.BodyTarget, "RangeInBytes", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SHA256TreeHash != nil {
+		v := *s.SHA256TreeHash
+
+		e.SetValue(protocol.BodyTarget, "SHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePartListElementList(vs []*PartListElement) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The definition for a provisioned capacity unit.
@@ -7028,6 +8190,35 @@ func (s *ProvisionedCapacityDescription) SetStartDate(v string) *ProvisionedCapa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProvisionedCapacityDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CapacityId != nil {
+		v := *s.CapacityId
+
+		e.SetValue(protocol.BodyTarget, "CapacityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExpirationDate != nil {
+		v := *s.ExpirationDate
+
+		e.SetValue(protocol.BodyTarget, "ExpirationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartDate != nil {
+		v := *s.StartDate
+
+		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeProvisionedCapacityDescriptionList(vs []*ProvisionedCapacityDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 type PurchaseProvisionedCapacityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7070,6 +8261,17 @@ func (s *PurchaseProvisionedCapacityInput) SetAccountId(v string) *PurchaseProvi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PurchaseProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PurchaseProvisionedCapacityOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7091,6 +8293,17 @@ func (s PurchaseProvisionedCapacityOutput) GoString() string {
 func (s *PurchaseProvisionedCapacityOutput) SetCapacityId(v string) *PurchaseProvisionedCapacityOutput {
 	s.CapacityId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PurchaseProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CapacityId != nil {
+		v := *s.CapacityId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-capacity-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input value for RemoveTagsFromVaultInput.
@@ -7159,6 +8372,27 @@ func (s *RemoveTagsFromVaultInput) SetVaultName(v string) *RemoveTagsFromVaultIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsFromVaultInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RemoveTagsFromVaultOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7171,6 +8405,12 @@ func (s RemoveTagsFromVaultOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsFromVaultOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveTagsFromVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // SetDataRetrievalPolicy input.
@@ -7226,6 +8466,22 @@ func (s *SetDataRetrievalPolicyInput) SetPolicy(v *DataRetrievalPolicy) *SetData
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetDataRetrievalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7238,6 +8494,12 @@ func (s SetDataRetrievalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s SetDataRetrievalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // SetVaultAccessPolicy input.
@@ -7306,6 +8568,27 @@ func (s *SetVaultAccessPolicyInput) SetVaultName(v string) *SetVaultAccessPolicy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := s.Policy
+
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetVaultAccessPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7318,6 +8601,12 @@ func (s SetVaultAccessPolicyOutput) String() string {
 // GoString returns the string representation
 func (s SetVaultAccessPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to configure notifications that will be sent when specific
@@ -7387,6 +8676,27 @@ func (s *SetVaultNotificationsInput) SetVaultNotificationConfig(v *VaultNotifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultNotificationConfig != nil {
+		v := s.VaultNotificationConfig
+
+		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetVaultNotificationsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7399,6 +8709,12 @@ func (s SetVaultNotificationsOutput) String() string {
 // GoString returns the string representation
 func (s SetVaultNotificationsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Provides options to add an archive to a vault.
@@ -7485,6 +8801,37 @@ func (s *UploadArchiveInput) SetVaultName(v string) *UploadArchiveInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A list of in-progress multipart uploads for a vault.
 type UploadListElement struct {
 	_ struct{} `type:"structure"`
@@ -7546,6 +8893,45 @@ func (s *UploadListElement) SetPartSizeInBytes(v int64) *UploadListElement {
 func (s *UploadListElement) SetVaultARN(v string) *UploadListElement {
 	s.VaultARN = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadListElement) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveDescription != nil {
+		v := *s.ArchiveDescription
+
+		e.SetValue(protocol.BodyTarget, "ArchiveDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUploadId != nil {
+		v := *s.MultipartUploadId
+
+		e.SetValue(protocol.BodyTarget, "MultipartUploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartSizeInBytes != nil {
+		v := *s.PartSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "PartSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VaultARN != nil {
+		v := *s.VaultARN
+
+		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUploadListElementList(vs []*UploadListElement) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides options to upload a part of an archive in a multipart upload operation.
@@ -7649,6 +9035,42 @@ func (s *UploadMultipartPartInput) SetVaultName(v string) *UploadMultipartPartIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMultipartPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.PathTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the Amazon Glacier response to your request.
 type UploadMultipartPartOutput struct {
 	_ struct{} `type:"structure"`
@@ -7671,6 +9093,17 @@ func (s UploadMultipartPartOutput) GoString() string {
 func (s *UploadMultipartPartOutput) SetChecksum(v string) *UploadMultipartPartOutput {
 	s.Checksum = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMultipartPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains the vault access policy.
@@ -7697,6 +9130,17 @@ func (s *VaultAccessPolicy) SetPolicy(v string) *VaultAccessPolicy {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultAccessPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains the vault lock policy.
 type VaultLockPolicy struct {
 	_ struct{} `type:"structure"`
@@ -7719,6 +9163,17 @@ func (s VaultLockPolicy) GoString() string {
 func (s *VaultLockPolicy) SetPolicy(v string) *VaultLockPolicy {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultLockPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Represents a vault's notification configuration.
@@ -7754,6 +9209,22 @@ func (s *VaultNotificationConfig) SetEvents(v []*string) *VaultNotificationConfi
 func (s *VaultNotificationConfig) SetSNSTopic(v string) *VaultNotificationConfig {
 	s.SNSTopic = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VaultNotificationConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Events", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SNSTopic != nil {
+		v := *s.SNSTopic
+
+		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -3948,7 +3948,6 @@ func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3968,7 +3967,6 @@ func (s AbortMultipartUploadOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4042,7 +4040,6 @@ func (s *AbortVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4062,7 +4059,6 @@ func (s AbortVaultLockOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AbortVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4135,22 +4131,21 @@ func (s *AddTagsToVaultInput) SetVaultName(v string) *AddTagsToVaultInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddTagsToVaultInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.Tags) > 0 {
 		v := s.Tags
 
 		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4170,7 +4165,6 @@ func (s AddTagsToVaultOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddTagsToVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4236,7 +4230,6 @@ func (s *ArchiveCreationOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4339,11 +4332,6 @@ func (s *CompleteMultipartUploadInput) SetVaultName(v string) *CompleteMultipart
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ArchiveSize != nil {
 		v := *s.ArchiveSize
 
@@ -4353,6 +4341,11 @@ func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) er
 		v := *s.Checksum
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.UploadId != nil {
 		v := *s.UploadId
@@ -4364,7 +4357,6 @@ func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4457,7 +4449,6 @@ func (s *CompleteVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4477,7 +4468,6 @@ func (s CompleteVaultLockOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CompleteVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4551,7 +4541,6 @@ func (s *CreateVaultInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4586,7 +4575,6 @@ func (s *CreateVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4622,7 +4610,6 @@ func (s *DataRetrievalPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Rules", encodeDataRetrievalRuleList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4677,7 +4664,6 @@ func (s *DataRetrievalRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Strategy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4777,7 +4763,6 @@ func (s *DeleteArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4797,7 +4782,6 @@ func (s DeleteArchiveOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteArchiveOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4870,7 +4854,6 @@ func (s *DeleteVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4890,7 +4873,6 @@ func (s DeleteVaultAccessPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4963,7 +4945,6 @@ func (s *DeleteVaultInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5037,7 +5018,6 @@ func (s *DeleteVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5057,7 +5037,6 @@ func (s DeleteVaultNotificationsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5077,7 +5056,6 @@ func (s DeleteVaultOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5169,7 +5147,6 @@ func (s *DescribeJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5242,7 +5219,6 @@ func (s *DescribeVaultInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5354,7 +5330,6 @@ func (s *DescribeVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5417,7 +5392,6 @@ func (s *GetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5452,7 +5426,6 @@ func (s *GetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5566,6 +5539,11 @@ func (s *GetJobOutputInput) SetVaultName(v string) *GetJobOutputInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetJobOutputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.AccountId != nil {
 		v := *s.AccountId
 
@@ -5576,17 +5554,11 @@ func (s *GetJobOutputInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "jobId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Range != nil {
-		v := *s.Range
-
-		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5702,7 +5674,6 @@ func (s *GetJobOutputOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	// Skipping Body Output type's body not valid.
 	if s.Checksum != nil {
 		v := *s.Checksum
 
@@ -5718,8 +5689,8 @@ func (s *GetJobOutputOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
 	}
+	// Skipping Body Output type's body not valid.
 	// ignoring invalid encode state, StatusCode. Status
-
 	return nil
 }
 
@@ -5792,7 +5763,6 @@ func (s *GetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5827,7 +5797,6 @@ func (s *GetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5900,7 +5869,6 @@ func (s *GetVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5979,7 +5947,6 @@ func (s *GetVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6053,7 +6020,6 @@ func (s *GetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6088,7 +6054,6 @@ func (s *GetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6165,17 +6130,16 @@ func (s *InitiateJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.JobParameters != nil {
-		v := s.JobParameters
-
-		e.SetFields(protocol.PayloadTarget, "jobParameters", v, protocol.Metadata{})
-	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.JobParameters != nil {
+		v := s.JobParameters
 
+		e.SetFields(protocol.PayloadTarget, "jobParameters", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6224,7 +6188,6 @@ func (s *InitiateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6311,11 +6274,6 @@ func (s *InitiateMultipartUploadInput) SetVaultName(v string) *InitiateMultipart
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InitiateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ArchiveDescription != nil {
 		v := *s.ArchiveDescription
 
@@ -6326,12 +6284,16 @@ func (s *InitiateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-part-size", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6381,7 +6343,6 @@ func (s *InitiateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-multipart-upload-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6459,17 +6420,16 @@ func (s *InitiateVaultLockInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Policy != nil {
-		v := s.Policy
-
-		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
-	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Policy != nil {
+		v := s.Policy
 
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6504,7 +6464,6 @@ func (s *InitiateVaultLockOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-lock-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6607,7 +6566,6 @@ func (s *InventoryRetrievalJobDescription) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6692,7 +6650,6 @@ func (s *InventoryRetrievalJobInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6994,7 +6951,6 @@ func (s *JobDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7155,7 +7111,6 @@ func (s *JobParameters) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7265,6 +7220,11 @@ func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Completed != nil {
 		v := *s.Completed
 
@@ -7285,12 +7245,6 @@ func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "statuscode", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VaultName != nil {
-		v := *s.VaultName
-
-		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7342,7 +7296,6 @@ func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7434,6 +7387,11 @@ func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.VaultName != nil {
+		v := *s.VaultName
+
+		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -7444,12 +7402,6 @@ func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VaultName != nil {
-		v := *s.VaultName
-
-		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7500,7 +7452,6 @@ func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "UploadsList", encodeUploadListElementList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7607,16 +7558,6 @@ func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Limit != nil {
-		v := *s.Limit
-
-		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Marker != nil {
-		v := *s.Marker
-
-		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
@@ -7627,7 +7568,16 @@ func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Limit != nil {
+		v := *s.Limit
 
+		e.SetValue(protocol.QueryTarget, "limit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7752,7 +7702,6 @@ func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7805,7 +7754,6 @@ func (s *ListProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7839,7 +7787,6 @@ func (s *ListProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetList(protocol.BodyTarget, "ProvisionedCapacityList", encodeProvisionedCapacityDescriptionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7912,7 +7859,6 @@ func (s *ListTagsForVaultInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7947,7 +7893,6 @@ func (s *ListTagsForVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8034,7 +7979,6 @@ func (s *ListVaultsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8084,7 +8028,6 @@ func (s *ListVaultsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "VaultList", encodeDescribeVaultOutputList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8134,7 +8077,6 @@ func (s *PartListElement) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SHA256TreeHash", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8207,7 +8149,6 @@ func (s *ProvisionedCapacityDescription) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "StartDate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8268,7 +8209,6 @@ func (s *PurchaseProvisionedCapacityInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8302,7 +8242,6 @@ func (s *PurchaseProvisionedCapacityOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-capacity-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8374,22 +8313,21 @@ func (s *RemoveTagsFromVaultInput) SetVaultName(v string) *RemoveTagsFromVaultIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveTagsFromVaultInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.TagKeys) > 0 {
 		v := s.TagKeys
 
 		e.SetList(protocol.BodyTarget, "TagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8409,7 +8347,6 @@ func (s RemoveTagsFromVaultOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveTagsFromVaultOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8468,17 +8405,16 @@ func (s *SetDataRetrievalPolicyInput) SetPolicy(v *DataRetrievalPolicy) *SetData
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetDataRetrievalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Policy != nil {
 		v := s.Policy
 
 		e.SetFields(protocol.BodyTarget, "Policy", v, protocol.Metadata{})
 	}
+	if s.AccountId != nil {
+		v := *s.AccountId
 
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8498,7 +8434,6 @@ func (s SetDataRetrievalPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetDataRetrievalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8575,17 +8510,16 @@ func (s *SetVaultAccessPolicyInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Policy != nil {
-		v := s.Policy
-
-		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
-	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Policy != nil {
+		v := s.Policy
 
+		e.SetFields(protocol.PayloadTarget, "policy", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8605,7 +8539,6 @@ func (s SetVaultAccessPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetVaultAccessPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8693,7 +8626,6 @@ func (s *SetVaultNotificationsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "vaultNotificationConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8713,7 +8645,6 @@ func (s SetVaultNotificationsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetVaultNotificationsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8803,32 +8734,31 @@ func (s *UploadArchiveInput) SetVaultName(v string) *UploadArchiveInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UploadArchiveInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ArchiveDescription != nil {
 		v := *s.ArchiveDescription
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-archive-description", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
 	}
 	if s.Checksum != nil {
 		v := *s.Checksum
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.VaultName != nil {
 		v := *s.VaultName
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Body != nil {
+		v := s.Body
 
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8922,7 +8852,6 @@ func (s *UploadListElement) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VaultARN", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9037,16 +8966,6 @@ func (s *UploadMultipartPartInput) SetVaultName(v string) *UploadMultipartPartIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UploadMultipartPartInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccountId != nil {
-		v := *s.AccountId
-
-		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
-	}
 	if s.Checksum != nil {
 		v := *s.Checksum
 
@@ -9056,6 +8975,11 @@ func (s *UploadMultipartPartInput) MarshalFields(e protocol.FieldEncoder) error 
 		v := *s.Range
 
 		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.PathTarget, "accountId", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.UploadId != nil {
 		v := *s.UploadId
@@ -9067,7 +8991,11 @@ func (s *UploadMultipartPartInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "vaultName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Body != nil {
+		v := s.Body
 
+		e.SetStream(protocol.PayloadTarget, "body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -9102,7 +9030,6 @@ func (s *UploadMultipartPartOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-sha256-tree-hash", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9137,7 +9064,6 @@ func (s *VaultAccessPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9172,7 +9098,6 @@ func (s *VaultLockPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9223,7 +9148,6 @@ func (s *VaultNotificationConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SNSTopic", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opAssociateRoleToGroup = "AssociateRoleToGroup"
@@ -5221,6 +5222,22 @@ func (s *AssociateRoleToGroupInput) SetRoleArn(v string) *AssociateRoleToGroupIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateRoleToGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateRoleToGroupResponse
 type AssociateRoleToGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -5243,6 +5260,17 @@ func (s AssociateRoleToGroupOutput) GoString() string {
 func (s *AssociateRoleToGroupOutput) SetAssociatedAt(v string) *AssociateRoleToGroupOutput {
 	s.AssociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateRoleToGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateServiceRoleToAccountRequest
@@ -5269,6 +5297,17 @@ func (s *AssociateServiceRoleToAccountInput) SetRoleArn(v string) *AssociateServ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateServiceRoleToAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/AssociateServiceRoleToAccountResponse
 type AssociateServiceRoleToAccountOutput struct {
 	_ struct{} `type:"structure"`
@@ -5291,6 +5330,17 @@ func (s AssociateServiceRoleToAccountOutput) GoString() string {
 func (s *AssociateServiceRoleToAccountOutput) SetAssociatedAt(v string) *AssociateServiceRoleToAccountOutput {
 	s.AssociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateServiceRoleToAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Connectivity Info
@@ -5343,6 +5393,40 @@ func (s *ConnectivityInfo) SetMetadata(v string) *ConnectivityInfo {
 func (s *ConnectivityInfo) SetPortNumber(v int64) *ConnectivityInfo {
 	s.PortNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ConnectivityInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostAddress != nil {
+		v := *s.HostAddress
+
+		e.SetValue(protocol.BodyTarget, "HostAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := *s.Metadata
+
+		e.SetValue(protocol.BodyTarget, "Metadata", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PortNumber != nil {
+		v := *s.PortNumber
+
+		e.SetValue(protocol.BodyTarget, "PortNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeConnectivityInfoList(vs []*ConnectivityInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on the core
@@ -5398,6 +5482,40 @@ func (s *Core) SetThingArn(v string) *Core {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Core) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "CertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncShadow != nil {
+		v := *s.SyncShadow
+
+		e.SetValue(protocol.BodyTarget, "SyncShadow", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCoreList(vs []*Core) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on core definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CoreDefinitionVersion
 type CoreDefinitionVersion struct {
@@ -5421,6 +5539,17 @@ func (s CoreDefinitionVersion) GoString() string {
 func (s *CoreDefinitionVersion) SetCores(v []*Core) *CoreDefinitionVersion {
 	s.Cores = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CoreDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Cores) > 0 {
+		v := s.Cores
+
+		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionRequest
@@ -5461,6 +5590,27 @@ func (s *CreateCoreDefinitionInput) SetInitialVersion(v *CoreDefinitionVersion) 
 func (s *CreateCoreDefinitionInput) SetName(v string) *CreateCoreDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionResponse
@@ -5534,6 +5684,47 @@ func (s *CreateCoreDefinitionOutput) SetName(v string) *CreateCoreDefinitionOutp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionVersionRequest
 type CreateCoreDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -5587,6 +5778,27 @@ func (s *CreateCoreDefinitionVersionInput) SetCores(v []*Core) *CreateCoreDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Cores) > 0 {
+		v := s.Cores
+
+		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateCoreDefinitionVersionResponse
 type CreateCoreDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5632,6 +5844,32 @@ func (s *CreateCoreDefinitionVersionOutput) SetId(v string) *CreateCoreDefinitio
 func (s *CreateCoreDefinitionVersionOutput) SetVersion(v string) *CreateCoreDefinitionVersionOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on Deployment
@@ -5708,6 +5946,37 @@ func (s *CreateDeploymentInput) SetGroupVersionId(v string) *CreateDeploymentInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupVersionId != nil {
+		v := *s.GroupVersionId
+
+		e.SetValue(protocol.BodyTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeploymentResponse
 type CreateDeploymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5739,6 +6008,22 @@ func (s *CreateDeploymentOutput) SetDeploymentArn(v string) *CreateDeploymentOut
 func (s *CreateDeploymentOutput) SetDeploymentId(v string) *CreateDeploymentOutput {
 	s.DeploymentId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionRequest
@@ -5779,6 +6064,27 @@ func (s *CreateDeviceDefinitionInput) SetInitialVersion(v *DeviceDefinitionVersi
 func (s *CreateDeviceDefinitionInput) SetName(v string) *CreateDeviceDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionResponse
@@ -5852,6 +6158,47 @@ func (s *CreateDeviceDefinitionOutput) SetName(v string) *CreateDeviceDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionVersionRequest
 type CreateDeviceDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -5905,6 +6252,27 @@ func (s *CreateDeviceDefinitionVersionInput) SetDevices(v []*Device) *CreateDevi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Devices) > 0 {
+		v := s.Devices
+
+		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateDeviceDefinitionVersionResponse
 type CreateDeviceDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5952,6 +6320,32 @@ func (s *CreateDeviceDefinitionVersionOutput) SetVersion(v string) *CreateDevice
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionRequest
 type CreateFunctionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -5990,6 +6384,27 @@ func (s *CreateFunctionDefinitionInput) SetInitialVersion(v *FunctionDefinitionV
 func (s *CreateFunctionDefinitionInput) SetName(v string) *CreateFunctionDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionResponse
@@ -6063,6 +6478,47 @@ func (s *CreateFunctionDefinitionOutput) SetName(v string) *CreateFunctionDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionVersionRequest
 type CreateFunctionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6116,6 +6572,27 @@ func (s *CreateFunctionDefinitionVersionInput) SetFunctions(v []*Function) *Crea
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateFunctionDefinitionVersionResponse
 type CreateFunctionDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6163,6 +6640,32 @@ func (s *CreateFunctionDefinitionVersionOutput) SetVersion(v string) *CreateFunc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupCertificateAuthorityRequest
 type CreateGroupCertificateAuthorityInput struct {
 	_ struct{} `type:"structure"`
@@ -6208,6 +6711,22 @@ func (s *CreateGroupCertificateAuthorityInput) SetGroupId(v string) *CreateGroup
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupCertificateAuthorityResponse
 type CreateGroupCertificateAuthorityOutput struct {
 	_ struct{} `type:"structure"`
@@ -6230,6 +6749,17 @@ func (s CreateGroupCertificateAuthorityOutput) GoString() string {
 func (s *CreateGroupCertificateAuthorityOutput) SetGroupCertificateAuthorityArn(v string) *CreateGroupCertificateAuthorityOutput {
 	s.GroupCertificateAuthorityArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupRequest
@@ -6270,6 +6800,27 @@ func (s *CreateGroupInput) SetInitialVersion(v *GroupVersion) *CreateGroupInput 
 func (s *CreateGroupInput) SetName(v string) *CreateGroupInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupResponse
@@ -6341,6 +6892,47 @@ func (s *CreateGroupOutput) SetLatestVersionArn(v string) *CreateGroupOutput {
 func (s *CreateGroupOutput) SetName(v string) *CreateGroupOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupVersionRequest
@@ -6428,6 +7020,47 @@ func (s *CreateGroupVersionInput) SetSubscriptionDefinitionVersionArn(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionVersionArn != nil {
+		v := *s.CoreDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "CoreDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionArn != nil {
+		v := *s.DeviceDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "DeviceDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionArn != nil {
+		v := *s.FunctionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionArn != nil {
+		v := *s.LoggerDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LoggerDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionArn != nil {
+		v := *s.SubscriptionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateGroupVersionResponse
 type CreateGroupVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6475,6 +7108,32 @@ func (s *CreateGroupVersionOutput) SetVersion(v string) *CreateGroupVersionOutpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionRequest
 type CreateLoggerDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -6513,6 +7172,27 @@ func (s *CreateLoggerDefinitionInput) SetInitialVersion(v *LoggerDefinitionVersi
 func (s *CreateLoggerDefinitionInput) SetName(v string) *CreateLoggerDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionResponse
@@ -6586,6 +7266,47 @@ func (s *CreateLoggerDefinitionOutput) SetName(v string) *CreateLoggerDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionVersionRequest
 type CreateLoggerDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6639,6 +7360,27 @@ func (s *CreateLoggerDefinitionVersionInput) SetLoggers(v []*Logger) *CreateLogg
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Loggers) > 0 {
+		v := s.Loggers
+
+		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateLoggerDefinitionVersionResponse
 type CreateLoggerDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6686,6 +7428,32 @@ func (s *CreateLoggerDefinitionVersionOutput) SetVersion(v string) *CreateLogger
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionRequest
 type CreateSubscriptionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -6724,6 +7492,27 @@ func (s *CreateSubscriptionDefinitionInput) SetInitialVersion(v *SubscriptionDef
 func (s *CreateSubscriptionDefinitionInput) SetName(v string) *CreateSubscriptionDefinitionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitialVersion != nil {
+		v := s.InitialVersion
+
+		e.SetFields(protocol.BodyTarget, "InitialVersion", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionResponse
@@ -6797,6 +7586,47 @@ func (s *CreateSubscriptionDefinitionOutput) SetName(v string) *CreateSubscripti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionVersionRequest
 type CreateSubscriptionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -6850,6 +7680,27 @@ func (s *CreateSubscriptionDefinitionVersionInput) SetSubscriptions(v []*Subscri
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/CreateSubscriptionDefinitionVersionResponse
 type CreateSubscriptionDefinitionVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6895,6 +7746,32 @@ func (s *CreateSubscriptionDefinitionVersionOutput) SetId(v string) *CreateSubsc
 func (s *CreateSubscriptionDefinitionVersionOutput) SetVersion(v string) *CreateSubscriptionDefinitionVersionOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Definition
@@ -6976,6 +7853,55 @@ func (s *DefinitionInformation) SetName(v string) *DefinitionInformation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefinitionInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDefinitionInformationList(vs []*DefinitionInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteCoreDefinitionRequest
 type DeleteCoreDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -7013,6 +7939,17 @@ func (s *DeleteCoreDefinitionInput) SetCoreDefinitionId(v string) *DeleteCoreDef
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteCoreDefinitionResponse
 type DeleteCoreDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7026,6 +7963,12 @@ func (s DeleteCoreDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCoreDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteDeviceDefinitionRequest
@@ -7065,6 +8008,17 @@ func (s *DeleteDeviceDefinitionInput) SetDeviceDefinitionId(v string) *DeleteDev
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteDeviceDefinitionResponse
 type DeleteDeviceDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7078,6 +8032,12 @@ func (s DeleteDeviceDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDeviceDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteFunctionDefinitionRequest
@@ -7117,6 +8077,17 @@ func (s *DeleteFunctionDefinitionInput) SetFunctionDefinitionId(v string) *Delet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteFunctionDefinitionResponse
 type DeleteFunctionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7130,6 +8101,12 @@ func (s DeleteFunctionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFunctionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteGroupRequest
@@ -7169,6 +8146,17 @@ func (s *DeleteGroupInput) SetGroupId(v string) *DeleteGroupInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteGroupResponse
 type DeleteGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -7182,6 +8170,12 @@ func (s DeleteGroupOutput) String() string {
 // GoString returns the string representation
 func (s DeleteGroupOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteLoggerDefinitionRequest
@@ -7221,6 +8215,17 @@ func (s *DeleteLoggerDefinitionInput) SetLoggerDefinitionId(v string) *DeleteLog
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteLoggerDefinitionResponse
 type DeleteLoggerDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7234,6 +8239,12 @@ func (s DeleteLoggerDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLoggerDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteSubscriptionDefinitionRequest
@@ -7273,6 +8284,17 @@ func (s *DeleteSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeleteSubscriptionDefinitionResponse
 type DeleteSubscriptionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -7286,6 +8308,12 @@ func (s DeleteSubscriptionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSubscriptionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information on the deployment
@@ -7349,6 +8377,45 @@ func (s *Deployment) SetGroupArn(v string) *Deployment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "CreatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupArn != nil {
+		v := *s.GroupArn
+
+		e.SetValue(protocol.BodyTarget, "GroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeploymentList(vs []*Deployment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on a Device
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/Device
 type Device struct {
@@ -7402,6 +8469,40 @@ func (s *Device) SetThingArn(v string) *Device {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Device) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "CertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncShadow != nil {
+		v := *s.SyncShadow
+
+		e.SetValue(protocol.BodyTarget, "SyncShadow", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeviceList(vs []*Device) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on device definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DeviceDefinitionVersion
 type DeviceDefinitionVersion struct {
@@ -7425,6 +8526,17 @@ func (s DeviceDefinitionVersion) GoString() string {
 func (s *DeviceDefinitionVersion) SetDevices(v []*Device) *DeviceDefinitionVersion {
 	s.Devices = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeviceDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Devices) > 0 {
+		v := s.Devices
+
+		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateRoleFromGroupRequest
@@ -7464,6 +8576,17 @@ func (s *DisassociateRoleFromGroupInput) SetGroupId(v string) *DisassociateRoleF
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateRoleFromGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateRoleFromGroupResponse
 type DisassociateRoleFromGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -7488,6 +8611,17 @@ func (s *DisassociateRoleFromGroupOutput) SetDisassociatedAt(v string) *Disassoc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateRoleFromGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisassociatedAt != nil {
+		v := *s.DisassociatedAt
+
+		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateServiceRoleFromAccountRequest
 type DisassociateServiceRoleFromAccountInput struct {
 	_ struct{} `type:"structure"`
@@ -7501,6 +8635,12 @@ func (s DisassociateServiceRoleFromAccountInput) String() string {
 // GoString returns the string representation
 func (s DisassociateServiceRoleFromAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateServiceRoleFromAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/DisassociateServiceRoleFromAccountResponse
@@ -7525,6 +8665,17 @@ func (s DisassociateServiceRoleFromAccountOutput) GoString() string {
 func (s *DisassociateServiceRoleFromAccountOutput) SetDisassociatedAt(v string) *DisassociateServiceRoleFromAccountOutput {
 	s.DisassociatedAt = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateServiceRoleFromAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisassociatedAt != nil {
+		v := *s.DisassociatedAt
+
+		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // ErrorDetail
@@ -7559,6 +8710,30 @@ func (s *ErrorDetail) SetDetailedErrorCode(v string) *ErrorDetail {
 func (s *ErrorDetail) SetDetailedErrorMessage(v string) *ErrorDetail {
 	s.DetailedErrorMessage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DetailedErrorCode != nil {
+		v := *s.DetailedErrorCode
+
+		e.SetValue(protocol.BodyTarget, "DetailedErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DetailedErrorMessage != nil {
+		v := *s.DetailedErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "DetailedErrorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeErrorDetailList(vs []*ErrorDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on function
@@ -7602,6 +8777,35 @@ func (s *Function) SetFunctionConfiguration(v *FunctionConfiguration) *Function 
 func (s *Function) SetId(v string) *Function {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Function) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionConfiguration != nil {
+		v := s.FunctionConfiguration
+
+		e.SetFields(protocol.BodyTarget, "FunctionConfiguration", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFunctionList(vs []*Function) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Configuration of the function
@@ -7676,6 +8880,42 @@ func (s *FunctionConfiguration) SetTimeout(v int64) *FunctionConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.ExecArgs != nil {
+		v := *s.ExecArgs
+
+		e.SetValue(protocol.BodyTarget, "ExecArgs", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Executable != nil {
+		v := *s.Executable
+
+		e.SetValue(protocol.BodyTarget, "Executable", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Pinned != nil {
+		v := *s.Pinned
+
+		e.SetValue(protocol.BodyTarget, "Pinned", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Environment of the function configuration
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/FunctionConfigurationEnvironment
 type FunctionConfigurationEnvironment struct {
@@ -7698,6 +8938,17 @@ func (s FunctionConfigurationEnvironment) GoString() string {
 func (s *FunctionConfigurationEnvironment) SetVariables(v map[string]*string) *FunctionConfigurationEnvironment {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfigurationEnvironment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the function definition version
@@ -7723,6 +8974,17 @@ func (s FunctionDefinitionVersion) GoString() string {
 func (s *FunctionDefinitionVersion) SetFunctions(v []*Function) *FunctionDefinitionVersion {
 	s.Functions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetAssociatedRoleRequest
@@ -7762,6 +9024,17 @@ func (s *GetAssociatedRoleInput) SetGroupId(v string) *GetAssociatedRoleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAssociatedRoleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetAssociatedRoleResponse
 type GetAssociatedRoleOutput struct {
 	_ struct{} `type:"structure"`
@@ -7793,6 +9066,22 @@ func (s *GetAssociatedRoleOutput) SetAssociatedAt(v string) *GetAssociatedRoleOu
 func (s *GetAssociatedRoleOutput) SetRoleArn(v string) *GetAssociatedRoleOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAssociatedRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetConnectivityInfoRequest
@@ -7832,6 +9121,17 @@ func (s *GetConnectivityInfoInput) SetThingName(v string) *GetConnectivityInfoIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // connectivity info response
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetConnectivityInfoResponse
 type GetConnectivityInfoOutput struct {
@@ -7863,6 +9163,22 @@ func (s *GetConnectivityInfoOutput) SetConnectivityInfo(v []*ConnectivityInfo) *
 func (s *GetConnectivityInfoOutput) SetMessage(v string) *GetConnectivityInfoOutput {
 	s.Message = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConnectivityInfo) > 0 {
+		v := s.ConnectivityInfo
+
+		e.SetList(protocol.BodyTarget, "ConnectivityInfo", encodeConnectivityInfoList(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionRequest
@@ -7900,6 +9216,17 @@ func (s *GetCoreDefinitionInput) Validate() error {
 func (s *GetCoreDefinitionInput) SetCoreDefinitionId(v string) *GetCoreDefinitionInput {
 	s.CoreDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionResponse
@@ -7973,6 +9300,47 @@ func (s *GetCoreDefinitionOutput) SetName(v string) *GetCoreDefinitionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionVersionRequest
 type GetCoreDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8020,6 +9388,22 @@ func (s *GetCoreDefinitionVersionInput) SetCoreDefinitionId(v string) *GetCoreDe
 func (s *GetCoreDefinitionVersionInput) SetCoreDefinitionVersionId(v string) *GetCoreDefinitionVersionInput {
 	s.CoreDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CoreDefinitionVersionId != nil {
+		v := *s.CoreDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetCoreDefinitionVersionResponse
@@ -8082,6 +9466,37 @@ func (s *GetCoreDefinitionVersionOutput) SetVersion(v string) *GetCoreDefinition
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeploymentStatusRequest
 type GetDeploymentStatusInput struct {
 	_ struct{} `type:"structure"`
@@ -8129,6 +9544,22 @@ func (s *GetDeploymentStatusInput) SetDeploymentId(v string) *GetDeploymentStatu
 func (s *GetDeploymentStatusInput) SetGroupId(v string) *GetDeploymentStatusInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.PathTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The response body contains the status of a deployment for a group.
@@ -8192,6 +9623,37 @@ func (s *GetDeploymentStatusOutput) SetUpdatedAt(v string) *GetDeploymentStatusO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeploymentStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentStatus != nil {
+		v := *s.DeploymentStatus
+
+		e.SetValue(protocol.BodyTarget, "DeploymentStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentType != nil {
+		v := *s.DeploymentType
+
+		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ErrorDetails) > 0 {
+		v := s.ErrorDetails
+
+		e.SetList(protocol.BodyTarget, "ErrorDetails", encodeErrorDetailList(v), protocol.Metadata{})
+	}
+	if s.ErrorMessage != nil {
+		v := *s.ErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "ErrorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdatedAt != nil {
+		v := *s.UpdatedAt
+
+		e.SetValue(protocol.BodyTarget, "UpdatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionRequest
 type GetDeviceDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -8227,6 +9689,17 @@ func (s *GetDeviceDefinitionInput) Validate() error {
 func (s *GetDeviceDefinitionInput) SetDeviceDefinitionId(v string) *GetDeviceDefinitionInput {
 	s.DeviceDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionResponse
@@ -8300,6 +9773,47 @@ func (s *GetDeviceDefinitionOutput) SetName(v string) *GetDeviceDefinitionOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionVersionRequest
 type GetDeviceDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8347,6 +9861,22 @@ func (s *GetDeviceDefinitionVersionInput) SetDeviceDefinitionId(v string) *GetDe
 func (s *GetDeviceDefinitionVersionInput) SetDeviceDefinitionVersionId(v string) *GetDeviceDefinitionVersionInput {
 	s.DeviceDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionId != nil {
+		v := *s.DeviceDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetDeviceDefinitionVersionResponse
@@ -8409,6 +9939,37 @@ func (s *GetDeviceDefinitionVersionOutput) SetVersion(v string) *GetDeviceDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionRequest
 type GetFunctionDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -8444,6 +10005,17 @@ func (s *GetFunctionDefinitionInput) Validate() error {
 func (s *GetFunctionDefinitionInput) SetFunctionDefinitionId(v string) *GetFunctionDefinitionInput {
 	s.FunctionDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionResponse
@@ -8517,6 +10089,47 @@ func (s *GetFunctionDefinitionOutput) SetName(v string) *GetFunctionDefinitionOu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetFunctionDefinitionVersionRequest
 type GetFunctionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8564,6 +10177,22 @@ func (s *GetFunctionDefinitionVersionInput) SetFunctionDefinitionId(v string) *G
 func (s *GetFunctionDefinitionVersionInput) SetFunctionDefinitionVersionId(v string) *GetFunctionDefinitionVersionInput {
 	s.FunctionDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionId != nil {
+		v := *s.FunctionDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Function definition version
@@ -8627,6 +10256,37 @@ func (s *GetFunctionDefinitionVersionOutput) SetVersion(v string) *GetFunctionDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateAuthorityRequest
 type GetGroupCertificateAuthorityInput struct {
 	_ struct{} `type:"structure"`
@@ -8676,6 +10336,22 @@ func (s *GetGroupCertificateAuthorityInput) SetGroupId(v string) *GetGroupCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityId != nil {
+		v := *s.CertificateAuthorityId
+
+		e.SetValue(protocol.PathTarget, "CertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Certificate authority for the group.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateAuthorityResponse
 type GetGroupCertificateAuthorityOutput struct {
@@ -8719,6 +10395,27 @@ func (s *GetGroupCertificateAuthorityOutput) SetPemEncodedCertificate(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupCertificateAuthorityId != nil {
+		v := *s.GroupCertificateAuthorityId
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PemEncodedCertificate != nil {
+		v := *s.PemEncodedCertificate
+
+		e.SetValue(protocol.BodyTarget, "PemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateConfigurationRequest
 type GetGroupCertificateConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -8754,6 +10451,17 @@ func (s *GetGroupCertificateConfigurationInput) Validate() error {
 func (s *GetGroupCertificateConfigurationInput) SetGroupId(v string) *GetGroupCertificateConfigurationInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupCertificateConfigurationResponse
@@ -8795,6 +10503,27 @@ func (s *GetGroupCertificateConfigurationOutput) SetGroupId(v string) *GetGroupC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupCertificateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityExpiryInMilliseconds != nil {
+		v := *s.CertificateAuthorityExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateAuthorityExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupRequest
 type GetGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -8830,6 +10559,17 @@ func (s *GetGroupInput) Validate() error {
 func (s *GetGroupInput) SetGroupId(v string) *GetGroupInput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupResponse
@@ -8903,6 +10643,47 @@ func (s *GetGroupOutput) SetName(v string) *GetGroupOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetGroupVersionRequest
 type GetGroupVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -8950,6 +10731,22 @@ func (s *GetGroupVersionInput) SetGroupId(v string) *GetGroupVersionInput {
 func (s *GetGroupVersionInput) SetGroupVersionId(v string) *GetGroupVersionInput {
 	s.GroupVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupVersionId != nil {
+		v := *s.GroupVersionId
+
+		e.SetValue(protocol.PathTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the group version
@@ -9013,6 +10810,37 @@ func (s *GetGroupVersionOutput) SetVersion(v string) *GetGroupVersionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionRequest
 type GetLoggerDefinitionInput struct {
 	_ struct{} `type:"structure"`
@@ -9048,6 +10876,17 @@ func (s *GetLoggerDefinitionInput) Validate() error {
 func (s *GetLoggerDefinitionInput) SetLoggerDefinitionId(v string) *GetLoggerDefinitionInput {
 	s.LoggerDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionResponse
@@ -9121,6 +10960,47 @@ func (s *GetLoggerDefinitionOutput) SetName(v string) *GetLoggerDefinitionOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetLoggerDefinitionVersionRequest
 type GetLoggerDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -9168,6 +11048,22 @@ func (s *GetLoggerDefinitionVersionInput) SetLoggerDefinitionId(v string) *GetLo
 func (s *GetLoggerDefinitionVersionInput) SetLoggerDefinitionVersionId(v string) *GetLoggerDefinitionVersionInput {
 	s.LoggerDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionId != nil {
+		v := *s.LoggerDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on logger definition version response
@@ -9231,6 +11127,37 @@ func (s *GetLoggerDefinitionVersionOutput) SetVersion(v string) *GetLoggerDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetServiceRoleForAccountRequest
 type GetServiceRoleForAccountInput struct {
 	_ struct{} `type:"structure"`
@@ -9244,6 +11171,12 @@ func (s GetServiceRoleForAccountInput) String() string {
 // GoString returns the string representation
 func (s GetServiceRoleForAccountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceRoleForAccountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetServiceRoleForAccountResponse
@@ -9277,6 +11210,22 @@ func (s *GetServiceRoleForAccountOutput) SetAssociatedAt(v string) *GetServiceRo
 func (s *GetServiceRoleForAccountOutput) SetRoleArn(v string) *GetServiceRoleForAccountOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceRoleForAccountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AssociatedAt != nil {
+		v := *s.AssociatedAt
+
+		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionRequest
@@ -9314,6 +11263,17 @@ func (s *GetSubscriptionDefinitionInput) Validate() error {
 func (s *GetSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string) *GetSubscriptionDefinitionInput {
 	s.SubscriptionDefinitionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionResponse
@@ -9387,6 +11347,47 @@ func (s *GetSubscriptionDefinitionOutput) SetName(v string) *GetSubscriptionDefi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GetSubscriptionDefinitionVersionRequest
 type GetSubscriptionDefinitionVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -9434,6 +11435,22 @@ func (s *GetSubscriptionDefinitionVersionInput) SetSubscriptionDefinitionId(v st
 func (s *GetSubscriptionDefinitionVersionInput) SetSubscriptionDefinitionVersionId(v string) *GetSubscriptionDefinitionVersionInput {
 	s.SubscriptionDefinitionVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionId != nil {
+		v := *s.SubscriptionDefinitionVersionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Subscription Definition Version
@@ -9497,6 +11514,37 @@ func (s *GetSubscriptionDefinitionVersionOutput) SetVersion(v string) *GetSubscr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information on group certificate authority properties
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GroupCertificateAuthorityProperties
 type GroupCertificateAuthorityProperties struct {
@@ -9529,6 +11577,30 @@ func (s *GroupCertificateAuthorityProperties) SetGroupCertificateAuthorityArn(v 
 func (s *GroupCertificateAuthorityProperties) SetGroupCertificateAuthorityId(v string) *GroupCertificateAuthorityProperties {
 	s.GroupCertificateAuthorityId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupCertificateAuthorityProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupCertificateAuthorityArn != nil {
+		v := *s.GroupCertificateAuthorityArn
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupCertificateAuthorityId != nil {
+		v := *s.GroupCertificateAuthorityId
+
+		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupCertificateAuthorityPropertiesList(vs []*GroupCertificateAuthorityProperties) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information on the group
@@ -9610,6 +11682,55 @@ func (s *GroupInformation) SetName(v string) *GroupInformation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedTimestamp != nil {
+		v := *s.LastUpdatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersionArn != nil {
+		v := *s.LatestVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupInformationList(vs []*GroupInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on group version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/GroupVersion
 type GroupVersion struct {
@@ -9671,6 +11792,37 @@ func (s *GroupVersion) SetSubscriptionDefinitionVersionArn(v string) *GroupVersi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionVersionArn != nil {
+		v := *s.CoreDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "CoreDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeviceDefinitionVersionArn != nil {
+		v := *s.DeviceDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "DeviceDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionDefinitionVersionArn != nil {
+		v := *s.FunctionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoggerDefinitionVersionArn != nil {
+		v := *s.LoggerDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "LoggerDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionVersionArn != nil {
+		v := *s.SubscriptionDefinitionVersionArn
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionVersionsRequest
 type ListCoreDefinitionVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -9724,6 +11876,27 @@ func (s *ListCoreDefinitionVersionsInput) SetNextToken(v string) *ListCoreDefini
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionVersionsResponse
 type ListCoreDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9753,6 +11926,22 @@ func (s *ListCoreDefinitionVersionsOutput) SetNextToken(v string) *ListCoreDefin
 func (s *ListCoreDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListCoreDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionsRequest
@@ -9786,6 +11975,22 @@ func (s *ListCoreDefinitionsInput) SetNextToken(v string) *ListCoreDefinitionsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListCoreDefinitionsResponse
 type ListCoreDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9815,6 +12020,22 @@ func (s *ListCoreDefinitionsOutput) SetDefinitions(v []*DefinitionInformation) *
 func (s *ListCoreDefinitionsOutput) SetNextToken(v string) *ListCoreDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCoreDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeploymentsRequest
@@ -9870,6 +12091,27 @@ func (s *ListDeploymentsInput) SetNextToken(v string) *ListDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeploymentsResponse
 type ListDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9902,6 +12144,22 @@ func (s *ListDeploymentsOutput) SetDeployments(v []*Deployment) *ListDeployments
 func (s *ListDeploymentsOutput) SetNextToken(v string) *ListDeploymentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Deployments) > 0 {
+		v := s.Deployments
+
+		e.SetList(protocol.BodyTarget, "Deployments", encodeDeploymentList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionVersionsRequest
@@ -9957,6 +12215,27 @@ func (s *ListDeviceDefinitionVersionsInput) SetNextToken(v string) *ListDeviceDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionVersionsResponse
 type ListDeviceDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9986,6 +12265,22 @@ func (s *ListDeviceDefinitionVersionsOutput) SetNextToken(v string) *ListDeviceD
 func (s *ListDeviceDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListDeviceDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionsRequest
@@ -10019,6 +12314,22 @@ func (s *ListDeviceDefinitionsInput) SetNextToken(v string) *ListDeviceDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListDeviceDefinitionsResponse
 type ListDeviceDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10048,6 +12359,22 @@ func (s *ListDeviceDefinitionsOutput) SetDefinitions(v []*DefinitionInformation)
 func (s *ListDeviceDefinitionsOutput) SetNextToken(v string) *ListDeviceDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListDeviceDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionVersionsRequest
@@ -10103,6 +12430,27 @@ func (s *ListFunctionDefinitionVersionsInput) SetNextToken(v string) *ListFuncti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionVersionsResponse
 type ListFunctionDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10132,6 +12480,22 @@ func (s *ListFunctionDefinitionVersionsOutput) SetNextToken(v string) *ListFunct
 func (s *ListFunctionDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListFunctionDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionsRequest
@@ -10165,6 +12529,22 @@ func (s *ListFunctionDefinitionsInput) SetNextToken(v string) *ListFunctionDefin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListFunctionDefinitionsResponse
 type ListFunctionDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10194,6 +12574,22 @@ func (s *ListFunctionDefinitionsOutput) SetDefinitions(v []*DefinitionInformatio
 func (s *ListFunctionDefinitionsOutput) SetNextToken(v string) *ListFunctionDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupCertificateAuthoritiesRequest
@@ -10233,6 +12629,17 @@ func (s *ListGroupCertificateAuthoritiesInput) SetGroupId(v string) *ListGroupCe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupCertificateAuthoritiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupCertificateAuthoritiesResponse
 type ListGroupCertificateAuthoritiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10255,6 +12662,17 @@ func (s ListGroupCertificateAuthoritiesOutput) GoString() string {
 func (s *ListGroupCertificateAuthoritiesOutput) SetGroupCertificateAuthorities(v []*GroupCertificateAuthorityProperties) *ListGroupCertificateAuthoritiesOutput {
 	s.GroupCertificateAuthorities = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupCertificateAuthoritiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.GroupCertificateAuthorities) > 0 {
+		v := s.GroupCertificateAuthorities
+
+		e.SetList(protocol.BodyTarget, "GroupCertificateAuthorities", encodeGroupCertificateAuthorityPropertiesList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupVersionsRequest
@@ -10310,6 +12728,27 @@ func (s *ListGroupVersionsInput) SetNextToken(v string) *ListGroupVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupVersionsResponse
 type ListGroupVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10341,6 +12780,22 @@ func (s *ListGroupVersionsOutput) SetVersions(v []*VersionInformation) *ListGrou
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupsRequest
 type ListGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -10370,6 +12825,22 @@ func (s *ListGroupsInput) SetMaxResults(v string) *ListGroupsInput {
 func (s *ListGroupsInput) SetNextToken(v string) *ListGroupsInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListGroupsResponse
@@ -10404,6 +12875,22 @@ func (s *ListGroupsOutput) SetGroups(v []*GroupInformation) *ListGroupsOutput {
 func (s *ListGroupsOutput) SetNextToken(v string) *ListGroupsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Groups) > 0 {
+		v := s.Groups
+
+		e.SetList(protocol.BodyTarget, "Groups", encodeGroupInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionVersionsRequest
@@ -10459,6 +12946,27 @@ func (s *ListLoggerDefinitionVersionsInput) SetNextToken(v string) *ListLoggerDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionVersionsResponse
 type ListLoggerDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10488,6 +12996,22 @@ func (s *ListLoggerDefinitionVersionsOutput) SetNextToken(v string) *ListLoggerD
 func (s *ListLoggerDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListLoggerDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionsRequest
@@ -10521,6 +13045,22 @@ func (s *ListLoggerDefinitionsInput) SetNextToken(v string) *ListLoggerDefinitio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListLoggerDefinitionsResponse
 type ListLoggerDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10550,6 +13090,22 @@ func (s *ListLoggerDefinitionsOutput) SetDefinitions(v []*DefinitionInformation)
 func (s *ListLoggerDefinitionsOutput) SetNextToken(v string) *ListLoggerDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLoggerDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionVersionsRequest
@@ -10605,6 +13161,27 @@ func (s *ListSubscriptionDefinitionVersionsInput) SetSubscriptionDefinitionId(v 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionVersionsResponse
 type ListSubscriptionDefinitionVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10634,6 +13211,22 @@ func (s *ListSubscriptionDefinitionVersionsOutput) SetNextToken(v string) *ListS
 func (s *ListSubscriptionDefinitionVersionsOutput) SetVersions(v []*VersionInformation) *ListSubscriptionDefinitionVersionsOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionsRequest
@@ -10667,6 +13260,22 @@ func (s *ListSubscriptionDefinitionsInput) SetNextToken(v string) *ListSubscript
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ListSubscriptionDefinitionsResponse
 type ListSubscriptionDefinitionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10696,6 +13305,22 @@ func (s *ListSubscriptionDefinitionsOutput) SetDefinitions(v []*DefinitionInform
 func (s *ListSubscriptionDefinitionsOutput) SetNextToken(v string) *ListSubscriptionDefinitionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListSubscriptionDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Definitions) > 0 {
+		v := s.Definitions
+
+		e.SetList(protocol.BodyTarget, "Definitions", encodeDefinitionInformationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on the Logger
@@ -10760,6 +13385,45 @@ func (s *Logger) SetType(v string) *Logger {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Logger) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Component != nil {
+		v := *s.Component
+
+		e.SetValue(protocol.BodyTarget, "Component", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Level != nil {
+		v := *s.Level
+
+		e.SetValue(protocol.BodyTarget, "Level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Space != nil {
+		v := *s.Space
+
+		e.SetValue(protocol.BodyTarget, "Space", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLoggerList(vs []*Logger) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on logger definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/LoggerDefinitionVersion
 type LoggerDefinitionVersion struct {
@@ -10783,6 +13447,17 @@ func (s LoggerDefinitionVersion) GoString() string {
 func (s *LoggerDefinitionVersion) SetLoggers(v []*Logger) *LoggerDefinitionVersion {
 	s.Loggers = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggerDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Loggers) > 0 {
+		v := s.Loggers
+
+		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information needed to perform a reset of a group's deployments.
@@ -10840,6 +13515,27 @@ func (s *ResetDeploymentsInput) SetGroupId(v string) *ResetDeploymentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Force != nil {
+		v := *s.Force
+
+		e.SetValue(protocol.BodyTarget, "Force", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/ResetDeploymentsResponse
 type ResetDeploymentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10871,6 +13567,22 @@ func (s *ResetDeploymentsOutput) SetDeploymentArn(v string) *ResetDeploymentsOut
 func (s *ResetDeploymentsOutput) SetDeploymentId(v string) *ResetDeploymentsOutput {
 	s.DeploymentId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeploymentArn != nil {
+		v := *s.DeploymentArn
+
+		e.SetValue(protocol.BodyTarget, "DeploymentArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeploymentId != nil {
+		v := *s.DeploymentId
+
+		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on subscription
@@ -10925,6 +13637,40 @@ func (s *Subscription) SetTarget(v string) *Subscription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source != nil {
+		v := *s.Source
+
+		e.SetValue(protocol.BodyTarget, "Source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Subject != nil {
+		v := *s.Subject
+
+		e.SetValue(protocol.BodyTarget, "Subject", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Target != nil {
+		v := *s.Target
+
+		e.SetValue(protocol.BodyTarget, "Target", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSubscriptionList(vs []*Subscription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information on subscription definition version
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/SubscriptionDefinitionVersion
 type SubscriptionDefinitionVersion struct {
@@ -10948,6 +13694,17 @@ func (s SubscriptionDefinitionVersion) GoString() string {
 func (s *SubscriptionDefinitionVersion) SetSubscriptions(v []*Subscription) *SubscriptionDefinitionVersion {
 	s.Subscriptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SubscriptionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information on connectivity info
@@ -10997,6 +13754,22 @@ func (s *UpdateConnectivityInfoInput) SetThingName(v string) *UpdateConnectivity
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ConnectivityInfo) > 0 {
+		v := s.ConnectivityInfo
+
+		e.SetList(protocol.BodyTarget, "ConnectivityInfo", encodeConnectivityInfoList(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateConnectivityInfoResponse
 type UpdateConnectivityInfoOutput struct {
 	_ struct{} `type:"structure"`
@@ -11027,6 +13800,22 @@ func (s *UpdateConnectivityInfoOutput) SetMessage(v string) *UpdateConnectivityI
 func (s *UpdateConnectivityInfoOutput) SetVersion(v string) *UpdateConnectivityInfoOutput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateCoreDefinitionRequest
@@ -11074,6 +13863,22 @@ func (s *UpdateCoreDefinitionInput) SetName(v string) *UpdateCoreDefinitionInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
+
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateCoreDefinitionResponse
 type UpdateCoreDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11087,6 +13892,12 @@ func (s UpdateCoreDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCoreDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateDeviceDefinitionRequest
@@ -11134,6 +13945,22 @@ func (s *UpdateDeviceDefinitionInput) SetName(v string) *UpdateDeviceDefinitionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
+
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateDeviceDefinitionResponse
 type UpdateDeviceDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11147,6 +13974,12 @@ func (s UpdateDeviceDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDeviceDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateFunctionDefinitionRequest
@@ -11194,6 +14027,22 @@ func (s *UpdateFunctionDefinitionInput) SetName(v string) *UpdateFunctionDefinit
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateFunctionDefinitionResponse
 type UpdateFunctionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11207,6 +14056,12 @@ func (s UpdateFunctionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFunctionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupCertificateConfigurationRequest
@@ -11255,6 +14110,22 @@ func (s *UpdateGroupCertificateConfigurationInput) SetGroupId(v string) *UpdateG
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupCertificateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupCertificateConfigurationResponse
 type UpdateGroupCertificateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -11292,6 +14163,27 @@ func (s *UpdateGroupCertificateConfigurationOutput) SetCertificateExpiryInMillis
 func (s *UpdateGroupCertificateConfigurationOutput) SetGroupId(v string) *UpdateGroupCertificateConfigurationOutput {
 	s.GroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupCertificateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateAuthorityExpiryInMilliseconds != nil {
+		v := *s.CertificateAuthorityExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateAuthorityExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateExpiryInMilliseconds != nil {
+		v := *s.CertificateExpiryInMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "CertificateExpiryInMilliseconds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupRequest
@@ -11339,6 +14231,22 @@ func (s *UpdateGroupInput) SetName(v string) *UpdateGroupInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateGroupResponse
 type UpdateGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -11352,6 +14260,12 @@ func (s UpdateGroupOutput) String() string {
 // GoString returns the string representation
 func (s UpdateGroupOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateLoggerDefinitionRequest
@@ -11399,6 +14313,22 @@ func (s *UpdateLoggerDefinitionInput) SetName(v string) *UpdateLoggerDefinitionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
+
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateLoggerDefinitionResponse
 type UpdateLoggerDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11412,6 +14342,12 @@ func (s UpdateLoggerDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateLoggerDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateSubscriptionDefinitionRequest
@@ -11459,6 +14395,22 @@ func (s *UpdateSubscriptionDefinitionInput) SetSubscriptionDefinitionId(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/greengrass-2017-06-07/UpdateSubscriptionDefinitionResponse
 type UpdateSubscriptionDefinitionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11472,6 +14424,12 @@ func (s UpdateSubscriptionDefinitionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateSubscriptionDefinitionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information on the version
@@ -11524,6 +14482,40 @@ func (s *VersionInformation) SetId(v string) *VersionInformation {
 func (s *VersionInformation) SetVersion(v string) *VersionInformation {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VersionInformation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "Arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationTimestamp != nil {
+		v := *s.CreationTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreationTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVersionInformationList(vs []*VersionInformation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -5224,17 +5224,16 @@ func (s *AssociateRoleToGroupInput) SetRoleArn(v string) *AssociateRoleToGroupIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AssociateRoleToGroupInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.GroupId != nil {
-		v := *s.GroupId
-
-		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.RoleArn != nil {
 		v := *s.RoleArn
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.GroupId != nil {
+		v := *s.GroupId
 
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5269,7 +5268,6 @@ func (s *AssociateRoleToGroupOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5304,7 +5302,6 @@ func (s *AssociateServiceRoleToAccountInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5339,7 +5336,6 @@ func (s *AssociateServiceRoleToAccountOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "AssociatedAt", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5417,7 +5413,6 @@ func (s *ConnectivityInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PortNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5504,7 +5499,6 @@ func (s *Core) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5548,7 +5542,6 @@ func (s *CoreDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5594,11 +5587,6 @@ func (s *CreateCoreDefinitionInput) SetName(v string) *CreateCoreDefinitionInput
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -5609,7 +5597,11 @@ func (s *CreateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5721,7 +5713,6 @@ func (s *CreateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5780,6 +5771,11 @@ func (s *CreateCoreDefinitionVersionInput) SetCores(v []*Core) *CreateCoreDefini
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Cores) > 0 {
+		v := s.Cores
+
+		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
+	}
 	if s.AmznClientToken != nil {
 		v := *s.AmznClientToken
 
@@ -5790,12 +5786,6 @@ func (s *CreateCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Cores) > 0 {
-		v := s.Cores
-
-		e.SetList(protocol.BodyTarget, "Cores", encodeCoreList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -5868,7 +5858,6 @@ func (s *CreateCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5948,11 +5937,6 @@ func (s *CreateDeploymentInput) SetGroupVersionId(v string) *CreateDeploymentInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.DeploymentId != nil {
 		v := *s.DeploymentId
 
@@ -5963,17 +5947,21 @@ func (s *CreateDeploymentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DeploymentType", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.GroupId != nil {
-		v := *s.GroupId
-
-		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.GroupVersionId != nil {
 		v := *s.GroupVersionId
 
 		e.SetValue(protocol.BodyTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6022,7 +6010,6 @@ func (s *CreateDeploymentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6068,11 +6055,6 @@ func (s *CreateDeviceDefinitionInput) SetName(v string) *CreateDeviceDefinitionI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -6083,7 +6065,11 @@ func (s *CreateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6195,7 +6181,6 @@ func (s *CreateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6254,6 +6239,11 @@ func (s *CreateDeviceDefinitionVersionInput) SetDevices(v []*Device) *CreateDevi
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Devices) > 0 {
+		v := s.Devices
+
+		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
+	}
 	if s.AmznClientToken != nil {
 		v := *s.AmznClientToken
 
@@ -6264,12 +6254,6 @@ func (s *CreateDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Devices) > 0 {
-		v := s.Devices
-
-		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6342,7 +6326,6 @@ func (s *CreateDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6388,11 +6371,6 @@ func (s *CreateFunctionDefinitionInput) SetName(v string) *CreateFunctionDefinit
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -6403,7 +6381,11 @@ func (s *CreateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6515,7 +6497,6 @@ func (s *CreateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6574,6 +6555,11 @@ func (s *CreateFunctionDefinitionVersionInput) SetFunctions(v []*Function) *Crea
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
+	}
 	if s.AmznClientToken != nil {
 		v := *s.AmznClientToken
 
@@ -6584,12 +6570,6 @@ func (s *CreateFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Functions) > 0 {
-		v := s.Functions
-
-		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6662,7 +6642,6 @@ func (s *CreateFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6723,7 +6702,6 @@ func (s *CreateGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6758,7 +6736,6 @@ func (s *CreateGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6804,11 +6781,6 @@ func (s *CreateGroupInput) SetName(v string) *CreateGroupInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -6819,7 +6791,11 @@ func (s *CreateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6931,7 +6907,6 @@ func (s *CreateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7022,11 +6997,6 @@ func (s *CreateGroupVersionInput) SetSubscriptionDefinitionVersionArn(v string) 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.CoreDefinitionVersionArn != nil {
 		v := *s.CoreDefinitionVersionArn
 
@@ -7042,11 +7012,6 @@ func (s *CreateGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "FunctionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.GroupId != nil {
-		v := *s.GroupId
-
-		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.LoggerDefinitionVersionArn != nil {
 		v := *s.LoggerDefinitionVersionArn
 
@@ -7057,7 +7022,16 @@ func (s *CreateGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GroupId != nil {
+		v := *s.GroupId
+
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7130,7 +7104,6 @@ func (s *CreateGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7176,11 +7149,6 @@ func (s *CreateLoggerDefinitionInput) SetName(v string) *CreateLoggerDefinitionI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -7191,7 +7159,11 @@ func (s *CreateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7303,7 +7275,6 @@ func (s *CreateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7362,6 +7333,11 @@ func (s *CreateLoggerDefinitionVersionInput) SetLoggers(v []*Logger) *CreateLogg
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Loggers) > 0 {
+		v := s.Loggers
+
+		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
+	}
 	if s.AmznClientToken != nil {
 		v := *s.AmznClientToken
 
@@ -7372,12 +7348,6 @@ func (s *CreateLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Loggers) > 0 {
-		v := s.Loggers
-
-		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7450,7 +7420,6 @@ func (s *CreateLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7496,11 +7465,6 @@ func (s *CreateSubscriptionDefinitionInput) SetName(v string) *CreateSubscriptio
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InitialVersion != nil {
 		v := s.InitialVersion
 
@@ -7511,7 +7475,11 @@ func (s *CreateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
 
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7623,7 +7591,6 @@ func (s *CreateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7682,6 +7649,11 @@ func (s *CreateSubscriptionDefinitionVersionInput) SetSubscriptions(v []*Subscri
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
 	if s.AmznClientToken != nil {
 		v := *s.AmznClientToken
 
@@ -7692,12 +7664,6 @@ func (s *CreateSubscriptionDefinitionVersionInput) MarshalFields(e protocol.Fiel
 
 		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Subscriptions) > 0 {
-		v := s.Subscriptions
-
-		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7770,7 +7736,6 @@ func (s *CreateSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.Fie
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7890,7 +7855,6 @@ func (s *DefinitionInformation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7946,7 +7910,6 @@ func (s *DeleteCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7967,7 +7930,6 @@ func (s DeleteCoreDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8015,7 +7977,6 @@ func (s *DeleteDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8036,7 +7997,6 @@ func (s DeleteDeviceDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8084,7 +8044,6 @@ func (s *DeleteFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8105,7 +8064,6 @@ func (s DeleteFunctionDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8153,7 +8111,6 @@ func (s *DeleteGroupInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8174,7 +8131,6 @@ func (s DeleteGroupOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8222,7 +8178,6 @@ func (s *DeleteLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8243,7 +8198,6 @@ func (s DeleteLoggerDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8291,7 +8245,6 @@ func (s *DeleteSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8312,7 +8265,6 @@ func (s DeleteSubscriptionDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8404,7 +8356,6 @@ func (s *Deployment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "GroupArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8491,7 +8442,6 @@ func (s *Device) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ThingArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8535,7 +8485,6 @@ func (s *DeviceDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Devices", encodeDeviceList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8583,7 +8532,6 @@ func (s *DisassociateRoleFromGroupInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8618,7 +8566,6 @@ func (s *DisassociateRoleFromGroupOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8639,7 +8586,6 @@ func (s DisassociateServiceRoleFromAccountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DisassociateServiceRoleFromAccountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8674,7 +8620,6 @@ func (s *DisassociateServiceRoleFromAccountOutput) MarshalFields(e protocol.Fiel
 
 		e.SetValue(protocol.BodyTarget, "DisassociatedAt", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8724,7 +8669,6 @@ func (s *ErrorDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DetailedErrorMessage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8796,7 +8740,6 @@ func (s *Function) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8912,7 +8855,6 @@ func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8947,7 +8889,6 @@ func (s *FunctionConfigurationEnvironment) MarshalFields(e protocol.FieldEncoder
 
 		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8983,7 +8924,6 @@ func (s *FunctionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9031,7 +8971,6 @@ func (s *GetAssociatedRoleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9080,7 +9019,6 @@ func (s *GetAssociatedRoleOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9128,7 +9066,6 @@ func (s *GetConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9177,7 +9114,6 @@ func (s *GetConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9225,7 +9161,6 @@ func (s *GetCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9337,7 +9272,6 @@ func (s *GetCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9402,7 +9336,6 @@ func (s *GetCoreDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "CoreDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9493,7 +9426,6 @@ func (s *GetCoreDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9558,7 +9490,6 @@ func (s *GetDeploymentStatusInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9650,7 +9581,6 @@ func (s *GetDeploymentStatusOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "UpdatedAt", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9698,7 +9628,6 @@ func (s *GetDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9810,7 +9739,6 @@ func (s *GetDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9875,7 +9803,6 @@ func (s *GetDeviceDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "DeviceDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9966,7 +9893,6 @@ func (s *GetDeviceDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10014,7 +9940,6 @@ func (s *GetFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10126,7 +10051,6 @@ func (s *GetFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10191,7 +10115,6 @@ func (s *GetFunctionDefinitionVersionInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "FunctionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10283,7 +10206,6 @@ func (s *GetFunctionDefinitionVersionOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10348,7 +10270,6 @@ func (s *GetGroupCertificateAuthorityInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10412,7 +10333,6 @@ func (s *GetGroupCertificateAuthorityOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "PemEncodedCertificate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10460,7 +10380,6 @@ func (s *GetGroupCertificateConfigurationInput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10520,7 +10439,6 @@ func (s *GetGroupCertificateConfigurationOutput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10568,7 +10486,6 @@ func (s *GetGroupInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10680,7 +10597,6 @@ func (s *GetGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10745,7 +10661,6 @@ func (s *GetGroupVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "GroupVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10837,7 +10752,6 @@ func (s *GetGroupVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10885,7 +10799,6 @@ func (s *GetLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10997,7 +10910,6 @@ func (s *GetLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11062,7 +10974,6 @@ func (s *GetLoggerDefinitionVersionInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "LoggerDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11154,7 +11065,6 @@ func (s *GetLoggerDefinitionVersionOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11175,7 +11085,6 @@ func (s GetServiceRoleForAccountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetServiceRoleForAccountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11224,7 +11133,6 @@ func (s *GetServiceRoleForAccountOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11272,7 +11180,6 @@ func (s *GetSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11384,7 +11291,6 @@ func (s *GetSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11449,7 +11355,6 @@ func (s *GetSubscriptionDefinitionVersionInput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11541,7 +11446,6 @@ func (s *GetSubscriptionDefinitionVersionOutput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11591,7 +11495,6 @@ func (s *GroupCertificateAuthorityProperties) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "GroupCertificateAuthorityId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11719,7 +11622,6 @@ func (s *GroupInformation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11819,7 +11721,6 @@ func (s *GroupVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubscriptionDefinitionVersionArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11893,7 +11794,6 @@ func (s *ListCoreDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11940,7 +11840,6 @@ func (s *ListCoreDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11987,7 +11886,6 @@ func (s *ListCoreDefinitionsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12034,7 +11932,6 @@ func (s *ListCoreDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12108,7 +12005,6 @@ func (s *ListDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12158,7 +12054,6 @@ func (s *ListDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12232,7 +12127,6 @@ func (s *ListDeviceDefinitionVersionsInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12279,7 +12173,6 @@ func (s *ListDeviceDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12326,7 +12219,6 @@ func (s *ListDeviceDefinitionsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12373,7 +12265,6 @@ func (s *ListDeviceDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12447,7 +12338,6 @@ func (s *ListFunctionDefinitionVersionsInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12494,7 +12384,6 @@ func (s *ListFunctionDefinitionVersionsOutput) MarshalFields(e protocol.FieldEnc
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12541,7 +12430,6 @@ func (s *ListFunctionDefinitionsInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12588,7 +12476,6 @@ func (s *ListFunctionDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12636,7 +12523,6 @@ func (s *ListGroupCertificateAuthoritiesInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12671,7 +12557,6 @@ func (s *ListGroupCertificateAuthoritiesOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetList(protocol.BodyTarget, "GroupCertificateAuthorities", encodeGroupCertificateAuthorityPropertiesList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12745,7 +12630,6 @@ func (s *ListGroupVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12792,7 +12676,6 @@ func (s *ListGroupVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12839,7 +12722,6 @@ func (s *ListGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12889,7 +12771,6 @@ func (s *ListGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12963,7 +12844,6 @@ func (s *ListLoggerDefinitionVersionsInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13010,7 +12890,6 @@ func (s *ListLoggerDefinitionVersionsOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13057,7 +12936,6 @@ func (s *ListLoggerDefinitionsInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13104,7 +12982,6 @@ func (s *ListLoggerDefinitionsOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13163,6 +13040,11 @@ func (s *ListSubscriptionDefinitionVersionsInput) SetSubscriptionDefinitionId(v 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListSubscriptionDefinitionVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SubscriptionDefinitionId != nil {
+		v := *s.SubscriptionDefinitionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -13173,12 +13055,6 @@ func (s *ListSubscriptionDefinitionVersionsInput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.SubscriptionDefinitionId != nil {
-		v := *s.SubscriptionDefinitionId
-
-		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -13225,7 +13101,6 @@ func (s *ListSubscriptionDefinitionVersionsOutput) MarshalFields(e protocol.Fiel
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeVersionInformationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13272,7 +13147,6 @@ func (s *ListSubscriptionDefinitionsInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13319,7 +13193,6 @@ func (s *ListSubscriptionDefinitionsOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13412,7 +13285,6 @@ func (s *Logger) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13456,7 +13328,6 @@ func (s *LoggerDefinitionVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Loggers", encodeLoggerList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13517,22 +13388,21 @@ func (s *ResetDeploymentsInput) SetGroupId(v string) *ResetDeploymentsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ResetDeploymentsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AmznClientToken != nil {
-		v := *s.AmznClientToken
-
-		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Force != nil {
 		v := *s.Force
 
 		e.SetValue(protocol.BodyTarget, "Force", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.AmznClientToken != nil {
+		v := *s.AmznClientToken
+
+		e.SetValue(protocol.HeaderTarget, "X-Amzn-Client-Token", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.GroupId != nil {
 		v := *s.GroupId
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13581,7 +13451,6 @@ func (s *ResetDeploymentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DeploymentId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13659,7 +13528,6 @@ func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Target", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13703,7 +13571,6 @@ func (s *SubscriptionDefinitionVersion) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13766,7 +13633,6 @@ func (s *UpdateConnectivityInfoInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "ThingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13814,7 +13680,6 @@ func (s *UpdateConnectivityInfoOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13865,17 +13730,16 @@ func (s *UpdateCoreDefinitionInput) SetName(v string) *UpdateCoreDefinitionInput
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCoreDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CoreDefinitionId != nil {
-		v := *s.CoreDefinitionId
-
-		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CoreDefinitionId != nil {
+		v := *s.CoreDefinitionId
 
+		e.SetValue(protocol.PathTarget, "CoreDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -13896,7 +13760,6 @@ func (s UpdateCoreDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCoreDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13947,17 +13810,16 @@ func (s *UpdateDeviceDefinitionInput) SetName(v string) *UpdateDeviceDefinitionI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDeviceDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.DeviceDefinitionId != nil {
-		v := *s.DeviceDefinitionId
-
-		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.DeviceDefinitionId != nil {
+		v := *s.DeviceDefinitionId
 
+		e.SetValue(protocol.PathTarget, "DeviceDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -13978,7 +13840,6 @@ func (s UpdateDeviceDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDeviceDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14029,17 +13890,16 @@ func (s *UpdateFunctionDefinitionInput) SetName(v string) *UpdateFunctionDefinit
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateFunctionDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.FunctionDefinitionId != nil {
-		v := *s.FunctionDefinitionId
-
-		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.FunctionDefinitionId != nil {
+		v := *s.FunctionDefinitionId
 
+		e.SetValue(protocol.PathTarget, "FunctionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14060,7 +13920,6 @@ func (s UpdateFunctionDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateFunctionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14122,7 +13981,6 @@ func (s *UpdateGroupCertificateConfigurationInput) MarshalFields(e protocol.Fiel
 
 		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14182,7 +14040,6 @@ func (s *UpdateGroupCertificateConfigurationOutput) MarshalFields(e protocol.Fie
 
 		e.SetValue(protocol.BodyTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14233,17 +14090,16 @@ func (s *UpdateGroupInput) SetName(v string) *UpdateGroupInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateGroupInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.GroupId != nil {
-		v := *s.GroupId
-
-		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.GroupId != nil {
+		v := *s.GroupId
 
+		e.SetValue(protocol.PathTarget, "GroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14264,7 +14120,6 @@ func (s UpdateGroupOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14315,17 +14170,16 @@ func (s *UpdateLoggerDefinitionInput) SetName(v string) *UpdateLoggerDefinitionI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateLoggerDefinitionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.LoggerDefinitionId != nil {
-		v := *s.LoggerDefinitionId
-
-		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.LoggerDefinitionId != nil {
+		v := *s.LoggerDefinitionId
 
+		e.SetValue(protocol.PathTarget, "LoggerDefinitionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14346,7 +14200,6 @@ func (s UpdateLoggerDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateLoggerDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14407,7 +14260,6 @@ func (s *UpdateSubscriptionDefinitionInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "SubscriptionDefinitionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14428,7 +14280,6 @@ func (s UpdateSubscriptionDefinitionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateSubscriptionDefinitionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14506,7 +14357,6 @@ func (s *VersionInformation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -5410,6 +5410,22 @@ func (s *AcceptCertificateTransferInput) SetSetAsActive(v bool) *AcceptCertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AcceptCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AcceptCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5422,6 +5438,12 @@ func (s AcceptCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s AcceptCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AcceptCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the actions associated with a rule.
@@ -5633,6 +5655,85 @@ func (s *Action) SetSqs(v *SqsAction) *Action {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudwatchAlarm != nil {
+		v := s.CloudwatchAlarm
+
+		e.SetFields(protocol.BodyTarget, "cloudwatchAlarm", v, protocol.Metadata{})
+	}
+	if s.CloudwatchMetric != nil {
+		v := s.CloudwatchMetric
+
+		e.SetFields(protocol.BodyTarget, "cloudwatchMetric", v, protocol.Metadata{})
+	}
+	if s.DynamoDB != nil {
+		v := s.DynamoDB
+
+		e.SetFields(protocol.BodyTarget, "dynamoDB", v, protocol.Metadata{})
+	}
+	if s.DynamoDBv2 != nil {
+		v := s.DynamoDBv2
+
+		e.SetFields(protocol.BodyTarget, "dynamoDBv2", v, protocol.Metadata{})
+	}
+	if s.Elasticsearch != nil {
+		v := s.Elasticsearch
+
+		e.SetFields(protocol.BodyTarget, "elasticsearch", v, protocol.Metadata{})
+	}
+	if s.Firehose != nil {
+		v := s.Firehose
+
+		e.SetFields(protocol.BodyTarget, "firehose", v, protocol.Metadata{})
+	}
+	if s.Kinesis != nil {
+		v := s.Kinesis
+
+		e.SetFields(protocol.BodyTarget, "kinesis", v, protocol.Metadata{})
+	}
+	if s.Lambda != nil {
+		v := s.Lambda
+
+		e.SetFields(protocol.BodyTarget, "lambda", v, protocol.Metadata{})
+	}
+	if s.Republish != nil {
+		v := s.Republish
+
+		e.SetFields(protocol.BodyTarget, "republish", v, protocol.Metadata{})
+	}
+	if s.S3 != nil {
+		v := s.S3
+
+		e.SetFields(protocol.BodyTarget, "s3", v, protocol.Metadata{})
+	}
+	if s.Salesforce != nil {
+		v := s.Salesforce
+
+		e.SetFields(protocol.BodyTarget, "salesforce", v, protocol.Metadata{})
+	}
+	if s.Sns != nil {
+		v := s.Sns
+
+		e.SetFields(protocol.BodyTarget, "sns", v, protocol.Metadata{})
+	}
+	if s.Sqs != nil {
+		v := s.Sqs
+
+		e.SetFields(protocol.BodyTarget, "sqs", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActionList(vs []*Action) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The input for the AttachPrincipalPolicy operation.
 type AttachPrincipalPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -5690,6 +5791,22 @@ func (s *AttachPrincipalPolicyInput) SetPrincipal(v string) *AttachPrincipalPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type AttachPrincipalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -5702,6 +5819,12 @@ func (s AttachPrincipalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s AttachPrincipalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the AttachThingPrincipal operation.
@@ -5760,6 +5883,22 @@ func (s *AttachThingPrincipalInput) SetThingName(v string) *AttachThingPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the AttachThingPrincipal operation.
 type AttachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -5773,6 +5912,12 @@ func (s AttachThingPrincipalOutput) String() string {
 // GoString returns the string representation
 func (s AttachThingPrincipalOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The attribute payload.
@@ -5814,6 +5959,22 @@ func (s *AttributePayload) SetAttributes(v map[string]*string) *AttributePayload
 func (s *AttributePayload) SetMerge(v bool) *AttributePayload {
 	s.Merge = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributePayload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Merge != nil {
+		v := *s.Merge
+
+		e.SetValue(protocol.BodyTarget, "merge", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A CA certificate.
@@ -5867,6 +6028,40 @@ func (s *CACertificate) SetCreationDate(v time.Time) *CACertificate {
 func (s *CACertificate) SetStatus(v string) *CACertificate {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CACertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCACertificateList(vs []*CACertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a CA certificate.
@@ -5948,6 +6143,47 @@ func (s *CACertificateDescription) SetStatus(v string) *CACertificateDescription
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CACertificateDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AutoRegistrationStatus != nil {
+		v := *s.AutoRegistrationStatus
+
+		e.SetValue(protocol.BodyTarget, "autoRegistrationStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OwnedBy != nil {
+		v := *s.OwnedBy
+
+		e.SetValue(protocol.BodyTarget, "ownedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CancelCertificateTransfer operation.
 type CancelCertificateTransferInput struct {
 	_ struct{} `type:"structure"`
@@ -5990,6 +6226,17 @@ func (s *CancelCertificateTransferInput) SetCertificateId(v string) *CancelCerti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CancelCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -6002,6 +6249,12 @@ func (s CancelCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s CancelCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Information about a certificate.
@@ -6055,6 +6308,40 @@ func (s *Certificate) SetCreationDate(v time.Time) *Certificate {
 func (s *Certificate) SetStatus(v string) *Certificate {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Certificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCertificateList(vs []*Certificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a certificate.
@@ -6162,6 +6449,62 @@ func (s *CertificateDescription) SetTransferData(v *TransferData) *CertificateDe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CertificateDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaCertificateId != nil {
+		v := *s.CaCertificateId
+
+		e.SetValue(protocol.BodyTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "lastModifiedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OwnedBy != nil {
+		v := *s.OwnedBy
+
+		e.SetValue(protocol.BodyTarget, "ownedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PreviousOwnedBy != nil {
+		v := *s.PreviousOwnedBy
+
+		e.SetValue(protocol.BodyTarget, "previousOwnedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferData != nil {
+		v := s.TransferData
+
+		e.SetFields(protocol.BodyTarget, "transferData", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action that updates a CloudWatch alarm.
 type CloudwatchAlarmAction struct {
 	_ struct{} `type:"structure"`
@@ -6241,6 +6584,32 @@ func (s *CloudwatchAlarmAction) SetStateReason(v string) *CloudwatchAlarmAction 
 func (s *CloudwatchAlarmAction) SetStateValue(v string) *CloudwatchAlarmAction {
 	s.StateValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudwatchAlarmAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmName != nil {
+		v := *s.AlarmName
+
+		e.SetValue(protocol.BodyTarget, "alarmName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateReason != nil {
+		v := *s.StateReason
+
+		e.SetValue(protocol.BodyTarget, "stateReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateValue != nil {
+		v := *s.StateValue
+
+		e.SetValue(protocol.BodyTarget, "stateValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action that captures a CloudWatch metric.
@@ -6348,6 +6717,42 @@ func (s *CloudwatchMetricAction) SetRoleArn(v string) *CloudwatchMetricAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudwatchMetricAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MetricName != nil {
+		v := *s.MetricName
+
+		e.SetValue(protocol.BodyTarget, "metricName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricNamespace != nil {
+		v := *s.MetricNamespace
+
+		e.SetValue(protocol.BodyTarget, "metricNamespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricTimestamp != nil {
+		v := *s.MetricTimestamp
+
+		e.SetValue(protocol.BodyTarget, "metricTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricUnit != nil {
+		v := *s.MetricUnit
+
+		e.SetValue(protocol.BodyTarget, "metricUnit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricValue != nil {
+		v := *s.MetricValue
+
+		e.SetValue(protocol.BodyTarget, "metricValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrInput struct {
 	_ struct{} `type:"structure"`
@@ -6399,6 +6804,22 @@ func (s *CreateCertificateFromCsrInput) SetSetAsActive(v bool) *CreateCertificat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCertificateFromCsrInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateSigningRequest != nil {
+		v := *s.CertificateSigningRequest
+
+		e.SetValue(protocol.BodyTarget, "certificateSigningRequest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the CreateCertificateFromCsr operation.
 type CreateCertificateFromCsrOutput struct {
 	_ struct{} `type:"structure"`
@@ -6443,6 +6864,27 @@ func (s *CreateCertificateFromCsrOutput) SetCertificatePem(v string) *CreateCert
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCertificateFromCsrOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the CreateKeysAndCertificate operation.
 type CreateKeysAndCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -6465,6 +6907,17 @@ func (s CreateKeysAndCertificateInput) GoString() string {
 func (s *CreateKeysAndCertificateInput) SetSetAsActive(v bool) *CreateKeysAndCertificateInput {
 	s.SetAsActive = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateKeysAndCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output of the CreateKeysAndCertificate operation.
@@ -6517,6 +6970,32 @@ func (s *CreateKeysAndCertificateOutput) SetCertificatePem(v string) *CreateKeys
 func (s *CreateKeysAndCertificateOutput) SetKeyPair(v *KeyPair) *CreateKeysAndCertificateOutput {
 	s.KeyPair = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateKeysAndCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPair != nil {
+		v := s.KeyPair
+
+		e.SetFields(protocol.BodyTarget, "keyPair", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreatePolicy operation.
@@ -6576,6 +7055,22 @@ func (s *CreatePolicyInput) SetPolicyName(v string) *CreatePolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the CreatePolicy operation.
 type CreatePolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -6625,6 +7120,32 @@ func (s *CreatePolicyOutput) SetPolicyName(v string) *CreatePolicyOutput {
 func (s *CreatePolicyOutput) SetPolicyVersionId(v string) *CreatePolicyOutput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreatePolicyVersion operation.
@@ -6695,6 +7216,27 @@ func (s *CreatePolicyVersionInput) SetSetAsDefault(v bool) *CreatePolicyVersionI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsDefault != nil {
+		v := *s.SetAsDefault
+
+		e.SetValue(protocol.QueryTarget, "setAsDefault", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreatePolicyVersion operation.
 type CreatePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -6744,6 +7286,32 @@ func (s *CreatePolicyVersionOutput) SetPolicyDocument(v string) *CreatePolicyVer
 func (s *CreatePolicyVersionOutput) SetPolicyVersionId(v string) *CreatePolicyVersionOutput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateThing operation.
@@ -6812,6 +7380,27 @@ func (s *CreateThingInput) SetThingTypeName(v string) *CreateThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributePayload != nil {
+		v := s.AttributePayload
+
+		e.SetFields(protocol.BodyTarget, "attributePayload", v, protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreateThing operation.
 type CreateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -6843,6 +7432,22 @@ func (s *CreateThingOutput) SetThingArn(v string) *CreateThingOutput {
 func (s *CreateThingOutput) SetThingName(v string) *CreateThingOutput {
 	s.ThingName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingArn != nil {
+		v := *s.ThingArn
+
+		e.SetValue(protocol.BodyTarget, "thingArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateThingType operation.
@@ -6898,6 +7503,22 @@ func (s *CreateThingTypeInput) SetThingTypeProperties(v *ThingTypeProperties) *C
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the CreateThingType operation.
 type CreateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -6929,6 +7550,22 @@ func (s *CreateThingTypeOutput) SetThingTypeArn(v string) *CreateThingTypeOutput
 func (s *CreateThingTypeOutput) SetThingTypeName(v string) *CreateThingTypeOutput {
 	s.ThingTypeName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeArn != nil {
+		v := *s.ThingTypeArn
+
+		e.SetValue(protocol.BodyTarget, "thingTypeArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the CreateTopicRule operation.
@@ -6992,6 +7629,22 @@ func (s *CreateTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *CreateT
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicRulePayload != nil {
+		v := s.TopicRulePayload
+
+		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type CreateTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7004,6 +7657,12 @@ func (s CreateTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s CreateTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Input for the DeleteCACertificate operation.
@@ -7048,6 +7707,17 @@ func (s *DeleteCACertificateInput) SetCertificateId(v string) *DeleteCACertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeleteCACertificate operation.
 type DeleteCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7061,6 +7731,12 @@ func (s DeleteCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteCertificate operation.
@@ -7105,6 +7781,17 @@ func (s *DeleteCertificateInput) SetCertificateId(v string) *DeleteCertificateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7117,6 +7804,12 @@ func (s DeleteCertificateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeletePolicy operation.
@@ -7161,6 +7854,17 @@ func (s *DeletePolicyInput) SetPolicyName(v string) *DeletePolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeletePolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7173,6 +7877,12 @@ func (s DeletePolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeletePolicyVersion operation.
@@ -7231,6 +7941,22 @@ func (s *DeletePolicyVersionInput) SetPolicyVersionId(v string) *DeletePolicyVer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeletePolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7243,6 +7969,12 @@ func (s DeletePolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeletePolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteRegistrationCode operation.
@@ -7260,6 +7992,12 @@ func (s DeleteRegistrationCodeInput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // The output for the DeleteRegistrationCode operation.
 type DeleteRegistrationCodeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7273,6 +8011,12 @@ func (s DeleteRegistrationCodeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteRegistrationCodeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteThing operation.
@@ -7328,6 +8072,22 @@ func (s *DeleteThingInput) SetThingName(v string) *DeleteThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExpectedVersion != nil {
+		v := *s.ExpectedVersion
+
+		e.SetValue(protocol.QueryTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the DeleteThing operation.
 type DeleteThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -7341,6 +8101,12 @@ func (s DeleteThingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteThingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteThingType operation.
@@ -7385,6 +8151,17 @@ func (s *DeleteThingTypeInput) SetThingTypeName(v string) *DeleteThingTypeInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeleteThingType operation.
 type DeleteThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7398,6 +8175,12 @@ func (s DeleteThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeleteTopicRule operation.
@@ -7442,6 +8225,17 @@ func (s *DeleteTopicRuleInput) SetRuleName(v string) *DeleteTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DeleteTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7454,6 +8248,12 @@ func (s DeleteTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DeprecateThingType operation.
@@ -7508,6 +8308,22 @@ func (s *DeprecateThingTypeInput) SetUndoDeprecate(v bool) *DeprecateThingTypeIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeprecateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UndoDeprecate != nil {
+		v := *s.UndoDeprecate
+
+		e.SetValue(protocol.BodyTarget, "undoDeprecate", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the DeprecateThingType operation.
 type DeprecateThingTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -7521,6 +8337,12 @@ func (s DeprecateThingTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeprecateThingTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeprecateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DescribeCACertificate operation.
@@ -7565,6 +8387,17 @@ func (s *DescribeCACertificateInput) SetCertificateId(v string) *DescribeCACerti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DescribeCACertificate operation.
 type DescribeCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7587,6 +8420,17 @@ func (s DescribeCACertificateOutput) GoString() string {
 func (s *DescribeCACertificateOutput) SetCertificateDescription(v *CACertificateDescription) *DescribeCACertificateOutput {
 	s.CertificateDescription = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateDescription != nil {
+		v := s.CertificateDescription
+
+		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DescribeCertificate operation.
@@ -7631,6 +8475,17 @@ func (s *DescribeCertificateInput) SetCertificateId(v string) *DescribeCertifica
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the DescribeCertificate operation.
 type DescribeCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -7655,6 +8510,17 @@ func (s *DescribeCertificateOutput) SetCertificateDescription(v *CertificateDesc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateDescription != nil {
+		v := s.CertificateDescription
+
+		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the DescribeEndpoint operation.
 type DescribeEndpointInput struct {
 	_ struct{} `type:"structure"`
@@ -7668,6 +8534,12 @@ func (s DescribeEndpointInput) String() string {
 // GoString returns the string representation
 func (s DescribeEndpointInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the DescribeEndpoint operation.
@@ -7692,6 +8564,17 @@ func (s DescribeEndpointOutput) GoString() string {
 func (s *DescribeEndpointOutput) SetEndpointAddress(v string) *DescribeEndpointOutput {
 	s.EndpointAddress = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndpointAddress != nil {
+		v := *s.EndpointAddress
+
+		e.SetValue(protocol.BodyTarget, "endpointAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DescribeThing operation.
@@ -7734,6 +8617,17 @@ func (s *DescribeThingInput) Validate() error {
 func (s *DescribeThingInput) SetThingName(v string) *DescribeThingInput {
 	s.ThingName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the DescribeThing operation.
@@ -7800,6 +8694,37 @@ func (s *DescribeThingOutput) SetVersion(v int64) *DescribeThingOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.DefaultClientId != nil {
+		v := *s.DefaultClientId
+
+		e.SetValue(protocol.BodyTarget, "defaultClientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the DescribeThingType operation.
 type DescribeThingTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -7840,6 +8765,17 @@ func (s *DescribeThingTypeInput) Validate() error {
 func (s *DescribeThingTypeInput) SetThingTypeName(v string) *DescribeThingTypeInput {
 	s.ThingTypeName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output for the DescribeThingType operation.
@@ -7885,6 +8821,27 @@ func (s *DescribeThingTypeOutput) SetThingTypeName(v string) *DescribeThingTypeO
 func (s *DescribeThingTypeOutput) SetThingTypeProperties(v *ThingTypeProperties) *DescribeThingTypeOutput {
 	s.ThingTypeProperties = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeMetadata != nil {
+		v := s.ThingTypeMetadata
+
+		e.SetFields(protocol.BodyTarget, "thingTypeMetadata", v, protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the DetachPrincipalPolicy operation.
@@ -7946,6 +8903,22 @@ func (s *DetachPrincipalPolicyInput) SetPrincipal(v string) *DetachPrincipalPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DetachPrincipalPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -7958,6 +8931,12 @@ func (s DetachPrincipalPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DetachPrincipalPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DetachThingPrincipal operation.
@@ -8018,6 +8997,22 @@ func (s *DetachThingPrincipalInput) SetThingName(v string) *DetachThingPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DetachThingPrincipal operation.
 type DetachThingPrincipalOutput struct {
 	_ struct{} `type:"structure"`
@@ -8031,6 +9026,12 @@ func (s DetachThingPrincipalOutput) String() string {
 // GoString returns the string representation
 func (s DetachThingPrincipalOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DetachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the DisableTopicRuleRequest operation.
@@ -8075,6 +9076,17 @@ func (s *DisableTopicRuleInput) SetRuleName(v string) *DisableTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type DisableTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8087,6 +9099,12 @@ func (s DisableTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s DisableTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to write to a DynamoDB table.
@@ -8242,6 +9260,62 @@ func (s *DynamoDBAction) SetTableName(v string) *DynamoDBAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DynamoDBAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HashKeyField != nil {
+		v := *s.HashKeyField
+
+		e.SetValue(protocol.BodyTarget, "hashKeyField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HashKeyType != nil {
+		v := *s.HashKeyType
+
+		e.SetValue(protocol.BodyTarget, "hashKeyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HashKeyValue != nil {
+		v := *s.HashKeyValue
+
+		e.SetValue(protocol.BodyTarget, "hashKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Operation != nil {
+		v := *s.Operation
+
+		e.SetValue(protocol.BodyTarget, "operation", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PayloadField != nil {
+		v := *s.PayloadField
+
+		e.SetValue(protocol.BodyTarget, "payloadField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyField != nil {
+		v := *s.RangeKeyField
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyField", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyType != nil {
+		v := *s.RangeKeyType
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RangeKeyValue != nil {
+		v := *s.RangeKeyValue
+
+		e.SetValue(protocol.BodyTarget, "rangeKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TableName != nil {
+		v := *s.TableName
+
+		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to write to a DynamoDB table.
 //
 // This DynamoDB action writes each attribute in the message payload into it's
@@ -8298,6 +9372,22 @@ func (s *DynamoDBv2Action) SetPutItem(v *PutItemInput) *DynamoDBv2Action {
 func (s *DynamoDBv2Action) SetRoleArn(v string) *DynamoDBv2Action {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DynamoDBv2Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PutItem != nil {
+		v := s.PutItem
+
+		e.SetFields(protocol.BodyTarget, "putItem", v, protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action that writes data to an Amazon Elasticsearch Service domain.
@@ -8395,6 +9485,37 @@ func (s *ElasticsearchAction) SetType(v string) *ElasticsearchAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ElasticsearchAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Index != nil {
+		v := *s.Index
+
+		e.SetValue(protocol.BodyTarget, "index", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the EnableTopicRuleRequest operation.
 type EnableTopicRuleInput struct {
 	_ struct{} `type:"structure"`
@@ -8437,6 +9558,17 @@ func (s *EnableTopicRuleInput) SetRuleName(v string) *EnableTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type EnableTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -8449,6 +9581,12 @@ func (s EnableTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s EnableTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action that writes data to an Amazon Kinesis Firehose stream.
@@ -8515,6 +9653,27 @@ func (s *FirehoseAction) SetSeparator(v string) *FirehoseAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FirehoseAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeliveryStreamName != nil {
+		v := *s.DeliveryStreamName
+
+		e.SetValue(protocol.BodyTarget, "deliveryStreamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Separator != nil {
+		v := *s.Separator
+
+		e.SetValue(protocol.BodyTarget, "separator", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the GetLoggingOptions operation.
 type GetLoggingOptionsInput struct {
 	_ struct{} `type:"structure"`
@@ -8528,6 +9687,12 @@ func (s GetLoggingOptionsInput) String() string {
 // GoString returns the string representation
 func (s GetLoggingOptionsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the GetLoggingOptions operation.
@@ -8561,6 +9726,22 @@ func (s *GetLoggingOptionsOutput) SetLogLevel(v string) *GetLoggingOptionsOutput
 func (s *GetLoggingOptionsOutput) SetRoleArn(v string) *GetLoggingOptionsOutput {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LogLevel != nil {
+		v := *s.LogLevel
+
+		e.SetValue(protocol.BodyTarget, "logLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetPolicy operation.
@@ -8603,6 +9784,17 @@ func (s *GetPolicyInput) Validate() error {
 func (s *GetPolicyInput) SetPolicyName(v string) *GetPolicyInput {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the GetPolicy operation.
@@ -8654,6 +9846,32 @@ func (s *GetPolicyOutput) SetPolicyDocument(v string) *GetPolicyOutput {
 func (s *GetPolicyOutput) SetPolicyName(v string) *GetPolicyOutput {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultVersionId != nil {
+		v := *s.DefaultVersionId
+
+		e.SetValue(protocol.BodyTarget, "defaultVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetPolicyVersion operation.
@@ -8710,6 +9928,22 @@ func (s *GetPolicyVersionInput) SetPolicyName(v string) *GetPolicyVersionInput {
 func (s *GetPolicyVersionInput) SetPolicyVersionId(v string) *GetPolicyVersionInput {
 	s.PolicyVersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The output from the GetPolicyVersion operation.
@@ -8772,6 +10006,37 @@ func (s *GetPolicyVersionOutput) SetPolicyVersionId(v string) *GetPolicyVersionO
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyDocument != nil {
+		v := *s.PolicyDocument
+
+		e.SetValue(protocol.BodyTarget, "policyDocument", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input to the GetRegistrationCode operation.
 type GetRegistrationCodeInput struct {
 	_ struct{} `type:"structure"`
@@ -8785,6 +10050,12 @@ func (s GetRegistrationCodeInput) String() string {
 // GoString returns the string representation
 func (s GetRegistrationCodeInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The output from the GetRegistrationCode operation.
@@ -8809,6 +10080,17 @@ func (s GetRegistrationCodeOutput) GoString() string {
 func (s *GetRegistrationCodeOutput) SetRegistrationCode(v string) *GetRegistrationCodeOutput {
 	s.RegistrationCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RegistrationCode != nil {
+		v := *s.RegistrationCode
+
+		e.SetValue(protocol.BodyTarget, "registrationCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetTopicRule operation.
@@ -8853,6 +10135,17 @@ func (s *GetTopicRuleInput) SetRuleName(v string) *GetTopicRuleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the GetTopicRule operation.
 type GetTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
@@ -8886,6 +10179,22 @@ func (s *GetTopicRuleOutput) SetRuleArn(v string) *GetTopicRuleOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Rule != nil {
+		v := s.Rule
+
+		e.SetFields(protocol.BodyTarget, "rule", v, protocol.Metadata{})
+	}
+	if s.RuleArn != nil {
+		v := *s.RuleArn
+
+		e.SetValue(protocol.BodyTarget, "ruleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes a key pair.
 type KeyPair struct {
 	_ struct{} `type:"structure"`
@@ -8917,6 +10226,22 @@ func (s *KeyPair) SetPrivateKey(v string) *KeyPair {
 func (s *KeyPair) SetPublicKey(v string) *KeyPair {
 	s.PublicKey = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyPair) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PublicKey != nil {
+		v := *s.PublicKey
+
+		e.SetValue(protocol.BodyTarget, "PublicKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action to write data to an Amazon Kinesis stream.
@@ -8981,6 +10306,27 @@ func (s *KinesisAction) SetStreamName(v string) *KinesisAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KinesisAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PartitionKey != nil {
+		v := *s.PartitionKey
+
+		e.SetValue(protocol.BodyTarget, "partitionKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to invoke a Lambda function.
 type LambdaAction struct {
 	_ struct{} `type:"structure"`
@@ -9018,6 +10364,17 @@ func (s *LambdaAction) Validate() error {
 func (s *LambdaAction) SetFunctionArn(v string) *LambdaAction {
 	s.FunctionArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "functionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Input for the ListCACertificates operation.
@@ -9075,6 +10432,27 @@ func (s *ListCACertificatesInput) SetPageSize(v int64) *ListCACertificatesInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCACertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListCACertificates operation.
 type ListCACertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9106,6 +10484,22 @@ func (s *ListCACertificatesOutput) SetCertificates(v []*CACertificate) *ListCACe
 func (s *ListCACertificatesOutput) SetNextMarker(v string) *ListCACertificatesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCACertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCACertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the ListCertificatesByCA operation.
@@ -9182,6 +10576,32 @@ func (s *ListCertificatesByCAInput) SetPageSize(v int64) *ListCertificatesByCAIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesByCAInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CaCertificateId != nil {
+		v := *s.CaCertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the ListCertificatesByCA operation.
 type ListCertificatesByCAOutput struct {
 	_ struct{} `type:"structure"`
@@ -9214,6 +10634,22 @@ func (s *ListCertificatesByCAOutput) SetCertificates(v []*Certificate) *ListCert
 func (s *ListCertificatesByCAOutput) SetNextMarker(v string) *ListCertificatesByCAOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesByCAOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListCertificates operation.
@@ -9272,6 +10708,27 @@ func (s *ListCertificatesInput) SetPageSize(v int64) *ListCertificatesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output of the ListCertificates operation.
 type ListCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9304,6 +10761,22 @@ func (s *ListCertificatesOutput) SetCertificates(v []*Certificate) *ListCertific
 func (s *ListCertificatesOutput) SetNextMarker(v string) *ListCertificatesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Certificates) > 0 {
+		v := s.Certificates
+
+		e.SetList(protocol.BodyTarget, "certificates", encodeCertificateList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the ListOutgoingCertificates operation.
@@ -9362,6 +10835,27 @@ func (s *ListOutgoingCertificatesInput) SetPageSize(v int64) *ListOutgoingCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListOutgoingCertificates operation.
 type ListOutgoingCertificatesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9393,6 +10887,22 @@ func (s *ListOutgoingCertificatesOutput) SetNextMarker(v string) *ListOutgoingCe
 func (s *ListOutgoingCertificatesOutput) SetOutgoingCertificates(v []*OutgoingCertificate) *ListOutgoingCertificatesOutput {
 	s.OutgoingCertificates = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOutgoingCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutgoingCertificates) > 0 {
+		v := s.OutgoingCertificates
+
+		e.SetList(protocol.BodyTarget, "outgoingCertificates", encodeOutgoingCertificateList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicies operation.
@@ -9451,6 +10961,27 @@ func (s *ListPoliciesInput) SetPageSize(v int64) *ListPoliciesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicies operation.
 type ListPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9483,6 +11014,22 @@ func (s *ListPoliciesOutput) SetNextMarker(v string) *ListPoliciesOutput {
 func (s *ListPoliciesOutput) SetPolicies(v []*Policy) *ListPoliciesOutput {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicyPrincipals operation.
@@ -9558,6 +11105,32 @@ func (s *ListPolicyPrincipalsInput) SetPolicyName(v string) *ListPolicyPrincipal
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicyPrincipals operation.
 type ListPolicyPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9590,6 +11163,22 @@ func (s *ListPolicyPrincipalsOutput) SetNextMarker(v string) *ListPolicyPrincipa
 func (s *ListPolicyPrincipalsOutput) SetPrincipals(v []*string) *ListPolicyPrincipalsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPolicyVersions operation.
@@ -9634,6 +11223,17 @@ func (s *ListPolicyVersionsInput) SetPolicyName(v string) *ListPolicyVersionsInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPolicyVersions operation.
 type ListPolicyVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9656,6 +11256,17 @@ func (s ListPolicyVersionsOutput) GoString() string {
 func (s *ListPolicyVersionsOutput) SetPolicyVersions(v []*PolicyVersion) *ListPolicyVersionsOutput {
 	s.PolicyVersions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.PolicyVersions) > 0 {
+		v := s.PolicyVersions
+
+		e.SetList(protocol.BodyTarget, "policyVersions", encodePolicyVersionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPrincipalPolicies operation.
@@ -9728,6 +11339,32 @@ func (s *ListPrincipalPoliciesInput) SetPrincipal(v string) *ListPrincipalPolici
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPrincipalPolicies operation.
 type ListPrincipalPoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -9760,6 +11397,22 @@ func (s *ListPrincipalPoliciesOutput) SetNextMarker(v string) *ListPrincipalPoli
 func (s *ListPrincipalPoliciesOutput) SetPolicies(v []*Policy) *ListPrincipalPoliciesOutput {
 	s.Policies = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Policies) > 0 {
+		v := s.Policies
+
+		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListPrincipalThings operation.
@@ -9823,6 +11476,27 @@ func (s *ListPrincipalThingsInput) SetPrincipal(v string) *ListPrincipalThingsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalThingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListPrincipalThings operation.
 type ListPrincipalThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9855,6 +11529,22 @@ func (s *ListPrincipalThingsOutput) SetNextToken(v string) *ListPrincipalThingsO
 func (s *ListPrincipalThingsOutput) SetThings(v []*string) *ListPrincipalThingsOutput {
 	s.Things = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPrincipalThingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Things) > 0 {
+		v := s.Things
+
+		e.SetList(protocol.BodyTarget, "things", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThingPrincipal operation.
@@ -9899,6 +11589,17 @@ func (s *ListThingPrincipalsInput) SetThingName(v string) *ListThingPrincipalsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListThingPrincipals operation.
 type ListThingPrincipalsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9921,6 +11622,17 @@ func (s ListThingPrincipalsOutput) GoString() string {
 func (s *ListThingPrincipalsOutput) SetPrincipals(v []*string) *ListThingPrincipalsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThingTypes operation.
@@ -9982,6 +11694,27 @@ func (s *ListThingTypesInput) SetThingTypeName(v string) *ListThingTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output for the ListThingTypes operation.
 type ListThingTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10014,6 +11747,22 @@ func (s *ListThingTypesOutput) SetNextToken(v string) *ListThingTypesOutput {
 func (s *ListThingTypesOutput) SetThingTypes(v []*ThingTypeDefinition) *ListThingTypesOutput {
 	s.ThingTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ThingTypes) > 0 {
+		v := s.ThingTypes
+
+		e.SetList(protocol.BodyTarget, "thingTypes", encodeThingTypeDefinitionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListThings operation.
@@ -10093,6 +11842,37 @@ func (s *ListThingsInput) SetThingTypeName(v string) *ListThingsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeName != nil {
+		v := *s.AttributeName
+
+		e.SetValue(protocol.QueryTarget, "attributeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AttributeValue != nil {
+		v := *s.AttributeValue
+
+		e.SetValue(protocol.QueryTarget, "attributeValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListThings operation.
 type ListThingsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10125,6 +11905,22 @@ func (s *ListThingsOutput) SetNextToken(v string) *ListThingsOutput {
 func (s *ListThingsOutput) SetThings(v []*ThingAttribute) *ListThingsOutput {
 	s.Things = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListThingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Things) > 0 {
+		v := s.Things
+
+		e.SetList(protocol.BodyTarget, "things", encodeThingAttributeList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the ListTopicRules operation.
@@ -10191,6 +11987,32 @@ func (s *ListTopicRulesInput) SetTopic(v string) *ListTopicRulesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTopicRulesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.QueryTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.QueryTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the ListTopicRules operation.
 type ListTopicRulesOutput struct {
 	_ struct{} `type:"structure"`
@@ -10222,6 +12044,22 @@ func (s *ListTopicRulesOutput) SetNextToken(v string) *ListTopicRulesOutput {
 func (s *ListTopicRulesOutput) SetRules(v []*TopicRuleListItem) *ListTopicRulesOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTopicRulesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "rules", encodeTopicRuleListItemList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the logging options payload.
@@ -10270,6 +12108,22 @@ func (s *LoggingOptionsPayload) SetLogLevel(v string) *LoggingOptionsPayload {
 func (s *LoggingOptionsPayload) SetRoleArn(v string) *LoggingOptionsPayload {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingOptionsPayload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LogLevel != nil {
+		v := *s.LogLevel
+
+		e.SetValue(protocol.BodyTarget, "logLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A certificate that has been transfered but not yet accepted.
@@ -10341,6 +12195,50 @@ func (s *OutgoingCertificate) SetTransferredTo(v string) *OutgoingCertificate {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutgoingCertificate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferDate != nil {
+		v := *s.TransferDate
+
+		e.SetValue(protocol.BodyTarget, "transferDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferredTo != nil {
+		v := *s.TransferredTo
+
+		e.SetValue(protocol.BodyTarget, "transferredTo", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutgoingCertificateList(vs []*OutgoingCertificate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes an AWS IoT policy.
 type Policy struct {
 	_ struct{} `type:"structure"`
@@ -10372,6 +12270,30 @@ func (s *Policy) SetPolicyArn(v string) *Policy {
 func (s *Policy) SetPolicyName(v string) *Policy {
 	s.PolicyName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Policy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyArn != nil {
+		v := *s.PolicyArn
+
+		e.SetValue(protocol.BodyTarget, "policyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyList(vs []*Policy) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a policy version.
@@ -10416,6 +12338,35 @@ func (s *PolicyVersion) SetVersionId(v string) *PolicyVersion {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PolicyVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateDate != nil {
+		v := *s.CreateDate
+
+		e.SetValue(protocol.BodyTarget, "createDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.IsDefaultVersion != nil {
+		v := *s.IsDefaultVersion
+
+		e.SetValue(protocol.BodyTarget, "isDefaultVersion", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePolicyVersionList(vs []*PolicyVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The input for the DynamoActionVS action that specifies the DynamoDB table
 // to which the message data will be written.
 type PutItemInput struct {
@@ -10454,6 +12405,17 @@ func (s *PutItemInput) Validate() error {
 func (s *PutItemInput) SetTableName(v string) *PutItemInput {
 	s.TableName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutItemInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TableName != nil {
+		v := *s.TableName
+
+		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the RegisterCACertificate operation.
@@ -10533,6 +12495,32 @@ func (s *RegisterCACertificateInput) SetVerificationCertificate(v string) *Regis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AllowAutoRegistration != nil {
+		v := *s.AllowAutoRegistration
+
+		e.SetValue(protocol.QueryTarget, "allowAutoRegistration", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.CaCertificate != nil {
+		v := *s.CaCertificate
+
+		e.SetValue(protocol.BodyTarget, "caCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VerificationCertificate != nil {
+		v := *s.VerificationCertificate
+
+		e.SetValue(protocol.BodyTarget, "verificationCertificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the RegisterCACertificateResponse operation.
 type RegisterCACertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -10564,6 +12552,22 @@ func (s *RegisterCACertificateOutput) SetCertificateArn(v string) *RegisterCACer
 func (s *RegisterCACertificateOutput) SetCertificateId(v string) *RegisterCACertificateOutput {
 	s.CertificateId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the RegisterCertificate operation.
@@ -10638,6 +12642,32 @@ func (s *RegisterCertificateInput) SetStatus(v string) *RegisterCertificateInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaCertificatePem != nil {
+		v := *s.CaCertificatePem
+
+		e.SetValue(protocol.BodyTarget, "caCertificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificatePem != nil {
+		v := *s.CertificatePem
+
+		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the RegisterCertificate operation.
 type RegisterCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -10669,6 +12699,22 @@ func (s *RegisterCertificateOutput) SetCertificateArn(v string) *RegisterCertifi
 func (s *RegisterCertificateOutput) SetCertificateId(v string) *RegisterCertificateOutput {
 	s.CertificateId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RegisterCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateArn != nil {
+		v := *s.CertificateArn
+
+		e.SetValue(protocol.BodyTarget, "certificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the RejectCertificateTransfer operation.
@@ -10722,6 +12768,22 @@ func (s *RejectCertificateTransferInput) SetRejectReason(v string) *RejectCertif
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RejectCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectReason != nil {
+		v := *s.RejectReason
+
+		e.SetValue(protocol.BodyTarget, "rejectReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type RejectCertificateTransferOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10734,6 +12796,12 @@ func (s RejectCertificateTransferOutput) String() string {
 // GoString returns the string representation
 func (s RejectCertificateTransferOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RejectCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the ReplaceTopicRule operation.
@@ -10797,6 +12865,22 @@ func (s *ReplaceTopicRuleInput) SetTopicRulePayload(v *TopicRulePayload) *Replac
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplaceTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicRulePayload != nil {
+		v := s.TopicRulePayload
+
+		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type ReplaceTopicRuleOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -10809,6 +12893,12 @@ func (s ReplaceTopicRuleOutput) String() string {
 // GoString returns the string representation
 func (s ReplaceTopicRuleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplaceTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to republish to another topic.
@@ -10862,6 +12952,22 @@ func (s *RepublishAction) SetRoleArn(v string) *RepublishAction {
 func (s *RepublishAction) SetTopic(v string) *RepublishAction {
 	s.Topic = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RepublishAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.BodyTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes an action to write data to an Amazon S3 bucket.
@@ -10941,6 +13047,32 @@ func (s *S3Action) SetRoleArn(v string) *S3Action {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *S3Action) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BucketName != nil {
+		v := *s.BucketName
+
+		e.SetValue(protocol.BodyTarget, "bucketName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CannedAcl != nil {
+		v := *s.CannedAcl
+
+		e.SetValue(protocol.BodyTarget, "cannedAcl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to write a message to a Salesforce IoT Cloud Input Stream.
 type SalesforceAction struct {
 	_ struct{} `type:"structure"`
@@ -11000,6 +13132,22 @@ func (s *SalesforceAction) SetUrl(v string) *SalesforceAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SalesforceAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.BodyTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the SetDefaultPolicyVersion operation.
 type SetDefaultPolicyVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -11056,6 +13204,22 @@ func (s *SetDefaultPolicyVersionInput) SetPolicyVersionId(v string) *SetDefaultP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDefaultPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PolicyVersionId != nil {
+		v := *s.PolicyVersionId
+
+		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetDefaultPolicyVersionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11068,6 +13232,12 @@ func (s SetDefaultPolicyVersionOutput) String() string {
 // GoString returns the string representation
 func (s SetDefaultPolicyVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDefaultPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the SetLoggingOptions operation.
@@ -11114,6 +13284,17 @@ func (s *SetLoggingOptionsInput) SetLoggingOptionsPayload(v *LoggingOptionsPaylo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingOptionsPayload != nil {
+		v := s.LoggingOptionsPayload
+
+		e.SetFields(protocol.PayloadTarget, "loggingOptionsPayload", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type SetLoggingOptionsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11126,6 +13307,12 @@ func (s SetLoggingOptionsOutput) String() string {
 // GoString returns the string representation
 func (s SetLoggingOptionsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes an action to publish to an Amazon SNS topic.
@@ -11195,6 +13382,27 @@ func (s *SnsAction) SetTargetArn(v string) *SnsAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SnsAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageFormat != nil {
+		v := *s.MessageFormat
+
+		e.SetValue(protocol.BodyTarget, "messageFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetArn != nil {
+		v := *s.TargetArn
+
+		e.SetValue(protocol.BodyTarget, "targetArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes an action to publish data to an Amazon SQS queue.
 type SqsAction struct {
 	_ struct{} `type:"structure"`
@@ -11257,6 +13465,27 @@ func (s *SqsAction) SetUseBase64(v bool) *SqsAction {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SqsAction) MarshalFields(e protocol.FieldEncoder) error {
+	if s.QueueUrl != nil {
+		v := *s.QueueUrl
+
+		e.SetValue(protocol.BodyTarget, "queueUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UseBase64 != nil {
+		v := *s.UseBase64
+
+		e.SetValue(protocol.BodyTarget, "useBase64", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The properties of the thing, including thing name, thing type name, and a
 // list of thing attributes.
 type ThingAttribute struct {
@@ -11309,6 +13538,40 @@ func (s *ThingAttribute) SetVersion(v int64) *ThingAttribute {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingAttribute) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeThingAttributeList(vs []*ThingAttribute) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The definition of the thing type, including thing type name and description.
 type ThingTypeDefinition struct {
 	_ struct{} `type:"structure"`
@@ -11351,6 +13614,35 @@ func (s *ThingTypeDefinition) SetThingTypeName(v string) *ThingTypeDefinition {
 func (s *ThingTypeDefinition) SetThingTypeProperties(v *ThingTypeProperties) *ThingTypeDefinition {
 	s.ThingTypeProperties = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeDefinition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingTypeMetadata != nil {
+		v := s.ThingTypeMetadata
+
+		e.SetFields(protocol.BodyTarget, "thingTypeMetadata", v, protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeProperties != nil {
+		v := s.ThingTypeProperties
+
+		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeThingTypeDefinitionList(vs []*ThingTypeDefinition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // The ThingTypeMetadata contains additional information about the thing type
@@ -11398,6 +13690,27 @@ func (s *ThingTypeMetadata) SetDeprecationDate(v time.Time) *ThingTypeMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "creationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Deprecated != nil {
+		v := *s.Deprecated
+
+		e.SetValue(protocol.BodyTarget, "deprecated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DeprecationDate != nil {
+		v := *s.DeprecationDate
+
+		e.SetValue(protocol.BodyTarget, "deprecationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The ThingTypeProperties contains information about the thing type including:
 // a thing type description, and a list of searchable thing attribute names.
 type ThingTypeProperties struct {
@@ -11430,6 +13743,22 @@ func (s *ThingTypeProperties) SetSearchableAttributes(v []*string) *ThingTypePro
 func (s *ThingTypeProperties) SetThingTypeDescription(v string) *ThingTypeProperties {
 	s.ThingTypeDescription = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ThingTypeProperties) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SearchableAttributes) > 0 {
+		v := s.SearchableAttributes
+
+		e.SetList(protocol.BodyTarget, "searchableAttributes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ThingTypeDescription != nil {
+		v := *s.ThingTypeDescription
+
+		e.SetValue(protocol.BodyTarget, "thingTypeDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a rule.
@@ -11511,6 +13840,47 @@ func (s *TopicRule) SetSql(v string) *TopicRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Actions) > 0 {
+		v := s.Actions
+
+		e.SetList(protocol.BodyTarget, "actions", encodeActionList(v), protocol.Metadata{})
+	}
+	if s.AwsIotSqlVersion != nil {
+		v := *s.AwsIotSqlVersion
+
+		e.SetValue(protocol.BodyTarget, "awsIotSqlVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.BodyTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sql != nil {
+		v := *s.Sql
+
+		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes a rule.
 type TopicRuleListItem struct {
 	_ struct{} `type:"structure"`
@@ -11569,6 +13939,45 @@ func (s *TopicRuleListItem) SetRuleName(v string) *TopicRuleListItem {
 func (s *TopicRuleListItem) SetTopicPattern(v string) *TopicRuleListItem {
 	s.TopicPattern = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRuleListItem) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RuleArn != nil {
+		v := *s.RuleArn
+
+		e.SetValue(protocol.BodyTarget, "ruleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RuleName != nil {
+		v := *s.RuleName
+
+		e.SetValue(protocol.BodyTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicPattern != nil {
+		v := *s.TopicPattern
+
+		e.SetValue(protocol.BodyTarget, "topicPattern", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTopicRuleListItemList(vs []*TopicRuleListItem) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a rule.
@@ -11663,6 +14072,37 @@ func (s *TopicRulePayload) SetSql(v string) *TopicRulePayload {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicRulePayload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Actions) > 0 {
+		v := s.Actions
+
+		e.SetList(protocol.BodyTarget, "actions", encodeActionList(v), protocol.Metadata{})
+	}
+	if s.AwsIotSqlVersion != nil {
+		v := *s.AwsIotSqlVersion
+
+		e.SetValue(protocol.BodyTarget, "awsIotSqlVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RuleDisabled != nil {
+		v := *s.RuleDisabled
+
+		e.SetValue(protocol.BodyTarget, "ruleDisabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Sql != nil {
+		v := *s.Sql
+
+		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for the TransferCertificate operation.
 type TransferCertificateInput struct {
 	_ struct{} `type:"structure"`
@@ -11728,6 +14168,27 @@ func (s *TransferCertificateInput) SetTransferMessage(v string) *TransferCertifi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetAwsAccount != nil {
+		v := *s.TargetAwsAccount
+
+		e.SetValue(protocol.QueryTarget, "targetAwsAccount", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the TransferCertificate operation.
 type TransferCertificateOutput struct {
 	_ struct{} `type:"structure"`
@@ -11750,6 +14211,17 @@ func (s TransferCertificateOutput) GoString() string {
 func (s *TransferCertificateOutput) SetTransferredCertificateArn(v string) *TransferCertificateOutput {
 	s.TransferredCertificateArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TransferredCertificateArn != nil {
+		v := *s.TransferredCertificateArn
+
+		e.SetValue(protocol.BodyTarget, "transferredCertificateArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Data used to transfer a certificate to an AWS account.
@@ -11810,6 +14282,37 @@ func (s *TransferData) SetTransferDate(v time.Time) *TransferData {
 func (s *TransferData) SetTransferMessage(v string) *TransferData {
 	s.TransferMessage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TransferData) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptDate != nil {
+		v := *s.AcceptDate
+
+		e.SetValue(protocol.BodyTarget, "acceptDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RejectDate != nil {
+		v := *s.RejectDate
+
+		e.SetValue(protocol.BodyTarget, "rejectDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RejectReason != nil {
+		v := *s.RejectReason
+
+		e.SetValue(protocol.BodyTarget, "rejectReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransferDate != nil {
+		v := *s.TransferDate
+
+		e.SetValue(protocol.BodyTarget, "transferDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input to the UpdateCACertificate operation.
@@ -11876,6 +14379,27 @@ func (s *UpdateCACertificateInput) SetNewStatus(v string) *UpdateCACertificateIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewAutoRegistrationStatus != nil {
+		v := *s.NewAutoRegistrationStatus
+
+		e.SetValue(protocol.QueryTarget, "newAutoRegistrationStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewStatus != nil {
+		v := *s.NewStatus
+
+		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateCACertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11888,6 +14412,12 @@ func (s UpdateCACertificateOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCACertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateCertificate operation.
@@ -11953,6 +14483,22 @@ func (s *UpdateCertificateInput) SetNewStatus(v string) *UpdateCertificateInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CertificateId != nil {
+		v := *s.CertificateId
+
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NewStatus != nil {
+		v := *s.NewStatus
+
+		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type UpdateCertificateOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -11965,6 +14511,12 @@ func (s UpdateCertificateOutput) String() string {
 // GoString returns the string representation
 func (s UpdateCertificateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateThing operation.
@@ -12055,6 +14607,37 @@ func (s *UpdateThingInput) SetThingTypeName(v string) *UpdateThingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributePayload != nil {
+		v := s.AttributePayload
+
+		e.SetFields(protocol.BodyTarget, "attributePayload", v, protocol.Metadata{})
+	}
+	if s.ExpectedVersion != nil {
+		v := *s.ExpectedVersion
+
+		e.SetValue(protocol.BodyTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RemoveThingType != nil {
+		v := *s.RemoveThingType
+
+		e.SetValue(protocol.BodyTarget, "removeThingType", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
+
+		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the UpdateThing operation.
 type UpdateThingOutput struct {
 	_ struct{} `type:"structure"`
@@ -12068,6 +14651,12 @@ func (s UpdateThingOutput) String() string {
 // GoString returns the string representation
 func (s UpdateThingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 const (

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -5422,7 +5422,6 @@ func (s *AcceptCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5442,7 +5441,6 @@ func (s AcceptCertificateTransferOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AcceptCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5722,7 +5720,6 @@ func (s *Action) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "sqs", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5793,17 +5790,16 @@ func (s *AttachPrincipalPolicyInput) SetPrincipal(v string) *AttachPrincipalPoli
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.PolicyName != nil {
-		v := *s.PolicyName
-
-		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Principal != nil {
 		v := *s.Principal
 
 		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
 
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5823,7 +5819,6 @@ func (s AttachPrincipalPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5895,7 +5890,6 @@ func (s *AttachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5916,7 +5910,6 @@ func (s AttachThingPrincipalOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AttachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5973,7 +5966,6 @@ func (s *AttributePayload) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "merge", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6052,7 +6044,6 @@ func (s *CACertificate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6180,7 +6171,6 @@ func (s *CACertificateDescription) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6233,7 +6223,6 @@ func (s *CancelCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6253,7 +6242,6 @@ func (s CancelCertificateTransferOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CancelCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6332,7 +6320,6 @@ func (s *Certificate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6501,7 +6488,6 @@ func (s *CertificateDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "transferData", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6608,7 +6594,6 @@ func (s *CloudwatchAlarmAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stateValue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6749,7 +6734,6 @@ func (s *CloudwatchMetricAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6816,7 +6800,6 @@ func (s *CreateCertificateFromCsrInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6881,7 +6864,6 @@ func (s *CreateCertificateFromCsrOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6916,7 +6898,6 @@ func (s *CreateKeysAndCertificateInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6994,7 +6975,6 @@ func (s *CreateKeysAndCertificateOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "keyPair", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7067,7 +7047,6 @@ func (s *CreatePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7144,7 +7123,6 @@ func (s *CreatePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7233,7 +7211,6 @@ func (s *CreatePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "setAsDefault", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7310,7 +7287,6 @@ func (s *CreatePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7387,17 +7363,16 @@ func (s *CreateThingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "attributePayload", v, protocol.Metadata{})
 	}
-	if s.ThingName != nil {
-		v := *s.ThingName
-
-		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ThingTypeName != nil {
 		v := *s.ThingTypeName
 
 		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ThingName != nil {
+		v := *s.ThingName
 
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7446,7 +7421,6 @@ func (s *CreateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7505,17 +7479,16 @@ func (s *CreateThingTypeInput) SetThingTypeProperties(v *ThingTypeProperties) *C
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ThingTypeName != nil {
-		v := *s.ThingTypeName
-
-		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ThingTypeProperties != nil {
 		v := s.ThingTypeProperties
 
 		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
 	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
 
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7564,7 +7537,6 @@ func (s *CreateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7641,7 +7613,6 @@ func (s *CreateTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7661,7 +7632,6 @@ func (s CreateTopicRuleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7714,7 +7684,6 @@ func (s *DeleteCACertificateInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7735,7 +7704,6 @@ func (s DeleteCACertificateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7788,7 +7756,6 @@ func (s *DeleteCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7808,7 +7775,6 @@ func (s DeleteCertificateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7861,7 +7827,6 @@ func (s *DeletePolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7881,7 +7846,6 @@ func (s DeletePolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeletePolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7953,7 +7917,6 @@ func (s *DeletePolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7973,7 +7936,6 @@ func (s DeletePolicyVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeletePolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7994,7 +7956,6 @@ func (s DeleteRegistrationCodeInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8015,7 +7976,6 @@ func (s DeleteRegistrationCodeOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8074,17 +8034,16 @@ func (s *DeleteThingInput) SetThingName(v string) *DeleteThingInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteThingInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ExpectedVersion != nil {
-		v := *s.ExpectedVersion
-
-		e.SetValue(protocol.QueryTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.ThingName != nil {
 		v := *s.ThingName
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ExpectedVersion != nil {
+		v := *s.ExpectedVersion
 
+		e.SetValue(protocol.QueryTarget, "expectedVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8105,7 +8064,6 @@ func (s DeleteThingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteThingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8158,7 +8116,6 @@ func (s *DeleteThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8179,7 +8136,6 @@ func (s DeleteThingTypeOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8232,7 +8188,6 @@ func (s *DeleteTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8252,7 +8207,6 @@ func (s DeleteTopicRuleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8310,17 +8264,16 @@ func (s *DeprecateThingTypeInput) SetUndoDeprecate(v bool) *DeprecateThingTypeIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeprecateThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ThingTypeName != nil {
-		v := *s.ThingTypeName
-
-		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.UndoDeprecate != nil {
 		v := *s.UndoDeprecate
 
 		e.SetValue(protocol.BodyTarget, "undoDeprecate", protocol.BoolValue(v), protocol.Metadata{})
 	}
+	if s.ThingTypeName != nil {
+		v := *s.ThingTypeName
 
+		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8341,7 +8294,6 @@ func (s DeprecateThingTypeOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeprecateThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8394,7 +8346,6 @@ func (s *DescribeCACertificateInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8429,7 +8380,6 @@ func (s *DescribeCACertificateOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8482,7 +8432,6 @@ func (s *DescribeCertificateInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8517,7 +8466,6 @@ func (s *DescribeCertificateOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "certificateDescription", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8538,7 +8486,6 @@ func (s DescribeEndpointInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DescribeEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8573,7 +8520,6 @@ func (s *DescribeEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "endpointAddress", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8626,7 +8572,6 @@ func (s *DescribeThingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8721,7 +8666,6 @@ func (s *DescribeThingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8774,7 +8718,6 @@ func (s *DescribeThingTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8840,7 +8783,6 @@ func (s *DescribeThingTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8905,17 +8847,16 @@ func (s *DetachPrincipalPolicyInput) SetPrincipal(v string) *DetachPrincipalPoli
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachPrincipalPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.PolicyName != nil {
-		v := *s.PolicyName
-
-		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Principal != nil {
 		v := *s.Principal
 
 		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.PolicyName != nil {
+		v := *s.PolicyName
 
+		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8935,7 +8876,6 @@ func (s DetachPrincipalPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachPrincipalPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9009,7 +8949,6 @@ func (s *DetachThingPrincipalInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9030,7 +8969,6 @@ func (s DetachThingPrincipalOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DetachThingPrincipalOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9083,7 +9021,6 @@ func (s *DisableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9103,7 +9040,6 @@ func (s DisableTopicRuleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DisableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9312,7 +9248,6 @@ func (s *DynamoDBAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9386,7 +9321,6 @@ func (s *DynamoDBv2Action) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9512,7 +9446,6 @@ func (s *ElasticsearchAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9565,7 +9498,6 @@ func (s *EnableTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9585,7 +9517,6 @@ func (s EnableTopicRuleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *EnableTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9670,7 +9601,6 @@ func (s *FirehoseAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "separator", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9691,7 +9621,6 @@ func (s GetLoggingOptionsInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9740,7 +9669,6 @@ func (s *GetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9793,7 +9721,6 @@ func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9870,7 +9797,6 @@ func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9942,7 +9868,6 @@ func (s *GetPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10033,7 +9958,6 @@ func (s *GetPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10054,7 +9978,6 @@ func (s GetRegistrationCodeInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetRegistrationCodeInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10089,7 +10012,6 @@ func (s *GetRegistrationCodeOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "registrationCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10142,7 +10064,6 @@ func (s *GetTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "ruleName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10191,7 +10112,6 @@ func (s *GetTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ruleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10240,7 +10160,6 @@ func (s *KeyPair) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PublicKey", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10323,7 +10242,6 @@ func (s *KinesisAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10373,7 +10291,6 @@ func (s *LambdaAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "functionArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10449,7 +10366,6 @@ func (s *ListCACertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10498,7 +10414,6 @@ func (s *ListCACertificatesOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10578,15 +10493,15 @@ func (s *ListCertificatesByCAInput) SetPageSize(v int64) *ListCertificatesByCAIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListCertificatesByCAInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AscendingOrder != nil {
-		v := *s.AscendingOrder
-
-		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
-	}
 	if s.CaCertificateId != nil {
 		v := *s.CaCertificateId
 
 		e.SetValue(protocol.PathTarget, "caCertificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AscendingOrder != nil {
+		v := *s.AscendingOrder
+
+		e.SetValue(protocol.QueryTarget, "isAscendingOrder", protocol.BoolValue(v), protocol.Metadata{})
 	}
 	if s.Marker != nil {
 		v := *s.Marker
@@ -10598,7 +10513,6 @@ func (s *ListCertificatesByCAInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10648,7 +10562,6 @@ func (s *ListCertificatesByCAOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10725,7 +10638,6 @@ func (s *ListCertificatesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10775,7 +10687,6 @@ func (s *ListCertificatesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10852,7 +10763,6 @@ func (s *ListOutgoingCertificatesInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10901,7 +10811,6 @@ func (s *ListOutgoingCertificatesOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetList(protocol.BodyTarget, "outgoingCertificates", encodeOutgoingCertificateList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10978,7 +10887,6 @@ func (s *ListPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11028,7 +10936,6 @@ func (s *ListPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11107,6 +11014,11 @@ func (s *ListPolicyPrincipalsInput) SetPolicyName(v string) *ListPolicyPrincipal
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPolicyPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PolicyName != nil {
+		v := *s.PolicyName
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-policy", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.AscendingOrder != nil {
 		v := *s.AscendingOrder
 
@@ -11122,12 +11034,6 @@ func (s *ListPolicyPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	if s.PolicyName != nil {
-		v := *s.PolicyName
-
-		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-policy", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -11177,7 +11083,6 @@ func (s *ListPolicyPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11230,7 +11135,6 @@ func (s *ListPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11265,7 +11169,6 @@ func (s *ListPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "policyVersions", encodePolicyVersionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11341,6 +11244,11 @@ func (s *ListPrincipalPoliciesInput) SetPrincipal(v string) *ListPrincipalPolici
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPrincipalPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.AscendingOrder != nil {
 		v := *s.AscendingOrder
 
@@ -11356,12 +11264,6 @@ func (s *ListPrincipalPoliciesInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "pageSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	if s.Principal != nil {
-		v := *s.Principal
-
-		e.SetValue(protocol.HeaderTarget, "x-amzn-iot-principal", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -11411,7 +11313,6 @@ func (s *ListPrincipalPoliciesOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "policies", encodePolicyList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11478,6 +11379,11 @@ func (s *ListPrincipalThingsInput) SetPrincipal(v string) *ListPrincipalThingsIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPrincipalThingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.MaxResults != nil {
 		v := *s.MaxResults
 
@@ -11488,12 +11394,6 @@ func (s *ListPrincipalThingsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Principal != nil {
-		v := *s.Principal
-
-		e.SetValue(protocol.HeaderTarget, "x-amzn-principal", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -11543,7 +11443,6 @@ func (s *ListPrincipalThingsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "things", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11596,7 +11495,6 @@ func (s *ListThingPrincipalsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11631,7 +11529,6 @@ func (s *ListThingPrincipalsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "principals", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11711,7 +11608,6 @@ func (s *ListThingTypesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11761,7 +11657,6 @@ func (s *ListThingTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "thingTypes", encodeThingTypeDefinitionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11869,7 +11764,6 @@ func (s *ListThingsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11919,7 +11813,6 @@ func (s *ListThingsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "things", encodeThingAttributeList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12009,7 +11902,6 @@ func (s *ListTopicRulesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12058,7 +11950,6 @@ func (s *ListTopicRulesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "rules", encodeTopicRuleListItemList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12122,7 +12013,6 @@ func (s *LoggingOptionsPayload) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12227,7 +12117,6 @@ func (s *OutgoingCertificate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "transferredTo", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12284,7 +12173,6 @@ func (s *Policy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "policyName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12355,7 +12243,6 @@ func (s *PolicyVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12414,7 +12301,6 @@ func (s *PutItemInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "tableName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12497,27 +12383,26 @@ func (s *RegisterCACertificateInput) SetVerificationCertificate(v string) *Regis
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RegisterCACertificateInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AllowAutoRegistration != nil {
-		v := *s.AllowAutoRegistration
-
-		e.SetValue(protocol.QueryTarget, "allowAutoRegistration", protocol.BoolValue(v), protocol.Metadata{})
-	}
 	if s.CaCertificate != nil {
 		v := *s.CaCertificate
 
 		e.SetValue(protocol.BodyTarget, "caCertificate", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SetAsActive != nil {
-		v := *s.SetAsActive
-
-		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
 	}
 	if s.VerificationCertificate != nil {
 		v := *s.VerificationCertificate
 
 		e.SetValue(protocol.BodyTarget, "verificationCertificate", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AllowAutoRegistration != nil {
+		v := *s.AllowAutoRegistration
 
+		e.SetValue(protocol.QueryTarget, "allowAutoRegistration", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
+
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12566,7 +12451,6 @@ func (s *RegisterCACertificateOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12654,17 +12538,16 @@ func (s *RegisterCertificateInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "certificatePem", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.SetAsActive != nil {
-		v := *s.SetAsActive
-
-		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
-	}
 	if s.Status != nil {
 		v := *s.Status
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.SetAsActive != nil {
+		v := *s.SetAsActive
 
+		e.SetValue(protocol.QueryTarget, "setAsActive", protocol.BoolValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12713,7 +12596,6 @@ func (s *RegisterCertificateOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12770,17 +12652,16 @@ func (s *RejectCertificateTransferInput) SetRejectReason(v string) *RejectCertif
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RejectCertificateTransferInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CertificateId != nil {
-		v := *s.CertificateId
-
-		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.RejectReason != nil {
 		v := *s.RejectReason
 
 		e.SetValue(protocol.BodyTarget, "rejectReason", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CertificateId != nil {
+		v := *s.CertificateId
 
+		e.SetValue(protocol.PathTarget, "certificateId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -12800,7 +12681,6 @@ func (s RejectCertificateTransferOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RejectCertificateTransferOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12877,7 +12757,6 @@ func (s *ReplaceTopicRuleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "topicRulePayload", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12897,7 +12776,6 @@ func (s ReplaceTopicRuleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ReplaceTopicRuleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12966,7 +12844,6 @@ func (s *RepublishAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13069,7 +12946,6 @@ func (s *S3Action) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13144,7 +13020,6 @@ func (s *SalesforceAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13216,7 +13091,6 @@ func (s *SetDefaultPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "policyVersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13236,7 +13110,6 @@ func (s SetDefaultPolicyVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetDefaultPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13291,7 +13164,6 @@ func (s *SetLoggingOptionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "loggingOptionsPayload", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13311,7 +13183,6 @@ func (s SetLoggingOptionsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SetLoggingOptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -13399,7 +13270,6 @@ func (s *SnsAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "targetArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13482,7 +13352,6 @@ func (s *SqsAction) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "useBase64", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13560,7 +13429,6 @@ func (s *ThingAttribute) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13633,7 +13501,6 @@ func (s *ThingTypeDefinition) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "thingTypeProperties", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13707,7 +13574,6 @@ func (s *ThingTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "deprecationDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13757,7 +13623,6 @@ func (s *ThingTypeProperties) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "thingTypeDescription", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13877,7 +13742,6 @@ func (s *TopicRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13968,7 +13832,6 @@ func (s *TopicRuleListItem) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "topicPattern", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14099,7 +13962,6 @@ func (s *TopicRulePayload) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sql", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14170,6 +14032,11 @@ func (s *TransferCertificateInput) SetTransferMessage(v string) *TransferCertifi
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TransferCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TransferMessage != nil {
+		v := *s.TransferMessage
+
+		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.CertificateId != nil {
 		v := *s.CertificateId
 
@@ -14180,12 +14047,6 @@ func (s *TransferCertificateInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "targetAwsAccount", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.TransferMessage != nil {
-		v := *s.TransferMessage
-
-		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -14220,7 +14081,6 @@ func (s *TransferCertificateOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "transferredCertificateArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14311,7 +14171,6 @@ func (s *TransferData) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "transferMessage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14396,7 +14255,6 @@ func (s *UpdateCACertificateInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14416,7 +14274,6 @@ func (s UpdateCACertificateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCACertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14495,7 +14352,6 @@ func (s *UpdateCertificateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "newStatus", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14515,7 +14371,6 @@ func (s UpdateCertificateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateCertificateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14624,17 +14479,16 @@ func (s *UpdateThingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "removeThingType", protocol.BoolValue(v), protocol.Metadata{})
 	}
-	if s.ThingName != nil {
-		v := *s.ThingName
-
-		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ThingTypeName != nil {
 		v := *s.ThingTypeName
 
 		e.SetValue(protocol.BodyTarget, "thingTypeName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ThingName != nil {
+		v := *s.ThingName
 
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14655,7 +14509,6 @@ func (s UpdateThingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateThingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -445,6 +445,17 @@ func (s *DeleteThingShadowInput) SetThingName(v string) *DeleteThingShadowInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the DeleteThingShadow operation.
 type DeleteThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -469,6 +480,17 @@ func (s DeleteThingShadowOutput) GoString() string {
 func (s *DeleteThingShadowOutput) SetPayload(v []byte) *DeleteThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the GetThingShadow operation.
@@ -513,6 +535,17 @@ func (s *GetThingShadowInput) SetThingName(v string) *GetThingShadowInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the GetThingShadow operation.
 type GetThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -535,6 +568,17 @@ func (s GetThingShadowOutput) GoString() string {
 func (s *GetThingShadowOutput) SetPayload(v []byte) *GetThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The input for the Publish operation.
@@ -594,6 +638,27 @@ func (s *PublishInput) SetTopic(v string) *PublishInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Qos != nil {
+		v := *s.Qos
+
+		e.SetValue(protocol.QueryTarget, "qos", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.PathTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PublishOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -606,6 +671,12 @@ func (s PublishOutput) String() string {
 // GoString returns the string representation
 func (s PublishOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The input for the UpdateThingShadow operation.
@@ -664,6 +735,22 @@ func (s *UpdateThingShadowInput) SetThingName(v string) *UpdateThingShadowInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ThingName != nil {
+		v := *s.ThingName
+
+		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The output from the UpdateThingShadow operation.
 type UpdateThingShadowOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
@@ -686,4 +773,15 @@ func (s UpdateThingShadowOutput) GoString() string {
 func (s *UpdateThingShadowOutput) SetPayload(v []byte) *UpdateThingShadowOutput {
 	s.Payload = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -452,7 +452,6 @@ func (s *DeleteThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -489,7 +488,6 @@ func (s *DeleteThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -542,7 +540,6 @@ func (s *GetThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -577,7 +574,6 @@ func (s *GetThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -640,6 +636,11 @@ func (s *PublishInput) SetTopic(v string) *PublishInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PublishInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.PathTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Payload != nil {
 		v := s.Payload
 
@@ -650,12 +651,6 @@ func (s *PublishInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "qos", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	if s.Topic != nil {
-		v := *s.Topic
-
-		e.SetValue(protocol.PathTarget, "topic", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -675,7 +670,6 @@ func (s PublishOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PublishOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -737,17 +731,16 @@ func (s *UpdateThingShadowInput) SetThingName(v string) *UpdateThingShadowInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateThingShadowInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Payload != nil {
-		v := s.Payload
-
-		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
-	}
 	if s.ThingName != nil {
 		v := *s.ThingName
 
 		e.SetValue(protocol.PathTarget, "thingName", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Payload != nil {
+		v := s.Payload
 
+		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -782,6 +775,5 @@ func (s *UpdateThingShadowOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "payload", protocol.BytesStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -3058,6 +3058,32 @@ func (s *AccountLimit) SetTotalCodeSize(v int64) *AccountLimit {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccountLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSizeUnzipped != nil {
+		v := *s.CodeSizeUnzipped
+
+		e.SetValue(protocol.BodyTarget, "CodeSizeUnzipped", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodeSizeZipped != nil {
+		v := *s.CodeSizeZipped
+
+		e.SetValue(protocol.BodyTarget, "CodeSizeZipped", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ConcurrentExecutions != nil {
+		v := *s.ConcurrentExecutions
+
+		e.SetValue(protocol.BodyTarget, "ConcurrentExecutions", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCodeSize != nil {
+		v := *s.TotalCodeSize
+
+		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides code size usage and function count associated with the current account
 // and region.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AccountUsage
@@ -3091,6 +3117,22 @@ func (s *AccountUsage) SetFunctionCount(v int64) *AccountUsage {
 func (s *AccountUsage) SetTotalCodeSize(v int64) *AccountUsage {
 	s.TotalCodeSize = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccountUsage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionCount != nil {
+		v := *s.FunctionCount
+
+		e.SetValue(protocol.BodyTarget, "FunctionCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCodeSize != nil {
+		v := *s.TotalCodeSize
+
+		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AddPermissionRequest
@@ -3264,6 +3306,52 @@ func (s *AddPermissionInput) SetStatementId(v string) *AddPermissionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddPermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EventSourceToken != nil {
+		v := *s.EventSourceToken
+
+		e.SetValue(protocol.BodyTarget, "EventSourceToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Principal != nil {
+		v := *s.Principal
+
+		e.SetValue(protocol.BodyTarget, "Principal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceAccount != nil {
+		v := *s.SourceAccount
+
+		e.SetValue(protocol.BodyTarget, "SourceAccount", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceArn != nil {
+		v := *s.SourceArn
+
+		e.SetValue(protocol.BodyTarget, "SourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatementId != nil {
+		v := *s.StatementId
+
+		e.SetValue(protocol.BodyTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/AddPermissionResponse
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -3288,6 +3376,17 @@ func (s AddPermissionOutput) GoString() string {
 func (s *AddPermissionOutput) SetStatement(v string) *AddPermissionOutput {
 	s.Statement = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddPermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Statement != nil {
+		v := *s.Statement
+
+		e.SetValue(protocol.BodyTarget, "Statement", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides configuration information about a Lambda function version alias.
@@ -3342,6 +3441,40 @@ func (s *AliasConfiguration) SetFunctionVersion(v string) *AliasConfiguration {
 func (s *AliasConfiguration) SetName(v string) *AliasConfiguration {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AliasConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AliasArn != nil {
+		v := *s.AliasArn
+
+		e.SetValue(protocol.BodyTarget, "AliasArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAliasConfigurationList(vs []*AliasConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateAliasRequest
@@ -3429,6 +3562,32 @@ func (s *CreateAliasInput) SetFunctionVersion(v string) *CreateAliasInput {
 func (s *CreateAliasInput) SetName(v string) *CreateAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateEventSourceMappingRequest
@@ -3557,6 +3716,42 @@ func (s *CreateEventSourceMappingInput) SetStartingPosition(v string) *CreateEve
 func (s *CreateEventSourceMappingInput) SetStartingPositionTimestamp(v time.Time) *CreateEventSourceMappingInput {
 	s.StartingPositionTimestamp = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.BodyTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartingPosition != nil {
+		v := *s.StartingPosition
+
+		e.SetValue(protocol.BodyTarget, "StartingPosition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartingPositionTimestamp != nil {
+		v := *s.StartingPositionTimestamp
+
+		e.SetValue(protocol.BodyTarget, "StartingPositionTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateFunctionRequest
@@ -3795,6 +3990,87 @@ func (s *CreateFunctionInput) SetVpcConfig(v *VpcConfig) *CreateFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := s.Code
+
+		e.SetFields(protocol.BodyTarget, "Code", v, protocol.Metadata{})
+	}
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Publish != nil {
+		v := *s.Publish
+
+		e.SetValue(protocol.BodyTarget, "Publish", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The parent object that contains the target ARN (Amazon Resource Name) of
 // an Amazon SQS queue or Amazon SNS topic.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeadLetterConfig
@@ -3820,6 +4096,17 @@ func (s DeadLetterConfig) GoString() string {
 func (s *DeadLetterConfig) SetTargetArn(v string) *DeadLetterConfig {
 	s.TargetArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeadLetterConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetArn != nil {
+		v := *s.TargetArn
+
+		e.SetValue(protocol.BodyTarget, "TargetArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteAliasRequest
@@ -3884,6 +4171,22 @@ func (s *DeleteAliasInput) SetName(v string) *DeleteAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteAliasOutput
 type DeleteAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -3897,6 +4200,12 @@ func (s DeleteAliasOutput) String() string {
 // GoString returns the string representation
 func (s DeleteAliasOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteEventSourceMappingRequest
@@ -3936,6 +4245,17 @@ func (s *DeleteEventSourceMappingInput) Validate() error {
 func (s *DeleteEventSourceMappingInput) SetUUID(v string) *DeleteEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteFunctionRequest
@@ -4013,6 +4333,22 @@ func (s *DeleteFunctionInput) SetQualifier(v string) *DeleteFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/DeleteFunctionOutput
 type DeleteFunctionOutput struct {
 	_ struct{} `type:"structure"`
@@ -4026,6 +4362,12 @@ func (s DeleteFunctionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFunctionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The parent object that contains your environment's configuration settings.
@@ -4051,6 +4393,17 @@ func (s Environment) GoString() string {
 func (s *Environment) SetVariables(v map[string]*string) *Environment {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Environment) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The parent object that contains error information associated with your configuration
@@ -4088,6 +4441,22 @@ func (s *EnvironmentError) SetMessage(v string) *EnvironmentError {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnvironmentError) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The parent object returned that contains your environment's configuration
 // settings or any error information associated with your configuration settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/EnvironmentResponse
@@ -4123,6 +4492,22 @@ func (s *EnvironmentResponse) SetError(v *EnvironmentError) *EnvironmentResponse
 func (s *EnvironmentResponse) SetVariables(v map[string]*string) *EnvironmentResponse {
 	s.Variables = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnvironmentResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Error != nil {
+		v := s.Error
+
+		e.SetFields(protocol.BodyTarget, "Error", v, protocol.Metadata{})
+	}
+	if len(s.Variables) > 0 {
+		v := s.Variables
+
+		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes mapping between an Amazon Kinesis stream and a Lambda function.
@@ -4218,6 +4603,60 @@ func (s *EventSourceMappingConfiguration) SetUUID(v string) *EventSourceMappingC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EventSourceMappingConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.BodyTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastProcessingResult != nil {
+		v := *s.LastProcessingResult
+
+		e.SetValue(protocol.BodyTarget, "LastProcessingResult", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StateTransitionReason != nil {
+		v := *s.StateTransitionReason
+
+		e.SetValue(protocol.BodyTarget, "StateTransitionReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.BodyTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEventSourceMappingConfigurationList(vs []*EventSourceMappingConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The code for the Lambda function.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/FunctionCode
 type FunctionCode struct {
@@ -4298,6 +4737,32 @@ func (s *FunctionCode) SetZipFile(v []byte) *FunctionCode {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionCode) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3Bucket != nil {
+		v := *s.S3Bucket
+
+		e.SetValue(protocol.BodyTarget, "S3Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Key != nil {
+		v := *s.S3Key
+
+		e.SetValue(protocol.BodyTarget, "S3Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3ObjectVersion != nil {
+		v := *s.S3ObjectVersion
+
+		e.SetValue(protocol.BodyTarget, "S3ObjectVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZipFile != nil {
+		v := s.ZipFile
+
+		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The object for the Lambda function location.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/FunctionCodeLocation
 type FunctionCodeLocation struct {
@@ -4331,6 +4796,22 @@ func (s *FunctionCodeLocation) SetLocation(v string) *FunctionCodeLocation {
 func (s *FunctionCodeLocation) SetRepositoryType(v string) *FunctionCodeLocation {
 	s.RepositoryType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionCodeLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.BodyTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepositoryType != nil {
+		v := *s.RepositoryType
+
+		e.SetValue(protocol.BodyTarget, "RepositoryType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes function metadata.
@@ -4523,6 +5004,110 @@ func (s *FunctionConfiguration) SetVpcConfig(v *VpcConfigResponse) *FunctionConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSha256 != nil {
+		v := *s.CodeSha256
+
+		e.SetValue(protocol.BodyTarget, "CodeSha256", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodeSize != nil {
+		v := *s.CodeSize
+
+		e.SetValue(protocol.BodyTarget, "CodeSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionArn != nil {
+		v := *s.FunctionArn
+
+		e.SetValue(protocol.BodyTarget, "FunctionArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MasterArn != nil {
+		v := *s.MasterArn
+
+		e.SetValue(protocol.BodyTarget, "MasterArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFunctionConfigurationList(vs []*FunctionConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAccountSettingsRequest
 type GetAccountSettingsInput struct {
 	_ struct{} `type:"structure"`
@@ -4536,6 +5121,12 @@ func (s GetAccountSettingsInput) String() string {
 // GoString returns the string representation
 func (s GetAccountSettingsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAccountSettingsResponse
@@ -4571,6 +5162,22 @@ func (s *GetAccountSettingsOutput) SetAccountLimit(v *AccountLimit) *GetAccountS
 func (s *GetAccountSettingsOutput) SetAccountUsage(v *AccountUsage) *GetAccountSettingsOutput {
 	s.AccountUsage = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountLimit != nil {
+		v := s.AccountLimit
+
+		e.SetFields(protocol.BodyTarget, "AccountLimit", v, protocol.Metadata{})
+	}
+	if s.AccountUsage != nil {
+		v := s.AccountUsage
+
+		e.SetFields(protocol.BodyTarget, "AccountUsage", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetAliasRequest
@@ -4636,6 +5243,22 @@ func (s *GetAliasInput) SetName(v string) *GetAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetEventSourceMappingRequest
 type GetEventSourceMappingInput struct {
 	_ struct{} `type:"structure"`
@@ -4673,6 +5296,17 @@ func (s *GetEventSourceMappingInput) Validate() error {
 func (s *GetEventSourceMappingInput) SetUUID(v string) *GetEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionConfigurationRequest
@@ -4743,6 +5377,22 @@ func (s *GetFunctionConfigurationInput) SetQualifier(v string) *GetFunctionConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionRequest
 type GetFunctionInput struct {
 	_ struct{} `type:"structure"`
@@ -4809,6 +5459,22 @@ func (s *GetFunctionInput) SetQualifier(v string) *GetFunctionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // This response contains the object for the Lambda function location (see FunctionCodeLocation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetFunctionResponse
 type GetFunctionOutput struct {
@@ -4850,6 +5516,27 @@ func (s *GetFunctionOutput) SetConfiguration(v *FunctionConfiguration) *GetFunct
 func (s *GetFunctionOutput) SetTags(v map[string]*string) *GetFunctionOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := s.Code
+
+		e.SetFields(protocol.BodyTarget, "Code", v, protocol.Metadata{})
+	}
+	if s.Configuration != nil {
+		v := s.Configuration
+
+		e.SetFields(protocol.BodyTarget, "Configuration", v, protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetPolicyRequest
@@ -4918,6 +5605,22 @@ func (s *GetPolicyInput) SetQualifier(v string) *GetPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetPolicyResponse
 type GetPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -4942,6 +5645,17 @@ func (s GetPolicyOutput) GoString() string {
 func (s *GetPolicyOutput) SetPolicy(v string) *GetPolicyOutput {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvokeAsyncRequest
@@ -5002,6 +5716,22 @@ func (s *InvokeAsyncInput) SetInvokeArgs(v io.ReadSeeker) *InvokeAsyncInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeAsyncInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvokeArgs != nil {
+		v := s.InvokeArgs
+
+		e.SetStream(protocol.PayloadTarget, "InvokeArgs", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Upon success, it returns empty response. Otherwise, throws an exception.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvokeAsyncResponse
 type InvokeAsyncOutput struct {
@@ -5025,6 +5755,13 @@ func (s InvokeAsyncOutput) GoString() string {
 func (s *InvokeAsyncOutput) SetStatus(v int64) *InvokeAsyncOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeAsyncOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// ignoring invalid encode state, StatusCode. Status
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvocationRequest
@@ -5145,6 +5882,42 @@ func (s *InvokeInput) SetQualifier(v string) *InvokeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvocationType != nil {
+		v := *s.InvocationType
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Invocation-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogType != nil {
+		v := *s.LogType
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Log-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "Payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Upon success, returns an empty response. Otherwise, throws an exception.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/InvocationResponse
 type InvokeOutput struct {
@@ -5210,6 +5983,28 @@ func (s *InvokeOutput) SetPayload(v []byte) *InvokeOutput {
 func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
 	s.StatusCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InvokeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionError != nil {
+		v := *s.FunctionError
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Function-Error", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LogResult != nil {
+		v := *s.LogResult
+
+		e.SetValue(protocol.HeaderTarget, "X-Amz-Log-Result", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Payload != nil {
+		v := s.Payload
+
+		e.SetStream(protocol.PayloadTarget, "Payload", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. StatusCode
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListAliasesRequest
@@ -5293,6 +6088,32 @@ func (s *ListAliasesInput) SetMaxItems(v int64) *ListAliasesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.QueryTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListAliasesResponse
 type ListAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5324,6 +6145,22 @@ func (s *ListAliasesOutput) SetAliases(v []*AliasConfiguration) *ListAliasesOutp
 func (s *ListAliasesOutput) SetNextMarker(v string) *ListAliasesOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Aliases) > 0 {
+		v := s.Aliases
+
+		e.SetList(protocol.BodyTarget, "Aliases", encodeAliasConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListEventSourceMappingsRequest
@@ -5406,6 +6243,32 @@ func (s *ListEventSourceMappingsInput) SetMaxItems(v int64) *ListEventSourceMapp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListEventSourceMappingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventSourceArn != nil {
+		v := *s.EventSourceArn
+
+		e.SetValue(protocol.QueryTarget, "EventSourceArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.QueryTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains a list of event sources (see EventSourceMappingConfiguration)
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListEventSourceMappingsResponse
 type ListEventSourceMappingsOutput struct {
@@ -5438,6 +6301,22 @@ func (s *ListEventSourceMappingsOutput) SetEventSourceMappings(v []*EventSourceM
 func (s *ListEventSourceMappingsOutput) SetNextMarker(v string) *ListEventSourceMappingsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListEventSourceMappingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.EventSourceMappings) > 0 {
+		v := s.EventSourceMappings
+
+		e.SetList(protocol.BodyTarget, "EventSourceMappings", encodeEventSourceMappingConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListFunctionsRequest
@@ -5521,6 +6400,32 @@ func (s *ListFunctionsInput) SetMaxItems(v int64) *ListFunctionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.QueryTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MasterRegion != nil {
+		v := *s.MasterRegion
+
+		e.SetValue(protocol.QueryTarget, "MasterRegion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListFunctionsResponse
 type ListFunctionsOutput struct {
@@ -5553,6 +6458,22 @@ func (s *ListFunctionsOutput) SetFunctions(v []*FunctionConfiguration) *ListFunc
 func (s *ListFunctionsOutput) SetNextMarker(v string) *ListFunctionsOutput {
 	s.NextMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListFunctionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Functions) > 0 {
+		v := s.Functions
+
+		e.SetList(protocol.BodyTarget, "Functions", encodeFunctionConfigurationList(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListTagsRequest
@@ -5594,6 +6515,17 @@ func (s *ListTagsInput) SetResource(v string) *ListTagsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListTagsResponse
 type ListTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5616,6 +6548,17 @@ func (s ListTagsOutput) GoString() string {
 func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListVersionsByFunctionRequest
@@ -5688,6 +6631,27 @@ func (s *ListVersionsByFunctionInput) SetMaxItems(v int64) *ListVersionsByFuncti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVersionsByFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/ListVersionsByFunctionResponse
 type ListVersionsByFunctionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5719,6 +6683,22 @@ func (s *ListVersionsByFunctionOutput) SetNextMarker(v string) *ListVersionsByFu
 func (s *ListVersionsByFunctionOutput) SetVersions(v []*FunctionConfiguration) *ListVersionsByFunctionOutput {
 	s.Versions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVersionsByFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Versions", encodeFunctionConfigurationList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/PublishVersionRequest
@@ -5788,6 +6768,27 @@ func (s *PublishVersionInput) SetDescription(v string) *PublishVersionInput {
 func (s *PublishVersionInput) SetFunctionName(v string) *PublishVersionInput {
 	s.FunctionName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PublishVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeSha256 != nil {
+		v := *s.CodeSha256
+
+		e.SetValue(protocol.BodyTarget, "CodeSha256", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/RemovePermissionRequest
@@ -5870,6 +6871,27 @@ func (s *RemovePermissionInput) SetStatementId(v string) *RemovePermissionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemovePermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatementId != nil {
+		v := *s.StatementId
+
+		e.SetValue(protocol.PathTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/RemovePermissionOutput
 type RemovePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5883,6 +6905,12 @@ func (s RemovePermissionOutput) String() string {
 // GoString returns the string representation
 func (s RemovePermissionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemovePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TagResourceRequest
@@ -5938,6 +6966,22 @@ func (s *TagResourceInput) SetTags(v map[string]*string) *TagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TagResourceOutput
 type TagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -5951,6 +6995,12 @@ func (s TagResourceOutput) String() string {
 // GoString returns the string representation
 func (s TagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // The parent object that contains your function's tracing settings.
@@ -5982,6 +7032,17 @@ func (s *TracingConfig) SetMode(v string) *TracingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TracingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Parent object of the tracing information associated with your Lambda function.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/TracingConfigResponse
 type TracingConfigResponse struct {
@@ -6005,6 +7066,17 @@ func (s TracingConfigResponse) GoString() string {
 func (s *TracingConfigResponse) SetMode(v string) *TracingConfigResponse {
 	s.Mode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TracingConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UntagResourceRequest
@@ -6060,6 +7132,22 @@ func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Resource != nil {
+		v := *s.Resource
+
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TagKeys) > 0 {
+		v := s.TagKeys
+
+		e.SetList(protocol.QueryTarget, "tagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UntagResourceOutput
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
@@ -6073,6 +7161,12 @@ func (s UntagResourceOutput) String() string {
 // GoString returns the string representation
 func (s UntagResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateAliasRequest
@@ -6156,6 +7250,32 @@ func (s *UpdateAliasInput) SetFunctionVersion(v string) *UpdateAliasInput {
 func (s *UpdateAliasInput) SetName(v string) *UpdateAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionVersion != nil {
+		v := *s.FunctionVersion
+
+		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateEventSourceMappingRequest
@@ -6244,6 +7364,32 @@ func (s *UpdateEventSourceMappingInput) SetFunctionName(v string) *UpdateEventSo
 func (s *UpdateEventSourceMappingInput) SetUUID(v string) *UpdateEventSourceMappingInput {
 	s.UUID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BatchSize != nil {
+		v := *s.BatchSize
+
+		e.SetValue(protocol.BodyTarget, "BatchSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.BodyTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UUID != nil {
+		v := *s.UUID
+
+		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateFunctionCodeRequest
@@ -6370,6 +7516,47 @@ func (s *UpdateFunctionCodeInput) SetS3ObjectVersion(v string) *UpdateFunctionCo
 func (s *UpdateFunctionCodeInput) SetZipFile(v []byte) *UpdateFunctionCodeInput {
 	s.ZipFile = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionCodeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DryRun != nil {
+		v := *s.DryRun
+
+		e.SetValue(protocol.BodyTarget, "DryRun", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Publish != nil {
+		v := *s.Publish
+
+		e.SetValue(protocol.BodyTarget, "Publish", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.S3Bucket != nil {
+		v := *s.S3Bucket
+
+		e.SetValue(protocol.BodyTarget, "S3Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Key != nil {
+		v := *s.S3Key
+
+		e.SetValue(protocol.BodyTarget, "S3Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3ObjectVersion != nil {
+		v := *s.S3ObjectVersion
+
+		e.SetValue(protocol.BodyTarget, "S3ObjectVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ZipFile != nil {
+		v := s.ZipFile
+
+		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/UpdateFunctionConfigurationRequest
@@ -6555,6 +7742,72 @@ func (s *UpdateFunctionConfigurationInput) SetVpcConfig(v *VpcConfig) *UpdateFun
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeadLetterConfig != nil {
+		v := s.DeadLetterConfig
+
+		e.SetFields(protocol.BodyTarget, "DeadLetterConfig", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Environment != nil {
+		v := s.Environment
+
+		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Handler != nil {
+		v := *s.Handler
+
+		e.SetValue(protocol.BodyTarget, "Handler", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KMSKeyArn != nil {
+		v := *s.KMSKeyArn
+
+		e.SetValue(protocol.BodyTarget, "KMSKeyArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MemorySize != nil {
+		v := *s.MemorySize
+
+		e.SetValue(protocol.BodyTarget, "MemorySize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Runtime != nil {
+		v := *s.Runtime
+
+		e.SetValue(protocol.BodyTarget, "Runtime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timeout != nil {
+		v := *s.Timeout
+
+		e.SetValue(protocol.BodyTarget, "Timeout", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TracingConfig != nil {
+		v := s.TracingConfig
+
+		e.SetFields(protocol.BodyTarget, "TracingConfig", v, protocol.Metadata{})
+	}
+	if s.VpcConfig != nil {
+		v := s.VpcConfig
+
+		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If your Lambda function accesses resources in a VPC, you provide this parameter
 // identifying the list of security group IDs and subnet IDs. These must belong
 // to the same VPC. You must provide at least one security group and one subnet
@@ -6590,6 +7843,22 @@ func (s *VpcConfig) SetSecurityGroupIds(v []*string) *VpcConfig {
 func (s *VpcConfig) SetSubnetIds(v []*string) *VpcConfig {
 	s.SubnetIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VpcConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // VPC configuration associated with your Lambda function.
@@ -6633,6 +7902,27 @@ func (s *VpcConfigResponse) SetSubnetIds(v []*string) *VpcConfigResponse {
 func (s *VpcConfigResponse) SetVpcId(v string) *VpcConfigResponse {
 	s.VpcId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VpcConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SecurityGroupIds) > 0 {
+		v := s.SecurityGroupIds
+
+		e.SetList(protocol.BodyTarget, "SecurityGroupIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.SubnetIds) > 0 {
+		v := s.SubnetIds
+
+		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.VpcId != nil {
+		v := *s.VpcId
+
+		e.SetValue(protocol.BodyTarget, "VpcId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -3080,7 +3080,6 @@ func (s *AccountLimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3131,7 +3130,6 @@ func (s *AccountUsage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalCodeSize", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3318,20 +3316,10 @@ func (s *AddPermissionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "EventSourceToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Principal != nil {
 		v := *s.Principal
 
 		e.SetValue(protocol.BodyTarget, "Principal", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Qualifier != nil {
-		v := *s.Qualifier
-
-		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.SourceAccount != nil {
 		v := *s.SourceAccount
@@ -3348,7 +3336,16 @@ func (s *AddPermissionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
 
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
+
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -3385,7 +3382,6 @@ func (s *AddPermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Statement", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3465,7 +3461,6 @@ func (s *AliasConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3571,11 +3566,6 @@ func (s *CreateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.FunctionVersion != nil {
 		v := *s.FunctionVersion
 
@@ -3586,7 +3576,11 @@ func (s *CreateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
 
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -3750,7 +3744,6 @@ func (s *CreateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "StartingPositionTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4067,7 +4060,6 @@ func (s *CreateFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4105,7 +4097,6 @@ func (s *DeadLetterConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TargetArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4183,7 +4174,6 @@ func (s *DeleteAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4204,7 +4194,6 @@ func (s DeleteAliasOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4254,7 +4243,6 @@ func (s *DeleteEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4345,7 +4333,6 @@ func (s *DeleteFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4366,7 +4353,6 @@ func (s DeleteFunctionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4402,7 +4388,6 @@ func (s *Environment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4453,7 +4438,6 @@ func (s *EnvironmentError) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4506,7 +4490,6 @@ func (s *EnvironmentResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Variables", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4645,7 +4628,6 @@ func (s *EventSourceMappingConfiguration) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4759,7 +4741,6 @@ func (s *FunctionCode) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4810,7 +4791,6 @@ func (s *FunctionCodeLocation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RepositoryType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5096,7 +5076,6 @@ func (s *FunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5125,7 +5104,6 @@ func (s GetAccountSettingsInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetAccountSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5176,7 +5154,6 @@ func (s *GetAccountSettingsOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "AccountUsage", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5255,7 +5232,6 @@ func (s *GetAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5305,7 +5281,6 @@ func (s *GetEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5389,7 +5364,6 @@ func (s *GetFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5471,7 +5445,6 @@ func (s *GetFunctionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5535,7 +5508,6 @@ func (s *GetFunctionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5617,7 +5589,6 @@ func (s *GetPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5654,7 +5625,6 @@ func (s *GetPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Policy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5728,7 +5698,6 @@ func (s *InvokeAsyncInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "InvokeArgs", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5760,7 +5729,6 @@ func (s *InvokeAsyncOutput) SetStatus(v int64) *InvokeAsyncOutput {
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InvokeAsyncOutput) MarshalFields(e protocol.FieldEncoder) error {
 	// ignoring invalid encode state, StatusCode. Status
-
 	return nil
 }
 
@@ -5889,11 +5857,6 @@ func (s *InvokeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "X-Amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InvocationType != nil {
 		v := *s.InvocationType
 
@@ -5903,6 +5866,11 @@ func (s *InvokeInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.LogType
 
 		e.SetValue(protocol.HeaderTarget, "X-Amz-Log-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Payload != nil {
 		v := s.Payload
@@ -5914,7 +5882,6 @@ func (s *InvokeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6003,7 +5970,6 @@ func (s *InvokeOutput) MarshalFields(e protocol.FieldEncoder) error {
 		e.SetStream(protocol.PayloadTarget, "Payload", protocol.BytesStream(v), protocol.Metadata{})
 	}
 	// ignoring invalid encode state, StatusCode. StatusCode
-
 	return nil
 }
 
@@ -6110,7 +6076,6 @@ func (s *ListAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6159,7 +6124,6 @@ func (s *ListAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6265,7 +6229,6 @@ func (s *ListEventSourceMappingsInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6315,7 +6278,6 @@ func (s *ListEventSourceMappingsOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6422,7 +6384,6 @@ func (s *ListFunctionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6472,7 +6433,6 @@ func (s *ListFunctionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6522,7 +6482,6 @@ func (s *ListTagsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6557,7 +6516,6 @@ func (s *ListTagsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6648,7 +6606,6 @@ func (s *ListVersionsByFunctionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.QueryTarget, "MaxItems", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6697,7 +6654,6 @@ func (s *ListVersionsByFunctionOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "Versions", encodeFunctionConfigurationList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6787,7 +6743,6 @@ func (s *PublishVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6878,17 +6833,16 @@ func (s *RemovePermissionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Qualifier != nil {
-		v := *s.Qualifier
-
-		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StatementId != nil {
 		v := *s.StatementId
 
 		e.SetValue(protocol.PathTarget, "StatementId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Qualifier != nil {
+		v := *s.Qualifier
 
+		e.SetValue(protocol.QueryTarget, "Qualifier", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6909,7 +6863,6 @@ func (s RemovePermissionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemovePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6968,17 +6921,16 @@ func (s *TagResourceInput) SetTags(v map[string]*string) *TagResourceInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Resource != nil {
-		v := *s.Resource
-
-		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.Tags) > 0 {
 		v := s.Tags
 
 		e.SetMap(protocol.BodyTarget, "Tags", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.Resource != nil {
+		v := *s.Resource
 
+		e.SetValue(protocol.PathTarget, "ARN", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -6999,7 +6951,6 @@ func (s TagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7039,7 +6990,6 @@ func (s *TracingConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7075,7 +7025,6 @@ func (s *TracingConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Mode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7144,7 +7093,6 @@ func (s *UntagResourceInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.QueryTarget, "tagKeys", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7165,7 +7113,6 @@ func (s UntagResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UntagResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -7259,22 +7206,21 @@ func (s *UpdateAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.FunctionVersion != nil {
 		v := *s.FunctionVersion
 
 		e.SetValue(protocol.BodyTarget, "FunctionVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
+
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.PathTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7388,7 +7334,6 @@ func (s *UpdateEventSourceMappingInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "UUID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7525,11 +7470,6 @@ func (s *UpdateFunctionCodeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "DryRun", protocol.BoolValue(v), protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Publish != nil {
 		v := *s.Publish
 
@@ -7555,7 +7495,11 @@ func (s *UpdateFunctionCodeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ZipFile", protocol.BytesValue(v), protocol.Metadata{})
 	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
 
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7759,11 +7703,6 @@ func (s *UpdateFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.BodyTarget, "Environment", v, protocol.Metadata{})
 	}
-	if s.FunctionName != nil {
-		v := *s.FunctionName
-
-		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Handler != nil {
 		v := *s.Handler
 
@@ -7804,7 +7743,11 @@ func (s *UpdateFunctionConfigurationInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.BodyTarget, "VpcConfig", v, protocol.Metadata{})
 	}
+	if s.FunctionName != nil {
+		v := *s.FunctionName
 
+		e.SetValue(protocol.PathTarget, "FunctionName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7857,7 +7800,6 @@ func (s *VpcConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "SubnetIds", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7921,7 +7863,6 @@ func (s *VpcConfigResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VpcId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4137,6 +4137,55 @@ func (s *BotAliasMetadata) SetName(v string) *BotAliasMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotAliasMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotAliasMetadataList(vs []*BotAliasMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an association between an Amazon Lex bot and an external messaging
 // platform.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BotChannelAssociation
@@ -4223,6 +4272,55 @@ func (s *BotChannelAssociation) SetType(v string) *BotChannelAssociation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotChannelAssociation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.BodyTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotConfiguration) > 0 {
+		v := s.BotConfiguration
+
+		e.SetMap(protocol.BodyTarget, "botConfiguration", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotChannelAssociationList(vs []*BotChannelAssociation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a bot. .
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BotMetadata
 type BotMetadata struct {
@@ -4294,6 +4392,50 @@ func (s *BotMetadata) SetVersion(v string) *BotMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BotMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBotMetadataList(vs []*BotMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides metadata for a built-in intent.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BuiltinIntentMetadata
 type BuiltinIntentMetadata struct {
@@ -4330,6 +4472,30 @@ func (s *BuiltinIntentMetadata) SetSupportedLocales(v []*string) *BuiltinIntentM
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinIntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinIntentMetadataList(vs []*BuiltinIntentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a slot used in a built-in intent.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/BuiltinIntentSlot
 type BuiltinIntentSlot struct {
@@ -4353,6 +4519,25 @@ func (s BuiltinIntentSlot) GoString() string {
 func (s *BuiltinIntentSlot) SetName(v string) *BuiltinIntentSlot {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinIntentSlot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinIntentSlotList(vs []*BuiltinIntentSlot) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides information about a built in slot type.
@@ -4389,6 +4574,30 @@ func (s *BuiltinSlotTypeMetadata) SetSignature(v string) *BuiltinSlotTypeMetadat
 func (s *BuiltinSlotTypeMetadata) SetSupportedLocales(v []*string) *BuiltinSlotTypeMetadata {
 	s.SupportedLocales = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BuiltinSlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBuiltinSlotTypeMetadataList(vs []*BuiltinSlotTypeMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specifies a Lambda function that verifies requests to a bot or fulfills the
@@ -4453,6 +4662,22 @@ func (s *CodeHook) SetUri(v string) *CodeHook {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CodeHook) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageVersion != nil {
+		v := *s.MessageVersion
+
+		e.SetValue(protocol.BodyTarget, "messageVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateBotVersionRequest
 type CreateBotVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4507,6 +4732,22 @@ func (s *CreateBotVersionInput) SetChecksum(v string) *CreateBotVersionInput {
 func (s *CreateBotVersionInput) SetName(v string) *CreateBotVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateBotVersionResponse
@@ -4689,6 +4930,87 @@ func (s *CreateBotVersionOutput) SetVoiceId(v string) *CreateBotVersionOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateIntentVersionRequest
 type CreateIntentVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4743,6 +5065,22 @@ func (s *CreateIntentVersionInput) SetChecksum(v string) *CreateIntentVersionInp
 func (s *CreateIntentVersionInput) SetName(v string) *CreateIntentVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateIntentVersionResponse
@@ -4900,6 +5238,87 @@ func (s *CreateIntentVersionOutput) SetVersion(v string) *CreateIntentVersionOut
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateSlotTypeVersionRequest
 type CreateSlotTypeVersionInput struct {
 	_ struct{} `type:"structure"`
@@ -4954,6 +5373,22 @@ func (s *CreateSlotTypeVersionInput) SetChecksum(v string) *CreateSlotTypeVersio
 func (s *CreateSlotTypeVersionInput) SetName(v string) *CreateSlotTypeVersionInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/CreateSlotTypeVersionResponse
@@ -5046,6 +5481,52 @@ func (s *CreateSlotTypeVersionOutput) SetVersion(v string) *CreateSlotTypeVersio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotAliasRequest
 type DeleteBotAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -5105,6 +5586,22 @@ func (s *DeleteBotAliasInput) SetName(v string) *DeleteBotAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotAliasOutput
 type DeleteBotAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -5118,6 +5615,12 @@ func (s DeleteBotAliasOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotAliasOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotChannelAssociationRequest
@@ -5197,6 +5700,27 @@ func (s *DeleteBotChannelAssociationInput) SetName(v string) *DeleteBotChannelAs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotChannelAssociationOutput
 type DeleteBotChannelAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -5210,6 +5734,12 @@ func (s DeleteBotChannelAssociationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotChannelAssociationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotRequest
@@ -5254,6 +5784,17 @@ func (s *DeleteBotInput) SetName(v string) *DeleteBotInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotOutput
 type DeleteBotOutput struct {
 	_ struct{} `type:"structure"`
@@ -5267,6 +5808,12 @@ func (s DeleteBotOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotVersionRequest
@@ -5329,6 +5876,22 @@ func (s *DeleteBotVersionInput) SetVersion(v string) *DeleteBotVersionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteBotVersionOutput
 type DeleteBotVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5342,6 +5905,12 @@ func (s DeleteBotVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBotVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentRequest
@@ -5386,6 +5955,17 @@ func (s *DeleteIntentInput) SetName(v string) *DeleteIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentOutput
 type DeleteIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5399,6 +5979,12 @@ func (s DeleteIntentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentVersionRequest
@@ -5461,6 +6047,22 @@ func (s *DeleteIntentVersionInput) SetVersion(v string) *DeleteIntentVersionInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteIntentVersionOutput
 type DeleteIntentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5474,6 +6076,12 @@ func (s DeleteIntentVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteIntentVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeRequest
@@ -5518,6 +6126,17 @@ func (s *DeleteSlotTypeInput) SetName(v string) *DeleteSlotTypeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeOutput
 type DeleteSlotTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -5531,6 +6150,12 @@ func (s DeleteSlotTypeOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSlotTypeOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeVersionRequest
@@ -5593,6 +6218,22 @@ func (s *DeleteSlotTypeVersionInput) SetVersion(v string) *DeleteSlotTypeVersion
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteSlotTypeVersionOutput
 type DeleteSlotTypeVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5606,6 +6247,12 @@ func (s DeleteSlotTypeVersionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteSlotTypeVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteUtterancesRequest
@@ -5670,6 +6317,22 @@ func (s *DeleteUtterancesInput) SetUserId(v string) *DeleteUtterancesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUtterancesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/DeleteUtterancesOutput
 type DeleteUtterancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -5683,6 +6346,12 @@ func (s DeleteUtterancesOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUtterancesOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUtterancesOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Each slot type can have a set of values. Each enumeration value represents
@@ -5746,6 +6415,30 @@ func (s *EnumerationValue) SetSynonyms(v []*string) *EnumerationValue {
 func (s *EnumerationValue) SetValue(v string) *EnumerationValue {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EnumerationValue) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Synonyms) > 0 {
+		v := s.Synonyms
+
+		e.SetList(protocol.BodyTarget, "synonyms", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEnumerationValueList(vs []*EnumerationValue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A prompt for additional activity after an intent is fulfilled. For example,
@@ -5813,6 +6506,22 @@ func (s *FollowUpPrompt) SetPrompt(v *Prompt) *FollowUpPrompt {
 func (s *FollowUpPrompt) SetRejectionStatement(v *Statement) *FollowUpPrompt {
 	s.RejectionStatement = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FollowUpPrompt) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prompt != nil {
+		v := s.Prompt
+
+		e.SetFields(protocol.BodyTarget, "prompt", v, protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes how the intent is fulfilled after the user provides all of the
@@ -5887,6 +6596,22 @@ func (s *FulfillmentActivity) SetType(v string) *FulfillmentActivity {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FulfillmentActivity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodeHook != nil {
+		v := s.CodeHook
+
+		e.SetFields(protocol.BodyTarget, "codeHook", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasRequest
 type GetBotAliasInput struct {
 	_ struct{} `type:"structure"`
@@ -5944,6 +6669,22 @@ func (s *GetBotAliasInput) SetBotName(v string) *GetBotAliasInput {
 func (s *GetBotAliasInput) SetName(v string) *GetBotAliasInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasResponse
@@ -6023,6 +6764,47 @@ func (s *GetBotAliasOutput) SetLastUpdatedDate(v time.Time) *GetBotAliasOutput {
 func (s *GetBotAliasOutput) SetName(v string) *GetBotAliasOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasesRequest
@@ -6106,6 +6888,32 @@ func (s *GetBotAliasesInput) SetNextToken(v string) *GetBotAliasesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotAliasesResponse
 type GetBotAliasesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6140,6 +6948,22 @@ func (s *GetBotAliasesOutput) SetBotAliases(v []*BotAliasMetadata) *GetBotAliase
 func (s *GetBotAliasesOutput) SetNextToken(v string) *GetBotAliasesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BotAliases) > 0 {
+		v := s.BotAliases
+
+		e.SetList(protocol.BodyTarget, "BotAliases", encodeBotAliasMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationRequest
@@ -6220,6 +7044,27 @@ func (s *GetBotChannelAssociationInput) SetName(v string) *GetBotChannelAssociat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationResponse
 type GetBotChannelAssociationOutput struct {
 	_ struct{} `type:"structure"`
@@ -6298,6 +7143,47 @@ func (s *GetBotChannelAssociationOutput) SetName(v string) *GetBotChannelAssocia
 func (s *GetBotChannelAssociationOutput) SetType(v string) *GetBotChannelAssociationOutput {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.BodyTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotConfiguration) > 0 {
+		v := s.BotConfiguration
+
+		e.SetMap(protocol.BodyTarget, "botConfiguration", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationsRequest
@@ -6400,6 +7286,37 @@ func (s *GetBotChannelAssociationsInput) SetNextToken(v string) *GetBotChannelAs
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "aliasName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotChannelAssociationsResponse
 type GetBotChannelAssociationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6435,6 +7352,22 @@ func (s *GetBotChannelAssociationsOutput) SetBotChannelAssociations(v []*BotChan
 func (s *GetBotChannelAssociationsOutput) SetNextToken(v string) *GetBotChannelAssociationsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotChannelAssociationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BotChannelAssociations) > 0 {
+		v := s.BotChannelAssociations
+
+		e.SetList(protocol.BodyTarget, "botChannelAssociations", encodeBotChannelAssociationList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotRequest
@@ -6491,6 +7424,22 @@ func (s *GetBotInput) SetName(v string) *GetBotInput {
 func (s *GetBotInput) SetVersionOrAlias(v string) *GetBotInput {
 	s.VersionOrAlias = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionOrAlias != nil {
+		v := *s.VersionOrAlias
+
+		e.SetValue(protocol.PathTarget, "versionoralias", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotResponse
@@ -6674,6 +7623,87 @@ func (s *GetBotOutput) SetVoiceId(v string) *GetBotOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotVersionsRequest
 type GetBotVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -6741,6 +7771,27 @@ func (s *GetBotVersionsInput) SetNextToken(v string) *GetBotVersionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotVersionsResponse
 type GetBotVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6776,6 +7827,22 @@ func (s *GetBotVersionsOutput) SetBots(v []*BotMetadata) *GetBotVersionsOutput {
 func (s *GetBotVersionsOutput) SetNextToken(v string) *GetBotVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Bots) > 0 {
+		v := s.Bots
+
+		e.SetList(protocol.BodyTarget, "bots", encodeBotMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotsRequest
@@ -6842,6 +7909,27 @@ func (s *GetBotsInput) SetNextToken(v string) *GetBotsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBotsResponse
 type GetBotsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6874,6 +7962,22 @@ func (s *GetBotsOutput) SetBots(v []*BotMetadata) *GetBotsOutput {
 func (s *GetBotsOutput) SetNextToken(v string) *GetBotsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBotsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Bots) > 0 {
+		v := s.Bots
+
+		e.SetList(protocol.BodyTarget, "bots", encodeBotMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentRequest
@@ -6917,6 +8021,17 @@ func (s *GetBuiltinIntentInput) SetSignature(v string) *GetBuiltinIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.PathTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentResponse
 type GetBuiltinIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -6958,6 +8073,27 @@ func (s *GetBuiltinIntentOutput) SetSlots(v []*BuiltinIntentSlot) *GetBuiltinInt
 func (s *GetBuiltinIntentOutput) SetSupportedLocales(v []*string) *GetBuiltinIntentOutput {
 	s.SupportedLocales = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeBuiltinIntentSlotList(v), protocol.Metadata{})
+	}
+	if len(s.SupportedLocales) > 0 {
+		v := s.SupportedLocales
+
+		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentsRequest
@@ -7030,6 +8166,32 @@ func (s *GetBuiltinIntentsInput) SetSignatureContains(v string) *GetBuiltinInten
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.QueryTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SignatureContains != nil {
+		v := *s.SignatureContains
+
+		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinIntentsResponse
 type GetBuiltinIntentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7064,6 +8226,22 @@ func (s *GetBuiltinIntentsOutput) SetIntents(v []*BuiltinIntentMetadata) *GetBui
 func (s *GetBuiltinIntentsOutput) SetNextToken(v string) *GetBuiltinIntentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeBuiltinIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinSlotTypesRequest
@@ -7136,6 +8314,32 @@ func (s *GetBuiltinSlotTypesInput) SetSignatureContains(v string) *GetBuiltinSlo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.QueryTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SignatureContains != nil {
+		v := *s.SignatureContains
+
+		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetBuiltinSlotTypesResponse
 type GetBuiltinSlotTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7169,6 +8373,22 @@ func (s *GetBuiltinSlotTypesOutput) SetNextToken(v string) *GetBuiltinSlotTypesO
 func (s *GetBuiltinSlotTypesOutput) SetSlotTypes(v []*BuiltinSlotTypeMetadata) *GetBuiltinSlotTypesOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBuiltinSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeBuiltinSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetExportRequest
@@ -7256,6 +8476,32 @@ func (s *GetExportInput) SetResourceType(v string) *GetExportInput {
 func (s *GetExportInput) SetVersion(v string) *GetExportInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.QueryTarget, "exportType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.QueryTarget, "resourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.QueryTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetExportResponse
@@ -7346,6 +8592,47 @@ func (s *GetExportOutput) SetVersion(v string) *GetExportOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ExportStatus != nil {
+		v := *s.ExportStatus
+
+		e.SetValue(protocol.BodyTarget, "exportStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExportType != nil {
+		v := *s.ExportType
+
+		e.SetValue(protocol.BodyTarget, "exportType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.BodyTarget, "resourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentRequest
 type GetIntentInput struct {
 	_ struct{} `type:"structure"`
@@ -7403,6 +8690,22 @@ func (s *GetIntentInput) SetName(v string) *GetIntentInput {
 func (s *GetIntentInput) SetVersion(v string) *GetIntentInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentResponse
@@ -7561,6 +8864,87 @@ func (s *GetIntentOutput) SetVersion(v string) *GetIntentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentVersionsRequest
 type GetIntentVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -7628,6 +9012,27 @@ func (s *GetIntentVersionsInput) SetNextToken(v string) *GetIntentVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentVersionsResponse
 type GetIntentVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7663,6 +9068,22 @@ func (s *GetIntentVersionsOutput) SetIntents(v []*IntentMetadata) *GetIntentVers
 func (s *GetIntentVersionsOutput) SetNextToken(v string) *GetIntentVersionsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentsRequest
@@ -7728,6 +9149,27 @@ func (s *GetIntentsInput) SetNextToken(v string) *GetIntentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetIntentsResponse
 type GetIntentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7760,6 +9202,22 @@ func (s *GetIntentsOutput) SetIntents(v []*IntentMetadata) *GetIntentsOutput {
 func (s *GetIntentsOutput) SetNextToken(v string) *GetIntentsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentMetadataList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeRequest
@@ -7819,6 +9277,22 @@ func (s *GetSlotTypeInput) SetName(v string) *GetSlotTypeInput {
 func (s *GetSlotTypeInput) SetVersion(v string) *GetSlotTypeInput {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeResponse
@@ -7911,6 +9385,52 @@ func (s *GetSlotTypeOutput) SetVersion(v string) *GetSlotTypeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeVersionsRequest
 type GetSlotTypeVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -7978,6 +9498,27 @@ func (s *GetSlotTypeVersionsInput) SetNextToken(v string) *GetSlotTypeVersionsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypeVersionsResponse
 type GetSlotTypeVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8013,6 +9554,22 @@ func (s *GetSlotTypeVersionsOutput) SetNextToken(v string) *GetSlotTypeVersionsO
 func (s *GetSlotTypeVersionsOutput) SetSlotTypes(v []*SlotTypeMetadata) *GetSlotTypeVersionsOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypeVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypesRequest
@@ -8079,6 +9636,27 @@ func (s *GetSlotTypesInput) SetNextToken(v string) *GetSlotTypesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NameContains != nil {
+		v := *s.NameContains
+
+		e.SetValue(protocol.QueryTarget, "nameContains", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetSlotTypesResponse
 type GetSlotTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8112,6 +9690,22 @@ func (s *GetSlotTypesOutput) SetNextToken(v string) *GetSlotTypesOutput {
 func (s *GetSlotTypesOutput) SetSlotTypes(v []*SlotTypeMetadata) *GetSlotTypesOutput {
 	s.SlotTypes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SlotTypes) > 0 {
+		v := s.SlotTypes
+
+		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetUtterancesViewRequest
@@ -8189,6 +9783,27 @@ func (s *GetUtterancesViewInput) SetStatusType(v string) *GetUtterancesViewInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUtterancesViewInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.BotVersions) > 0 {
+		v := s.BotVersions
+
+		e.SetList(protocol.QueryTarget, "bot_versions", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.StatusType != nil {
+		v := *s.StatusType
+
+		e.SetValue(protocol.QueryTarget, "status_type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/GetUtterancesViewResponse
 type GetUtterancesViewOutput struct {
 	_ struct{} `type:"structure"`
@@ -8222,6 +9837,22 @@ func (s *GetUtterancesViewOutput) SetBotName(v string) *GetUtterancesViewOutput 
 func (s *GetUtterancesViewOutput) SetUtterances(v []*UtteranceList) *GetUtterancesViewOutput {
 	s.Utterances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetUtterancesViewOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Utterances) > 0 {
+		v := s.Utterances
+
+		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceListList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Identifies the specific version of an intent.
@@ -8282,6 +9913,30 @@ func (s *Intent) SetIntentName(v string) *Intent {
 func (s *Intent) SetIntentVersion(v string) *Intent {
 	s.IntentVersion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Intent) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.BodyTarget, "intentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentVersion != nil {
+		v := *s.IntentVersion
+
+		e.SetValue(protocol.BodyTarget, "intentVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntentList(vs []*Intent) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Provides information about an intent.
@@ -8346,6 +10001,45 @@ func (s *IntentMetadata) SetVersion(v string) *IntentMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIntentMetadataList(vs []*IntentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The message object that provides the message text and its type.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/Message
 type Message struct {
@@ -8401,6 +10095,30 @@ func (s *Message) SetContent(v string) *Message {
 func (s *Message) SetContentType(v string) *Message {
 	s.ContentType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMessageList(vs []*Message) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Obtains information from the user. To define a prompt, provide one or more
@@ -8490,6 +10208,27 @@ func (s *Prompt) SetMessages(v []*Message) *Prompt {
 func (s *Prompt) SetResponseCard(v string) *Prompt {
 	s.ResponseCard = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Prompt) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxAttempts != nil {
+		v := *s.MaxAttempts
+
+		e.SetValue(protocol.BodyTarget, "maxAttempts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "messages", encodeMessageList(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotAliasRequest
@@ -8594,6 +10333,37 @@ func (s *PutBotAliasInput) SetName(v string) *PutBotAliasInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotAliasResponse
 type PutBotAliasOutput struct {
 	_ struct{} `type:"structure"`
@@ -8671,6 +10441,47 @@ func (s *PutBotAliasOutput) SetLastUpdatedDate(v time.Time) *PutBotAliasOutput {
 func (s *PutBotAliasOutput) SetName(v string) *PutBotAliasOutput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.BodyTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotRequest
@@ -8917,6 +10728,67 @@ func (s *PutBotInput) SetVoiceId(v string) *PutBotInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProcessBehavior != nil {
+		v := *s.ProcessBehavior
+
+		e.SetValue(protocol.BodyTarget, "processBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutBotResponse
 type PutBotOutput struct {
 	_ struct{} `type:"structure"`
@@ -9100,6 +10972,87 @@ func (s *PutBotOutput) SetVersion(v string) *PutBotOutput {
 func (s *PutBotOutput) SetVoiceId(v string) *PutBotOutput {
 	s.VoiceId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBotOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortStatement != nil {
+		v := s.AbortStatement
+
+		e.SetFields(protocol.BodyTarget, "abortStatement", v, protocol.Metadata{})
+	}
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChildDirected != nil {
+		v := *s.ChildDirected
+
+		e.SetValue(protocol.BodyTarget, "childDirected", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ClarificationPrompt != nil {
+		v := s.ClarificationPrompt
+
+		e.SetFields(protocol.BodyTarget, "clarificationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FailureReason != nil {
+		v := *s.FailureReason
+
+		e.SetValue(protocol.BodyTarget, "failureReason", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IdleSessionTTLInSeconds != nil {
+		v := *s.IdleSessionTTLInSeconds
+
+		e.SetValue(protocol.BodyTarget, "idleSessionTTLInSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Intents) > 0 {
+		v := s.Intents
+
+		e.SetList(protocol.BodyTarget, "intents", encodeIntentList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutIntentRequest
@@ -9360,6 +11313,72 @@ func (s *PutIntentInput) SetSlots(v []*Slot) *PutIntentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutIntentResponse
 type PutIntentOutput struct {
 	_ struct{} `type:"structure"`
@@ -9518,6 +11537,87 @@ func (s *PutIntentOutput) SetVersion(v string) *PutIntentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConclusionStatement != nil {
+		v := s.ConclusionStatement
+
+		e.SetFields(protocol.BodyTarget, "conclusionStatement", v, protocol.Metadata{})
+	}
+	if s.ConfirmationPrompt != nil {
+		v := s.ConfirmationPrompt
+
+		e.SetFields(protocol.BodyTarget, "confirmationPrompt", v, protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogCodeHook != nil {
+		v := s.DialogCodeHook
+
+		e.SetFields(protocol.BodyTarget, "dialogCodeHook", v, protocol.Metadata{})
+	}
+	if s.FollowUpPrompt != nil {
+		v := s.FollowUpPrompt
+
+		e.SetFields(protocol.BodyTarget, "followUpPrompt", v, protocol.Metadata{})
+	}
+	if s.FulfillmentActivity != nil {
+		v := s.FulfillmentActivity
+
+		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentIntentSignature != nil {
+		v := *s.ParentIntentSignature
+
+		e.SetValue(protocol.BodyTarget, "parentIntentSignature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RejectionStatement != nil {
+		v := s.RejectionStatement
+
+		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutSlotTypeRequest
 type PutSlotTypeInput struct {
 	_ struct{} `type:"structure"`
@@ -9644,6 +11744,37 @@ func (s *PutSlotTypeInput) SetValueSelectionStrategy(v string) *PutSlotTypeInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/PutSlotTypeResponse
 type PutSlotTypeOutput struct {
 	_ struct{} `type:"structure"`
@@ -9735,6 +11866,52 @@ func (s *PutSlotTypeOutput) SetVersion(v string) *PutSlotTypeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Checksum != nil {
+		v := *s.Checksum
+
+		e.SetValue(protocol.BodyTarget, "checksum", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EnumerationValues) > 0 {
+		v := s.EnumerationValues
+
+		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueSelectionStrategy != nil {
+		v := *s.ValueSelectionStrategy
+
+		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the resource that refers to the resource that you are attempting
 // to delete. This object is returned as part of the ResourceInUseException
 // exception.
@@ -9771,6 +11948,22 @@ func (s *ResourceReference) SetName(v string) *ResourceReference {
 func (s *ResourceReference) SetVersion(v string) *ResourceReference {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceReference) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Identifies the version of a specific slot.
@@ -9918,6 +12111,65 @@ func (s *Slot) SetValueElicitationPrompt(v *Prompt) *Slot {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Slot) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "priority", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SampleUtterances) > 0 {
+		v := s.SampleUtterances
+
+		e.SetList(protocol.BodyTarget, "sampleUtterances", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.SlotConstraint != nil {
+		v := *s.SlotConstraint
+
+		e.SetValue(protocol.BodyTarget, "slotConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SlotType != nil {
+		v := *s.SlotType
+
+		e.SetValue(protocol.BodyTarget, "slotType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SlotTypeVersion != nil {
+		v := *s.SlotTypeVersion
+
+		e.SetValue(protocol.BodyTarget, "slotTypeVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ValueElicitationPrompt != nil {
+		v := s.ValueElicitationPrompt
+
+		e.SetFields(protocol.BodyTarget, "valueElicitationPrompt", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSlotList(vs []*Slot) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides information about a slot type..
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/SlotTypeMetadata
 type SlotTypeMetadata struct {
@@ -9978,6 +12230,45 @@ func (s *SlotTypeMetadata) SetName(v string) *SlotTypeMetadata {
 func (s *SlotTypeMetadata) SetVersion(v string) *SlotTypeMetadata {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSlotTypeMetadataList(vs []*SlotTypeMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A collection of messages that convey information to the user. At runtime,
@@ -10049,6 +12340,22 @@ func (s *Statement) SetResponseCard(v string) *Statement {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Statement) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Messages) > 0 {
+		v := s.Messages
+
+		e.SetList(protocol.BodyTarget, "messages", encodeMessageList(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := *s.ResponseCard
+
+		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Provides information about a single utterance that was made to your bot.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/UtteranceData
 type UtteranceData struct {
@@ -10111,6 +12418,45 @@ func (s *UtteranceData) SetUtteranceString(v string) *UtteranceData {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UtteranceData) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DistinctUsers != nil {
+		v := *s.DistinctUsers
+
+		e.SetValue(protocol.BodyTarget, "distinctUsers", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FirstUtteredDate != nil {
+		v := *s.FirstUtteredDate
+
+		e.SetValue(protocol.BodyTarget, "firstUtteredDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastUtteredDate != nil {
+		v := *s.LastUtteredDate
+
+		e.SetValue(protocol.BodyTarget, "lastUtteredDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UtteranceString != nil {
+		v := *s.UtteranceString
+
+		e.SetValue(protocol.BodyTarget, "utteranceString", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUtteranceDataList(vs []*UtteranceData) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Provides a list of utterances that have been made to a specific version of
 // your bot. The list contains a maximum of 100 utterances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/lex-models-2017-04-19/UtteranceList
@@ -10145,6 +12491,30 @@ func (s *UtteranceList) SetBotVersion(v string) *UtteranceList {
 func (s *UtteranceList) SetUtterances(v []*UtteranceData) *UtteranceList {
 	s.Utterances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UtteranceList) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotVersion != nil {
+		v := *s.BotVersion
+
+		e.SetValue(protocol.BodyTarget, "botVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Utterances) > 0 {
+		v := s.Utterances
+
+		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceDataList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUtteranceListList(vs []*UtteranceList) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -4174,7 +4174,6 @@ func (s *BotAliasMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4309,7 +4308,6 @@ func (s *BotChannelAssociation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4424,7 +4422,6 @@ func (s *BotMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4484,7 +4481,6 @@ func (s *BuiltinIntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4528,7 +4524,6 @@ func (s *BuiltinIntentSlot) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4588,7 +4583,6 @@ func (s *BuiltinSlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4674,7 +4668,6 @@ func (s *CodeHook) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4746,7 +4739,6 @@ func (s *CreateBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5007,7 +4999,6 @@ func (s *CreateBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5079,7 +5070,6 @@ func (s *CreateIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5315,7 +5305,6 @@ func (s *CreateIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5387,7 +5376,6 @@ func (s *CreateSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5523,7 +5511,6 @@ func (s *CreateSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5598,7 +5585,6 @@ func (s *DeleteBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5619,7 +5605,6 @@ func (s DeleteBotAliasOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5717,7 +5702,6 @@ func (s *DeleteBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5738,7 +5722,6 @@ func (s DeleteBotChannelAssociationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5791,7 +5774,6 @@ func (s *DeleteBotInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5812,7 +5794,6 @@ func (s DeleteBotOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBotOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5888,7 +5869,6 @@ func (s *DeleteBotVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5909,7 +5889,6 @@ func (s DeleteBotVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBotVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5962,7 +5941,6 @@ func (s *DeleteIntentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5983,7 +5961,6 @@ func (s DeleteIntentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6059,7 +6036,6 @@ func (s *DeleteIntentVersionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6080,7 +6056,6 @@ func (s DeleteIntentVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteIntentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6133,7 +6108,6 @@ func (s *DeleteSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6154,7 +6128,6 @@ func (s DeleteSlotTypeOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6230,7 +6203,6 @@ func (s *DeleteSlotTypeVersionInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6251,7 +6223,6 @@ func (s DeleteSlotTypeVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteSlotTypeVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6329,7 +6300,6 @@ func (s *DeleteUtterancesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6350,7 +6320,6 @@ func (s DeleteUtterancesOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteUtterancesOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6429,7 +6398,6 @@ func (s *EnumerationValue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6520,7 +6488,6 @@ func (s *FollowUpPrompt) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "rejectionStatement", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6608,7 +6575,6 @@ func (s *FulfillmentActivity) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6683,7 +6649,6 @@ func (s *GetBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6803,7 +6768,6 @@ func (s *GetBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6910,7 +6874,6 @@ func (s *GetBotAliasesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6962,7 +6925,6 @@ func (s *GetBotAliasesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7061,7 +7023,6 @@ func (s *GetBotChannelAssociationInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7182,7 +7143,6 @@ func (s *GetBotChannelAssociationOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7313,7 +7273,6 @@ func (s *GetBotChannelAssociationsInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7366,7 +7325,6 @@ func (s *GetBotChannelAssociationsOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7438,7 +7396,6 @@ func (s *GetBotInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "versionoralias", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7700,7 +7657,6 @@ func (s *GetBotOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7773,22 +7729,21 @@ func (s *GetBotVersionsInput) SetNextToken(v string) *GetBotVersionsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetBotVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.MaxResults != nil {
-		v := *s.MaxResults
-
-		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.NextToken != nil {
 		v := *s.NextToken
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7841,7 +7796,6 @@ func (s *GetBotVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7926,7 +7880,6 @@ func (s *GetBotsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7976,7 +7929,6 @@ func (s *GetBotsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8028,7 +7980,6 @@ func (s *GetBuiltinIntentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "signature", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8092,7 +8043,6 @@ func (s *GetBuiltinIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "supportedLocales", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8188,7 +8138,6 @@ func (s *GetBuiltinIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8240,7 +8189,6 @@ func (s *GetBuiltinIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8336,7 +8284,6 @@ func (s *GetBuiltinSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "signatureContains", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8387,7 +8334,6 @@ func (s *GetBuiltinSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "slotTypes", encodeBuiltinSlotTypeMetadataList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8500,7 +8446,6 @@ func (s *GetExportInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8629,7 +8574,6 @@ func (s *GetExportOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8704,7 +8648,6 @@ func (s *GetIntentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8941,7 +8884,6 @@ func (s *GetIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9014,22 +8956,21 @@ func (s *GetIntentVersionsInput) SetNextToken(v string) *GetIntentVersionsInput 
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetIntentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.MaxResults != nil {
-		v := *s.MaxResults
-
-		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.NextToken != nil {
 		v := *s.NextToken
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9082,7 +9023,6 @@ func (s *GetIntentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9166,7 +9106,6 @@ func (s *GetIntentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9216,7 +9155,6 @@ func (s *GetIntentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9291,7 +9229,6 @@ func (s *GetSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9427,7 +9364,6 @@ func (s *GetSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9500,22 +9436,21 @@ func (s *GetSlotTypeVersionsInput) SetNextToken(v string) *GetSlotTypeVersionsIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetSlotTypeVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.MaxResults != nil {
-		v := *s.MaxResults
-
-		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.NextToken != nil {
 		v := *s.NextToken
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9568,7 +9503,6 @@ func (s *GetSlotTypeVersionsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9653,7 +9587,6 @@ func (s *GetSlotTypesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9704,7 +9637,6 @@ func (s *GetSlotTypesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "slotTypes", encodeSlotTypeMetadataList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9800,7 +9732,6 @@ func (s *GetUtterancesViewInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "status_type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9851,7 +9782,6 @@ func (s *GetUtterancesViewOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceListList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9927,7 +9857,6 @@ func (s *Intent) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "intentVersion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10028,7 +9957,6 @@ func (s *IntentMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10109,7 +10037,6 @@ func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10227,7 +10154,6 @@ func (s *Prompt) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10335,11 +10261,6 @@ func (s *PutBotAliasInput) SetName(v string) *PutBotAliasInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.BotName != nil {
-		v := *s.BotName
-
-		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.BotVersion != nil {
 		v := *s.BotVersion
 
@@ -10355,12 +10276,16 @@ func (s *PutBotAliasInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Name != nil {
 		v := *s.Name
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10480,7 +10405,6 @@ func (s *PutBotAliasOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10770,11 +10694,6 @@ func (s *PutBotInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "locale", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ProcessBehavior != nil {
 		v := *s.ProcessBehavior
 
@@ -10785,7 +10704,11 @@ func (s *PutBotInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11051,7 +10974,6 @@ func (s *PutBotOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "voiceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11350,11 +11272,6 @@ func (s *PutIntentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "fulfillmentActivity", v, protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ParentIntentSignature != nil {
 		v := *s.ParentIntentSignature
 
@@ -11375,7 +11292,11 @@ func (s *PutIntentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "slots", encodeSlotList(v), protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11614,7 +11535,6 @@ func (s *PutIntentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11761,17 +11681,16 @@ func (s *PutSlotTypeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "enumerationValues", encodeEnumerationValueList(v), protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ValueSelectionStrategy != nil {
 		v := *s.ValueSelectionStrategy
 
 		e.SetValue(protocol.BodyTarget, "valueSelectionStrategy", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11908,7 +11827,6 @@ func (s *PutSlotTypeOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11962,7 +11880,6 @@ func (s *ResourceReference) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12158,7 +12075,6 @@ func (s *Slot) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "valueElicitationPrompt", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12259,7 +12175,6 @@ func (s *SlotTypeMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12352,7 +12267,6 @@ func (s *Statement) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "responseCard", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12445,7 +12359,6 @@ func (s *UtteranceData) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "utteranceString", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12505,7 +12418,6 @@ func (s *UtteranceList) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "utterances", encodeUtteranceDataList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opPostContent = "PostContent"
@@ -390,6 +391,30 @@ func (s *Button) SetValue(v string) *Button {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Button) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeButtonList(vs []*Button) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Represents an option rendered to the user when a prompt is shown. It could
 // be an image, a button, a link, or text.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/GenericAttachment
@@ -450,6 +475,45 @@ func (s *GenericAttachment) SetSubTitle(v string) *GenericAttachment {
 func (s *GenericAttachment) SetTitle(v string) *GenericAttachment {
 	s.Title = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GenericAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttachmentLinkUrl != nil {
+		v := *s.AttachmentLinkUrl
+
+		e.SetValue(protocol.BodyTarget, "attachmentLinkUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Buttons) > 0 {
+		v := s.Buttons
+
+		e.SetList(protocol.BodyTarget, "buttons", encodeButtonList(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "imageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubTitle != nil {
+		v := *s.SubTitle
+
+		e.SetValue(protocol.BodyTarget, "subTitle", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "title", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGenericAttachmentList(vs []*GenericAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostContentRequest
@@ -664,6 +728,52 @@ func (s *PostContentInput) SetUserId(v string) *PostContentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostContentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Accept != nil {
+		v := *s.Accept
+
+		e.SetValue(protocol.HeaderTarget, "Accept", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputStream != nil {
+		v := s.InputStream
+
+		e.SetStream(protocol.PayloadTarget, "inputStream", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.RequestAttributes != nil {
+		v := s.RequestAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-request-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.SessionAttributes != nil {
+		v := s.SessionAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-session-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostContentResponse
 type PostContentOutput struct {
 	_ struct{} `type:"structure" payload:"AudioStream"`
@@ -833,6 +943,53 @@ func (s *PostContentOutput) SetSlots(v aws.JSONValue) *PostContentOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostContentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping AudioStream Output type's body not valid.
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DialogState != nil {
+		v := *s.DialogState
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-dialog-state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputTranscript != nil {
+		v := *s.InputTranscript
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-input-transcript", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-intent-name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SessionAttributes != nil {
+		v := s.SessionAttributes
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-session-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+	if s.SlotToElicit != nil {
+		v := *s.SlotToElicit
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-slot-to-elicit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Slots != nil {
+		v := s.Slots
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-lex-slots", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostTextRequest
 type PostTextInput struct {
 	_ struct{} `type:"structure"`
@@ -965,6 +1122,42 @@ func (s *PostTextInput) SetSessionAttributes(v map[string]*string) *PostTextInpu
 func (s *PostTextInput) SetUserId(v string) *PostTextInput {
 	s.UserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostTextInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputText != nil {
+		v := *s.InputText
+
+		e.SetValue(protocol.BodyTarget, "inputText", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RequestAttributes) > 0 {
+		v := s.RequestAttributes
+
+		e.SetMap(protocol.BodyTarget, "requestAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.SessionAttributes) > 0 {
+		v := s.SessionAttributes
+
+		e.SetMap(protocol.BodyTarget, "sessionAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/runtime.lex-2016-11-28/PostTextResponse
@@ -1109,6 +1302,47 @@ func (s *PostTextOutput) SetSlots(v map[string]*string) *PostTextOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PostTextOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DialogState != nil {
+		v := *s.DialogState
+
+		e.SetValue(protocol.BodyTarget, "dialogState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntentName != nil {
+		v := *s.IntentName
+
+		e.SetValue(protocol.BodyTarget, "intentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCard != nil {
+		v := s.ResponseCard
+
+		e.SetFields(protocol.BodyTarget, "responseCard", v, protocol.Metadata{})
+	}
+	if len(s.SessionAttributes) > 0 {
+		v := s.SessionAttributes
+
+		e.SetMap(protocol.BodyTarget, "sessionAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SlotToElicit != nil {
+		v := *s.SlotToElicit
+
+		e.SetValue(protocol.BodyTarget, "slotToElicit", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Slots) > 0 {
+		v := s.Slots
+
+		e.SetMap(protocol.BodyTarget, "slots", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If you configure a response card when creating your bots, Amazon Lex substitutes
 // the session attributes and slot values that are available, and then returns
 // it. The response card can also come from a Lambda function ( dialogCodeHook
@@ -1153,6 +1387,27 @@ func (s *ResponseCard) SetGenericAttachments(v []*GenericAttachment) *ResponseCa
 func (s *ResponseCard) SetVersion(v string) *ResponseCard {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResponseCard) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "contentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.GenericAttachments) > 0 {
+		v := s.GenericAttachments
+
+		e.SetList(protocol.BodyTarget, "genericAttachments", encodeGenericAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -403,7 +403,6 @@ func (s *Button) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -504,7 +503,6 @@ func (s *GenericAttachment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "title", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -735,25 +733,10 @@ func (s *PostContentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Accept", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.BotAlias != nil {
-		v := *s.BotAlias
-
-		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.BotName != nil {
-		v := *s.BotName
-
-		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ContentType != nil {
 		v := *s.ContentType
 
 		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.InputStream != nil {
-		v := s.InputStream
-
-		e.SetStream(protocol.PayloadTarget, "inputStream", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
 	}
 	if s.RequestAttributes != nil {
 		v := s.RequestAttributes
@@ -765,12 +748,26 @@ func (s *PostContentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-lex-session-attributes", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
 	}
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.UserId != nil {
 		v := *s.UserId
 
 		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.InputStream != nil {
+		v := s.InputStream
 
+		e.SetStream(protocol.PayloadTarget, "inputStream", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -945,7 +942,6 @@ func (s *PostContentOutput) SetSlots(v aws.JSONValue) *PostContentOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PostContentOutput) MarshalFields(e protocol.FieldEncoder) error {
-	// Skipping AudioStream Output type's body not valid.
 	if s.ContentType != nil {
 		v := *s.ContentType
 
@@ -986,7 +982,7 @@ func (s *PostContentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-lex-slots", protocol.JSONValue{V: v, Base64: true}, protocol.Metadata{})
 	}
-
+	// Skipping AudioStream Output type's body not valid.
 	return nil
 }
 
@@ -1126,16 +1122,6 @@ func (s *PostTextInput) SetUserId(v string) *PostTextInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PostTextInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.BotAlias != nil {
-		v := *s.BotAlias
-
-		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.BotName != nil {
-		v := *s.BotName
-
-		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InputText != nil {
 		v := *s.InputText
 
@@ -1151,12 +1137,21 @@ func (s *PostTextInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "sessionAttributes", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
+	if s.BotAlias != nil {
+		v := *s.BotAlias
+
+		e.SetValue(protocol.PathTarget, "botAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BotName != nil {
+		v := *s.BotName
+
+		e.SetValue(protocol.PathTarget, "botName", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.UserId != nil {
 		v := *s.UserId
 
 		e.SetValue(protocol.PathTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1339,7 +1334,6 @@ func (s *PostTextOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "slots", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1406,7 +1400,6 @@ func (s *ResponseCard) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -1946,7 +1946,6 @@ func (s *AacSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "vbrQuality", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2087,7 +2086,6 @@ func (s *Ac3Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2155,7 +2153,6 @@ func (s *AiffSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2192,7 +2189,6 @@ func (s *AncillarySourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sourceAncillaryChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2323,7 +2319,6 @@ func (s *AudioCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "wavSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2500,7 +2495,6 @@ func (s *AudioDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2622,7 +2616,6 @@ func (s *AudioNormalizationSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "targetLkfs", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2783,7 +2776,6 @@ func (s *AudioSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "tracks", protocol.EncodeInt64List(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2830,7 +2822,6 @@ func (s *AudioSelectorGroup) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "audioSelectorNames", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2875,7 +2866,6 @@ func (s *AvailBlanking) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "availBlankingImage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3165,7 +3155,6 @@ func (s *BurninDestinationSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3216,7 +3205,6 @@ func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3238,7 +3226,6 @@ func (s CancelJobOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -3322,7 +3309,6 @@ func (s *CaptionDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3397,7 +3383,6 @@ func (s *CaptionDescriptionPreset) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3514,7 +3499,6 @@ func (s *CaptionDestinationSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "ttmlDestinationSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3570,7 +3554,6 @@ func (s *CaptionSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "sourceSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3686,7 +3669,6 @@ func (s *CaptionSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "teletextSourceSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3725,7 +3707,6 @@ func (s *ChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "outputChannels", encodeOutputChannelMappingList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3838,7 +3819,6 @@ func (s *ColorCorrector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "saturation", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3945,7 +3925,6 @@ func (s *ContainerSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "mp4Settings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4063,7 +4042,6 @@ func (s *CreateJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "userMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4100,7 +4078,6 @@ func (s *CreateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "job", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4196,7 +4173,6 @@ func (s *CreateJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4233,7 +4209,6 @@ func (s *CreateJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4312,7 +4287,6 @@ func (s *CreatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4349,7 +4323,6 @@ func (s *CreatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4399,7 +4372,6 @@ func (s *CreateQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4438,7 +4410,6 @@ func (s *CreateQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4474,7 +4445,6 @@ func (s *DashIsoEncryptionSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4627,7 +4597,6 @@ func (s *DashIsoGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "segmentLength", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4705,7 +4674,6 @@ func (s *Deinterlacer) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4756,7 +4724,6 @@ func (s *DeleteJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4779,7 +4746,6 @@ func (s DeleteJobTemplateOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4830,7 +4796,6 @@ func (s *DeletePresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4853,7 +4818,6 @@ func (s DeletePresetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeletePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4904,7 +4868,6 @@ func (s *DeleteQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4927,7 +4890,6 @@ func (s DeleteQueueOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4980,7 +4942,6 @@ func (s *DescribeEndpointsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5030,7 +4991,6 @@ func (s *DescribeEndpointsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5097,7 +5057,6 @@ func (s *DvbNitSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nitInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5184,7 +5143,6 @@ func (s *DvbSdtSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "serviceProviderName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5474,7 +5432,6 @@ func (s *DvbSubDestinationSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5512,7 +5469,6 @@ func (s *DvbSubSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5549,7 +5505,6 @@ func (s *DvbTdtSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "tdtInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5884,7 +5839,6 @@ func (s *Eac3Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "surroundMode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5952,7 +5906,6 @@ func (s *EmbeddedSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "source608TrackNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5988,7 +5941,6 @@ func (s *Endpoint) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6034,7 +5986,6 @@ func (s *F4vSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "moovPlacement", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6075,7 +6026,6 @@ func (s *FileGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "destination", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6144,7 +6094,6 @@ func (s *FileSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timeDelta", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6233,7 +6182,6 @@ func (s *FrameCaptureSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "quality", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6284,7 +6232,6 @@ func (s *GetJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6321,7 +6268,6 @@ func (s *GetJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "job", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6372,7 +6318,6 @@ func (s *GetJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6410,7 +6355,6 @@ func (s *GetJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6461,7 +6405,6 @@ func (s *GetPresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6498,7 +6441,6 @@ func (s *GetPresetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6549,7 +6491,6 @@ func (s *GetQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6587,7 +6528,6 @@ func (s *GetQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7183,7 +7123,6 @@ func (s *H264Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "unregisteredSeiTimecode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7769,7 +7708,6 @@ func (s *H265Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "unregisteredSeiTimecode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7982,7 +7920,6 @@ func (s *Hdr10Metadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "whitePointY", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8047,7 +7984,6 @@ func (s *HlsCaptionLanguageMapping) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8166,7 +8102,6 @@ func (s *HlsEncryptionSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8526,7 +8461,6 @@ func (s *HlsGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timestampDeltaMilliseconds", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8630,7 +8564,6 @@ func (s *HlsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "segmentModifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8683,7 +8616,6 @@ func (s *Id3Insertion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timecode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8730,7 +8662,6 @@ func (s *ImageInserter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "insertableImages", encodeInsertableImageList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8969,7 +8900,6 @@ func (s *Input) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9038,7 +8968,6 @@ func (s *InputClipping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "startTimecode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9269,7 +9198,6 @@ func (s *InputTemplate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9471,7 +9399,6 @@ func (s *InsertableImage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9691,7 +9618,6 @@ func (s *Job) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "userMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9834,7 +9760,6 @@ func (s *JobSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "timedMetadataInsertion", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9987,7 +9912,6 @@ func (s *JobTemplate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10131,7 +10055,6 @@ func (s *JobTemplateSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "timedMetadataInsertion", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10232,7 +10155,6 @@ func (s *ListJobTemplatesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10284,7 +10206,6 @@ func (s *ListJobTemplatesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10381,7 +10302,6 @@ func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10433,7 +10353,6 @@ func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10533,7 +10452,6 @@ func (s *ListPresetsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10585,7 +10503,6 @@ func (s *ListPresetsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "presets", encodePresetList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10668,7 +10585,6 @@ func (s *ListQueuesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10719,7 +10635,6 @@ func (s *ListQueuesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "queues", encodeQueueList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11246,7 +11161,6 @@ func (s *M2tsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "videoPid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11493,7 +11407,6 @@ func (s *M3u8Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "videoPid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11593,7 +11506,6 @@ func (s *MovSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "reference", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11660,7 +11572,6 @@ func (s *Mp2Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11744,7 +11655,6 @@ func (s *Mp4Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "mp4MajorBrand", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12231,7 +12141,6 @@ func (s *Mpeg2Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "temporalAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12268,7 +12177,6 @@ func (s *MsSmoothEncryptionSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12369,7 +12277,6 @@ func (s *MsSmoothGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "manifestEncoding", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12421,7 +12328,6 @@ func (s *NielsenConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "distributorId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12494,7 +12400,6 @@ func (s *NoiseReducer) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "spatialFilterSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12531,7 +12436,6 @@ func (s *NoiseReducerFilterSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "strength", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12598,7 +12502,6 @@ func (s *NoiseReducerSpatialFilterSettings) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.BodyTarget, "strength", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12751,7 +12654,6 @@ func (s *Output) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoDescription", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12795,7 +12697,6 @@ func (s *OutputChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "inputChannels", protocol.EncodeInt64List(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12853,7 +12754,6 @@ func (s *OutputDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoDetails", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12943,7 +12843,6 @@ func (s *OutputGroup) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "outputs", encodeOutputList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12987,7 +12886,6 @@ func (s *OutputGroupDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "outputDetails", encodeOutputDetailList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13091,7 +12989,6 @@ func (s *OutputGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13127,7 +13024,6 @@ func (s *OutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "hlsSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13263,7 +13159,6 @@ func (s *Preset) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13354,7 +13249,6 @@ func (s *PresetSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoDescription", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13555,7 +13449,6 @@ func (s *ProresSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "telecine", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13680,7 +13573,6 @@ func (s *Queue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13768,7 +13660,6 @@ func (s *Rectangle) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "y", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13840,7 +13731,6 @@ func (s *RemixSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "channelsOut", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13880,7 +13770,6 @@ func (s *SccDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "framerate", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13946,7 +13835,6 @@ func (s *SpekeKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14029,7 +13917,6 @@ func (s *StaticKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14068,7 +13955,6 @@ func (s *TeletextDestinationSettings) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14106,7 +13992,6 @@ func (s *TeletextSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14177,7 +14062,6 @@ func (s *TimecodeBurnin) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14283,7 +14167,6 @@ func (s *TimecodeConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timestampOffset", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14322,7 +14205,6 @@ func (s *TimedMetadataInsertion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "id3Insertions", encodeId3InsertionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14387,7 +14269,6 @@ func (s *Timing) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "submitTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14424,7 +14305,6 @@ func (s *TtmlDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stylePassthrough", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14519,11 +14399,6 @@ func (s *UpdateJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Queue != nil {
 		v := *s.Queue
 
@@ -14534,7 +14409,11 @@ func (s *UpdateJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14572,7 +14451,6 @@ func (s *UpdateJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14657,17 +14535,16 @@ func (s *UpdatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Settings != nil {
 		v := s.Settings
 
 		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14704,7 +14581,6 @@ func (s *UpdatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14777,17 +14653,16 @@ func (s *UpdateQueueInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Name != nil {
-		v := *s.Name
-
-		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Status != nil {
 		v := *s.Status
 
 		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Name != nil {
+		v := *s.Name
 
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -14825,7 +14700,6 @@ func (s *UpdateQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14941,7 +14815,6 @@ func (s *VideoCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "proresSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15223,7 +15096,6 @@ func (s *VideoDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15273,7 +15145,6 @@ func (s *VideoDetail) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "widthInPx", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15375,7 +15246,6 @@ func (s *VideoPreprocessor) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "timecodeBurnin", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15481,7 +15351,6 @@ func (s *VideoSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15549,7 +15418,6 @@ func (s *WavSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCancelJob = "CancelJob"
@@ -1898,6 +1899,57 @@ func (s *AacSettings) SetVbrQuality(v string) *AacSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AacSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioDescriptionBroadcasterMix != nil {
+		v := *s.AudioDescriptionBroadcasterMix
+
+		e.SetValue(protocol.BodyTarget, "audioDescriptionBroadcasterMix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodecProfile != nil {
+		v := *s.CodecProfile
+
+		e.SetValue(protocol.BodyTarget, "codecProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawFormat != nil {
+		v := *s.RawFormat
+
+		e.SetValue(protocol.BodyTarget, "rawFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Specification != nil {
+		v := *s.Specification
+
+		e.SetValue(protocol.BodyTarget, "specification", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VbrQuality != nil {
+		v := *s.VbrQuality
+
+		e.SetValue(protocol.BodyTarget, "vbrQuality", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
 // the value AC3.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/Ac3Settings
@@ -1993,6 +2045,52 @@ func (s *Ac3Settings) SetSampleRate(v int64) *Ac3Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Ac3Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BitstreamMode != nil {
+		v := *s.BitstreamMode
+
+		e.SetValue(protocol.BodyTarget, "bitstreamMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dialnorm != nil {
+		v := *s.Dialnorm
+
+		e.SetValue(protocol.BodyTarget, "dialnorm", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DynamicRangeCompressionProfile != nil {
+		v := *s.DynamicRangeCompressionProfile
+
+		e.SetValue(protocol.BodyTarget, "dynamicRangeCompressionProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeFilter != nil {
+		v := *s.LfeFilter
+
+		e.SetValue(protocol.BodyTarget, "lfeFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetadataControl != nil {
+		v := *s.MetadataControl
+
+		e.SetValue(protocol.BodyTarget, "metadataControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
 // the value AIFF.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/AiffSettings
@@ -2040,6 +2138,27 @@ func (s *AiffSettings) SetSampleRate(v int64) *AiffSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AiffSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BitDepth != nil {
+		v := *s.BitDepth
+
+		e.SetValue(protocol.BodyTarget, "bitDepth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Channels != nil {
+		v := *s.Channels
+
+		e.SetValue(protocol.BodyTarget, "channels", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for ancillary captions source.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/AncillarySourceSettings
 type AncillarySourceSettings struct {
@@ -2064,6 +2183,17 @@ func (s AncillarySourceSettings) GoString() string {
 func (s *AncillarySourceSettings) SetSourceAncillaryChannelNumber(v int64) *AncillarySourceSettings {
 	s.SourceAncillaryChannelNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AncillarySourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SourceAncillaryChannelNumber != nil {
+		v := *s.SourceAncillaryChannelNumber
+
+		e.SetValue(protocol.BodyTarget, "sourceAncillaryChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Audio codec settings (CodecSettings) under (AudioDescriptions) contains the
@@ -2154,6 +2284,47 @@ func (s *AudioCodecSettings) SetMp2Settings(v *Mp2Settings) *AudioCodecSettings 
 func (s *AudioCodecSettings) SetWavSettings(v *WavSettings) *AudioCodecSettings {
 	s.WavSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AacSettings != nil {
+		v := s.AacSettings
+
+		e.SetFields(protocol.BodyTarget, "aacSettings", v, protocol.Metadata{})
+	}
+	if s.Ac3Settings != nil {
+		v := s.Ac3Settings
+
+		e.SetFields(protocol.BodyTarget, "ac3Settings", v, protocol.Metadata{})
+	}
+	if s.AiffSettings != nil {
+		v := s.AiffSettings
+
+		e.SetFields(protocol.BodyTarget, "aiffSettings", v, protocol.Metadata{})
+	}
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Eac3Settings != nil {
+		v := s.Eac3Settings
+
+		e.SetFields(protocol.BodyTarget, "eac3Settings", v, protocol.Metadata{})
+	}
+	if s.Mp2Settings != nil {
+		v := s.Mp2Settings
+
+		e.SetFields(protocol.BodyTarget, "mp2Settings", v, protocol.Metadata{})
+	}
+	if s.WavSettings != nil {
+		v := s.WavSettings
+
+		e.SetFields(protocol.BodyTarget, "wavSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Description of audio output
@@ -2282,6 +2453,65 @@ func (s *AudioDescription) SetStreamName(v string) *AudioDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioNormalizationSettings != nil {
+		v := s.AudioNormalizationSettings
+
+		e.SetFields(protocol.BodyTarget, "audioNormalizationSettings", v, protocol.Metadata{})
+	}
+	if s.AudioSourceName != nil {
+		v := *s.AudioSourceName
+
+		e.SetValue(protocol.BodyTarget, "audioSourceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioType != nil {
+		v := *s.AudioType
+
+		e.SetValue(protocol.BodyTarget, "audioType", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AudioTypeControl != nil {
+		v := *s.AudioTypeControl
+
+		e.SetValue(protocol.BodyTarget, "audioTypeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecSettings != nil {
+		v := s.CodecSettings
+
+		e.SetFields(protocol.BodyTarget, "codecSettings", v, protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCodeControl != nil {
+		v := *s.LanguageCodeControl
+
+		e.SetValue(protocol.BodyTarget, "languageCodeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RemixSettings != nil {
+		v := s.RemixSettings
+
+		e.SetFields(protocol.BodyTarget, "remixSettings", v, protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioDescriptionList(vs []*AudioDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Advanced audio normalization settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/AudioNormalizationSettings
 type AudioNormalizationSettings struct {
@@ -2358,6 +2588,42 @@ func (s *AudioNormalizationSettings) SetPeakCalculation(v string) *AudioNormaliz
 func (s *AudioNormalizationSettings) SetTargetLkfs(v float64) *AudioNormalizationSettings {
 	s.TargetLkfs = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioNormalizationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Algorithm != nil {
+		v := *s.Algorithm
+
+		e.SetValue(protocol.BodyTarget, "algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AlgorithmControl != nil {
+		v := *s.AlgorithmControl
+
+		e.SetValue(protocol.BodyTarget, "algorithmControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CorrectionGateLevel != nil {
+		v := *s.CorrectionGateLevel
+
+		e.SetValue(protocol.BodyTarget, "correctionGateLevel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LoudnessLogging != nil {
+		v := *s.LoudnessLogging
+
+		e.SetValue(protocol.BodyTarget, "loudnessLogging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PeakCalculation != nil {
+		v := *s.PeakCalculation
+
+		e.SetValue(protocol.BodyTarget, "peakCalculation", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetLkfs != nil {
+		v := *s.TargetLkfs
+
+		e.SetValue(protocol.BodyTarget, "targetLkfs", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Selector for Audio
@@ -2470,6 +2736,65 @@ func (s *AudioSelector) SetTracks(v []*int64) *AudioSelector {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefaultSelection != nil {
+		v := *s.DefaultSelection
+
+		e.SetValue(protocol.BodyTarget, "defaultSelection", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExternalAudioFileInput != nil {
+		v := *s.ExternalAudioFileInput
+
+		e.SetValue(protocol.BodyTarget, "externalAudioFileInput", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Offset != nil {
+		v := *s.Offset
+
+		e.SetValue(protocol.BodyTarget, "offset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Pids) > 0 {
+		v := s.Pids
+
+		e.SetList(protocol.BodyTarget, "pids", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+	if s.ProgramSelection != nil {
+		v := *s.ProgramSelection
+
+		e.SetValue(protocol.BodyTarget, "programSelection", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RemixSettings != nil {
+		v := s.RemixSettings
+
+		e.SetFields(protocol.BodyTarget, "remixSettings", v, protocol.Metadata{})
+	}
+	if s.SelectorType != nil {
+		v := *s.SelectorType
+
+		e.SetValue(protocol.BodyTarget, "selectorType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tracks) > 0 {
+		v := s.Tracks
+
+		e.SetList(protocol.BodyTarget, "tracks", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioSelectorMap(vs map[string]*AudioSelector) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Group of Audio Selectors
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/AudioSelectorGroup
 type AudioSelectorGroup struct {
@@ -2498,6 +2823,25 @@ func (s *AudioSelectorGroup) SetAudioSelectorNames(v []*string) *AudioSelectorGr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioSelectorGroup) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioSelectorNames) > 0 {
+		v := s.AudioSelectorNames
+
+		e.SetList(protocol.BodyTarget, "audioSelectorNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioSelectorGroupMap(vs map[string]*AudioSelectorGroup) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Settings for Avail Blanking
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/AvailBlanking
 type AvailBlanking struct {
@@ -2522,6 +2866,17 @@ func (s AvailBlanking) GoString() string {
 func (s *AvailBlanking) SetAvailBlankingImage(v string) *AvailBlanking {
 	s.AvailBlankingImage = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AvailBlanking) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AvailBlankingImage != nil {
+		v := *s.AvailBlankingImage
+
+		e.SetValue(protocol.BodyTarget, "availBlankingImage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Burn-In Destination Settings.
@@ -2728,6 +3083,92 @@ func (s *BurninDestinationSettings) SetYPosition(v int64) *BurninDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BurninDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alignment != nil {
+		v := *s.Alignment
+
+		e.SetValue(protocol.BodyTarget, "alignment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundColor != nil {
+		v := *s.BackgroundColor
+
+		e.SetValue(protocol.BodyTarget, "backgroundColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundOpacity != nil {
+		v := *s.BackgroundOpacity
+
+		e.SetValue(protocol.BodyTarget, "backgroundOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontColor != nil {
+		v := *s.FontColor
+
+		e.SetValue(protocol.BodyTarget, "fontColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FontOpacity != nil {
+		v := *s.FontOpacity
+
+		e.SetValue(protocol.BodyTarget, "fontOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontResolution != nil {
+		v := *s.FontResolution
+
+		e.SetValue(protocol.BodyTarget, "fontResolution", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontSize != nil {
+		v := *s.FontSize
+
+		e.SetValue(protocol.BodyTarget, "fontSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OutlineColor != nil {
+		v := *s.OutlineColor
+
+		e.SetValue(protocol.BodyTarget, "outlineColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineSize != nil {
+		v := *s.OutlineSize
+
+		e.SetValue(protocol.BodyTarget, "outlineSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowColor != nil {
+		v := *s.ShadowColor
+
+		e.SetValue(protocol.BodyTarget, "shadowColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShadowOpacity != nil {
+		v := *s.ShadowOpacity
+
+		e.SetValue(protocol.BodyTarget, "shadowOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowXOffset != nil {
+		v := *s.ShadowXOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowXOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowYOffset != nil {
+		v := *s.ShadowYOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowYOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TeletextSpacing != nil {
+		v := *s.TeletextSpacing
+
+		e.SetValue(protocol.BodyTarget, "teletextSpacing", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.XPosition != nil {
+		v := *s.XPosition
+
+		e.SetValue(protocol.BodyTarget, "xPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.YPosition != nil {
+		v := *s.YPosition
+
+		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Cancel a job by sending a request with the job ID
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CancelJobRequest
 type CancelJobInput struct {
@@ -2768,6 +3209,17 @@ func (s *CancelJobInput) SetId(v string) *CancelJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A cancel job request will receive a response with an empty body.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CancelJobResponse
 type CancelJobOutput struct {
@@ -2782,6 +3234,12 @@ func (s CancelJobOutput) String() string {
 // GoString returns the string representation
 func (s CancelJobOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CancelJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Description of Caption output
@@ -2842,6 +3300,40 @@ func (s *CaptionDescription) SetLanguageDescription(v string) *CaptionDescriptio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaptionSelectorName != nil {
+		v := *s.CaptionSelectorName
+
+		e.SetValue(protocol.BodyTarget, "captionSelectorName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DestinationSettings != nil {
+		v := s.DestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "destinationSettings", v, protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageDescription != nil {
+		v := *s.LanguageDescription
+
+		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionDescriptionList(vs []*CaptionDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Caption Description for preset
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CaptionDescriptionPreset
 type CaptionDescriptionPreset struct {
@@ -2886,6 +3378,35 @@ func (s *CaptionDescriptionPreset) SetLanguageCode(v string) *CaptionDescription
 func (s *CaptionDescriptionPreset) SetLanguageDescription(v string) *CaptionDescriptionPreset {
 	s.LanguageDescription = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionDescriptionPreset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DestinationSettings != nil {
+		v := s.DestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "destinationSettings", v, protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageDescription != nil {
+		v := *s.LanguageDescription
+
+		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionDescriptionPresetList(vs []*CaptionDescriptionPreset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specific settings required by destination type. Note that burnin_destination_settings
@@ -2961,6 +3482,42 @@ func (s *CaptionDestinationSettings) SetTtmlDestinationSettings(v *TtmlDestinati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BurninDestinationSettings != nil {
+		v := s.BurninDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "burninDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.DestinationType != nil {
+		v := *s.DestinationType
+
+		e.SetValue(protocol.BodyTarget, "destinationType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DvbSubDestinationSettings != nil {
+		v := s.DvbSubDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSubDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.SccDestinationSettings != nil {
+		v := s.SccDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "sccDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.TeletextDestinationSettings != nil {
+		v := s.TeletextDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "teletextDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.TtmlDestinationSettings != nil {
+		v := s.TtmlDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "ttmlDestinationSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Caption inputs to be mapped to caption outputs.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CaptionSelector
 type CaptionSelector struct {
@@ -2999,6 +3556,30 @@ func (s *CaptionSelector) SetLanguageCode(v string) *CaptionSelector {
 func (s *CaptionSelector) SetSourceSettings(v *CaptionSourceSettings) *CaptionSelector {
 	s.SourceSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceSettings != nil {
+		v := s.SourceSettings
+
+		e.SetFields(protocol.BodyTarget, "sourceSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionSelectorMap(vs map[string]*CaptionSelector) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Source settings (SourceSettings) contains the group of settings for captions
@@ -3073,6 +3654,42 @@ func (s *CaptionSourceSettings) SetTeletextSourceSettings(v *TeletextSourceSetti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AncillarySourceSettings != nil {
+		v := s.AncillarySourceSettings
+
+		e.SetFields(protocol.BodyTarget, "ancillarySourceSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSubSourceSettings != nil {
+		v := s.DvbSubSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSubSourceSettings", v, protocol.Metadata{})
+	}
+	if s.EmbeddedSourceSettings != nil {
+		v := s.EmbeddedSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "embeddedSourceSettings", v, protocol.Metadata{})
+	}
+	if s.FileSourceSettings != nil {
+		v := s.FileSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "fileSourceSettings", v, protocol.Metadata{})
+	}
+	if s.SourceType != nil {
+		v := *s.SourceType
+
+		e.SetValue(protocol.BodyTarget, "sourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TeletextSourceSettings != nil {
+		v := s.TeletextSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "teletextSourceSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Channel mapping (ChannelMapping) contains the group of fields that hold the
 // remixing value for each channel. Units are in dB. Acceptable values are within
 // the range from -60 (mute) through 6. A setting of 0 passes the input channel
@@ -3099,6 +3716,17 @@ func (s ChannelMapping) GoString() string {
 func (s *ChannelMapping) SetOutputChannels(v []*OutputChannelMapping) *ChannelMapping {
 	s.OutputChannels = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.OutputChannels) > 0 {
+		v := s.OutputChannels
+
+		e.SetList(protocol.BodyTarget, "outputChannels", encodeOutputChannelMappingList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for color correction.
@@ -3178,6 +3806,42 @@ func (s *ColorCorrector) SetSaturation(v int64) *ColorCorrector {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ColorCorrector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Brightness != nil {
+		v := *s.Brightness
+
+		e.SetValue(protocol.BodyTarget, "brightness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ColorSpaceConversion != nil {
+		v := *s.ColorSpaceConversion
+
+		e.SetValue(protocol.BodyTarget, "colorSpaceConversion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Contrast != nil {
+		v := *s.Contrast
+
+		e.SetValue(protocol.BodyTarget, "contrast", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Hdr10Metadata != nil {
+		v := s.Hdr10Metadata
+
+		e.SetFields(protocol.BodyTarget, "hdr10Metadata", v, protocol.Metadata{})
+	}
+	if s.Hue != nil {
+		v := *s.Hue
+
+		e.SetValue(protocol.BodyTarget, "hue", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Saturation != nil {
+		v := *s.Saturation
+
+		e.SetValue(protocol.BodyTarget, "saturation", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container specific settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/ContainerSettings
 type ContainerSettings struct {
@@ -3247,6 +3911,42 @@ func (s *ContainerSettings) SetMovSettings(v *MovSettings) *ContainerSettings {
 func (s *ContainerSettings) SetMp4Settings(v *Mp4Settings) *ContainerSettings {
 	s.Mp4Settings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ContainerSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Container != nil {
+		v := *s.Container
+
+		e.SetValue(protocol.BodyTarget, "container", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.F4vSettings != nil {
+		v := s.F4vSettings
+
+		e.SetFields(protocol.BodyTarget, "f4vSettings", v, protocol.Metadata{})
+	}
+	if s.M2tsSettings != nil {
+		v := s.M2tsSettings
+
+		e.SetFields(protocol.BodyTarget, "m2tsSettings", v, protocol.Metadata{})
+	}
+	if s.M3u8Settings != nil {
+		v := s.M3u8Settings
+
+		e.SetFields(protocol.BodyTarget, "m3u8Settings", v, protocol.Metadata{})
+	}
+	if s.MovSettings != nil {
+		v := s.MovSettings
+
+		e.SetFields(protocol.BodyTarget, "movSettings", v, protocol.Metadata{})
+	}
+	if s.Mp4Settings != nil {
+		v := s.Mp4Settings
+
+		e.SetFields(protocol.BodyTarget, "mp4Settings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send your create job request with your job settings and IAM role. Optionally,
@@ -3325,6 +4025,48 @@ func (s *CreateJobInput) SetUserMetadata(v map[string]*string) *CreateJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	var ClientRequestToken string
+	if s.ClientRequestToken != nil {
+		ClientRequestToken = *s.ClientRequestToken
+	} else {
+		ClientRequestToken = protocol.GetIdempotencyToken()
+	}
+	{
+		v := ClientRequestToken
+
+		e.SetValue(protocol.BodyTarget, "clientRequestToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobTemplate != nil {
+		v := *s.JobTemplate
+
+		e.SetValue(protocol.BodyTarget, "jobTemplate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "userMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful create job requests will return the job JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CreateJobResponse
 type CreateJobOutput struct {
@@ -3349,6 +4091,17 @@ func (s CreateJobOutput) GoString() string {
 func (s *CreateJobOutput) SetJob(v *Job) *CreateJobOutput {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send your create job template request with the name of the template and the
@@ -3416,6 +4169,37 @@ func (s *CreateJobTemplateInput) SetSettings(v *JobTemplateSettings) *CreateJobT
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful create job template requests will return the template JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CreateJobTemplateResponse
 type CreateJobTemplateOutput struct {
@@ -3440,6 +4224,17 @@ func (s CreateJobTemplateOutput) GoString() string {
 func (s *CreateJobTemplateOutput) SetJobTemplate(v *JobTemplate) *CreateJobTemplateOutput {
 	s.JobTemplate = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobTemplate != nil {
+		v := s.JobTemplate
+
+		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send your create preset request with the name of the preset and the JSON
@@ -3495,6 +4290,32 @@ func (s *CreatePresetInput) SetSettings(v *PresetSettings) *CreatePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful create preset requests will return the preset JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CreatePresetResponse
 type CreatePresetOutput struct {
@@ -3519,6 +4340,17 @@ func (s CreatePresetOutput) GoString() string {
 func (s *CreatePresetOutput) SetPreset(v *Preset) *CreatePresetOutput {
 	s.Preset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send your create queue request with the name of the queue.
@@ -3555,6 +4387,22 @@ func (s *CreateQueueInput) SetName(v string) *CreateQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful create queue requests will return the name of the queue you just
 // created and information about it.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/CreateQueueResponse
@@ -3583,6 +4431,17 @@ func (s *CreateQueueOutput) SetQueue(v *Queue) *CreateQueueOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Queue != nil {
+		v := s.Queue
+
+		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Specifies DRM settings for DASH outputs.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DashIsoEncryptionSettings
 type DashIsoEncryptionSettings struct {
@@ -3606,6 +4465,17 @@ func (s DashIsoEncryptionSettings) GoString() string {
 func (s *DashIsoEncryptionSettings) SetSpekeKeyProvider(v *SpekeKeyProvider) *DashIsoEncryptionSettings {
 	s.SpekeKeyProvider = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DashIsoEncryptionSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Type) under (OutputGroups)>(OutputGroupSettings) to
@@ -3715,6 +4585,52 @@ func (s *DashIsoGroupSettings) SetSegmentLength(v int64) *DashIsoGroupSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DashIsoGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BaseUrl != nil {
+		v := *s.BaseUrl
+
+		e.SetValue(protocol.BodyTarget, "baseUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := *s.Destination
+
+		e.SetValue(protocol.BodyTarget, "destination", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.FragmentLength != nil {
+		v := *s.FragmentLength
+
+		e.SetValue(protocol.BodyTarget, "fragmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HbbtvCompliance != nil {
+		v := *s.HbbtvCompliance
+
+		e.SetValue(protocol.BodyTarget, "hbbtvCompliance", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MinBufferTime != nil {
+		v := *s.MinBufferTime
+
+		e.SetValue(protocol.BodyTarget, "minBufferTime", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentControl != nil {
+		v := *s.SegmentControl
+
+		e.SetValue(protocol.BodyTarget, "segmentControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentLength != nil {
+		v := *s.SegmentLength
+
+		e.SetValue(protocol.BodyTarget, "segmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for deinterlacer
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/Deinterlacer
 type Deinterlacer struct {
@@ -3772,6 +4688,27 @@ func (s *Deinterlacer) SetMode(v string) *Deinterlacer {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Deinterlacer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Algorithm != nil {
+		v := *s.Algorithm
+
+		e.SetValue(protocol.BodyTarget, "algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Control != nil {
+		v := *s.Control
+
+		e.SetValue(protocol.BodyTarget, "control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Delete a job template by sending a request with the job template name
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DeleteJobTemplateRequest
 type DeleteJobTemplateInput struct {
@@ -3812,6 +4749,17 @@ func (s *DeleteJobTemplateInput) SetName(v string) *DeleteJobTemplateInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Delete job template requests will return an OK message or error message with
 // an empty body.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DeleteJobTemplateResponse
@@ -3827,6 +4775,12 @@ func (s DeleteJobTemplateOutput) String() string {
 // GoString returns the string representation
 func (s DeleteJobTemplateOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Delete a preset by sending a request with the preset name
@@ -3869,6 +4823,17 @@ func (s *DeletePresetInput) SetName(v string) *DeletePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Delete preset requests will return an OK message or error message with an
 // empty body.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DeletePresetResponse
@@ -3884,6 +4849,12 @@ func (s DeletePresetOutput) String() string {
 // GoString returns the string representation
 func (s DeletePresetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Delete a queue by sending a request with the queue name
@@ -3926,6 +4897,17 @@ func (s *DeleteQueueInput) SetName(v string) *DeleteQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Delete queue requests will return an OK message or error message with an
 // empty body.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DeleteQueueResponse
@@ -3941,6 +4923,12 @@ func (s DeleteQueueOutput) String() string {
 // GoString returns the string representation
 func (s DeleteQueueOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Send an request with an empty body to the regional API endpoint to get your
@@ -3980,6 +4968,22 @@ func (s *DescribeEndpointsInput) SetNextToken(v string) *DescribeEndpointsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.BodyTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful describe endpoints requests will return your account API endpoint.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DescribeEndpointsResponse
 type DescribeEndpointsOutput struct {
@@ -4012,6 +5016,22 @@ func (s *DescribeEndpointsOutput) SetEndpoints(v []*Endpoint) *DescribeEndpoints
 func (s *DescribeEndpointsOutput) SetNextToken(v string) *DescribeEndpointsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeEndpointsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Endpoints) > 0 {
+		v := s.Endpoints
+
+		e.SetList(protocol.BodyTarget, "endpoints", encodeEndpointList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Inserts DVB Network Information Table (NIT) at the specified table repetition
@@ -4058,6 +5078,27 @@ func (s *DvbNitSettings) SetNetworkName(v string) *DvbNitSettings {
 func (s *DvbNitSettings) SetNitInterval(v int64) *DvbNitSettings {
 	s.NitInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbNitSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NetworkId != nil {
+		v := *s.NetworkId
+
+		e.SetValue(protocol.BodyTarget, "networkId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NetworkName != nil {
+		v := *s.NetworkName
+
+		e.SetValue(protocol.BodyTarget, "networkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NitInterval != nil {
+		v := *s.NitInterval
+
+		e.SetValue(protocol.BodyTarget, "nitInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Inserts DVB Service Description Table (NIT) at the specified table repetition
@@ -4119,6 +5160,32 @@ func (s *DvbSdtSettings) SetServiceName(v string) *DvbSdtSettings {
 func (s *DvbSdtSettings) SetServiceProviderName(v string) *DvbSdtSettings {
 	s.ServiceProviderName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSdtSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OutputSdt != nil {
+		v := *s.OutputSdt
+
+		e.SetValue(protocol.BodyTarget, "outputSdt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SdtInterval != nil {
+		v := *s.SdtInterval
+
+		e.SetValue(protocol.BodyTarget, "sdtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ServiceName != nil {
+		v := *s.ServiceName
+
+		e.SetValue(protocol.BodyTarget, "serviceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServiceProviderName != nil {
+		v := *s.ServiceProviderName
+
+		e.SetValue(protocol.BodyTarget, "serviceProviderName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // DVB-Sub Destination Settings
@@ -4325,6 +5392,92 @@ func (s *DvbSubDestinationSettings) SetYPosition(v int64) *DvbSubDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSubDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alignment != nil {
+		v := *s.Alignment
+
+		e.SetValue(protocol.BodyTarget, "alignment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundColor != nil {
+		v := *s.BackgroundColor
+
+		e.SetValue(protocol.BodyTarget, "backgroundColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundOpacity != nil {
+		v := *s.BackgroundOpacity
+
+		e.SetValue(protocol.BodyTarget, "backgroundOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontColor != nil {
+		v := *s.FontColor
+
+		e.SetValue(protocol.BodyTarget, "fontColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FontOpacity != nil {
+		v := *s.FontOpacity
+
+		e.SetValue(protocol.BodyTarget, "fontOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontResolution != nil {
+		v := *s.FontResolution
+
+		e.SetValue(protocol.BodyTarget, "fontResolution", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontSize != nil {
+		v := *s.FontSize
+
+		e.SetValue(protocol.BodyTarget, "fontSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OutlineColor != nil {
+		v := *s.OutlineColor
+
+		e.SetValue(protocol.BodyTarget, "outlineColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineSize != nil {
+		v := *s.OutlineSize
+
+		e.SetValue(protocol.BodyTarget, "outlineSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowColor != nil {
+		v := *s.ShadowColor
+
+		e.SetValue(protocol.BodyTarget, "shadowColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShadowOpacity != nil {
+		v := *s.ShadowOpacity
+
+		e.SetValue(protocol.BodyTarget, "shadowOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowXOffset != nil {
+		v := *s.ShadowXOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowXOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowYOffset != nil {
+		v := *s.ShadowYOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowYOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TeletextSpacing != nil {
+		v := *s.TeletextSpacing
+
+		e.SetValue(protocol.BodyTarget, "teletextSpacing", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.XPosition != nil {
+		v := *s.XPosition
+
+		e.SetValue(protocol.BodyTarget, "xPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.YPosition != nil {
+		v := *s.YPosition
+
+		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // DVB Sub Source Settings
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DvbSubSourceSettings
 type DvbSubSourceSettings struct {
@@ -4352,6 +5505,17 @@ func (s *DvbSubSourceSettings) SetPid(v int64) *DvbSubSourceSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSubSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Inserts DVB Time and Date Table (TDT) at the specified table repetition interval.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/DvbTdtSettings
 type DvbTdtSettings struct {
@@ -4376,6 +5540,17 @@ func (s DvbTdtSettings) GoString() string {
 func (s *DvbTdtSettings) SetTdtInterval(v int64) *DvbTdtSettings {
 	s.TdtInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbTdtSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TdtInterval != nil {
+		v := *s.TdtInterval
+
+		e.SetValue(protocol.BodyTarget, "tdtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
@@ -4602,6 +5777,117 @@ func (s *Eac3Settings) SetSurroundMode(v string) *Eac3Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Eac3Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttenuationControl != nil {
+		v := *s.AttenuationControl
+
+		e.SetValue(protocol.BodyTarget, "attenuationControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BitstreamMode != nil {
+		v := *s.BitstreamMode
+
+		e.SetValue(protocol.BodyTarget, "bitstreamMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DcFilter != nil {
+		v := *s.DcFilter
+
+		e.SetValue(protocol.BodyTarget, "dcFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dialnorm != nil {
+		v := *s.Dialnorm
+
+		e.SetValue(protocol.BodyTarget, "dialnorm", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DynamicRangeCompressionLine != nil {
+		v := *s.DynamicRangeCompressionLine
+
+		e.SetValue(protocol.BodyTarget, "dynamicRangeCompressionLine", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DynamicRangeCompressionRf != nil {
+		v := *s.DynamicRangeCompressionRf
+
+		e.SetValue(protocol.BodyTarget, "dynamicRangeCompressionRf", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeControl != nil {
+		v := *s.LfeControl
+
+		e.SetValue(protocol.BodyTarget, "lfeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeFilter != nil {
+		v := *s.LfeFilter
+
+		e.SetValue(protocol.BodyTarget, "lfeFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoRoCenterMixLevel != nil {
+		v := *s.LoRoCenterMixLevel
+
+		e.SetValue(protocol.BodyTarget, "loRoCenterMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LoRoSurroundMixLevel != nil {
+		v := *s.LoRoSurroundMixLevel
+
+		e.SetValue(protocol.BodyTarget, "loRoSurroundMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LtRtCenterMixLevel != nil {
+		v := *s.LtRtCenterMixLevel
+
+		e.SetValue(protocol.BodyTarget, "ltRtCenterMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LtRtSurroundMixLevel != nil {
+		v := *s.LtRtSurroundMixLevel
+
+		e.SetValue(protocol.BodyTarget, "ltRtSurroundMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.MetadataControl != nil {
+		v := *s.MetadataControl
+
+		e.SetValue(protocol.BodyTarget, "metadataControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PassthroughControl != nil {
+		v := *s.PassthroughControl
+
+		e.SetValue(protocol.BodyTarget, "passthroughControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PhaseControl != nil {
+		v := *s.PhaseControl
+
+		e.SetValue(protocol.BodyTarget, "phaseControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StereoDownmix != nil {
+		v := *s.StereoDownmix
+
+		e.SetValue(protocol.BodyTarget, "stereoDownmix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SurroundExMode != nil {
+		v := *s.SurroundExMode
+
+		e.SetValue(protocol.BodyTarget, "surroundExMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SurroundMode != nil {
+		v := *s.SurroundMode
+
+		e.SetValue(protocol.BodyTarget, "surroundMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for embedded captions Source
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/EmbeddedSourceSettings
 type EmbeddedSourceSettings struct {
@@ -4649,6 +5935,27 @@ func (s *EmbeddedSourceSettings) SetSource608TrackNumber(v int64) *EmbeddedSourc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmbeddedSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Convert608To708 != nil {
+		v := *s.Convert608To708
+
+		e.SetValue(protocol.BodyTarget, "convert608To708", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source608ChannelNumber != nil {
+		v := *s.Source608ChannelNumber
+
+		e.SetValue(protocol.BodyTarget, "source608ChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Source608TrackNumber != nil {
+		v := *s.Source608TrackNumber
+
+		e.SetValue(protocol.BodyTarget, "source608TrackNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes account specific API endpoint
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/Endpoint
 type Endpoint struct {
@@ -4672,6 +5979,25 @@ func (s Endpoint) GoString() string {
 func (s *Endpoint) SetUrl(v string) *Endpoint {
 	s.Url = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Endpoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEndpointList(vs []*Endpoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for F4v container
@@ -4699,6 +6025,17 @@ func (s F4vSettings) GoString() string {
 func (s *F4vSettings) SetMoovPlacement(v string) *F4vSettings {
 	s.MoovPlacement = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *F4vSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MoovPlacement != nil {
+		v := *s.MoovPlacement
+
+		e.SetValue(protocol.BodyTarget, "moovPlacement", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Type) under (OutputGroups)>(OutputGroupSettings) to
@@ -4729,6 +6066,17 @@ func (s FileGroupSettings) GoString() string {
 func (s *FileGroupSettings) SetDestination(v string) *FileGroupSettings {
 	s.Destination = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := *s.Destination
+
+		e.SetValue(protocol.BodyTarget, "destination", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for File-based Captions in Source
@@ -4777,6 +6125,27 @@ func (s *FileSourceSettings) SetSourceFile(v string) *FileSourceSettings {
 func (s *FileSourceSettings) SetTimeDelta(v int64) *FileSourceSettings {
 	s.TimeDelta = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FileSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Convert608To708 != nil {
+		v := *s.Convert608To708
+
+		e.SetValue(protocol.BodyTarget, "convert608To708", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceFile != nil {
+		v := *s.SourceFile
+
+		e.SetValue(protocol.BodyTarget, "sourceFile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeDelta != nil {
+		v := *s.TimeDelta
+
+		e.SetValue(protocol.BodyTarget, "timeDelta", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
@@ -4842,6 +6211,32 @@ func (s *FrameCaptureSettings) SetQuality(v int64) *FrameCaptureSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FrameCaptureSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxCaptures != nil {
+		v := *s.MaxCaptures
+
+		e.SetValue(protocol.BodyTarget, "maxCaptures", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Quality != nil {
+		v := *s.Quality
+
+		e.SetValue(protocol.BodyTarget, "quality", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Query a job by sending a request with the job ID.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/GetJobRequest
 type GetJobInput struct {
@@ -4882,6 +6277,17 @@ func (s *GetJobInput) SetId(v string) *GetJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful get job requests will return an OK message and the job JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/GetJobResponse
 type GetJobOutput struct {
@@ -4906,6 +6312,17 @@ func (s GetJobOutput) GoString() string {
 func (s *GetJobOutput) SetJob(v *Job) *GetJobOutput {
 	s.Job = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Job != nil {
+		v := s.Job
+
+		e.SetFields(protocol.BodyTarget, "job", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Query a job template by sending a request with the job template name.
@@ -4948,6 +6365,17 @@ func (s *GetJobTemplateInput) SetName(v string) *GetJobTemplateInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful get job template requests will return an OK message and the job
 // template JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/GetJobTemplateResponse
@@ -4973,6 +6401,17 @@ func (s GetJobTemplateOutput) GoString() string {
 func (s *GetJobTemplateOutput) SetJobTemplate(v *JobTemplate) *GetJobTemplateOutput {
 	s.JobTemplate = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobTemplate != nil {
+		v := s.JobTemplate
+
+		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Query a preset by sending a request with the preset name.
@@ -5015,6 +6454,17 @@ func (s *GetPresetInput) SetName(v string) *GetPresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful get preset requests will return an OK message and the preset JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/GetPresetResponse
 type GetPresetOutput struct {
@@ -5039,6 +6489,17 @@ func (s GetPresetOutput) GoString() string {
 func (s *GetPresetOutput) SetPreset(v *Preset) *GetPresetOutput {
 	s.Preset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetPresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Query a queue by sending a request with the queue name.
@@ -5081,6 +6542,17 @@ func (s *GetQueueInput) SetName(v string) *GetQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful get queue requests will return an OK message and the queue JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/GetQueueResponse
 type GetQueueOutput struct {
@@ -5106,6 +6578,17 @@ func (s GetQueueOutput) GoString() string {
 func (s *GetQueueOutput) SetQueue(v *Queue) *GetQueueOutput {
 	s.Queue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Queue != nil {
+		v := s.Queue
+
+		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
@@ -5513,6 +6996,197 @@ func (s *H264Settings) SetUnregisteredSeiTimecode(v string) *H264Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *H264Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdaptiveQuantization != nil {
+		v := *s.AdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "adaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodecLevel != nil {
+		v := *s.CodecLevel
+
+		e.SetValue(protocol.BodyTarget, "codecLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecProfile != nil {
+		v := *s.CodecProfile
+
+		e.SetValue(protocol.BodyTarget, "codecProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EntropyEncoding != nil {
+		v := *s.EntropyEncoding
+
+		e.SetValue(protocol.BodyTarget, "entropyEncoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FieldEncoding != nil {
+		v := *s.FieldEncoding
+
+		e.SetValue(protocol.BodyTarget, "fieldEncoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FlickerAdaptiveQuantization != nil {
+		v := *s.FlickerAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "flickerAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateControl != nil {
+		v := *s.FramerateControl
+
+		e.SetValue(protocol.BodyTarget, "framerateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateConversionAlgorithm != nil {
+		v := *s.FramerateConversionAlgorithm
+
+		e.SetValue(protocol.BodyTarget, "framerateConversionAlgorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopBReference != nil {
+		v := *s.GopBReference
+
+		e.SetValue(protocol.BodyTarget, "gopBReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GopClosedCadence != nil {
+		v := *s.GopClosedCadence
+
+		e.SetValue(protocol.BodyTarget, "gopClosedCadence", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopSize != nil {
+		v := *s.GopSize
+
+		e.SetValue(protocol.BodyTarget, "gopSize", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.GopSizeUnits != nil {
+		v := *s.GopSizeUnits
+
+		e.SetValue(protocol.BodyTarget, "gopSizeUnits", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HrdBufferInitialFillPercentage != nil {
+		v := *s.HrdBufferInitialFillPercentage
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferInitialFillPercentage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HrdBufferSize != nil {
+		v := *s.HrdBufferSize
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InterlaceMode != nil {
+		v := *s.InterlaceMode
+
+		e.SetValue(protocol.BodyTarget, "interlaceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxBitrate != nil {
+		v := *s.MaxBitrate
+
+		e.SetValue(protocol.BodyTarget, "maxBitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinIInterval != nil {
+		v := *s.MinIInterval
+
+		e.SetValue(protocol.BodyTarget, "minIInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumberBFramesBetweenReferenceFrames != nil {
+		v := *s.NumberBFramesBetweenReferenceFrames
+
+		e.SetValue(protocol.BodyTarget, "numberBFramesBetweenReferenceFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumberReferenceFrames != nil {
+		v := *s.NumberReferenceFrames
+
+		e.SetValue(protocol.BodyTarget, "numberReferenceFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParControl != nil {
+		v := *s.ParControl
+
+		e.SetValue(protocol.BodyTarget, "parControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParDenominator != nil {
+		v := *s.ParDenominator
+
+		e.SetValue(protocol.BodyTarget, "parDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParNumerator != nil {
+		v := *s.ParNumerator
+
+		e.SetValue(protocol.BodyTarget, "parNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.QualityTuningLevel != nil {
+		v := *s.QualityTuningLevel
+
+		e.SetValue(protocol.BodyTarget, "qualityTuningLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepeatPps != nil {
+		v := *s.RepeatPps
+
+		e.SetValue(protocol.BodyTarget, "repeatPps", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SceneChangeDetect != nil {
+		v := *s.SceneChangeDetect
+
+		e.SetValue(protocol.BodyTarget, "sceneChangeDetect", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Slices != nil {
+		v := *s.Slices
+
+		e.SetValue(protocol.BodyTarget, "slices", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SlowPal != nil {
+		v := *s.SlowPal
+
+		e.SetValue(protocol.BodyTarget, "slowPal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Softness != nil {
+		v := *s.Softness
+
+		e.SetValue(protocol.BodyTarget, "softness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SpatialAdaptiveQuantization != nil {
+		v := *s.SpatialAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "spatialAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Syntax != nil {
+		v := *s.Syntax
+
+		e.SetValue(protocol.BodyTarget, "syntax", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Telecine != nil {
+		v := *s.Telecine
+
+		e.SetValue(protocol.BodyTarget, "telecine", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TemporalAdaptiveQuantization != nil {
+		v := *s.TemporalAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "temporalAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UnregisteredSeiTimecode != nil {
+		v := *s.UnregisteredSeiTimecode
+
+		e.SetValue(protocol.BodyTarget, "unregisteredSeiTimecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for H265 codec
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/H265Settings
 type H265Settings struct {
@@ -5913,6 +7587,192 @@ func (s *H265Settings) SetUnregisteredSeiTimecode(v string) *H265Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *H265Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdaptiveQuantization != nil {
+		v := *s.AdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "adaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AlternateTransferFunctionSei != nil {
+		v := *s.AlternateTransferFunctionSei
+
+		e.SetValue(protocol.BodyTarget, "alternateTransferFunctionSei", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodecLevel != nil {
+		v := *s.CodecLevel
+
+		e.SetValue(protocol.BodyTarget, "codecLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecProfile != nil {
+		v := *s.CodecProfile
+
+		e.SetValue(protocol.BodyTarget, "codecProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FlickerAdaptiveQuantization != nil {
+		v := *s.FlickerAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "flickerAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateControl != nil {
+		v := *s.FramerateControl
+
+		e.SetValue(protocol.BodyTarget, "framerateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateConversionAlgorithm != nil {
+		v := *s.FramerateConversionAlgorithm
+
+		e.SetValue(protocol.BodyTarget, "framerateConversionAlgorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopBReference != nil {
+		v := *s.GopBReference
+
+		e.SetValue(protocol.BodyTarget, "gopBReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GopClosedCadence != nil {
+		v := *s.GopClosedCadence
+
+		e.SetValue(protocol.BodyTarget, "gopClosedCadence", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopSize != nil {
+		v := *s.GopSize
+
+		e.SetValue(protocol.BodyTarget, "gopSize", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.GopSizeUnits != nil {
+		v := *s.GopSizeUnits
+
+		e.SetValue(protocol.BodyTarget, "gopSizeUnits", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HrdBufferInitialFillPercentage != nil {
+		v := *s.HrdBufferInitialFillPercentage
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferInitialFillPercentage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HrdBufferSize != nil {
+		v := *s.HrdBufferSize
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InterlaceMode != nil {
+		v := *s.InterlaceMode
+
+		e.SetValue(protocol.BodyTarget, "interlaceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxBitrate != nil {
+		v := *s.MaxBitrate
+
+		e.SetValue(protocol.BodyTarget, "maxBitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinIInterval != nil {
+		v := *s.MinIInterval
+
+		e.SetValue(protocol.BodyTarget, "minIInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumberBFramesBetweenReferenceFrames != nil {
+		v := *s.NumberBFramesBetweenReferenceFrames
+
+		e.SetValue(protocol.BodyTarget, "numberBFramesBetweenReferenceFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumberReferenceFrames != nil {
+		v := *s.NumberReferenceFrames
+
+		e.SetValue(protocol.BodyTarget, "numberReferenceFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParControl != nil {
+		v := *s.ParControl
+
+		e.SetValue(protocol.BodyTarget, "parControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParDenominator != nil {
+		v := *s.ParDenominator
+
+		e.SetValue(protocol.BodyTarget, "parDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParNumerator != nil {
+		v := *s.ParNumerator
+
+		e.SetValue(protocol.BodyTarget, "parNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.QualityTuningLevel != nil {
+		v := *s.QualityTuningLevel
+
+		e.SetValue(protocol.BodyTarget, "qualityTuningLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleAdaptiveOffsetFilterMode != nil {
+		v := *s.SampleAdaptiveOffsetFilterMode
+
+		e.SetValue(protocol.BodyTarget, "sampleAdaptiveOffsetFilterMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SceneChangeDetect != nil {
+		v := *s.SceneChangeDetect
+
+		e.SetValue(protocol.BodyTarget, "sceneChangeDetect", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Slices != nil {
+		v := *s.Slices
+
+		e.SetValue(protocol.BodyTarget, "slices", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SlowPal != nil {
+		v := *s.SlowPal
+
+		e.SetValue(protocol.BodyTarget, "slowPal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SpatialAdaptiveQuantization != nil {
+		v := *s.SpatialAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "spatialAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Telecine != nil {
+		v := *s.Telecine
+
+		e.SetValue(protocol.BodyTarget, "telecine", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TemporalAdaptiveQuantization != nil {
+		v := *s.TemporalAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "temporalAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TemporalIds != nil {
+		v := *s.TemporalIds
+
+		e.SetValue(protocol.BodyTarget, "temporalIds", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tiles != nil {
+		v := *s.Tiles
+
+		e.SetValue(protocol.BodyTarget, "tiles", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UnregisteredSeiTimecode != nil {
+		v := *s.UnregisteredSeiTimecode
+
+		e.SetValue(protocol.BodyTarget, "unregisteredSeiTimecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Use the HDR master display (Hdr10Metadata) settings to provide values for
 // HDR color. These values vary depending on the input video and must be provided
 // by a color grader. Range is 0 to 50,000, each increment represents 0.00002
@@ -6060,6 +7920,72 @@ func (s *Hdr10Metadata) SetWhitePointY(v int64) *Hdr10Metadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Hdr10Metadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BluePrimaryX != nil {
+		v := *s.BluePrimaryX
+
+		e.SetValue(protocol.BodyTarget, "bluePrimaryX", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BluePrimaryY != nil {
+		v := *s.BluePrimaryY
+
+		e.SetValue(protocol.BodyTarget, "bluePrimaryY", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GreenPrimaryX != nil {
+		v := *s.GreenPrimaryX
+
+		e.SetValue(protocol.BodyTarget, "greenPrimaryX", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GreenPrimaryY != nil {
+		v := *s.GreenPrimaryY
+
+		e.SetValue(protocol.BodyTarget, "greenPrimaryY", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxContentLightLevel != nil {
+		v := *s.MaxContentLightLevel
+
+		e.SetValue(protocol.BodyTarget, "maxContentLightLevel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxFrameAverageLightLevel != nil {
+		v := *s.MaxFrameAverageLightLevel
+
+		e.SetValue(protocol.BodyTarget, "maxFrameAverageLightLevel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxLuminance != nil {
+		v := *s.MaxLuminance
+
+		e.SetValue(protocol.BodyTarget, "maxLuminance", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinLuminance != nil {
+		v := *s.MinLuminance
+
+		e.SetValue(protocol.BodyTarget, "minLuminance", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RedPrimaryX != nil {
+		v := *s.RedPrimaryX
+
+		e.SetValue(protocol.BodyTarget, "redPrimaryX", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RedPrimaryY != nil {
+		v := *s.RedPrimaryY
+
+		e.SetValue(protocol.BodyTarget, "redPrimaryY", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.WhitePointX != nil {
+		v := *s.WhitePointX
+
+		e.SetValue(protocol.BodyTarget, "whitePointX", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.WhitePointY != nil {
+		v := *s.WhitePointY
+
+		e.SetValue(protocol.BodyTarget, "whitePointY", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Caption Language Mapping
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/HlsCaptionLanguageMapping
 type HlsCaptionLanguageMapping struct {
@@ -6102,6 +8028,35 @@ func (s *HlsCaptionLanguageMapping) SetLanguageCode(v string) *HlsCaptionLanguag
 func (s *HlsCaptionLanguageMapping) SetLanguageDescription(v string) *HlsCaptionLanguageMapping {
 	s.LanguageDescription = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsCaptionLanguageMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaptionChannel != nil {
+		v := *s.CaptionChannel
+
+		e.SetValue(protocol.BodyTarget, "captionChannel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageDescription != nil {
+		v := *s.LanguageDescription
+
+		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHlsCaptionLanguageMappingList(vs []*HlsCaptionLanguageMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for HLS encryption
@@ -6177,6 +8132,42 @@ func (s *HlsEncryptionSettings) SetStaticKeyProvider(v *StaticKeyProvider) *HlsE
 func (s *HlsEncryptionSettings) SetType(v string) *HlsEncryptionSettings {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsEncryptionSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConstantInitializationVector != nil {
+		v := *s.ConstantInitializationVector
+
+		e.SetValue(protocol.BodyTarget, "constantInitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncryptionMethod != nil {
+		v := *s.EncryptionMethod
+
+		e.SetValue(protocol.BodyTarget, "encryptionMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InitializationVectorInManifest != nil {
+		v := *s.InitializationVectorInManifest
+
+		e.SetValue(protocol.BodyTarget, "initializationVectorInManifest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+	if s.StaticKeyProvider != nil {
+		v := s.StaticKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "staticKeyProvider", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Type) under (OutputGroups)>(OutputGroupSettings) to
@@ -6423,6 +8414,122 @@ func (s *HlsGroupSettings) SetTimestampDeltaMilliseconds(v int64) *HlsGroupSetti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdMarkers) > 0 {
+		v := s.AdMarkers
+
+		e.SetList(protocol.BodyTarget, "adMarkers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.BaseUrl != nil {
+		v := *s.BaseUrl
+
+		e.SetValue(protocol.BodyTarget, "baseUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CaptionLanguageMappings) > 0 {
+		v := s.CaptionLanguageMappings
+
+		e.SetList(protocol.BodyTarget, "captionLanguageMappings", encodeHlsCaptionLanguageMappingList(v), protocol.Metadata{})
+	}
+	if s.CaptionLanguageSetting != nil {
+		v := *s.CaptionLanguageSetting
+
+		e.SetValue(protocol.BodyTarget, "captionLanguageSetting", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCache != nil {
+		v := *s.ClientCache
+
+		e.SetValue(protocol.BodyTarget, "clientCache", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecSpecification != nil {
+		v := *s.CodecSpecification
+
+		e.SetValue(protocol.BodyTarget, "codecSpecification", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := *s.Destination
+
+		e.SetValue(protocol.BodyTarget, "destination", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DirectoryStructure != nil {
+		v := *s.DirectoryStructure
+
+		e.SetValue(protocol.BodyTarget, "directoryStructure", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.ManifestCompression != nil {
+		v := *s.ManifestCompression
+
+		e.SetValue(protocol.BodyTarget, "manifestCompression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestDurationFormat != nil {
+		v := *s.ManifestDurationFormat
+
+		e.SetValue(protocol.BodyTarget, "manifestDurationFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MinSegmentLength != nil {
+		v := *s.MinSegmentLength
+
+		e.SetValue(protocol.BodyTarget, "minSegmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OutputSelection != nil {
+		v := *s.OutputSelection
+
+		e.SetValue(protocol.BodyTarget, "outputSelection", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramDateTime != nil {
+		v := *s.ProgramDateTime
+
+		e.SetValue(protocol.BodyTarget, "programDateTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramDateTimePeriod != nil {
+		v := *s.ProgramDateTimePeriod
+
+		e.SetValue(protocol.BodyTarget, "programDateTimePeriod", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentControl != nil {
+		v := *s.SegmentControl
+
+		e.SetValue(protocol.BodyTarget, "segmentControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentLength != nil {
+		v := *s.SegmentLength
+
+		e.SetValue(protocol.BodyTarget, "segmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsPerSubdirectory != nil {
+		v := *s.SegmentsPerSubdirectory
+
+		e.SetValue(protocol.BodyTarget, "segmentsPerSubdirectory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamInfResolution != nil {
+		v := *s.StreamInfResolution
+
+		e.SetValue(protocol.BodyTarget, "streamInfResolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Frame != nil {
+		v := *s.TimedMetadataId3Frame
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Frame", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Period != nil {
+		v := *s.TimedMetadataId3Period
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Period", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimestampDeltaMilliseconds != nil {
+		v := *s.TimestampDeltaMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "timestampDeltaMilliseconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for HLS output groups
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/HlsSettings
 type HlsSettings struct {
@@ -6496,6 +8603,37 @@ func (s *HlsSettings) SetSegmentModifier(v string) *HlsSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioGroupId != nil {
+		v := *s.AudioGroupId
+
+		e.SetValue(protocol.BodyTarget, "audioGroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioRenditionSets != nil {
+		v := *s.AudioRenditionSets
+
+		e.SetValue(protocol.BodyTarget, "audioRenditionSets", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioTrackType != nil {
+		v := *s.AudioTrackType
+
+		e.SetValue(protocol.BodyTarget, "audioTrackType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IFrameOnlyManifest != nil {
+		v := *s.IFrameOnlyManifest
+
+		e.SetValue(protocol.BodyTarget, "iFrameOnlyManifest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentModifier != nil {
+		v := *s.SegmentModifier
+
+		e.SetValue(protocol.BodyTarget, "segmentModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // To insert ID3 tags in your output, specify two values. Use ID3 tag (Id3)
 // to specify the base 64 encoded string and use Timecode (TimeCode) to specify
 // the time when the tag should be inserted. To insert multiple ID3 tags in
@@ -6533,6 +8671,30 @@ func (s *Id3Insertion) SetTimecode(v string) *Id3Insertion {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Id3Insertion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id3 != nil {
+		v := *s.Id3
+
+		e.SetValue(protocol.BodyTarget, "id3", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timecode != nil {
+		v := *s.Timecode
+
+		e.SetValue(protocol.BodyTarget, "timecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeId3InsertionList(vs []*Id3Insertion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Enable the Image inserter (ImageInserter) feature to include a graphic overlay
 // on your video. Enable or disable this feature for each output individually.
 // This setting is disabled by default.
@@ -6559,6 +8721,17 @@ func (s ImageInserter) GoString() string {
 func (s *ImageInserter) SetInsertableImages(v []*InsertableImage) *ImageInserter {
 	s.InsertableImages = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImageInserter) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.InsertableImages) > 0 {
+		v := s.InsertableImages
+
+		e.SetList(protocol.BodyTarget, "insertableImages", encodeInsertableImageList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Specifies media input
@@ -6729,6 +8902,85 @@ func (s *Input) SetVideoSelector(v *VideoSelector) *Input {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Input) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioSelectorGroups) > 0 {
+		v := s.AudioSelectorGroups
+
+		e.SetMap(protocol.BodyTarget, "audioSelectorGroups", encodeAudioSelectorGroupMap(v), protocol.Metadata{})
+	}
+	if len(s.AudioSelectors) > 0 {
+		v := s.AudioSelectors
+
+		e.SetMap(protocol.BodyTarget, "audioSelectors", encodeAudioSelectorMap(v), protocol.Metadata{})
+	}
+	if len(s.CaptionSelectors) > 0 {
+		v := s.CaptionSelectors
+
+		e.SetMap(protocol.BodyTarget, "captionSelectors", encodeCaptionSelectorMap(v), protocol.Metadata{})
+	}
+	if s.DeblockFilter != nil {
+		v := *s.DeblockFilter
+
+		e.SetValue(protocol.BodyTarget, "deblockFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DenoiseFilter != nil {
+		v := *s.DenoiseFilter
+
+		e.SetValue(protocol.BodyTarget, "denoiseFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FileInput != nil {
+		v := *s.FileInput
+
+		e.SetValue(protocol.BodyTarget, "fileInput", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterEnable != nil {
+		v := *s.FilterEnable
+
+		e.SetValue(protocol.BodyTarget, "filterEnable", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterStrength != nil {
+		v := *s.FilterStrength
+
+		e.SetValue(protocol.BodyTarget, "filterStrength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.InputClippings) > 0 {
+		v := s.InputClippings
+
+		e.SetList(protocol.BodyTarget, "inputClippings", encodeInputClippingList(v), protocol.Metadata{})
+	}
+	if s.ProgramNumber != nil {
+		v := *s.ProgramNumber
+
+		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PsiControl != nil {
+		v := *s.PsiControl
+
+		e.SetValue(protocol.BodyTarget, "psiControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimecodeSource != nil {
+		v := *s.TimecodeSource
+
+		e.SetValue(protocol.BodyTarget, "timecodeSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VideoSelector != nil {
+		v := s.VideoSelector
+
+		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputList(vs []*Input) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Include one instance of (InputClipping) for each input clip.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/InputClipping
 type InputClipping struct {
@@ -6772,6 +9024,30 @@ func (s *InputClipping) SetEndTimecode(v string) *InputClipping {
 func (s *InputClipping) SetStartTimecode(v string) *InputClipping {
 	s.StartTimecode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputClipping) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTimecode != nil {
+		v := *s.EndTimecode
+
+		e.SetValue(protocol.BodyTarget, "endTimecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTimecode != nil {
+		v := *s.StartTimecode
+
+		e.SetValue(protocol.BodyTarget, "startTimecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputClippingList(vs []*InputClipping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Specified video input in a template.
@@ -6931,6 +9207,80 @@ func (s *InputTemplate) SetVideoSelector(v *VideoSelector) *InputTemplate {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputTemplate) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioSelectorGroups) > 0 {
+		v := s.AudioSelectorGroups
+
+		e.SetMap(protocol.BodyTarget, "audioSelectorGroups", encodeAudioSelectorGroupMap(v), protocol.Metadata{})
+	}
+	if len(s.AudioSelectors) > 0 {
+		v := s.AudioSelectors
+
+		e.SetMap(protocol.BodyTarget, "audioSelectors", encodeAudioSelectorMap(v), protocol.Metadata{})
+	}
+	if len(s.CaptionSelectors) > 0 {
+		v := s.CaptionSelectors
+
+		e.SetMap(protocol.BodyTarget, "captionSelectors", encodeCaptionSelectorMap(v), protocol.Metadata{})
+	}
+	if s.DeblockFilter != nil {
+		v := *s.DeblockFilter
+
+		e.SetValue(protocol.BodyTarget, "deblockFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DenoiseFilter != nil {
+		v := *s.DenoiseFilter
+
+		e.SetValue(protocol.BodyTarget, "denoiseFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterEnable != nil {
+		v := *s.FilterEnable
+
+		e.SetValue(protocol.BodyTarget, "filterEnable", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterStrength != nil {
+		v := *s.FilterStrength
+
+		e.SetValue(protocol.BodyTarget, "filterStrength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.InputClippings) > 0 {
+		v := s.InputClippings
+
+		e.SetList(protocol.BodyTarget, "inputClippings", encodeInputClippingList(v), protocol.Metadata{})
+	}
+	if s.ProgramNumber != nil {
+		v := *s.ProgramNumber
+
+		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PsiControl != nil {
+		v := *s.PsiControl
+
+		e.SetValue(protocol.BodyTarget, "psiControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimecodeSource != nil {
+		v := *s.TimecodeSource
+
+		e.SetValue(protocol.BodyTarget, "timecodeSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VideoSelector != nil {
+		v := s.VideoSelector
+
+		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputTemplateList(vs []*InputTemplate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Settings for Insertable Image
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/InsertableImage
 type InsertableImage struct {
@@ -7062,6 +9412,75 @@ func (s *InsertableImage) SetStartTime(v string) *InsertableImage {
 func (s *InsertableImage) SetWidth(v int64) *InsertableImage {
 	s.Width = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InsertableImage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "duration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FadeIn != nil {
+		v := *s.FadeIn
+
+		e.SetValue(protocol.BodyTarget, "fadeIn", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FadeOut != nil {
+		v := *s.FadeOut
+
+		e.SetValue(protocol.BodyTarget, "fadeOut", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ImageInserterInput != nil {
+		v := *s.ImageInserterInput
+
+		e.SetValue(protocol.BodyTarget, "imageInserterInput", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageX != nil {
+		v := *s.ImageX
+
+		e.SetValue(protocol.BodyTarget, "imageX", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ImageY != nil {
+		v := *s.ImageY
+
+		e.SetValue(protocol.BodyTarget, "imageY", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Layer != nil {
+		v := *s.Layer
+
+		e.SetValue(protocol.BodyTarget, "layer", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Opacity != nil {
+		v := *s.Opacity
+
+		e.SetValue(protocol.BodyTarget, "opacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "startTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInsertableImageList(vs []*InsertableImage) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Each job converts an input file into an output file or files. For more information,
@@ -7205,6 +9624,85 @@ func (s *Job) SetUserMetadata(v map[string]*string) *Job {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Job) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "errorCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ErrorMessage != nil {
+		v := *s.ErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "errorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobTemplate != nil {
+		v := *s.JobTemplate
+
+		e.SetValue(protocol.BodyTarget, "jobTemplate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OutputGroupDetails) > 0 {
+		v := s.OutputGroupDetails
+
+		e.SetList(protocol.BodyTarget, "outputGroupDetails", encodeOutputGroupDetailList(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timing != nil {
+		v := s.Timing
+
+		e.SetFields(protocol.BodyTarget, "timing", v, protocol.Metadata{})
+	}
+	if len(s.UserMetadata) > 0 {
+		v := s.UserMetadata
+
+		e.SetMap(protocol.BodyTarget, "userMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobList(vs []*Job) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // JobSettings contains all the transcode settings for a job.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/JobSettings
 type JobSettings struct {
@@ -7297,6 +9795,47 @@ func (s *JobSettings) SetTimecodeConfig(v *TimecodeConfig) *JobSettings {
 func (s *JobSettings) SetTimedMetadataInsertion(v *TimedMetadataInsertion) *JobSettings {
 	s.TimedMetadataInsertion = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdAvailOffset != nil {
+		v := *s.AdAvailOffset
+
+		e.SetValue(protocol.BodyTarget, "adAvailOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AvailBlanking != nil {
+		v := s.AvailBlanking
+
+		e.SetFields(protocol.BodyTarget, "availBlanking", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "inputs", encodeInputList(v), protocol.Metadata{})
+	}
+	if s.NielsenConfiguration != nil {
+		v := s.NielsenConfiguration
+
+		e.SetFields(protocol.BodyTarget, "nielsenConfiguration", v, protocol.Metadata{})
+	}
+	if len(s.OutputGroups) > 0 {
+		v := s.OutputGroups
+
+		e.SetList(protocol.BodyTarget, "outputGroups", encodeOutputGroupList(v), protocol.Metadata{})
+	}
+	if s.TimecodeConfig != nil {
+		v := s.TimecodeConfig
+
+		e.SetFields(protocol.BodyTarget, "timecodeConfig", v, protocol.Metadata{})
+	}
+	if s.TimedMetadataInsertion != nil {
+		v := s.TimedMetadataInsertion
+
+		e.SetFields(protocol.BodyTarget, "timedMetadataInsertion", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A job template is a pre-made set of encoding instructions that you can use
@@ -7401,6 +9940,65 @@ func (s *JobTemplate) SetType(v string) *JobTemplate {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobTemplate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdated != nil {
+		v := *s.LastUpdated
+
+		e.SetValue(protocol.BodyTarget, "lastUpdated", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeJobTemplateList(vs []*JobTemplate) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // JobTemplateSettings contains all the transcode settings saved in the template
 // that will be applied to jobs created from it.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/JobTemplateSettings
@@ -7496,6 +10094,47 @@ func (s *JobTemplateSettings) SetTimedMetadataInsertion(v *TimedMetadataInsertio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *JobTemplateSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdAvailOffset != nil {
+		v := *s.AdAvailOffset
+
+		e.SetValue(protocol.BodyTarget, "adAvailOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AvailBlanking != nil {
+		v := s.AvailBlanking
+
+		e.SetFields(protocol.BodyTarget, "availBlanking", v, protocol.Metadata{})
+	}
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "inputs", encodeInputTemplateList(v), protocol.Metadata{})
+	}
+	if s.NielsenConfiguration != nil {
+		v := s.NielsenConfiguration
+
+		e.SetFields(protocol.BodyTarget, "nielsenConfiguration", v, protocol.Metadata{})
+	}
+	if len(s.OutputGroups) > 0 {
+		v := s.OutputGroups
+
+		e.SetList(protocol.BodyTarget, "outputGroups", encodeOutputGroupList(v), protocol.Metadata{})
+	}
+	if s.TimecodeConfig != nil {
+		v := s.TimecodeConfig
+
+		e.SetFields(protocol.BodyTarget, "timecodeConfig", v, protocol.Metadata{})
+	}
+	if s.TimedMetadataInsertion != nil {
+		v := s.TimedMetadataInsertion
+
+		e.SetFields(protocol.BodyTarget, "timedMetadataInsertion", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // You can send list job templates requests with an empty body. Optionally,
 // you can filter the response by category by specifying it in your request
 // body. You can also optionally specify the maximum number, up to twenty, of
@@ -7566,6 +10205,37 @@ func (s *ListJobTemplatesInput) SetOrder(v string) *ListJobTemplatesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobTemplatesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.QueryTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ListBy != nil {
+		v := *s.ListBy
+
+		e.SetValue(protocol.QueryTarget, "listBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful list job templates requests return a JSON array of job templates.
 // If you do not specify how they are ordered, you will receive them in alphabetical
 // order by name.
@@ -7600,6 +10270,22 @@ func (s *ListJobTemplatesOutput) SetJobTemplates(v []*JobTemplate) *ListJobTempl
 func (s *ListJobTemplatesOutput) SetNextToken(v string) *ListJobTemplatesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobTemplatesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.JobTemplates) > 0 {
+		v := s.JobTemplates
+
+		e.SetList(protocol.BodyTarget, "jobTemplates", encodeJobTemplateList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // You can send list jobs requests with an empty body. Optionally, you can filter
@@ -7668,6 +10354,37 @@ func (s *ListJobsInput) SetStatus(v string) *ListJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.QueryTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.QueryTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful list jobs requests return a JSON array of jobs. If you do not
 // specify how they are ordered, you will receive the most recently created
 // first.
@@ -7702,6 +10419,22 @@ func (s *ListJobsOutput) SetJobs(v []*Job) *ListJobsOutput {
 func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Jobs) > 0 {
+		v := s.Jobs
+
+		e.SetList(protocol.BodyTarget, "jobs", encodeJobList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // You can send list presets requests with an empty body. Optionally, you can
@@ -7773,6 +10506,37 @@ func (s *ListPresetsInput) SetOrder(v string) *ListPresetsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.QueryTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ListBy != nil {
+		v := *s.ListBy
+
+		e.SetValue(protocol.QueryTarget, "listBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful list presets requests return a JSON array of presets. If you do
 // not specify how they are ordered, you will receive them alphabetically by
 // name.
@@ -7807,6 +10571,22 @@ func (s *ListPresetsOutput) SetNextToken(v string) *ListPresetsOutput {
 func (s *ListPresetsOutput) SetPresets(v []*Preset) *ListPresetsOutput {
 	s.Presets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPresetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Presets) > 0 {
+		v := s.Presets
+
+		e.SetList(protocol.BodyTarget, "presets", encodePresetList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // You can send list queues requests with an empty body. You can optionally
@@ -7866,6 +10646,32 @@ func (s *ListQueuesInput) SetOrder(v string) *ListQueuesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueuesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ListBy != nil {
+		v := *s.ListBy
+
+		e.SetValue(protocol.QueryTarget, "listBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful list queues return a JSON array of queues. If you do not specify
 // how they are ordered, you will receive them alphabetically by name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/ListQueuesResponse
@@ -7899,6 +10705,22 @@ func (s *ListQueuesOutput) SetNextToken(v string) *ListQueuesOutput {
 func (s *ListQueuesOutput) SetQueues(v []*Queue) *ListQueuesOutput {
 	s.Queues = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueuesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Queues) > 0 {
+		v := s.Queues
+
+		e.SetList(protocol.BodyTarget, "queues", encodeQueueList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for M2TS Container.
@@ -8262,6 +11084,172 @@ func (s *M2tsSettings) SetVideoPid(v int64) *M2tsSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *M2tsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioBufferModel != nil {
+		v := *s.AudioBufferModel
+
+		e.SetValue(protocol.BodyTarget, "audioBufferModel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioFramesPerPes != nil {
+		v := *s.AudioFramesPerPes
+
+		e.SetValue(protocol.BodyTarget, "audioFramesPerPes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.AudioPids) > 0 {
+		v := s.AudioPids
+
+		e.SetList(protocol.BodyTarget, "audioPids", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BufferModel != nil {
+		v := *s.BufferModel
+
+		e.SetValue(protocol.BodyTarget, "bufferModel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DvbNitSettings != nil {
+		v := s.DvbNitSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbNitSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSdtSettings != nil {
+		v := s.DvbSdtSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSdtSettings", v, protocol.Metadata{})
+	}
+	if len(s.DvbSubPids) > 0 {
+		v := s.DvbSubPids
+
+		e.SetList(protocol.BodyTarget, "dvbSubPids", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+	if s.DvbTdtSettings != nil {
+		v := s.DvbTdtSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbTdtSettings", v, protocol.Metadata{})
+	}
+	if s.DvbTeletextPid != nil {
+		v := *s.DvbTeletextPid
+
+		e.SetValue(protocol.BodyTarget, "dvbTeletextPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.EbpAudioInterval != nil {
+		v := *s.EbpAudioInterval
+
+		e.SetValue(protocol.BodyTarget, "ebpAudioInterval", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EbpPlacement != nil {
+		v := *s.EbpPlacement
+
+		e.SetValue(protocol.BodyTarget, "ebpPlacement", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EsRateInPes != nil {
+		v := *s.EsRateInPes
+
+		e.SetValue(protocol.BodyTarget, "esRateInPes", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FragmentTime != nil {
+		v := *s.FragmentTime
+
+		e.SetValue(protocol.BodyTarget, "fragmentTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.MaxPcrInterval != nil {
+		v := *s.MaxPcrInterval
+
+		e.SetValue(protocol.BodyTarget, "maxPcrInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinEbpInterval != nil {
+		v := *s.MinEbpInterval
+
+		e.SetValue(protocol.BodyTarget, "minEbpInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NullPacketBitrate != nil {
+		v := *s.NullPacketBitrate
+
+		e.SetValue(protocol.BodyTarget, "nullPacketBitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.PatInterval != nil {
+		v := *s.PatInterval
+
+		e.SetValue(protocol.BodyTarget, "patInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrControl != nil {
+		v := *s.PcrControl
+
+		e.SetValue(protocol.BodyTarget, "pcrControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PcrPid != nil {
+		v := *s.PcrPid
+
+		e.SetValue(protocol.BodyTarget, "pcrPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtInterval != nil {
+		v := *s.PmtInterval
+
+		e.SetValue(protocol.BodyTarget, "pmtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtPid != nil {
+		v := *s.PmtPid
+
+		e.SetValue(protocol.BodyTarget, "pmtPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PrivateMetadataPid != nil {
+		v := *s.PrivateMetadataPid
+
+		e.SetValue(protocol.BodyTarget, "privateMetadataPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ProgramNumber != nil {
+		v := *s.ProgramNumber
+
+		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RateMode != nil {
+		v := *s.RateMode
+
+		e.SetValue(protocol.BodyTarget, "rateMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte35Pid != nil {
+		v := *s.Scte35Pid
+
+		e.SetValue(protocol.BodyTarget, "scte35Pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Scte35Source != nil {
+		v := *s.Scte35Source
+
+		e.SetValue(protocol.BodyTarget, "scte35Source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationMarkers != nil {
+		v := *s.SegmentationMarkers
+
+		e.SetValue(protocol.BodyTarget, "segmentationMarkers", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationStyle != nil {
+		v := *s.SegmentationStyle
+
+		e.SetValue(protocol.BodyTarget, "segmentationStyle", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationTime != nil {
+		v := *s.SegmentationTime
+
+		e.SetValue(protocol.BodyTarget, "segmentationTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.TransportStreamId != nil {
+		v := *s.TransportStreamId
+
+		e.SetValue(protocol.BodyTarget, "transportStreamId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VideoPid != nil {
+		v := *s.VideoPid
+
+		e.SetValue(protocol.BodyTarget, "videoPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for TS segments in HLS
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/M3u8Settings
 type M3u8Settings struct {
@@ -8428,6 +11416,87 @@ func (s *M3u8Settings) SetVideoPid(v int64) *M3u8Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *M3u8Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioFramesPerPes != nil {
+		v := *s.AudioFramesPerPes
+
+		e.SetValue(protocol.BodyTarget, "audioFramesPerPes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.AudioPids) > 0 {
+		v := s.AudioPids
+
+		e.SetList(protocol.BodyTarget, "audioPids", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+	if s.PatInterval != nil {
+		v := *s.PatInterval
+
+		e.SetValue(protocol.BodyTarget, "patInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrControl != nil {
+		v := *s.PcrControl
+
+		e.SetValue(protocol.BodyTarget, "pcrControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PcrPid != nil {
+		v := *s.PcrPid
+
+		e.SetValue(protocol.BodyTarget, "pcrPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtInterval != nil {
+		v := *s.PmtInterval
+
+		e.SetValue(protocol.BodyTarget, "pmtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtPid != nil {
+		v := *s.PmtPid
+
+		e.SetValue(protocol.BodyTarget, "pmtPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PrivateMetadataPid != nil {
+		v := *s.PrivateMetadataPid
+
+		e.SetValue(protocol.BodyTarget, "privateMetadataPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ProgramNumber != nil {
+		v := *s.ProgramNumber
+
+		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Scte35Pid != nil {
+		v := *s.Scte35Pid
+
+		e.SetValue(protocol.BodyTarget, "scte35Pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Scte35Source != nil {
+		v := *s.Scte35Source
+
+		e.SetValue(protocol.BodyTarget, "scte35Source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadata != nil {
+		v := *s.TimedMetadata
+
+		e.SetValue(protocol.BodyTarget, "timedMetadata", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataPid != nil {
+		v := *s.TimedMetadataPid
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TransportStreamId != nil {
+		v := *s.TransportStreamId
+
+		e.SetValue(protocol.BodyTarget, "transportStreamId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VideoPid != nil {
+		v := *s.VideoPid
+
+		e.SetValue(protocol.BodyTarget, "videoPid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for MOV Container.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/MovSettings
 type MovSettings struct {
@@ -8497,6 +11566,37 @@ func (s *MovSettings) SetReference(v string) *MovSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MovSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClapAtom != nil {
+		v := *s.ClapAtom
+
+		e.SetValue(protocol.BodyTarget, "clapAtom", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CslgAtom != nil {
+		v := *s.CslgAtom
+
+		e.SetValue(protocol.BodyTarget, "cslgAtom", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mpeg2FourCCControl != nil {
+		v := *s.Mpeg2FourCCControl
+
+		e.SetValue(protocol.BodyTarget, "mpeg2FourCCControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PaddingControl != nil {
+		v := *s.PaddingControl
+
+		e.SetValue(protocol.BodyTarget, "paddingControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reference != nil {
+		v := *s.Reference
+
+		e.SetValue(protocol.BodyTarget, "reference", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
 // the value MP2.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/Mp2Settings
@@ -8541,6 +11641,27 @@ func (s *Mp2Settings) SetChannels(v int64) *Mp2Settings {
 func (s *Mp2Settings) SetSampleRate(v int64) *Mp2Settings {
 	s.SampleRate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Mp2Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Channels != nil {
+		v := *s.Channels
+
+		e.SetValue(protocol.BodyTarget, "channels", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for MP4 Container
@@ -8599,6 +11720,32 @@ func (s *Mp4Settings) SetMoovPlacement(v string) *Mp4Settings {
 func (s *Mp4Settings) SetMp4MajorBrand(v string) *Mp4Settings {
 	s.Mp4MajorBrand = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Mp4Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CslgAtom != nil {
+		v := *s.CslgAtom
+
+		e.SetValue(protocol.BodyTarget, "cslgAtom", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FreeSpaceBox != nil {
+		v := *s.FreeSpaceBox
+
+		e.SetValue(protocol.BodyTarget, "freeSpaceBox", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MoovPlacement != nil {
+		v := *s.MoovPlacement
+
+		e.SetValue(protocol.BodyTarget, "moovPlacement", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Mp4MajorBrand != nil {
+		v := *s.Mp4MajorBrand
+
+		e.SetValue(protocol.BodyTarget, "mp4MajorBrand", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
@@ -8932,6 +12079,162 @@ func (s *Mpeg2Settings) SetTemporalAdaptiveQuantization(v string) *Mpeg2Settings
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Mpeg2Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdaptiveQuantization != nil {
+		v := *s.AdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "adaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CodecLevel != nil {
+		v := *s.CodecLevel
+
+		e.SetValue(protocol.BodyTarget, "codecLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecProfile != nil {
+		v := *s.CodecProfile
+
+		e.SetValue(protocol.BodyTarget, "codecProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateControl != nil {
+		v := *s.FramerateControl
+
+		e.SetValue(protocol.BodyTarget, "framerateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateConversionAlgorithm != nil {
+		v := *s.FramerateConversionAlgorithm
+
+		e.SetValue(protocol.BodyTarget, "framerateConversionAlgorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopClosedCadence != nil {
+		v := *s.GopClosedCadence
+
+		e.SetValue(protocol.BodyTarget, "gopClosedCadence", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopSize != nil {
+		v := *s.GopSize
+
+		e.SetValue(protocol.BodyTarget, "gopSize", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.GopSizeUnits != nil {
+		v := *s.GopSizeUnits
+
+		e.SetValue(protocol.BodyTarget, "gopSizeUnits", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HrdBufferInitialFillPercentage != nil {
+		v := *s.HrdBufferInitialFillPercentage
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferInitialFillPercentage", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HrdBufferSize != nil {
+		v := *s.HrdBufferSize
+
+		e.SetValue(protocol.BodyTarget, "hrdBufferSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InterlaceMode != nil {
+		v := *s.InterlaceMode
+
+		e.SetValue(protocol.BodyTarget, "interlaceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IntraDcPrecision != nil {
+		v := *s.IntraDcPrecision
+
+		e.SetValue(protocol.BodyTarget, "intraDcPrecision", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxBitrate != nil {
+		v := *s.MaxBitrate
+
+		e.SetValue(protocol.BodyTarget, "maxBitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinIInterval != nil {
+		v := *s.MinIInterval
+
+		e.SetValue(protocol.BodyTarget, "minIInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumberBFramesBetweenReferenceFrames != nil {
+		v := *s.NumberBFramesBetweenReferenceFrames
+
+		e.SetValue(protocol.BodyTarget, "numberBFramesBetweenReferenceFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParControl != nil {
+		v := *s.ParControl
+
+		e.SetValue(protocol.BodyTarget, "parControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParDenominator != nil {
+		v := *s.ParDenominator
+
+		e.SetValue(protocol.BodyTarget, "parDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParNumerator != nil {
+		v := *s.ParNumerator
+
+		e.SetValue(protocol.BodyTarget, "parNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.QualityTuningLevel != nil {
+		v := *s.QualityTuningLevel
+
+		e.SetValue(protocol.BodyTarget, "qualityTuningLevel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SceneChangeDetect != nil {
+		v := *s.SceneChangeDetect
+
+		e.SetValue(protocol.BodyTarget, "sceneChangeDetect", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SlowPal != nil {
+		v := *s.SlowPal
+
+		e.SetValue(protocol.BodyTarget, "slowPal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Softness != nil {
+		v := *s.Softness
+
+		e.SetValue(protocol.BodyTarget, "softness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SpatialAdaptiveQuantization != nil {
+		v := *s.SpatialAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "spatialAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Syntax != nil {
+		v := *s.Syntax
+
+		e.SetValue(protocol.BodyTarget, "syntax", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Telecine != nil {
+		v := *s.Telecine
+
+		e.SetValue(protocol.BodyTarget, "telecine", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TemporalAdaptiveQuantization != nil {
+		v := *s.TemporalAdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "temporalAdaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If you are using DRM, set DRM System (MsSmoothEncryptionSettings) to specify
 // the value SpekeKeyProvider.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/MsSmoothEncryptionSettings
@@ -8956,6 +12259,17 @@ func (s MsSmoothEncryptionSettings) GoString() string {
 func (s *MsSmoothEncryptionSettings) SetSpekeKeyProvider(v *SpekeKeyProvider) *MsSmoothEncryptionSettings {
 	s.SpekeKeyProvider = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MsSmoothEncryptionSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Type) under (OutputGroups)>(OutputGroupSettings) to
@@ -9028,6 +12342,37 @@ func (s *MsSmoothGroupSettings) SetManifestEncoding(v string) *MsSmoothGroupSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MsSmoothGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioDeduplication != nil {
+		v := *s.AudioDeduplication
+
+		e.SetValue(protocol.BodyTarget, "audioDeduplication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := *s.Destination
+
+		e.SetValue(protocol.BodyTarget, "destination", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.FragmentLength != nil {
+		v := *s.FragmentLength
+
+		e.SetValue(protocol.BodyTarget, "fragmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ManifestEncoding != nil {
+		v := *s.ManifestEncoding
+
+		e.SetValue(protocol.BodyTarget, "manifestEncoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for Nielsen Configuration
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/NielsenConfiguration
 type NielsenConfiguration struct {
@@ -9062,6 +12407,22 @@ func (s *NielsenConfiguration) SetBreakoutCode(v int64) *NielsenConfiguration {
 func (s *NielsenConfiguration) SetDistributorId(v string) *NielsenConfiguration {
 	s.DistributorId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NielsenConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BreakoutCode != nil {
+		v := *s.BreakoutCode
+
+		e.SetValue(protocol.BodyTarget, "breakoutCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DistributorId != nil {
+		v := *s.DistributorId
+
+		e.SetValue(protocol.BodyTarget, "distributorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Enable the Noise reducer (NoiseReducer) feature to remove noise from your
@@ -9116,6 +12477,27 @@ func (s *NoiseReducer) SetSpatialFilterSettings(v *NoiseReducerSpatialFilterSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoiseReducer) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Filter != nil {
+		v := *s.Filter
+
+		e.SetValue(protocol.BodyTarget, "filter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterSettings != nil {
+		v := s.FilterSettings
+
+		e.SetFields(protocol.BodyTarget, "filterSettings", v, protocol.Metadata{})
+	}
+	if s.SpatialFilterSettings != nil {
+		v := s.SpatialFilterSettings
+
+		e.SetFields(protocol.BodyTarget, "spatialFilterSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for a noise reducer filter
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/NoiseReducerFilterSettings
 type NoiseReducerFilterSettings struct {
@@ -9140,6 +12522,17 @@ func (s NoiseReducerFilterSettings) GoString() string {
 func (s *NoiseReducerFilterSettings) SetStrength(v int64) *NoiseReducerFilterSettings {
 	s.Strength = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoiseReducerFilterSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Strength != nil {
+		v := *s.Strength
+
+		e.SetValue(protocol.BodyTarget, "strength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Noise reducer filter settings for spatial filter.
@@ -9186,6 +12579,27 @@ func (s *NoiseReducerSpatialFilterSettings) SetSpeed(v int64) *NoiseReducerSpati
 func (s *NoiseReducerSpatialFilterSettings) SetStrength(v int64) *NoiseReducerSpatialFilterSettings {
 	s.Strength = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoiseReducerSpatialFilterSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PostFilterSharpenStrength != nil {
+		v := *s.PostFilterSharpenStrength
+
+		e.SetValue(protocol.BodyTarget, "postFilterSharpenStrength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Speed != nil {
+		v := *s.Speed
+
+		e.SetValue(protocol.BodyTarget, "speed", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Strength != nil {
+		v := *s.Strength
+
+		e.SetValue(protocol.BodyTarget, "strength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An output object describes the settings for a single output file or stream
@@ -9295,6 +12709,60 @@ func (s *Output) SetVideoDescription(v *VideoDescription) *Output {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioDescriptions) > 0 {
+		v := s.AudioDescriptions
+
+		e.SetList(protocol.BodyTarget, "audioDescriptions", encodeAudioDescriptionList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionDescriptions) > 0 {
+		v := s.CaptionDescriptions
+
+		e.SetList(protocol.BodyTarget, "captionDescriptions", encodeCaptionDescriptionList(v), protocol.Metadata{})
+	}
+	if s.ContainerSettings != nil {
+		v := s.ContainerSettings
+
+		e.SetFields(protocol.BodyTarget, "containerSettings", v, protocol.Metadata{})
+	}
+	if s.Extension != nil {
+		v := *s.Extension
+
+		e.SetValue(protocol.BodyTarget, "extension", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NameModifier != nil {
+		v := *s.NameModifier
+
+		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputSettings != nil {
+		v := s.OutputSettings
+
+		e.SetFields(protocol.BodyTarget, "outputSettings", v, protocol.Metadata{})
+	}
+	if s.Preset != nil {
+		v := *s.Preset
+
+		e.SetValue(protocol.BodyTarget, "preset", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VideoDescription != nil {
+		v := s.VideoDescription
+
+		e.SetFields(protocol.BodyTarget, "videoDescription", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputList(vs []*Output) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // OutputChannel mapping settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/OutputChannelMapping
 type OutputChannelMapping struct {
@@ -9318,6 +12786,25 @@ func (s OutputChannelMapping) GoString() string {
 func (s *OutputChannelMapping) SetInputChannels(v []*int64) *OutputChannelMapping {
 	s.InputChannels = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.InputChannels) > 0 {
+		v := s.InputChannels
+
+		e.SetList(protocol.BodyTarget, "inputChannels", protocol.EncodeInt64List(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputChannelMappingList(vs []*OutputChannelMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Details regarding output
@@ -9352,6 +12839,30 @@ func (s *OutputDetail) SetDurationInMs(v int64) *OutputDetail {
 func (s *OutputDetail) SetVideoDetails(v *VideoDetail) *OutputDetail {
 	s.VideoDetails = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DurationInMs != nil {
+		v := *s.DurationInMs
+
+		e.SetValue(protocol.BodyTarget, "durationInMs", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VideoDetails != nil {
+		v := s.VideoDetails
+
+		e.SetFields(protocol.BodyTarget, "videoDetails", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputDetailList(vs []*OutputDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Group of outputs
@@ -9410,6 +12921,40 @@ func (s *OutputGroup) SetOutputs(v []*Output) *OutputGroup {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputGroup) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CustomName != nil {
+		v := *s.CustomName
+
+		e.SetValue(protocol.BodyTarget, "customName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputGroupSettings != nil {
+		v := s.OutputGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "outputGroupSettings", v, protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "outputs", encodeOutputList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputGroupList(vs []*OutputGroup) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Contains details about the output groups specified in the job settings.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/OutputGroupDetail
 type OutputGroupDetail struct {
@@ -9433,6 +12978,25 @@ func (s OutputGroupDetail) GoString() string {
 func (s *OutputGroupDetail) SetOutputDetails(v []*OutputDetail) *OutputGroupDetail {
 	s.OutputDetails = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputGroupDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.OutputDetails) > 0 {
+		v := s.OutputDetails
+
+		e.SetList(protocol.BodyTarget, "outputDetails", encodeOutputDetailList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputGroupDetailList(vs []*OutputGroupDetail) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Output Group settings, including type
@@ -9500,6 +13064,37 @@ func (s *OutputGroupSettings) SetType(v string) *OutputGroupSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DashIsoGroupSettings != nil {
+		v := s.DashIsoGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "dashIsoGroupSettings", v, protocol.Metadata{})
+	}
+	if s.FileGroupSettings != nil {
+		v := s.FileGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "fileGroupSettings", v, protocol.Metadata{})
+	}
+	if s.HlsGroupSettings != nil {
+		v := s.HlsGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsGroupSettings", v, protocol.Metadata{})
+	}
+	if s.MsSmoothGroupSettings != nil {
+		v := s.MsSmoothGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "msSmoothGroupSettings", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Specific settings for this type of output.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/OutputSettings
 type OutputSettings struct {
@@ -9523,6 +13118,17 @@ func (s OutputSettings) GoString() string {
 func (s *OutputSettings) SetHlsSettings(v *HlsSettings) *OutputSettings {
 	s.HlsSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HlsSettings != nil {
+		v := s.HlsSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A preset is a collection of preconfigured media conversion settings that
@@ -9615,6 +13221,60 @@ func (s *Preset) SetType(v string) *Preset {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Preset) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdated != nil {
+		v := *s.LastUpdated
+
+		e.SetValue(protocol.BodyTarget, "lastUpdated", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePresetList(vs []*Preset) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Settings for preset
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/PresetSettings
 type PresetSettings struct {
@@ -9670,6 +13330,32 @@ func (s *PresetSettings) SetContainerSettings(v *ContainerSettings) *PresetSetti
 func (s *PresetSettings) SetVideoDescription(v *VideoDescription) *PresetSettings {
 	s.VideoDescription = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PresetSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioDescriptions) > 0 {
+		v := s.AudioDescriptions
+
+		e.SetList(protocol.BodyTarget, "audioDescriptions", encodeAudioDescriptionList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionDescriptions) > 0 {
+		v := s.CaptionDescriptions
+
+		e.SetList(protocol.BodyTarget, "captionDescriptions", encodeCaptionDescriptionPresetList(v), protocol.Metadata{})
+	}
+	if s.ContainerSettings != nil {
+		v := s.ContainerSettings
+
+		e.SetFields(protocol.BodyTarget, "containerSettings", v, protocol.Metadata{})
+	}
+	if s.VideoDescription != nil {
+		v := s.VideoDescription
+
+		e.SetFields(protocol.BodyTarget, "videoDescription", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
@@ -9812,6 +13498,67 @@ func (s *ProresSettings) SetTelecine(v string) *ProresSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProresSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodecProfile != nil {
+		v := *s.CodecProfile
+
+		e.SetValue(protocol.BodyTarget, "codecProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateControl != nil {
+		v := *s.FramerateControl
+
+		e.SetValue(protocol.BodyTarget, "framerateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateConversionAlgorithm != nil {
+		v := *s.FramerateConversionAlgorithm
+
+		e.SetValue(protocol.BodyTarget, "framerateConversionAlgorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InterlaceMode != nil {
+		v := *s.InterlaceMode
+
+		e.SetValue(protocol.BodyTarget, "interlaceMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParControl != nil {
+		v := *s.ParControl
+
+		e.SetValue(protocol.BodyTarget, "parControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParDenominator != nil {
+		v := *s.ParDenominator
+
+		e.SetValue(protocol.BodyTarget, "parDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParNumerator != nil {
+		v := *s.ParNumerator
+
+		e.SetValue(protocol.BodyTarget, "parNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SlowPal != nil {
+		v := *s.SlowPal
+
+		e.SetValue(protocol.BodyTarget, "slowPal", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Telecine != nil {
+		v := *s.Telecine
+
+		e.SetValue(protocol.BodyTarget, "telecine", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // MediaConvert jobs are submitted to a queue. Unless specified otherwise jobs
 // are submitted to a built-in default queue. User can create additional queues
 // to separate the jobs of different categories or priority.
@@ -9896,6 +13643,55 @@ func (s *Queue) SetType(v string) *Queue {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Queue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedAt != nil {
+		v := *s.CreatedAt
+
+		e.SetValue(protocol.BodyTarget, "createdAt", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdated != nil {
+		v := *s.LastUpdated
+
+		e.SetValue(protocol.BodyTarget, "lastUpdated", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeQueueList(vs []*Queue) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Use Rectangle to identify a specific area of the video frame.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/Rectangle
 type Rectangle struct {
@@ -9950,6 +13746,32 @@ func (s *Rectangle) SetY(v int64) *Rectangle {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Rectangle) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.X != nil {
+		v := *s.X
+
+		e.SetValue(protocol.BodyTarget, "x", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Y != nil {
+		v := *s.Y
+
+		e.SetValue(protocol.BodyTarget, "y", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Use Manual audio remixing (RemixSettings) to adjust audio levels for each
 // output channel. With audio remixing, you can output more or fewer audio channels
 // than your input audio source provides.
@@ -10001,6 +13823,27 @@ func (s *RemixSettings) SetChannelsOut(v int64) *RemixSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemixSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelMapping != nil {
+		v := s.ChannelMapping
+
+		e.SetFields(protocol.BodyTarget, "channelMapping", v, protocol.Metadata{})
+	}
+	if s.ChannelsIn != nil {
+		v := *s.ChannelsIn
+
+		e.SetValue(protocol.BodyTarget, "channelsIn", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ChannelsOut != nil {
+		v := *s.ChannelsOut
+
+		e.SetValue(protocol.BodyTarget, "channelsOut", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for SCC caption output.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/SccDestinationSettings
 type SccDestinationSettings struct {
@@ -10028,6 +13871,17 @@ func (s SccDestinationSettings) GoString() string {
 func (s *SccDestinationSettings) SetFramerate(v string) *SccDestinationSettings {
 	s.Framerate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SccDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Framerate != nil {
+		v := *s.Framerate
+
+		e.SetValue(protocol.BodyTarget, "framerate", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for use with a SPEKE key provider
@@ -10073,6 +13927,27 @@ func (s *SpekeKeyProvider) SetSystemIds(v []*string) *SpekeKeyProvider {
 func (s *SpekeKeyProvider) SetUrl(v string) *SpekeKeyProvider {
 	s.Url = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SpekeKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.BodyTarget, "resourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SystemIds) > 0 {
+		v := s.SystemIds
+
+		e.SetList(protocol.BodyTarget, "systemIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for use with a SPEKE key provider.
@@ -10132,6 +14007,32 @@ func (s *StaticKeyProvider) SetUrl(v string) *StaticKeyProvider {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StaticKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyFormat != nil {
+		v := *s.KeyFormat
+
+		e.SetValue(protocol.BodyTarget, "keyFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyFormatVersions != nil {
+		v := *s.KeyFormatVersions
+
+		e.SetValue(protocol.BodyTarget, "keyFormatVersions", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StaticKeyValue != nil {
+		v := *s.StaticKeyValue
+
+		e.SetValue(protocol.BodyTarget, "staticKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for Teletext caption output
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/TeletextDestinationSettings
 type TeletextDestinationSettings struct {
@@ -10160,6 +14061,17 @@ func (s *TeletextDestinationSettings) SetPageNumber(v string) *TeletextDestinati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TeletextDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PageNumber != nil {
+		v := *s.PageNumber
+
+		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings specific to Teletext caption sources, including Page number.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/TeletextSourceSettings
 type TeletextSourceSettings struct {
@@ -10185,6 +14097,17 @@ func (s TeletextSourceSettings) GoString() string {
 func (s *TeletextSourceSettings) SetPageNumber(v string) *TeletextSourceSettings {
 	s.PageNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TeletextSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PageNumber != nil {
+		v := *s.PageNumber
+
+		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Timecode burn-in (TimecodeBurnIn)--Burns the output timecode and specified
@@ -10235,6 +14158,27 @@ func (s *TimecodeBurnin) SetPosition(v string) *TimecodeBurnin {
 func (s *TimecodeBurnin) SetPrefix(v string) *TimecodeBurnin {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimecodeBurnin) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FontSize != nil {
+		v := *s.FontSize
+
+		e.SetValue(protocol.BodyTarget, "fontSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := *s.Position
+
+		e.SetValue(protocol.BodyTarget, "position", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains settings used to acquire and adjust timecode information from inputs.
@@ -10317,6 +14261,32 @@ func (s *TimecodeConfig) SetTimestampOffset(v string) *TimecodeConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimecodeConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Anchor != nil {
+		v := *s.Anchor
+
+		e.SetValue(protocol.BodyTarget, "anchor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source != nil {
+		v := *s.Source
+
+		e.SetValue(protocol.BodyTarget, "source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "start", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimestampOffset != nil {
+		v := *s.TimestampOffset
+
+		e.SetValue(protocol.BodyTarget, "timestampOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Enable Timed metadata insertion (TimedMetadataInsertion) to include ID3 tags
 // in your job. To include timed metadata, you must enable it here, enable it
 // in each output container, and specify tags and timecodes in ID3 insertion
@@ -10343,6 +14313,17 @@ func (s TimedMetadataInsertion) GoString() string {
 func (s *TimedMetadataInsertion) SetId3Insertions(v []*Id3Insertion) *TimedMetadataInsertion {
 	s.Id3Insertions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimedMetadataInsertion) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Id3Insertions) > 0 {
+		v := s.Id3Insertions
+
+		e.SetList(protocol.BodyTarget, "id3Insertions", encodeId3InsertionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information about when jobs are submitted, started, and finished is specified
@@ -10389,6 +14370,27 @@ func (s *Timing) SetSubmitTime(v time.Time) *Timing {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Timing) MarshalFields(e protocol.FieldEncoder) error {
+	if s.FinishTime != nil {
+		v := *s.FinishTime
+
+		e.SetValue(protocol.BodyTarget, "finishTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "startTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SubmitTime != nil {
+		v := *s.SubmitTime
+
+		e.SetValue(protocol.BodyTarget, "submitTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for TTML caption output
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/TtmlDestinationSettings
 type TtmlDestinationSettings struct {
@@ -10413,6 +14415,17 @@ func (s TtmlDestinationSettings) GoString() string {
 func (s *TtmlDestinationSettings) SetStylePassthrough(v string) *TtmlDestinationSettings {
 	s.StylePassthrough = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TtmlDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StylePassthrough != nil {
+		v := *s.StylePassthrough
+
+		e.SetValue(protocol.BodyTarget, "stylePassthrough", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Modify a job template by sending a request with the job template name and
@@ -10494,6 +14507,37 @@ func (s *UpdateJobTemplateInput) SetSettings(v *JobTemplateSettings) *UpdateJobT
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobTemplateInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful update job template requests will return the new job template
 // JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/UpdateJobTemplateResponse
@@ -10519,6 +14563,17 @@ func (s UpdateJobTemplateOutput) GoString() string {
 func (s *UpdateJobTemplateOutput) SetJobTemplate(v *JobTemplate) *UpdateJobTemplateOutput {
 	s.JobTemplate = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateJobTemplateOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.JobTemplate != nil {
+		v := s.JobTemplate
+
+		e.SetFields(protocol.BodyTarget, "jobTemplate", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Modify a preset by sending a request with the preset name and any of the
@@ -10590,6 +14645,32 @@ func (s *UpdatePresetInput) SetSettings(v *PresetSettings) *UpdatePresetInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePresetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Settings != nil {
+		v := s.Settings
+
+		e.SetFields(protocol.BodyTarget, "settings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful update preset requests will return the new preset JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/UpdatePresetResponse
 type UpdatePresetOutput struct {
@@ -10614,6 +14695,17 @@ func (s UpdatePresetOutput) GoString() string {
 func (s *UpdatePresetOutput) SetPreset(v *Preset) *UpdatePresetOutput {
 	s.Preset = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdatePresetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Preset != nil {
+		v := s.Preset
+
+		e.SetFields(protocol.BodyTarget, "preset", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Modify a queue by sending a request with the queue name and any of the following
@@ -10678,6 +14770,27 @@ func (s *UpdateQueueInput) SetStatus(v string) *UpdateQueueInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateQueueInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Successful update queue requests will return the new queue JSON.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/UpdateQueueResponse
 type UpdateQueueOutput struct {
@@ -10703,6 +14816,17 @@ func (s UpdateQueueOutput) GoString() string {
 func (s *UpdateQueueOutput) SetQueue(v *Queue) *UpdateQueueOutput {
 	s.Queue = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateQueueOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Queue != nil {
+		v := s.Queue
+
+		e.SetFields(protocol.BodyTarget, "queue", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Video codec settings, (CodecSettings) under (VideoDescription), contains
@@ -10783,6 +14907,42 @@ func (s *VideoCodecSettings) SetMpeg2Settings(v *Mpeg2Settings) *VideoCodecSetti
 func (s *VideoCodecSettings) SetProresSettings(v *ProresSettings) *VideoCodecSettings {
 	s.ProresSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Codec != nil {
+		v := *s.Codec
+
+		e.SetValue(protocol.BodyTarget, "codec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FrameCaptureSettings != nil {
+		v := s.FrameCaptureSettings
+
+		e.SetFields(protocol.BodyTarget, "frameCaptureSettings", v, protocol.Metadata{})
+	}
+	if s.H264Settings != nil {
+		v := s.H264Settings
+
+		e.SetFields(protocol.BodyTarget, "h264Settings", v, protocol.Metadata{})
+	}
+	if s.H265Settings != nil {
+		v := s.H265Settings
+
+		e.SetFields(protocol.BodyTarget, "h265Settings", v, protocol.Metadata{})
+	}
+	if s.Mpeg2Settings != nil {
+		v := s.Mpeg2Settings
+
+		e.SetFields(protocol.BodyTarget, "mpeg2Settings", v, protocol.Metadata{})
+	}
+	if s.ProresSettings != nil {
+		v := s.ProresSettings
+
+		e.SetFields(protocol.BodyTarget, "proresSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Settings for video outputs
@@ -10986,6 +15146,87 @@ func (s *VideoDescription) SetWidth(v int64) *VideoDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AfdSignaling != nil {
+		v := *s.AfdSignaling
+
+		e.SetValue(protocol.BodyTarget, "afdSignaling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AntiAlias != nil {
+		v := *s.AntiAlias
+
+		e.SetValue(protocol.BodyTarget, "antiAlias", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecSettings != nil {
+		v := s.CodecSettings
+
+		e.SetFields(protocol.BodyTarget, "codecSettings", v, protocol.Metadata{})
+	}
+	if s.ColorMetadata != nil {
+		v := *s.ColorMetadata
+
+		e.SetValue(protocol.BodyTarget, "colorMetadata", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Crop != nil {
+		v := s.Crop
+
+		e.SetFields(protocol.BodyTarget, "crop", v, protocol.Metadata{})
+	}
+	if s.DropFrameTimecode != nil {
+		v := *s.DropFrameTimecode
+
+		e.SetValue(protocol.BodyTarget, "dropFrameTimecode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FixedAfd != nil {
+		v := *s.FixedAfd
+
+		e.SetValue(protocol.BodyTarget, "fixedAfd", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Position != nil {
+		v := s.Position
+
+		e.SetFields(protocol.BodyTarget, "position", v, protocol.Metadata{})
+	}
+	if s.RespondToAfd != nil {
+		v := *s.RespondToAfd
+
+		e.SetValue(protocol.BodyTarget, "respondToAfd", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ScalingBehavior != nil {
+		v := *s.ScalingBehavior
+
+		e.SetValue(protocol.BodyTarget, "scalingBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sharpness != nil {
+		v := *s.Sharpness
+
+		e.SetValue(protocol.BodyTarget, "sharpness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimecodeInsertion != nil {
+		v := *s.TimecodeInsertion
+
+		e.SetValue(protocol.BodyTarget, "timecodeInsertion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VideoPreprocessors != nil {
+		v := s.VideoPreprocessors
+
+		e.SetFields(protocol.BodyTarget, "videoPreprocessors", v, protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Contains details about the output's video stream
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/VideoDetail
 type VideoDetail struct {
@@ -11018,6 +15259,22 @@ func (s *VideoDetail) SetHeightInPx(v int64) *VideoDetail {
 func (s *VideoDetail) SetWidthInPx(v int64) *VideoDetail {
 	s.WidthInPx = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoDetail) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HeightInPx != nil {
+		v := *s.HeightInPx
+
+		e.SetValue(protocol.BodyTarget, "heightInPx", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.WidthInPx != nil {
+		v := *s.WidthInPx
+
+		e.SetValue(protocol.BodyTarget, "widthInPx", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Find additional transcoding features under Preprocessors (VideoPreprocessors).
@@ -11089,6 +15346,37 @@ func (s *VideoPreprocessor) SetNoiseReducer(v *NoiseReducer) *VideoPreprocessor 
 func (s *VideoPreprocessor) SetTimecodeBurnin(v *TimecodeBurnin) *VideoPreprocessor {
 	s.TimecodeBurnin = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoPreprocessor) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ColorCorrector != nil {
+		v := s.ColorCorrector
+
+		e.SetFields(protocol.BodyTarget, "colorCorrector", v, protocol.Metadata{})
+	}
+	if s.Deinterlacer != nil {
+		v := s.Deinterlacer
+
+		e.SetFields(protocol.BodyTarget, "deinterlacer", v, protocol.Metadata{})
+	}
+	if s.ImageInserter != nil {
+		v := s.ImageInserter
+
+		e.SetFields(protocol.BodyTarget, "imageInserter", v, protocol.Metadata{})
+	}
+	if s.NoiseReducer != nil {
+		v := s.NoiseReducer
+
+		e.SetFields(protocol.BodyTarget, "noiseReducer", v, protocol.Metadata{})
+	}
+	if s.TimecodeBurnin != nil {
+		v := s.TimecodeBurnin
+
+		e.SetFields(protocol.BodyTarget, "timecodeBurnin", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Selector for video.
@@ -11166,6 +15454,37 @@ func (s *VideoSelector) SetProgramNumber(v int64) *VideoSelector {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ColorSpace != nil {
+		v := *s.ColorSpace
+
+		e.SetValue(protocol.BodyTarget, "colorSpace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ColorSpaceUsage != nil {
+		v := *s.ColorSpaceUsage
+
+		e.SetValue(protocol.BodyTarget, "colorSpaceUsage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Hdr10Metadata != nil {
+		v := s.Hdr10Metadata
+
+		e.SetFields(protocol.BodyTarget, "hdr10Metadata", v, protocol.Metadata{})
+	}
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ProgramNumber != nil {
+		v := *s.ProgramNumber
+
+		e.SetValue(protocol.BodyTarget, "programNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
 // the value WAV.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/WavSettings
@@ -11211,6 +15530,27 @@ func (s *WavSettings) SetChannels(v int64) *WavSettings {
 func (s *WavSettings) SetSampleRate(v int64) *WavSettings {
 	s.SampleRate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WavSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BitDepth != nil {
+		v := *s.BitDepth
+
+		e.SetValue(protocol.BodyTarget, "bitDepth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Channels != nil {
+		v := *s.Channels
+
+		e.SetValue(protocol.BodyTarget, "channels", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Choose BROADCASTER_MIXED_AD when the input contains pre-mixed main audio

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateChannel = "CreateChannel"
@@ -1542,6 +1543,57 @@ func (s *AacSettings) SetVbrQuality(v string) *AacSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AacSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputType != nil {
+		v := *s.InputType
+
+		e.SetValue(protocol.BodyTarget, "inputType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Profile != nil {
+		v := *s.Profile
+
+		e.SetValue(protocol.BodyTarget, "profile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawFormat != nil {
+		v := *s.RawFormat
+
+		e.SetValue(protocol.BodyTarget, "rawFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Spec != nil {
+		v := *s.Spec
+
+		e.SetValue(protocol.BodyTarget, "spec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VbrQuality != nil {
+		v := *s.VbrQuality
+
+		e.SetValue(protocol.BodyTarget, "vbrQuality", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Ac3Settings
 type Ac3Settings struct {
 	_ struct{} `type:"structure"`
@@ -1626,6 +1678,47 @@ func (s *Ac3Settings) SetMetadataControl(v string) *Ac3Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Ac3Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.BitstreamMode != nil {
+		v := *s.BitstreamMode
+
+		e.SetValue(protocol.BodyTarget, "bitstreamMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dialnorm != nil {
+		v := *s.Dialnorm
+
+		e.SetValue(protocol.BodyTarget, "dialnorm", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DrcProfile != nil {
+		v := *s.DrcProfile
+
+		e.SetValue(protocol.BodyTarget, "drcProfile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeFilter != nil {
+		v := *s.LfeFilter
+
+		e.SetValue(protocol.BodyTarget, "lfeFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetadataControl != nil {
+		v := *s.MetadataControl
+
+		e.SetValue(protocol.BodyTarget, "metadataControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ArchiveContainerSettings
 type ArchiveContainerSettings struct {
 	_ struct{} `type:"structure"`
@@ -1647,6 +1740,17 @@ func (s ArchiveContainerSettings) GoString() string {
 func (s *ArchiveContainerSettings) SetM2tsSettings(v *M2tsSettings) *ArchiveContainerSettings {
 	s.M2tsSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ArchiveContainerSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.M2tsSettings != nil {
+		v := s.M2tsSettings
+
+		e.SetFields(protocol.BodyTarget, "m2tsSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ArchiveGroupSettings
@@ -1683,6 +1787,22 @@ func (s *ArchiveGroupSettings) SetDestination(v *OutputLocationRef) *ArchiveGrou
 func (s *ArchiveGroupSettings) SetRolloverInterval(v int64) *ArchiveGroupSettings {
 	s.RolloverInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ArchiveGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "destination", v, protocol.Metadata{})
+	}
+	if s.RolloverInterval != nil {
+		v := *s.RolloverInterval
+
+		e.SetValue(protocol.BodyTarget, "rolloverInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ArchiveOutputSettings
@@ -1729,6 +1849,27 @@ func (s *ArchiveOutputSettings) SetNameModifier(v string) *ArchiveOutputSettings
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ArchiveOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContainerSettings != nil {
+		v := s.ContainerSettings
+
+		e.SetFields(protocol.BodyTarget, "containerSettings", v, protocol.Metadata{})
+	}
+	if s.Extension != nil {
+		v := *s.Extension
+
+		e.SetValue(protocol.BodyTarget, "extension", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NameModifier != nil {
+		v := *s.NameModifier
+
+		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AribDestinationSettings
 type AribDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -1744,6 +1885,12 @@ func (s AribDestinationSettings) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AribDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AribSourceSettings
 type AribSourceSettings struct {
 	_ struct{} `type:"structure"`
@@ -1757,6 +1904,12 @@ func (s AribSourceSettings) String() string {
 // GoString returns the string representation
 func (s AribSourceSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AribSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioChannelMapping
@@ -1791,6 +1944,30 @@ func (s *AudioChannelMapping) SetInputChannelLevels(v []*InputChannelLevel) *Aud
 func (s *AudioChannelMapping) SetOutputChannel(v int64) *AudioChannelMapping {
 	s.OutputChannel = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.InputChannelLevels) > 0 {
+		v := s.InputChannelLevels
+
+		e.SetList(protocol.BodyTarget, "inputChannelLevels", encodeInputChannelLevelList(v), protocol.Metadata{})
+	}
+	if s.OutputChannel != nil {
+		v := *s.OutputChannel
+
+		e.SetValue(protocol.BodyTarget, "outputChannel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioChannelMappingList(vs []*AudioChannelMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioCodecSettings
@@ -1846,6 +2023,37 @@ func (s *AudioCodecSettings) SetMp2Settings(v *Mp2Settings) *AudioCodecSettings 
 func (s *AudioCodecSettings) SetPassThroughSettings(v *PassThroughSettings) *AudioCodecSettings {
 	s.PassThroughSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AacSettings != nil {
+		v := s.AacSettings
+
+		e.SetFields(protocol.BodyTarget, "aacSettings", v, protocol.Metadata{})
+	}
+	if s.Ac3Settings != nil {
+		v := s.Ac3Settings
+
+		e.SetFields(protocol.BodyTarget, "ac3Settings", v, protocol.Metadata{})
+	}
+	if s.Eac3Settings != nil {
+		v := s.Eac3Settings
+
+		e.SetFields(protocol.BodyTarget, "eac3Settings", v, protocol.Metadata{})
+	}
+	if s.Mp2Settings != nil {
+		v := s.Mp2Settings
+
+		e.SetFields(protocol.BodyTarget, "mp2Settings", v, protocol.Metadata{})
+	}
+	if s.PassThroughSettings != nil {
+		v := s.PassThroughSettings
+
+		e.SetFields(protocol.BodyTarget, "passThroughSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioDescription
@@ -1967,6 +2175,70 @@ func (s *AudioDescription) SetStreamName(v string) *AudioDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioNormalizationSettings != nil {
+		v := s.AudioNormalizationSettings
+
+		e.SetFields(protocol.BodyTarget, "audioNormalizationSettings", v, protocol.Metadata{})
+	}
+	if s.AudioSelectorName != nil {
+		v := *s.AudioSelectorName
+
+		e.SetValue(protocol.BodyTarget, "audioSelectorName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioType != nil {
+		v := *s.AudioType
+
+		e.SetValue(protocol.BodyTarget, "audioType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioTypeControl != nil {
+		v := *s.AudioTypeControl
+
+		e.SetValue(protocol.BodyTarget, "audioTypeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecSettings != nil {
+		v := s.CodecSettings
+
+		e.SetFields(protocol.BodyTarget, "codecSettings", v, protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCodeControl != nil {
+		v := *s.LanguageCodeControl
+
+		e.SetValue(protocol.BodyTarget, "languageCodeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RemixSettings != nil {
+		v := s.RemixSettings
+
+		e.SetFields(protocol.BodyTarget, "remixSettings", v, protocol.Metadata{})
+	}
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioDescriptionList(vs []*AudioDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioLanguageSelection
 type AudioLanguageSelection struct {
 	_ struct{} `type:"structure"`
@@ -2003,6 +2275,22 @@ func (s *AudioLanguageSelection) SetLanguageCode(v string) *AudioLanguageSelecti
 func (s *AudioLanguageSelection) SetLanguageSelectionPolicy(v string) *AudioLanguageSelection {
 	s.LanguageSelectionPolicy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioLanguageSelection) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageSelectionPolicy != nil {
+		v := *s.LanguageSelectionPolicy
+
+		e.SetValue(protocol.BodyTarget, "languageSelectionPolicy", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioNormalizationSettings
@@ -2050,6 +2338,27 @@ func (s *AudioNormalizationSettings) SetAlgorithmControl(v string) *AudioNormali
 func (s *AudioNormalizationSettings) SetTargetLkfs(v float64) *AudioNormalizationSettings {
 	s.TargetLkfs = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioNormalizationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Algorithm != nil {
+		v := *s.Algorithm
+
+		e.SetValue(protocol.BodyTarget, "algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AlgorithmControl != nil {
+		v := *s.AlgorithmControl
+
+		e.SetValue(protocol.BodyTarget, "algorithmControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TargetLkfs != nil {
+		v := *s.TargetLkfs
+
+		e.SetValue(protocol.BodyTarget, "targetLkfs", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioOnlyHlsSettings
@@ -2110,6 +2419,27 @@ func (s *AudioOnlyHlsSettings) SetAudioTrackType(v string) *AudioOnlyHlsSettings
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioOnlyHlsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioGroupId != nil {
+		v := *s.AudioGroupId
+
+		e.SetValue(protocol.BodyTarget, "audioGroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioOnlyImage != nil {
+		v := s.AudioOnlyImage
+
+		e.SetFields(protocol.BodyTarget, "audioOnlyImage", v, protocol.Metadata{})
+	}
+	if s.AudioTrackType != nil {
+		v := *s.AudioTrackType
+
+		e.SetValue(protocol.BodyTarget, "audioTrackType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioPidSelection
 type AudioPidSelection struct {
 	_ struct{} `type:"structure"`
@@ -2132,6 +2462,17 @@ func (s AudioPidSelection) GoString() string {
 func (s *AudioPidSelection) SetPid(v int64) *AudioPidSelection {
 	s.Pid = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioPidSelection) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioSelector
@@ -2168,6 +2509,30 @@ func (s *AudioSelector) SetSelectorSettings(v *AudioSelectorSettings) *AudioSele
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SelectorSettings != nil {
+		v := s.SelectorSettings
+
+		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAudioSelectorList(vs []*AudioSelector) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AudioSelectorSettings
 type AudioSelectorSettings struct {
 	_ struct{} `type:"structure"`
@@ -2197,6 +2562,22 @@ func (s *AudioSelectorSettings) SetAudioLanguageSelection(v *AudioLanguageSelect
 func (s *AudioSelectorSettings) SetAudioPidSelection(v *AudioPidSelection) *AudioSelectorSettings {
 	s.AudioPidSelection = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AudioSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioLanguageSelection != nil {
+		v := s.AudioLanguageSelection
+
+		e.SetFields(protocol.BodyTarget, "audioLanguageSelection", v, protocol.Metadata{})
+	}
+	if s.AudioPidSelection != nil {
+		v := s.AudioPidSelection
+
+		e.SetFields(protocol.BodyTarget, "audioPidSelection", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AvailBlanking
@@ -2234,6 +2615,22 @@ func (s *AvailBlanking) SetState(v string) *AvailBlanking {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AvailBlanking) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AvailBlankingImage != nil {
+		v := s.AvailBlankingImage
+
+		e.SetFields(protocol.BodyTarget, "availBlankingImage", v, protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AvailConfiguration
 type AvailConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -2256,6 +2653,17 @@ func (s AvailConfiguration) GoString() string {
 func (s *AvailConfiguration) SetAvailSettings(v *AvailSettings) *AvailConfiguration {
 	s.AvailSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AvailConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AvailSettings != nil {
+		v := s.AvailSettings
+
+		e.SetFields(protocol.BodyTarget, "availSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/AvailSettings
@@ -2287,6 +2695,22 @@ func (s *AvailSettings) SetScte35SpliceInsert(v *Scte35SpliceInsert) *AvailSetti
 func (s *AvailSettings) SetScte35TimeSignalApos(v *Scte35TimeSignalApos) *AvailSettings {
 	s.Scte35TimeSignalApos = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AvailSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Scte35SpliceInsert != nil {
+		v := s.Scte35SpliceInsert
+
+		e.SetFields(protocol.BodyTarget, "scte35SpliceInsert", v, protocol.Metadata{})
+	}
+	if s.Scte35TimeSignalApos != nil {
+		v := s.Scte35TimeSignalApos
+
+		e.SetFields(protocol.BodyTarget, "scte35TimeSignalApos", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/BlackoutSlate
@@ -2355,6 +2779,37 @@ func (s *BlackoutSlate) SetNetworkId(v string) *BlackoutSlate {
 func (s *BlackoutSlate) SetState(v string) *BlackoutSlate {
 	s.State = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BlackoutSlate) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BlackoutSlateImage != nil {
+		v := s.BlackoutSlateImage
+
+		e.SetFields(protocol.BodyTarget, "blackoutSlateImage", v, protocol.Metadata{})
+	}
+	if s.NetworkEndBlackout != nil {
+		v := *s.NetworkEndBlackout
+
+		e.SetValue(protocol.BodyTarget, "networkEndBlackout", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NetworkEndBlackoutImage != nil {
+		v := s.NetworkEndBlackoutImage
+
+		e.SetFields(protocol.BodyTarget, "networkEndBlackoutImage", v, protocol.Metadata{})
+	}
+	if s.NetworkId != nil {
+		v := *s.NetworkId
+
+		e.SetValue(protocol.BodyTarget, "networkId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/BurnInDestinationSettings
@@ -2567,6 +3022,97 @@ func (s *BurnInDestinationSettings) SetYPosition(v int64) *BurnInDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BurnInDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alignment != nil {
+		v := *s.Alignment
+
+		e.SetValue(protocol.BodyTarget, "alignment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundColor != nil {
+		v := *s.BackgroundColor
+
+		e.SetValue(protocol.BodyTarget, "backgroundColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundOpacity != nil {
+		v := *s.BackgroundOpacity
+
+		e.SetValue(protocol.BodyTarget, "backgroundOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Font != nil {
+		v := s.Font
+
+		e.SetFields(protocol.BodyTarget, "font", v, protocol.Metadata{})
+	}
+	if s.FontColor != nil {
+		v := *s.FontColor
+
+		e.SetValue(protocol.BodyTarget, "fontColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FontOpacity != nil {
+		v := *s.FontOpacity
+
+		e.SetValue(protocol.BodyTarget, "fontOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontResolution != nil {
+		v := *s.FontResolution
+
+		e.SetValue(protocol.BodyTarget, "fontResolution", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontSize != nil {
+		v := *s.FontSize
+
+		e.SetValue(protocol.BodyTarget, "fontSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineColor != nil {
+		v := *s.OutlineColor
+
+		e.SetValue(protocol.BodyTarget, "outlineColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineSize != nil {
+		v := *s.OutlineSize
+
+		e.SetValue(protocol.BodyTarget, "outlineSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowColor != nil {
+		v := *s.ShadowColor
+
+		e.SetValue(protocol.BodyTarget, "shadowColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShadowOpacity != nil {
+		v := *s.ShadowOpacity
+
+		e.SetValue(protocol.BodyTarget, "shadowOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowXOffset != nil {
+		v := *s.ShadowXOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowXOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowYOffset != nil {
+		v := *s.ShadowYOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowYOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TeletextGridControl != nil {
+		v := *s.TeletextGridControl
+
+		e.SetValue(protocol.BodyTarget, "teletextGridControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.XPosition != nil {
+		v := *s.XPosition
+
+		e.SetValue(protocol.BodyTarget, "xPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.YPosition != nil {
+		v := *s.YPosition
+
+		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Output groups for this Live Event. Output groups contain information about
 // where streams should be distributed.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CaptionDescription
@@ -2631,6 +3177,45 @@ func (s *CaptionDescription) SetLanguageDescription(v string) *CaptionDescriptio
 func (s *CaptionDescription) SetName(v string) *CaptionDescription {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaptionSelectorName != nil {
+		v := *s.CaptionSelectorName
+
+		e.SetValue(protocol.BodyTarget, "captionSelectorName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DestinationSettings != nil {
+		v := s.DestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "destinationSettings", v, protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageDescription != nil {
+		v := *s.LanguageDescription
+
+		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionDescriptionList(vs []*CaptionDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CaptionDestinationSettings
@@ -2736,6 +3321,67 @@ func (s *CaptionDestinationSettings) SetWebvttDestinationSettings(v *WebvttDesti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AribDestinationSettings != nil {
+		v := s.AribDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "aribDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.BurnInDestinationSettings != nil {
+		v := s.BurnInDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "burnInDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSubDestinationSettings != nil {
+		v := s.DvbSubDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSubDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.EmbeddedDestinationSettings != nil {
+		v := s.EmbeddedDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "embeddedDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.EmbeddedPlusScte20DestinationSettings != nil {
+		v := s.EmbeddedPlusScte20DestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "embeddedPlusScte20DestinationSettings", v, protocol.Metadata{})
+	}
+	if s.Scte20PlusEmbeddedDestinationSettings != nil {
+		v := s.Scte20PlusEmbeddedDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "scte20PlusEmbeddedDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.Scte27DestinationSettings != nil {
+		v := s.Scte27DestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "scte27DestinationSettings", v, protocol.Metadata{})
+	}
+	if s.SmpteTtDestinationSettings != nil {
+		v := s.SmpteTtDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "smpteTtDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.TeletextDestinationSettings != nil {
+		v := s.TeletextDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "teletextDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.TtmlDestinationSettings != nil {
+		v := s.TtmlDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "ttmlDestinationSettings", v, protocol.Metadata{})
+	}
+	if s.WebvttDestinationSettings != nil {
+		v := s.WebvttDestinationSettings
+
+		e.SetFields(protocol.BodyTarget, "webvttDestinationSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Maps a caption channel to an ISO 693-2 language code (http://www.loc.gov/standards/iso639-2),
 // with an optional description.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CaptionLanguageMapping
@@ -2779,6 +3425,35 @@ func (s *CaptionLanguageMapping) SetLanguageCode(v string) *CaptionLanguageMappi
 func (s *CaptionLanguageMapping) SetLanguageDescription(v string) *CaptionLanguageMapping {
 	s.LanguageDescription = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionLanguageMapping) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CaptionChannel != nil {
+		v := *s.CaptionChannel
+
+		e.SetValue(protocol.BodyTarget, "captionChannel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageDescription != nil {
+		v := *s.LanguageDescription
+
+		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionLanguageMappingList(vs []*CaptionLanguageMapping) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Output groups for this Live Event. Output groups contain information about
@@ -2826,6 +3501,35 @@ func (s *CaptionSelector) SetName(v string) *CaptionSelector {
 func (s *CaptionSelector) SetSelectorSettings(v *CaptionSelectorSettings) *CaptionSelector {
 	s.SelectorSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "languageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SelectorSettings != nil {
+		v := s.SelectorSettings
+
+		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCaptionSelectorList(vs []*CaptionSelector) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CaptionSelectorSettings
@@ -2889,6 +3593,42 @@ func (s *CaptionSelectorSettings) SetScte27SourceSettings(v *Scte27SourceSetting
 func (s *CaptionSelectorSettings) SetTeletextSourceSettings(v *TeletextSourceSettings) *CaptionSelectorSettings {
 	s.TeletextSourceSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CaptionSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AribSourceSettings != nil {
+		v := s.AribSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "aribSourceSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSubSourceSettings != nil {
+		v := s.DvbSubSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSubSourceSettings", v, protocol.Metadata{})
+	}
+	if s.EmbeddedSourceSettings != nil {
+		v := s.EmbeddedSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "embeddedSourceSettings", v, protocol.Metadata{})
+	}
+	if s.Scte20SourceSettings != nil {
+		v := s.Scte20SourceSettings
+
+		e.SetFields(protocol.BodyTarget, "scte20SourceSettings", v, protocol.Metadata{})
+	}
+	if s.Scte27SourceSettings != nil {
+		v := s.Scte27SourceSettings
+
+		e.SetFields(protocol.BodyTarget, "scte27SourceSettings", v, protocol.Metadata{})
+	}
+	if s.TeletextSourceSettings != nil {
+		v := s.TeletextSourceSettings
+
+		e.SetFields(protocol.BodyTarget, "teletextSourceSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Channel
@@ -2996,6 +3736,62 @@ func (s *Channel) SetState(v string) *Channel {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Channel) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ChannelEgressEndpoint
 type ChannelEgressEndpoint struct {
 	_ struct{} `type:"structure"`
@@ -3018,6 +3814,25 @@ func (s ChannelEgressEndpoint) GoString() string {
 func (s *ChannelEgressEndpoint) SetSourceIp(v string) *ChannelEgressEndpoint {
 	s.SourceIp = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChannelEgressEndpoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SourceIp != nil {
+		v := *s.SourceIp
+
+		e.SetValue(protocol.BodyTarget, "sourceIp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeChannelEgressEndpointList(vs []*ChannelEgressEndpoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ChannelSummary
@@ -3117,6 +3932,65 @@ func (s *ChannelSummary) SetState(v string) *ChannelSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChannelSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeChannelSummaryList(vs []*ChannelSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateChannelRequest
 type CreateChannelInput struct {
 	_ struct{} `type:"structure"`
@@ -3188,6 +4062,53 @@ func (s *CreateChannelInput) SetRoleArn(v string) *CreateChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	var RequestId string
+	if s.RequestId != nil {
+		RequestId = *s.RequestId
+	} else {
+		RequestId = protocol.GetIdempotencyToken()
+	}
+	{
+		v := RequestId
+
+		e.SetValue(protocol.BodyTarget, "requestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Reserved != nil {
+		v := *s.Reserved
+
+		e.SetValue(protocol.BodyTarget, "reserved", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateChannelResponse
 type CreateChannelOutput struct {
 	_ struct{} `type:"structure"`
@@ -3209,6 +4130,17 @@ func (s CreateChannelOutput) GoString() string {
 func (s *CreateChannelOutput) SetChannel(v *Channel) *CreateChannelOutput {
 	s.Channel = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Channel != nil {
+		v := s.Channel
+
+		e.SetFields(protocol.BodyTarget, "channel", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateInputRequest
@@ -3274,6 +4206,48 @@ func (s *CreateInputInput) SetType(v string) *CreateInputInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeInputDestinationRequestList(v), protocol.Metadata{})
+	}
+	if len(s.InputSecurityGroups) > 0 {
+		v := s.InputSecurityGroups
+
+		e.SetList(protocol.BodyTarget, "inputSecurityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	var RequestId string
+	if s.RequestId != nil {
+		RequestId = *s.RequestId
+	} else {
+		RequestId = protocol.GetIdempotencyToken()
+	}
+	{
+		v := RequestId
+
+		e.SetValue(protocol.BodyTarget, "requestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Sources) > 0 {
+		v := s.Sources
+
+		e.SetList(protocol.BodyTarget, "sources", encodeInputSourceRequestList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateInputResponse
 type CreateInputOutput struct {
 	_ struct{} `type:"structure"`
@@ -3295,6 +4269,17 @@ func (s CreateInputOutput) GoString() string {
 func (s *CreateInputOutput) SetInput(v *Input) *CreateInputOutput {
 	s.Input = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInputOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Input != nil {
+		v := s.Input
+
+		e.SetFields(protocol.BodyTarget, "input", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateInputSecurityGroupRequest
@@ -3320,6 +4305,17 @@ func (s *CreateInputSecurityGroupInput) SetWhitelistRules(v []*InputWhitelistRul
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.WhitelistRules) > 0 {
+		v := s.WhitelistRules
+
+		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleCidrList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/CreateInputSecurityGroupResponse
 type CreateInputSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -3342,6 +4338,17 @@ func (s CreateInputSecurityGroupOutput) GoString() string {
 func (s *CreateInputSecurityGroupOutput) SetSecurityGroup(v *InputSecurityGroup) *CreateInputSecurityGroupOutput {
 	s.SecurityGroup = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SecurityGroup != nil {
+		v := s.SecurityGroup
+
+		e.SetFields(protocol.BodyTarget, "securityGroup", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteChannelRequest
@@ -3379,6 +4386,17 @@ func (s *DeleteChannelInput) Validate() error {
 func (s *DeleteChannelInput) SetChannelId(v string) *DeleteChannelInput {
 	s.ChannelId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteChannelResponse
@@ -3476,6 +4494,62 @@ func (s *DeleteChannelOutput) SetState(v string) *DeleteChannelOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteInputRequest
 type DeleteInputInput struct {
 	_ struct{} `type:"structure"`
@@ -3513,6 +4587,17 @@ func (s *DeleteInputInput) SetInputId(v string) *DeleteInputInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteInputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputId != nil {
+		v := *s.InputId
+
+		e.SetValue(protocol.PathTarget, "inputId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteInputResponse
 type DeleteInputOutput struct {
 	_ struct{} `type:"structure"`
@@ -3526,6 +4611,12 @@ func (s DeleteInputOutput) String() string {
 // GoString returns the string representation
 func (s DeleteInputOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteInputOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteInputSecurityGroupRequest
@@ -3565,6 +4656,17 @@ func (s *DeleteInputSecurityGroupInput) SetInputSecurityGroupId(v string) *Delet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputSecurityGroupId != nil {
+		v := *s.InputSecurityGroupId
+
+		e.SetValue(protocol.PathTarget, "inputSecurityGroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteInputSecurityGroupResponse
 type DeleteInputSecurityGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -3578,6 +4680,12 @@ func (s DeleteInputSecurityGroupOutput) String() string {
 // GoString returns the string representation
 func (s DeleteInputSecurityGroupOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeChannelRequest
@@ -3615,6 +4723,17 @@ func (s *DescribeChannelInput) Validate() error {
 func (s *DescribeChannelInput) SetChannelId(v string) *DescribeChannelInput {
 	s.ChannelId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeChannelResponse
@@ -3712,6 +4831,62 @@ func (s *DescribeChannelOutput) SetState(v string) *DescribeChannelOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeInputRequest
 type DescribeInputInput struct {
 	_ struct{} `type:"structure"`
@@ -3747,6 +4922,17 @@ func (s *DescribeInputInput) Validate() error {
 func (s *DescribeInputInput) SetInputId(v string) *DescribeInputInput {
 	s.InputId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeInputInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputId != nil {
+		v := *s.InputId
+
+		e.SetValue(protocol.PathTarget, "inputId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeInputResponse
@@ -3836,6 +5022,57 @@ func (s *DescribeInputOutput) SetType(v string) *DescribeInputOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeInputOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AttachedChannels) > 0 {
+		v := s.AttachedChannels
+
+		e.SetList(protocol.BodyTarget, "attachedChannels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeInputDestinationList(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "securityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Sources) > 0 {
+		v := s.Sources
+
+		e.SetList(protocol.BodyTarget, "sources", encodeInputSourceList(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeInputSecurityGroupRequest
 type DescribeInputSecurityGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -3871,6 +5108,17 @@ func (s *DescribeInputSecurityGroupInput) Validate() error {
 func (s *DescribeInputSecurityGroupInput) SetInputSecurityGroupId(v string) *DescribeInputSecurityGroupInput {
 	s.InputSecurityGroupId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputSecurityGroupId != nil {
+		v := *s.InputSecurityGroupId
+
+		e.SetValue(protocol.PathTarget, "inputSecurityGroupId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeInputSecurityGroupResponse
@@ -3910,6 +5158,27 @@ func (s *DescribeInputSecurityGroupOutput) SetId(v string) *DescribeInputSecurit
 func (s *DescribeInputSecurityGroupOutput) SetWhitelistRules(v []*InputWhitelistRule) *DescribeInputSecurityGroupOutput {
 	s.WhitelistRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.WhitelistRules) > 0 {
+		v := s.WhitelistRules
+
+		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // DVB Network Information Table (NIT)
@@ -3955,6 +5224,27 @@ func (s *DvbNitSettings) SetNetworkName(v string) *DvbNitSettings {
 func (s *DvbNitSettings) SetRepInterval(v int64) *DvbNitSettings {
 	s.RepInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbNitSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NetworkId != nil {
+		v := *s.NetworkId
+
+		e.SetValue(protocol.BodyTarget, "networkId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NetworkName != nil {
+		v := *s.NetworkName
+
+		e.SetValue(protocol.BodyTarget, "networkName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepInterval != nil {
+		v := *s.RepInterval
+
+		e.SetValue(protocol.BodyTarget, "repInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // DVB Service Description Table (SDT)
@@ -4015,6 +5305,32 @@ func (s *DvbSdtSettings) SetServiceName(v string) *DvbSdtSettings {
 func (s *DvbSdtSettings) SetServiceProviderName(v string) *DvbSdtSettings {
 	s.ServiceProviderName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSdtSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OutputSdt != nil {
+		v := *s.OutputSdt
+
+		e.SetValue(protocol.BodyTarget, "outputSdt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepInterval != nil {
+		v := *s.RepInterval
+
+		e.SetValue(protocol.BodyTarget, "repInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ServiceName != nil {
+		v := *s.ServiceName
+
+		e.SetValue(protocol.BodyTarget, "serviceName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServiceProviderName != nil {
+		v := *s.ServiceProviderName
+
+		e.SetValue(protocol.BodyTarget, "serviceProviderName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DvbSubDestinationSettings
@@ -4233,6 +5549,97 @@ func (s *DvbSubDestinationSettings) SetYPosition(v int64) *DvbSubDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSubDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alignment != nil {
+		v := *s.Alignment
+
+		e.SetValue(protocol.BodyTarget, "alignment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundColor != nil {
+		v := *s.BackgroundColor
+
+		e.SetValue(protocol.BodyTarget, "backgroundColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BackgroundOpacity != nil {
+		v := *s.BackgroundOpacity
+
+		e.SetValue(protocol.BodyTarget, "backgroundOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Font != nil {
+		v := s.Font
+
+		e.SetFields(protocol.BodyTarget, "font", v, protocol.Metadata{})
+	}
+	if s.FontColor != nil {
+		v := *s.FontColor
+
+		e.SetValue(protocol.BodyTarget, "fontColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FontOpacity != nil {
+		v := *s.FontOpacity
+
+		e.SetValue(protocol.BodyTarget, "fontOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontResolution != nil {
+		v := *s.FontResolution
+
+		e.SetValue(protocol.BodyTarget, "fontResolution", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FontSize != nil {
+		v := *s.FontSize
+
+		e.SetValue(protocol.BodyTarget, "fontSize", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineColor != nil {
+		v := *s.OutlineColor
+
+		e.SetValue(protocol.BodyTarget, "outlineColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutlineSize != nil {
+		v := *s.OutlineSize
+
+		e.SetValue(protocol.BodyTarget, "outlineSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowColor != nil {
+		v := *s.ShadowColor
+
+		e.SetValue(protocol.BodyTarget, "shadowColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShadowOpacity != nil {
+		v := *s.ShadowOpacity
+
+		e.SetValue(protocol.BodyTarget, "shadowOpacity", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowXOffset != nil {
+		v := *s.ShadowXOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowXOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ShadowYOffset != nil {
+		v := *s.ShadowYOffset
+
+		e.SetValue(protocol.BodyTarget, "shadowYOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TeletextGridControl != nil {
+		v := *s.TeletextGridControl
+
+		e.SetValue(protocol.BodyTarget, "teletextGridControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.XPosition != nil {
+		v := *s.XPosition
+
+		e.SetValue(protocol.BodyTarget, "xPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.YPosition != nil {
+		v := *s.YPosition
+
+		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DvbSubSourceSettings
 type DvbSubSourceSettings struct {
 	_ struct{} `type:"structure"`
@@ -4259,6 +5666,17 @@ func (s *DvbSubSourceSettings) SetPid(v int64) *DvbSubSourceSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbSubSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // DVB Time and Date Table (SDT)
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DvbTdtSettings
 type DvbTdtSettings struct {
@@ -4283,6 +5701,17 @@ func (s DvbTdtSettings) GoString() string {
 func (s *DvbTdtSettings) SetRepInterval(v int64) *DvbTdtSettings {
 	s.RepInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DvbTdtSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RepInterval != nil {
+		v := *s.RepInterval
+
+		e.SetValue(protocol.BodyTarget, "repInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Eac3Settings
@@ -4493,6 +5922,112 @@ func (s *Eac3Settings) SetSurroundMode(v string) *Eac3Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Eac3Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttenuationControl != nil {
+		v := *s.AttenuationControl
+
+		e.SetValue(protocol.BodyTarget, "attenuationControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.BitstreamMode != nil {
+		v := *s.BitstreamMode
+
+		e.SetValue(protocol.BodyTarget, "bitstreamMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DcFilter != nil {
+		v := *s.DcFilter
+
+		e.SetValue(protocol.BodyTarget, "dcFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dialnorm != nil {
+		v := *s.Dialnorm
+
+		e.SetValue(protocol.BodyTarget, "dialnorm", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.DrcLine != nil {
+		v := *s.DrcLine
+
+		e.SetValue(protocol.BodyTarget, "drcLine", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DrcRf != nil {
+		v := *s.DrcRf
+
+		e.SetValue(protocol.BodyTarget, "drcRf", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeControl != nil {
+		v := *s.LfeControl
+
+		e.SetValue(protocol.BodyTarget, "lfeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LfeFilter != nil {
+		v := *s.LfeFilter
+
+		e.SetValue(protocol.BodyTarget, "lfeFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LoRoCenterMixLevel != nil {
+		v := *s.LoRoCenterMixLevel
+
+		e.SetValue(protocol.BodyTarget, "loRoCenterMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LoRoSurroundMixLevel != nil {
+		v := *s.LoRoSurroundMixLevel
+
+		e.SetValue(protocol.BodyTarget, "loRoSurroundMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LtRtCenterMixLevel != nil {
+		v := *s.LtRtCenterMixLevel
+
+		e.SetValue(protocol.BodyTarget, "ltRtCenterMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.LtRtSurroundMixLevel != nil {
+		v := *s.LtRtSurroundMixLevel
+
+		e.SetValue(protocol.BodyTarget, "ltRtSurroundMixLevel", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.MetadataControl != nil {
+		v := *s.MetadataControl
+
+		e.SetValue(protocol.BodyTarget, "metadataControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PassthroughControl != nil {
+		v := *s.PassthroughControl
+
+		e.SetValue(protocol.BodyTarget, "passthroughControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PhaseControl != nil {
+		v := *s.PhaseControl
+
+		e.SetValue(protocol.BodyTarget, "phaseControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StereoDownmix != nil {
+		v := *s.StereoDownmix
+
+		e.SetValue(protocol.BodyTarget, "stereoDownmix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SurroundExMode != nil {
+		v := *s.SurroundExMode
+
+		e.SetValue(protocol.BodyTarget, "surroundExMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SurroundMode != nil {
+		v := *s.SurroundMode
+
+		e.SetValue(protocol.BodyTarget, "surroundMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/EmbeddedDestinationSettings
 type EmbeddedDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -4508,6 +6043,12 @@ func (s EmbeddedDestinationSettings) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmbeddedDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/EmbeddedPlusScte20DestinationSettings
 type EmbeddedPlusScte20DestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -4521,6 +6062,12 @@ func (s EmbeddedPlusScte20DestinationSettings) String() string {
 // GoString returns the string representation
 func (s EmbeddedPlusScte20DestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmbeddedPlusScte20DestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/EmbeddedSourceSettings
@@ -4576,6 +6123,32 @@ func (s *EmbeddedSourceSettings) SetSource608ChannelNumber(v int64) *EmbeddedSou
 func (s *EmbeddedSourceSettings) SetSource608TrackNumber(v int64) *EmbeddedSourceSettings {
 	s.Source608TrackNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmbeddedSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Convert608To708 != nil {
+		v := *s.Convert608To708
+
+		e.SetValue(protocol.BodyTarget, "convert608To708", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte20Detection != nil {
+		v := *s.Scte20Detection
+
+		e.SetValue(protocol.BodyTarget, "scte20Detection", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source608ChannelNumber != nil {
+		v := *s.Source608ChannelNumber
+
+		e.SetValue(protocol.BodyTarget, "source608ChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Source608TrackNumber != nil {
+		v := *s.Source608TrackNumber
+
+		e.SetValue(protocol.BodyTarget, "source608TrackNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/EncoderSettings
@@ -4671,6 +6244,57 @@ func (s *EncoderSettings) SetVideoDescriptions(v []*VideoDescription) *EncoderSe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EncoderSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioDescriptions) > 0 {
+		v := s.AudioDescriptions
+
+		e.SetList(protocol.BodyTarget, "audioDescriptions", encodeAudioDescriptionList(v), protocol.Metadata{})
+	}
+	if s.AvailBlanking != nil {
+		v := s.AvailBlanking
+
+		e.SetFields(protocol.BodyTarget, "availBlanking", v, protocol.Metadata{})
+	}
+	if s.AvailConfiguration != nil {
+		v := s.AvailConfiguration
+
+		e.SetFields(protocol.BodyTarget, "availConfiguration", v, protocol.Metadata{})
+	}
+	if s.BlackoutSlate != nil {
+		v := s.BlackoutSlate
+
+		e.SetFields(protocol.BodyTarget, "blackoutSlate", v, protocol.Metadata{})
+	}
+	if len(s.CaptionDescriptions) > 0 {
+		v := s.CaptionDescriptions
+
+		e.SetList(protocol.BodyTarget, "captionDescriptions", encodeCaptionDescriptionList(v), protocol.Metadata{})
+	}
+	if s.GlobalConfiguration != nil {
+		v := s.GlobalConfiguration
+
+		e.SetFields(protocol.BodyTarget, "globalConfiguration", v, protocol.Metadata{})
+	}
+	if len(s.OutputGroups) > 0 {
+		v := s.OutputGroups
+
+		e.SetList(protocol.BodyTarget, "outputGroups", encodeOutputGroupList(v), protocol.Metadata{})
+	}
+	if s.TimecodeConfig != nil {
+		v := s.TimecodeConfig
+
+		e.SetFields(protocol.BodyTarget, "timecodeConfig", v, protocol.Metadata{})
+	}
+	if len(s.VideoDescriptions) > 0 {
+		v := s.VideoDescriptions
+
+		e.SetList(protocol.BodyTarget, "videoDescriptions", encodeVideoDescriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/FecOutputSettings
 type FecOutputSettings struct {
 	_ struct{} `type:"structure"`
@@ -4718,6 +6342,27 @@ func (s *FecOutputSettings) SetIncludeFec(v string) *FecOutputSettings {
 func (s *FecOutputSettings) SetRowLength(v int64) *FecOutputSettings {
 	s.RowLength = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FecOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ColumnDepth != nil {
+		v := *s.ColumnDepth
+
+		e.SetValue(protocol.BodyTarget, "columnDepth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IncludeFec != nil {
+		v := *s.IncludeFec
+
+		e.SetValue(protocol.BodyTarget, "includeFec", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RowLength != nil {
+		v := *s.RowLength
+
+		e.SetValue(protocol.BodyTarget, "rowLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/GlobalConfiguration
@@ -4788,6 +6433,37 @@ func (s *GlobalConfiguration) SetOutputTimingSource(v string) *GlobalConfigurati
 func (s *GlobalConfiguration) SetSupportLowFramerateInputs(v string) *GlobalConfiguration {
 	s.SupportLowFramerateInputs = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GlobalConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InitialAudioGain != nil {
+		v := *s.InitialAudioGain
+
+		e.SetValue(protocol.BodyTarget, "initialAudioGain", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputEndAction != nil {
+		v := *s.InputEndAction
+
+		e.SetValue(protocol.BodyTarget, "inputEndAction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputLossBehavior != nil {
+		v := s.InputLossBehavior
+
+		e.SetFields(protocol.BodyTarget, "inputLossBehavior", v, protocol.Metadata{})
+	}
+	if s.OutputTimingSource != nil {
+		v := *s.OutputTimingSource
+
+		e.SetValue(protocol.BodyTarget, "outputTimingSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SupportLowFramerateInputs != nil {
+		v := *s.SupportLowFramerateInputs
+
+		e.SetValue(protocol.BodyTarget, "supportLowFramerateInputs", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/H264Settings
@@ -5159,6 +6835,187 @@ func (s *H264Settings) SetTimecodeInsertion(v string) *H264Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *H264Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdaptiveQuantization != nil {
+		v := *s.AdaptiveQuantization
+
+		e.SetValue(protocol.BodyTarget, "adaptiveQuantization", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AfdSignaling != nil {
+		v := *s.AfdSignaling
+
+		e.SetValue(protocol.BodyTarget, "afdSignaling", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BufFillPct != nil {
+		v := *s.BufFillPct
+
+		e.SetValue(protocol.BodyTarget, "bufFillPct", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BufSize != nil {
+		v := *s.BufSize
+
+		e.SetValue(protocol.BodyTarget, "bufSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ColorMetadata != nil {
+		v := *s.ColorMetadata
+
+		e.SetValue(protocol.BodyTarget, "colorMetadata", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EntropyEncoding != nil {
+		v := *s.EntropyEncoding
+
+		e.SetValue(protocol.BodyTarget, "entropyEncoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FixedAfd != nil {
+		v := *s.FixedAfd
+
+		e.SetValue(protocol.BodyTarget, "fixedAfd", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FlickerAq != nil {
+		v := *s.FlickerAq
+
+		e.SetValue(protocol.BodyTarget, "flickerAq", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateControl != nil {
+		v := *s.FramerateControl
+
+		e.SetValue(protocol.BodyTarget, "framerateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FramerateDenominator != nil {
+		v := *s.FramerateDenominator
+
+		e.SetValue(protocol.BodyTarget, "framerateDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FramerateNumerator != nil {
+		v := *s.FramerateNumerator
+
+		e.SetValue(protocol.BodyTarget, "framerateNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopBReference != nil {
+		v := *s.GopBReference
+
+		e.SetValue(protocol.BodyTarget, "gopBReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GopClosedCadence != nil {
+		v := *s.GopClosedCadence
+
+		e.SetValue(protocol.BodyTarget, "gopClosedCadence", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopNumBFrames != nil {
+		v := *s.GopNumBFrames
+
+		e.SetValue(protocol.BodyTarget, "gopNumBFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GopSize != nil {
+		v := *s.GopSize
+
+		e.SetValue(protocol.BodyTarget, "gopSize", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.GopSizeUnits != nil {
+		v := *s.GopSizeUnits
+
+		e.SetValue(protocol.BodyTarget, "gopSizeUnits", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Level != nil {
+		v := *s.Level
+
+		e.SetValue(protocol.BodyTarget, "level", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LookAheadRateControl != nil {
+		v := *s.LookAheadRateControl
+
+		e.SetValue(protocol.BodyTarget, "lookAheadRateControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxBitrate != nil {
+		v := *s.MaxBitrate
+
+		e.SetValue(protocol.BodyTarget, "maxBitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinIInterval != nil {
+		v := *s.MinIInterval
+
+		e.SetValue(protocol.BodyTarget, "minIInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumRefFrames != nil {
+		v := *s.NumRefFrames
+
+		e.SetValue(protocol.BodyTarget, "numRefFrames", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParControl != nil {
+		v := *s.ParControl
+
+		e.SetValue(protocol.BodyTarget, "parControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParDenominator != nil {
+		v := *s.ParDenominator
+
+		e.SetValue(protocol.BodyTarget, "parDenominator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ParNumerator != nil {
+		v := *s.ParNumerator
+
+		e.SetValue(protocol.BodyTarget, "parNumerator", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Profile != nil {
+		v := *s.Profile
+
+		e.SetValue(protocol.BodyTarget, "profile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RateControlMode != nil {
+		v := *s.RateControlMode
+
+		e.SetValue(protocol.BodyTarget, "rateControlMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ScanType != nil {
+		v := *s.ScanType
+
+		e.SetValue(protocol.BodyTarget, "scanType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SceneChangeDetect != nil {
+		v := *s.SceneChangeDetect
+
+		e.SetValue(protocol.BodyTarget, "sceneChangeDetect", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Slices != nil {
+		v := *s.Slices
+
+		e.SetValue(protocol.BodyTarget, "slices", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Softness != nil {
+		v := *s.Softness
+
+		e.SetValue(protocol.BodyTarget, "softness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SpatialAq != nil {
+		v := *s.SpatialAq
+
+		e.SetValue(protocol.BodyTarget, "spatialAq", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Syntax != nil {
+		v := *s.Syntax
+
+		e.SetValue(protocol.BodyTarget, "syntax", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TemporalAq != nil {
+		v := *s.TemporalAq
+
+		e.SetValue(protocol.BodyTarget, "temporalAq", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimecodeInsertion != nil {
+		v := *s.TimecodeInsertion
+
+		e.SetValue(protocol.BodyTarget, "timecodeInsertion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsAkamaiSettings
 type HlsAkamaiSettings struct {
 	_ struct{} `type:"structure"`
@@ -5241,6 +7098,47 @@ func (s *HlsAkamaiSettings) SetToken(v string) *HlsAkamaiSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsAkamaiSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRetryInterval != nil {
+		v := *s.ConnectionRetryInterval
+
+		e.SetValue(protocol.BodyTarget, "connectionRetryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FilecacheDuration != nil {
+		v := *s.FilecacheDuration
+
+		e.SetValue(protocol.BodyTarget, "filecacheDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HttpTransferMode != nil {
+		v := *s.HttpTransferMode
+
+		e.SetValue(protocol.BodyTarget, "httpTransferMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumRetries != nil {
+		v := *s.NumRetries
+
+		e.SetValue(protocol.BodyTarget, "numRetries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestartDelay != nil {
+		v := *s.RestartDelay
+
+		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Salt != nil {
+		v := *s.Salt
+
+		e.SetValue(protocol.BodyTarget, "salt", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.BodyTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsBasicPutSettings
 type HlsBasicPutSettings struct {
 	_ struct{} `type:"structure"`
@@ -5295,6 +7193,32 @@ func (s *HlsBasicPutSettings) SetRestartDelay(v int64) *HlsBasicPutSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsBasicPutSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRetryInterval != nil {
+		v := *s.ConnectionRetryInterval
+
+		e.SetValue(protocol.BodyTarget, "connectionRetryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FilecacheDuration != nil {
+		v := *s.FilecacheDuration
+
+		e.SetValue(protocol.BodyTarget, "filecacheDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NumRetries != nil {
+		v := *s.NumRetries
+
+		e.SetValue(protocol.BodyTarget, "numRetries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestartDelay != nil {
+		v := *s.RestartDelay
+
+		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsCdnSettings
 type HlsCdnSettings struct {
 	_ struct{} `type:"structure"`
@@ -5340,6 +7264,32 @@ func (s *HlsCdnSettings) SetHlsMediaStoreSettings(v *HlsMediaStoreSettings) *Hls
 func (s *HlsCdnSettings) SetHlsWebdavSettings(v *HlsWebdavSettings) *HlsCdnSettings {
 	s.HlsWebdavSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsCdnSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HlsAkamaiSettings != nil {
+		v := s.HlsAkamaiSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsAkamaiSettings", v, protocol.Metadata{})
+	}
+	if s.HlsBasicPutSettings != nil {
+		v := s.HlsBasicPutSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsBasicPutSettings", v, protocol.Metadata{})
+	}
+	if s.HlsMediaStoreSettings != nil {
+		v := s.HlsMediaStoreSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsMediaStoreSettings", v, protocol.Metadata{})
+	}
+	if s.HlsWebdavSettings != nil {
+		v := s.HlsWebdavSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsWebdavSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsGroupSettings
@@ -5721,6 +7671,187 @@ func (s *HlsGroupSettings) SetTsFileMode(v string) *HlsGroupSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdMarkers) > 0 {
+		v := s.AdMarkers
+
+		e.SetList(protocol.BodyTarget, "adMarkers", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.BaseUrlContent != nil {
+		v := *s.BaseUrlContent
+
+		e.SetValue(protocol.BodyTarget, "baseUrlContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BaseUrlManifest != nil {
+		v := *s.BaseUrlManifest
+
+		e.SetValue(protocol.BodyTarget, "baseUrlManifest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CaptionLanguageMappings) > 0 {
+		v := s.CaptionLanguageMappings
+
+		e.SetList(protocol.BodyTarget, "captionLanguageMappings", encodeCaptionLanguageMappingList(v), protocol.Metadata{})
+	}
+	if s.CaptionLanguageSetting != nil {
+		v := *s.CaptionLanguageSetting
+
+		e.SetValue(protocol.BodyTarget, "captionLanguageSetting", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientCache != nil {
+		v := *s.ClientCache
+
+		e.SetValue(protocol.BodyTarget, "clientCache", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CodecSpecification != nil {
+		v := *s.CodecSpecification
+
+		e.SetValue(protocol.BodyTarget, "codecSpecification", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConstantIv != nil {
+		v := *s.ConstantIv
+
+		e.SetValue(protocol.BodyTarget, "constantIv", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "destination", v, protocol.Metadata{})
+	}
+	if s.DirectoryStructure != nil {
+		v := *s.DirectoryStructure
+
+		e.SetValue(protocol.BodyTarget, "directoryStructure", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncryptionType != nil {
+		v := *s.EncryptionType
+
+		e.SetValue(protocol.BodyTarget, "encryptionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsCdnSettings != nil {
+		v := s.HlsCdnSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsCdnSettings", v, protocol.Metadata{})
+	}
+	if s.IndexNSegments != nil {
+		v := *s.IndexNSegments
+
+		e.SetValue(protocol.BodyTarget, "indexNSegments", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputLossAction != nil {
+		v := *s.InputLossAction
+
+		e.SetValue(protocol.BodyTarget, "inputLossAction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IvInManifest != nil {
+		v := *s.IvInManifest
+
+		e.SetValue(protocol.BodyTarget, "ivInManifest", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IvSource != nil {
+		v := *s.IvSource
+
+		e.SetValue(protocol.BodyTarget, "ivSource", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeepSegments != nil {
+		v := *s.KeepSegments
+
+		e.SetValue(protocol.BodyTarget, "keepSegments", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.KeyFormat != nil {
+		v := *s.KeyFormat
+
+		e.SetValue(protocol.BodyTarget, "keyFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyFormatVersions != nil {
+		v := *s.KeyFormatVersions
+
+		e.SetValue(protocol.BodyTarget, "keyFormatVersions", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyProviderSettings != nil {
+		v := s.KeyProviderSettings
+
+		e.SetFields(protocol.BodyTarget, "keyProviderSettings", v, protocol.Metadata{})
+	}
+	if s.ManifestCompression != nil {
+		v := *s.ManifestCompression
+
+		e.SetValue(protocol.BodyTarget, "manifestCompression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestDurationFormat != nil {
+		v := *s.ManifestDurationFormat
+
+		e.SetValue(protocol.BodyTarget, "manifestDurationFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MinSegmentLength != nil {
+		v := *s.MinSegmentLength
+
+		e.SetValue(protocol.BodyTarget, "minSegmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Mode != nil {
+		v := *s.Mode
+
+		e.SetValue(protocol.BodyTarget, "mode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputSelection != nil {
+		v := *s.OutputSelection
+
+		e.SetValue(protocol.BodyTarget, "outputSelection", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramDateTime != nil {
+		v := *s.ProgramDateTime
+
+		e.SetValue(protocol.BodyTarget, "programDateTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramDateTimePeriod != nil {
+		v := *s.ProgramDateTimePeriod
+
+		e.SetValue(protocol.BodyTarget, "programDateTimePeriod", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentLength != nil {
+		v := *s.SegmentLength
+
+		e.SetValue(protocol.BodyTarget, "segmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentationMode != nil {
+		v := *s.SegmentationMode
+
+		e.SetValue(protocol.BodyTarget, "segmentationMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentsPerSubdirectory != nil {
+		v := *s.SegmentsPerSubdirectory
+
+		e.SetValue(protocol.BodyTarget, "segmentsPerSubdirectory", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamInfResolution != nil {
+		v := *s.StreamInfResolution
+
+		e.SetValue(protocol.BodyTarget, "streamInfResolution", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Frame != nil {
+		v := *s.TimedMetadataId3Frame
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Frame", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Period != nil {
+		v := *s.TimedMetadataId3Period
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Period", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimestampDeltaMilliseconds != nil {
+		v := *s.TimestampDeltaMilliseconds
+
+		e.SetValue(protocol.BodyTarget, "timestampDeltaMilliseconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TsFileMode != nil {
+		v := *s.TsFileMode
+
+		e.SetValue(protocol.BodyTarget, "tsFileMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsInputSettings
 type HlsInputSettings struct {
 	_ struct{} `type:"structure"`
@@ -5777,6 +7908,32 @@ func (s *HlsInputSettings) SetRetries(v int64) *HlsInputSettings {
 func (s *HlsInputSettings) SetRetryInterval(v int64) *HlsInputSettings {
 	s.RetryInterval = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsInputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bandwidth != nil {
+		v := *s.Bandwidth
+
+		e.SetValue(protocol.BodyTarget, "bandwidth", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BufferSegments != nil {
+		v := *s.BufferSegments
+
+		e.SetValue(protocol.BodyTarget, "bufferSegments", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Retries != nil {
+		v := *s.Retries
+
+		e.SetValue(protocol.BodyTarget, "retries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RetryInterval != nil {
+		v := *s.RetryInterval
+
+		e.SetValue(protocol.BodyTarget, "retryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsMediaStoreSettings
@@ -5843,6 +8000,37 @@ func (s *HlsMediaStoreSettings) SetRestartDelay(v int64) *HlsMediaStoreSettings 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsMediaStoreSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRetryInterval != nil {
+		v := *s.ConnectionRetryInterval
+
+		e.SetValue(protocol.BodyTarget, "connectionRetryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FilecacheDuration != nil {
+		v := *s.FilecacheDuration
+
+		e.SetValue(protocol.BodyTarget, "filecacheDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MediaStoreStorageClass != nil {
+		v := *s.MediaStoreStorageClass
+
+		e.SetValue(protocol.BodyTarget, "mediaStoreStorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumRetries != nil {
+		v := *s.NumRetries
+
+		e.SetValue(protocol.BodyTarget, "numRetries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestartDelay != nil {
+		v := *s.RestartDelay
+
+		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsOutputSettings
 type HlsOutputSettings struct {
 	_ struct{} `type:"structure"`
@@ -5887,6 +8075,27 @@ func (s *HlsOutputSettings) SetSegmentModifier(v string) *HlsOutputSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HlsSettings != nil {
+		v := s.HlsSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsSettings", v, protocol.Metadata{})
+	}
+	if s.NameModifier != nil {
+		v := *s.NameModifier
+
+		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentModifier != nil {
+		v := *s.SegmentModifier
+
+		e.SetValue(protocol.BodyTarget, "segmentModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsSettings
 type HlsSettings struct {
 	_ struct{} `type:"structure"`
@@ -5916,6 +8125,22 @@ func (s *HlsSettings) SetAudioOnlyHlsSettings(v *AudioOnlyHlsSettings) *HlsSetti
 func (s *HlsSettings) SetStandardHlsSettings(v *StandardHlsSettings) *HlsSettings {
 	s.StandardHlsSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioOnlyHlsSettings != nil {
+		v := s.AudioOnlyHlsSettings
+
+		e.SetFields(protocol.BodyTarget, "audioOnlyHlsSettings", v, protocol.Metadata{})
+	}
+	if s.StandardHlsSettings != nil {
+		v := s.StandardHlsSettings
+
+		e.SetFields(protocol.BodyTarget, "standardHlsSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/HlsWebdavSettings
@@ -5979,6 +8204,37 @@ func (s *HlsWebdavSettings) SetNumRetries(v int64) *HlsWebdavSettings {
 func (s *HlsWebdavSettings) SetRestartDelay(v int64) *HlsWebdavSettings {
 	s.RestartDelay = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsWebdavSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRetryInterval != nil {
+		v := *s.ConnectionRetryInterval
+
+		e.SetValue(protocol.BodyTarget, "connectionRetryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FilecacheDuration != nil {
+		v := *s.FilecacheDuration
+
+		e.SetValue(protocol.BodyTarget, "filecacheDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HttpTransferMode != nil {
+		v := *s.HttpTransferMode
+
+		e.SetValue(protocol.BodyTarget, "httpTransferMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumRetries != nil {
+		v := *s.NumRetries
+
+		e.SetValue(protocol.BodyTarget, "numRetries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestartDelay != nil {
+		v := *s.RestartDelay
+
+		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Input
@@ -6076,6 +8332,65 @@ func (s *Input) SetType(v string) *Input {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.AttachedChannels) > 0 {
+		v := s.AttachedChannels
+
+		e.SetList(protocol.BodyTarget, "attachedChannels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeInputDestinationList(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SecurityGroups) > 0 {
+		v := s.SecurityGroups
+
+		e.SetList(protocol.BodyTarget, "securityGroups", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.Sources) > 0 {
+		v := s.Sources
+
+		e.SetList(protocol.BodyTarget, "sources", encodeInputSourceList(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputList(vs []*Input) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputAttachment
 type InputAttachment struct {
 	_ struct{} `type:"structure"`
@@ -6107,6 +8422,30 @@ func (s *InputAttachment) SetInputId(v string) *InputAttachment {
 func (s *InputAttachment) SetInputSettings(v *InputSettings) *InputAttachment {
 	s.InputSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputAttachment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputId != nil {
+		v := *s.InputId
+
+		e.SetValue(protocol.BodyTarget, "inputId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputSettings != nil {
+		v := s.InputSettings
+
+		e.SetFields(protocol.BodyTarget, "inputSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputAttachmentList(vs []*InputAttachment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputChannelLevel
@@ -6141,6 +8480,30 @@ func (s *InputChannelLevel) SetGain(v int64) *InputChannelLevel {
 func (s *InputChannelLevel) SetInputChannel(v int64) *InputChannelLevel {
 	s.InputChannel = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputChannelLevel) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Gain != nil {
+		v := *s.Gain
+
+		e.SetValue(protocol.BodyTarget, "gain", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputChannel != nil {
+		v := *s.InputChannel
+
+		e.SetValue(protocol.BodyTarget, "inputChannel", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputChannelLevelList(vs []*InputChannelLevel) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for a PUSH type input
@@ -6187,6 +8550,35 @@ func (s *InputDestination) SetUrl(v string) *InputDestination {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Ip != nil {
+		v := *s.Ip
+
+		e.SetValue(protocol.BodyTarget, "ip", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Port != nil {
+		v := *s.Port
+
+		e.SetValue(protocol.BodyTarget, "port", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputDestinationList(vs []*InputDestination) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Endpoint settings for a PUSH type input
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputDestinationRequest
 type InputDestinationRequest struct {
@@ -6210,6 +8602,25 @@ func (s InputDestinationRequest) GoString() string {
 func (s *InputDestinationRequest) SetStreamName(v string) *InputDestinationRequest {
 	s.StreamName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputDestinationRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StreamName != nil {
+		v := *s.StreamName
+
+		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputDestinationRequestList(vs []*InputDestinationRequest) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputLocation
@@ -6257,6 +8668,27 @@ func (s *InputLocation) SetUri(v string) *InputLocation {
 func (s *InputLocation) SetUsername(v string) *InputLocation {
 	s.Username = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PasswordParam != nil {
+		v := *s.PasswordParam
+
+		e.SetValue(protocol.BodyTarget, "passwordParam", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Uri != nil {
+		v := *s.Uri
+
+		e.SetValue(protocol.BodyTarget, "uri", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputLossBehavior
@@ -6327,6 +8759,37 @@ func (s *InputLossBehavior) SetRepeatFrameMsec(v int64) *InputLossBehavior {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputLossBehavior) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BlackFrameMsec != nil {
+		v := *s.BlackFrameMsec
+
+		e.SetValue(protocol.BodyTarget, "blackFrameMsec", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputLossImageColor != nil {
+		v := *s.InputLossImageColor
+
+		e.SetValue(protocol.BodyTarget, "inputLossImageColor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InputLossImageSlate != nil {
+		v := s.InputLossImageSlate
+
+		e.SetFields(protocol.BodyTarget, "inputLossImageSlate", v, protocol.Metadata{})
+	}
+	if s.InputLossImageType != nil {
+		v := *s.InputLossImageType
+
+		e.SetValue(protocol.BodyTarget, "inputLossImageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RepeatFrameMsec != nil {
+		v := *s.RepeatFrameMsec
+
+		e.SetValue(protocol.BodyTarget, "repeatFrameMsec", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An Input Security Group
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputSecurityGroup
 type InputSecurityGroup struct {
@@ -6368,6 +8831,35 @@ func (s *InputSecurityGroup) SetId(v string) *InputSecurityGroup {
 func (s *InputSecurityGroup) SetWhitelistRules(v []*InputWhitelistRule) *InputSecurityGroup {
 	s.WhitelistRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputSecurityGroup) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.WhitelistRules) > 0 {
+		v := s.WhitelistRules
+
+		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputSecurityGroupList(vs []*InputSecurityGroup) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Live Event input parameters. There can be multiple inputs in a single Live
@@ -6472,6 +8964,57 @@ func (s *InputSettings) SetVideoSelector(v *VideoSelector) *InputSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioSelectors) > 0 {
+		v := s.AudioSelectors
+
+		e.SetList(protocol.BodyTarget, "audioSelectors", encodeAudioSelectorList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionSelectors) > 0 {
+		v := s.CaptionSelectors
+
+		e.SetList(protocol.BodyTarget, "captionSelectors", encodeCaptionSelectorList(v), protocol.Metadata{})
+	}
+	if s.DeblockFilter != nil {
+		v := *s.DeblockFilter
+
+		e.SetValue(protocol.BodyTarget, "deblockFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DenoiseFilter != nil {
+		v := *s.DenoiseFilter
+
+		e.SetValue(protocol.BodyTarget, "denoiseFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilterStrength != nil {
+		v := *s.FilterStrength
+
+		e.SetValue(protocol.BodyTarget, "filterStrength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputFilter != nil {
+		v := *s.InputFilter
+
+		e.SetValue(protocol.BodyTarget, "inputFilter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NetworkInputSettings != nil {
+		v := s.NetworkInputSettings
+
+		e.SetFields(protocol.BodyTarget, "networkInputSettings", v, protocol.Metadata{})
+	}
+	if s.SourceEndBehavior != nil {
+		v := *s.SourceEndBehavior
+
+		e.SetValue(protocol.BodyTarget, "sourceEndBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VideoSelector != nil {
+		v := s.VideoSelector
+
+		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings for a PULL type input
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputSource
 type InputSource struct {
@@ -6513,6 +9056,35 @@ func (s *InputSource) SetUrl(v string) *InputSource {
 func (s *InputSource) SetUsername(v string) *InputSource {
 	s.Username = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputSource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PasswordParam != nil {
+		v := *s.PasswordParam
+
+		e.SetValue(protocol.BodyTarget, "passwordParam", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputSourceList(vs []*InputSource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Settings for for a PULL type input
@@ -6558,6 +9130,35 @@ func (s *InputSourceRequest) SetUsername(v string) *InputSourceRequest {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputSourceRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PasswordParam != nil {
+		v := *s.PasswordParam
+
+		e.SetValue(protocol.BodyTarget, "passwordParam", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputSourceRequestList(vs []*InputSourceRequest) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Whitelist rule
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/InputWhitelistRule
 type InputWhitelistRule struct {
@@ -6581,6 +9182,25 @@ func (s InputWhitelistRule) GoString() string {
 func (s *InputWhitelistRule) SetCidr(v string) *InputWhitelistRule {
 	s.Cidr = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputWhitelistRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cidr != nil {
+		v := *s.Cidr
+
+		e.SetValue(protocol.BodyTarget, "cidr", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputWhitelistRuleList(vs []*InputWhitelistRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // An IPv4 CIDR to whitelist.
@@ -6608,6 +9228,25 @@ func (s *InputWhitelistRuleCidr) SetCidr(v string) *InputWhitelistRuleCidr {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InputWhitelistRuleCidr) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Cidr != nil {
+		v := *s.Cidr
+
+		e.SetValue(protocol.BodyTarget, "cidr", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInputWhitelistRuleCidrList(vs []*InputWhitelistRuleCidr) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/KeyProviderSettings
 type KeyProviderSettings struct {
 	_ struct{} `type:"structure"`
@@ -6629,6 +9268,17 @@ func (s KeyProviderSettings) GoString() string {
 func (s *KeyProviderSettings) SetStaticKeySettings(v *StaticKeySettings) *KeyProviderSettings {
 	s.StaticKeySettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyProviderSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StaticKeySettings != nil {
+		v := s.StaticKeySettings
+
+		e.SetFields(protocol.BodyTarget, "staticKeySettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListChannelsRequest
@@ -6675,6 +9325,22 @@ func (s *ListChannelsInput) SetNextToken(v string) *ListChannelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListChannelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListChannelsResponse
 type ListChannelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6704,6 +9370,22 @@ func (s *ListChannelsOutput) SetChannels(v []*ChannelSummary) *ListChannelsOutpu
 func (s *ListChannelsOutput) SetNextToken(v string) *ListChannelsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListChannelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Channels) > 0 {
+		v := s.Channels
+
+		e.SetList(protocol.BodyTarget, "channels", encodeChannelSummaryList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListInputSecurityGroupsRequest
@@ -6750,6 +9432,22 @@ func (s *ListInputSecurityGroupsInput) SetNextToken(v string) *ListInputSecurity
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInputSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListInputSecurityGroupsResponse
 type ListInputSecurityGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6779,6 +9477,22 @@ func (s *ListInputSecurityGroupsOutput) SetInputSecurityGroups(v []*InputSecurit
 func (s *ListInputSecurityGroupsOutput) SetNextToken(v string) *ListInputSecurityGroupsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInputSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.InputSecurityGroups) > 0 {
+		v := s.InputSecurityGroups
+
+		e.SetList(protocol.BodyTarget, "inputSecurityGroups", encodeInputSecurityGroupList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListInputsRequest
@@ -6825,6 +9539,22 @@ func (s *ListInputsInput) SetNextToken(v string) *ListInputsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInputsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListInputsResponse
 type ListInputsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6854,6 +9584,22 @@ func (s *ListInputsOutput) SetInputs(v []*Input) *ListInputsOutput {
 func (s *ListInputsOutput) SetNextToken(v string) *ListInputsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListInputsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Inputs) > 0 {
+		v := s.Inputs
+
+		e.SetList(protocol.BodyTarget, "inputs", encodeInputList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/M2tsSettings
@@ -7370,6 +10116,242 @@ func (s *M2tsSettings) SetVideoPid(v string) *M2tsSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *M2tsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbsentInputAudioBehavior != nil {
+		v := *s.AbsentInputAudioBehavior
+
+		e.SetValue(protocol.BodyTarget, "absentInputAudioBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Arib != nil {
+		v := *s.Arib
+
+		e.SetValue(protocol.BodyTarget, "arib", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AribCaptionsPid != nil {
+		v := *s.AribCaptionsPid
+
+		e.SetValue(protocol.BodyTarget, "aribCaptionsPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AribCaptionsPidControl != nil {
+		v := *s.AribCaptionsPidControl
+
+		e.SetValue(protocol.BodyTarget, "aribCaptionsPidControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioBufferModel != nil {
+		v := *s.AudioBufferModel
+
+		e.SetValue(protocol.BodyTarget, "audioBufferModel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioFramesPerPes != nil {
+		v := *s.AudioFramesPerPes
+
+		e.SetValue(protocol.BodyTarget, "audioFramesPerPes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AudioPids != nil {
+		v := *s.AudioPids
+
+		e.SetValue(protocol.BodyTarget, "audioPids", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioStreamType != nil {
+		v := *s.AudioStreamType
+
+		e.SetValue(protocol.BodyTarget, "audioStreamType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.BufferModel != nil {
+		v := *s.BufferModel
+
+		e.SetValue(protocol.BodyTarget, "bufferModel", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CcDescriptor != nil {
+		v := *s.CcDescriptor
+
+		e.SetValue(protocol.BodyTarget, "ccDescriptor", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DvbNitSettings != nil {
+		v := s.DvbNitSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbNitSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSdtSettings != nil {
+		v := s.DvbSdtSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbSdtSettings", v, protocol.Metadata{})
+	}
+	if s.DvbSubPids != nil {
+		v := *s.DvbSubPids
+
+		e.SetValue(protocol.BodyTarget, "dvbSubPids", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DvbTdtSettings != nil {
+		v := s.DvbTdtSettings
+
+		e.SetFields(protocol.BodyTarget, "dvbTdtSettings", v, protocol.Metadata{})
+	}
+	if s.DvbTeletextPid != nil {
+		v := *s.DvbTeletextPid
+
+		e.SetValue(protocol.BodyTarget, "dvbTeletextPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Ebif != nil {
+		v := *s.Ebif
+
+		e.SetValue(protocol.BodyTarget, "ebif", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EbpAudioInterval != nil {
+		v := *s.EbpAudioInterval
+
+		e.SetValue(protocol.BodyTarget, "ebpAudioInterval", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EbpLookaheadMs != nil {
+		v := *s.EbpLookaheadMs
+
+		e.SetValue(protocol.BodyTarget, "ebpLookaheadMs", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.EbpPlacement != nil {
+		v := *s.EbpPlacement
+
+		e.SetValue(protocol.BodyTarget, "ebpPlacement", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EcmPid != nil {
+		v := *s.EcmPid
+
+		e.SetValue(protocol.BodyTarget, "ecmPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EsRateInPes != nil {
+		v := *s.EsRateInPes
+
+		e.SetValue(protocol.BodyTarget, "esRateInPes", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EtvPlatformPid != nil {
+		v := *s.EtvPlatformPid
+
+		e.SetValue(protocol.BodyTarget, "etvPlatformPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EtvSignalPid != nil {
+		v := *s.EtvSignalPid
+
+		e.SetValue(protocol.BodyTarget, "etvSignalPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FragmentTime != nil {
+		v := *s.FragmentTime
+
+		e.SetValue(protocol.BodyTarget, "fragmentTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Klv != nil {
+		v := *s.Klv
+
+		e.SetValue(protocol.BodyTarget, "klv", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KlvDataPids != nil {
+		v := *s.KlvDataPids
+
+		e.SetValue(protocol.BodyTarget, "klvDataPids", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NullPacketBitrate != nil {
+		v := *s.NullPacketBitrate
+
+		e.SetValue(protocol.BodyTarget, "nullPacketBitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.PatInterval != nil {
+		v := *s.PatInterval
+
+		e.SetValue(protocol.BodyTarget, "patInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrControl != nil {
+		v := *s.PcrControl
+
+		e.SetValue(protocol.BodyTarget, "pcrControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PcrPeriod != nil {
+		v := *s.PcrPeriod
+
+		e.SetValue(protocol.BodyTarget, "pcrPeriod", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrPid != nil {
+		v := *s.PcrPid
+
+		e.SetValue(protocol.BodyTarget, "pcrPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PmtInterval != nil {
+		v := *s.PmtInterval
+
+		e.SetValue(protocol.BodyTarget, "pmtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtPid != nil {
+		v := *s.PmtPid
+
+		e.SetValue(protocol.BodyTarget, "pmtPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramNum != nil {
+		v := *s.ProgramNum
+
+		e.SetValue(protocol.BodyTarget, "programNum", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RateMode != nil {
+		v := *s.RateMode
+
+		e.SetValue(protocol.BodyTarget, "rateMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte27Pids != nil {
+		v := *s.Scte27Pids
+
+		e.SetValue(protocol.BodyTarget, "scte27Pids", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte35Control != nil {
+		v := *s.Scte35Control
+
+		e.SetValue(protocol.BodyTarget, "scte35Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte35Pid != nil {
+		v := *s.Scte35Pid
+
+		e.SetValue(protocol.BodyTarget, "scte35Pid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationMarkers != nil {
+		v := *s.SegmentationMarkers
+
+		e.SetValue(protocol.BodyTarget, "segmentationMarkers", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationStyle != nil {
+		v := *s.SegmentationStyle
+
+		e.SetValue(protocol.BodyTarget, "segmentationStyle", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentationTime != nil {
+		v := *s.SegmentationTime
+
+		e.SetValue(protocol.BodyTarget, "segmentationTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataBehavior != nil {
+		v := *s.TimedMetadataBehavior
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataPid != nil {
+		v := *s.TimedMetadataPid
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransportStreamId != nil {
+		v := *s.TransportStreamId
+
+		e.SetValue(protocol.BodyTarget, "transportStreamId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VideoPid != nil {
+		v := *s.VideoPid
+
+		e.SetValue(protocol.BodyTarget, "videoPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Settings information for the .m3u8 container
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/M3u8Settings
 type M3u8Settings struct {
@@ -7537,6 +10519,87 @@ func (s *M3u8Settings) SetVideoPid(v string) *M3u8Settings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *M3u8Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioFramesPerPes != nil {
+		v := *s.AudioFramesPerPes
+
+		e.SetValue(protocol.BodyTarget, "audioFramesPerPes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.AudioPids != nil {
+		v := *s.AudioPids
+
+		e.SetValue(protocol.BodyTarget, "audioPids", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EcmPid != nil {
+		v := *s.EcmPid
+
+		e.SetValue(protocol.BodyTarget, "ecmPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PatInterval != nil {
+		v := *s.PatInterval
+
+		e.SetValue(protocol.BodyTarget, "patInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrControl != nil {
+		v := *s.PcrControl
+
+		e.SetValue(protocol.BodyTarget, "pcrControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PcrPeriod != nil {
+		v := *s.PcrPeriod
+
+		e.SetValue(protocol.BodyTarget, "pcrPeriod", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PcrPid != nil {
+		v := *s.PcrPid
+
+		e.SetValue(protocol.BodyTarget, "pcrPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PmtInterval != nil {
+		v := *s.PmtInterval
+
+		e.SetValue(protocol.BodyTarget, "pmtInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PmtPid != nil {
+		v := *s.PmtPid
+
+		e.SetValue(protocol.BodyTarget, "pmtPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProgramNum != nil {
+		v := *s.ProgramNum
+
+		e.SetValue(protocol.BodyTarget, "programNum", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Scte35Behavior != nil {
+		v := *s.Scte35Behavior
+
+		e.SetValue(protocol.BodyTarget, "scte35Behavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Scte35Pid != nil {
+		v := *s.Scte35Pid
+
+		e.SetValue(protocol.BodyTarget, "scte35Pid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataBehavior != nil {
+		v := *s.TimedMetadataBehavior
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TransportStreamId != nil {
+		v := *s.TransportStreamId
+
+		e.SetValue(protocol.BodyTarget, "transportStreamId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VideoPid != nil {
+		v := *s.VideoPid
+
+		e.SetValue(protocol.BodyTarget, "videoPid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Mp2Settings
 type Mp2Settings struct {
 	_ struct{} `type:"structure"`
@@ -7578,6 +10641,27 @@ func (s *Mp2Settings) SetCodingMode(v string) *Mp2Settings {
 func (s *Mp2Settings) SetSampleRate(v float64) *Mp2Settings {
 	s.SampleRate = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Mp2Settings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bitrate != nil {
+		v := *s.Bitrate
+
+		e.SetValue(protocol.BodyTarget, "bitrate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.CodingMode != nil {
+		v := *s.CodingMode
+
+		e.SetValue(protocol.BodyTarget, "codingMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/MsSmoothGroupSettings
@@ -7797,6 +10881,107 @@ func (s *MsSmoothGroupSettings) SetTimestampOffsetMode(v string) *MsSmoothGroupS
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MsSmoothGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcquisitionPointId != nil {
+		v := *s.AcquisitionPointId
+
+		e.SetValue(protocol.BodyTarget, "acquisitionPointId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AudioOnlyTimecodeControl != nil {
+		v := *s.AudioOnlyTimecodeControl
+
+		e.SetValue(protocol.BodyTarget, "audioOnlyTimecodeControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CertificateMode != nil {
+		v := *s.CertificateMode
+
+		e.SetValue(protocol.BodyTarget, "certificateMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConnectionRetryInterval != nil {
+		v := *s.ConnectionRetryInterval
+
+		e.SetValue(protocol.BodyTarget, "connectionRetryInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "destination", v, protocol.Metadata{})
+	}
+	if s.EventId != nil {
+		v := *s.EventId
+
+		e.SetValue(protocol.BodyTarget, "eventId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EventIdMode != nil {
+		v := *s.EventIdMode
+
+		e.SetValue(protocol.BodyTarget, "eventIdMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EventStopBehavior != nil {
+		v := *s.EventStopBehavior
+
+		e.SetValue(protocol.BodyTarget, "eventStopBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FilecacheDuration != nil {
+		v := *s.FilecacheDuration
+
+		e.SetValue(protocol.BodyTarget, "filecacheDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FragmentLength != nil {
+		v := *s.FragmentLength
+
+		e.SetValue(protocol.BodyTarget, "fragmentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.InputLossAction != nil {
+		v := *s.InputLossAction
+
+		e.SetValue(protocol.BodyTarget, "inputLossAction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NumRetries != nil {
+		v := *s.NumRetries
+
+		e.SetValue(protocol.BodyTarget, "numRetries", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RestartDelay != nil {
+		v := *s.RestartDelay
+
+		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentationMode != nil {
+		v := *s.SegmentationMode
+
+		e.SetValue(protocol.BodyTarget, "segmentationMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SendDelayMs != nil {
+		v := *s.SendDelayMs
+
+		e.SetValue(protocol.BodyTarget, "sendDelayMs", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SparseTrackType != nil {
+		v := *s.SparseTrackType
+
+		e.SetValue(protocol.BodyTarget, "sparseTrackType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StreamManifestBehavior != nil {
+		v := *s.StreamManifestBehavior
+
+		e.SetValue(protocol.BodyTarget, "streamManifestBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimestampOffset != nil {
+		v := *s.TimestampOffset
+
+		e.SetValue(protocol.BodyTarget, "timestampOffset", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimestampOffsetMode != nil {
+		v := *s.TimestampOffsetMode
+
+		e.SetValue(protocol.BodyTarget, "timestampOffsetMode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/MsSmoothOutputSettings
 type MsSmoothOutputSettings struct {
 	_ struct{} `type:"structure"`
@@ -7820,6 +11005,17 @@ func (s MsSmoothOutputSettings) GoString() string {
 func (s *MsSmoothOutputSettings) SetNameModifier(v string) *MsSmoothOutputSettings {
 	s.NameModifier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MsSmoothOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NameModifier != nil {
+		v := *s.NameModifier
+
+		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Network source to transcode. Must be accessible to the Elemental Live node
@@ -7860,6 +11056,22 @@ func (s *NetworkInputSettings) SetHlsInputSettings(v *HlsInputSettings) *Network
 func (s *NetworkInputSettings) SetServerValidation(v string) *NetworkInputSettings {
 	s.ServerValidation = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NetworkInputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HlsInputSettings != nil {
+		v := s.HlsInputSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsInputSettings", v, protocol.Metadata{})
+	}
+	if s.ServerValidation != nil {
+		v := *s.ServerValidation
+
+		e.SetValue(protocol.BodyTarget, "serverValidation", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Output settings. There can be multiple outputs within a group.
@@ -7923,6 +11135,45 @@ func (s *Output) SetVideoDescriptionName(v string) *Output {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AudioDescriptionNames) > 0 {
+		v := s.AudioDescriptionNames
+
+		e.SetList(protocol.BodyTarget, "audioDescriptionNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if len(s.CaptionDescriptionNames) > 0 {
+		v := s.CaptionDescriptionNames
+
+		e.SetList(protocol.BodyTarget, "captionDescriptionNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.OutputName != nil {
+		v := *s.OutputName
+
+		e.SetValue(protocol.BodyTarget, "outputName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputSettings != nil {
+		v := s.OutputSettings
+
+		e.SetFields(protocol.BodyTarget, "outputSettings", v, protocol.Metadata{})
+	}
+	if s.VideoDescriptionName != nil {
+		v := *s.VideoDescriptionName
+
+		e.SetValue(protocol.BodyTarget, "videoDescriptionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputList(vs []*Output) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputDestination
 type OutputDestination struct {
 	_ struct{} `type:"structure"`
@@ -7954,6 +11205,30 @@ func (s *OutputDestination) SetId(v string) *OutputDestination {
 func (s *OutputDestination) SetSettings(v []*OutputDestinationSettings) *OutputDestination {
 	s.Settings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Settings) > 0 {
+		v := s.Settings
+
+		e.SetList(protocol.BodyTarget, "settings", encodeOutputDestinationSettingsList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputDestinationList(vs []*OutputDestination) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputDestinationSettings
@@ -7998,6 +11273,35 @@ func (s *OutputDestinationSettings) SetUsername(v string) *OutputDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PasswordParam != nil {
+		v := *s.PasswordParam
+
+		e.SetValue(protocol.BodyTarget, "passwordParam", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputDestinationSettingsList(vs []*OutputDestinationSettings) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Output groups for this Live Event. Output groups contain information about
 // where streams should be distributed.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputGroup
@@ -8040,6 +11344,35 @@ func (s *OutputGroup) SetOutputGroupSettings(v *OutputGroupSettings) *OutputGrou
 func (s *OutputGroup) SetOutputs(v []*Output) *OutputGroup {
 	s.Outputs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputGroup) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OutputGroupSettings != nil {
+		v := s.OutputGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "outputGroupSettings", v, protocol.Metadata{})
+	}
+	if len(s.Outputs) > 0 {
+		v := s.Outputs
+
+		e.SetList(protocol.BodyTarget, "outputs", encodeOutputList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOutputGroupList(vs []*OutputGroup) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputGroupSettings
@@ -8089,6 +11422,32 @@ func (s *OutputGroupSettings) SetUdpGroupSettings(v *UdpGroupSettings) *OutputGr
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveGroupSettings != nil {
+		v := s.ArchiveGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "archiveGroupSettings", v, protocol.Metadata{})
+	}
+	if s.HlsGroupSettings != nil {
+		v := s.HlsGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsGroupSettings", v, protocol.Metadata{})
+	}
+	if s.MsSmoothGroupSettings != nil {
+		v := s.MsSmoothGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "msSmoothGroupSettings", v, protocol.Metadata{})
+	}
+	if s.UdpGroupSettings != nil {
+		v := s.UdpGroupSettings
+
+		e.SetFields(protocol.BodyTarget, "udpGroupSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Reference to an OutputDestination ID defined in the channel
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputLocationRef
 type OutputLocationRef struct {
@@ -8111,6 +11470,17 @@ func (s OutputLocationRef) GoString() string {
 func (s *OutputLocationRef) SetDestinationRefId(v string) *OutputLocationRef {
 	s.DestinationRefId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputLocationRef) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DestinationRefId != nil {
+		v := *s.DestinationRefId
+
+		e.SetValue(protocol.BodyTarget, "destinationRefId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/OutputSettings
@@ -8160,6 +11530,32 @@ func (s *OutputSettings) SetUdpOutputSettings(v *UdpOutputSettings) *OutputSetti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ArchiveOutputSettings != nil {
+		v := s.ArchiveOutputSettings
+
+		e.SetFields(protocol.BodyTarget, "archiveOutputSettings", v, protocol.Metadata{})
+	}
+	if s.HlsOutputSettings != nil {
+		v := s.HlsOutputSettings
+
+		e.SetFields(protocol.BodyTarget, "hlsOutputSettings", v, protocol.Metadata{})
+	}
+	if s.MsSmoothOutputSettings != nil {
+		v := s.MsSmoothOutputSettings
+
+		e.SetFields(protocol.BodyTarget, "msSmoothOutputSettings", v, protocol.Metadata{})
+	}
+	if s.UdpOutputSettings != nil {
+		v := s.UdpOutputSettings
+
+		e.SetFields(protocol.BodyTarget, "udpOutputSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/PassThroughSettings
 type PassThroughSettings struct {
 	_ struct{} `type:"structure"`
@@ -8173,6 +11569,12 @@ func (s PassThroughSettings) String() string {
 // GoString returns the string representation
 func (s PassThroughSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PassThroughSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/RemixSettings
@@ -8217,6 +11619,27 @@ func (s *RemixSettings) SetChannelsOut(v int64) *RemixSettings {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemixSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ChannelMappings) > 0 {
+		v := s.ChannelMappings
+
+		e.SetList(protocol.BodyTarget, "channelMappings", encodeAudioChannelMappingList(v), protocol.Metadata{})
+	}
+	if s.ChannelsIn != nil {
+		v := *s.ChannelsIn
+
+		e.SetValue(protocol.BodyTarget, "channelsIn", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ChannelsOut != nil {
+		v := *s.ChannelsOut
+
+		e.SetValue(protocol.BodyTarget, "channelsOut", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte20PlusEmbeddedDestinationSettings
 type Scte20PlusEmbeddedDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -8230,6 +11653,12 @@ func (s Scte20PlusEmbeddedDestinationSettings) String() string {
 // GoString returns the string representation
 func (s Scte20PlusEmbeddedDestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte20PlusEmbeddedDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte20SourceSettings
@@ -8268,6 +11697,22 @@ func (s *Scte20SourceSettings) SetSource608ChannelNumber(v int64) *Scte20SourceS
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte20SourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Convert608To708 != nil {
+		v := *s.Convert608To708
+
+		e.SetValue(protocol.BodyTarget, "convert608To708", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Source608ChannelNumber != nil {
+		v := *s.Source608ChannelNumber
+
+		e.SetValue(protocol.BodyTarget, "source608ChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte27DestinationSettings
 type Scte27DestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -8281,6 +11726,12 @@ func (s Scte27DestinationSettings) String() string {
 // GoString returns the string representation
 func (s Scte27DestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte27DestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte27SourceSettings
@@ -8311,6 +11762,17 @@ func (s Scte27SourceSettings) GoString() string {
 func (s *Scte27SourceSettings) SetPid(v int64) *Scte27SourceSettings {
 	s.Pid = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte27SourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte35SpliceInsert
@@ -8359,6 +11821,27 @@ func (s *Scte35SpliceInsert) SetWebDeliveryAllowedFlag(v string) *Scte35SpliceIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte35SpliceInsert) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdAvailOffset != nil {
+		v := *s.AdAvailOffset
+
+		e.SetValue(protocol.BodyTarget, "adAvailOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NoRegionalBlackoutFlag != nil {
+		v := *s.NoRegionalBlackoutFlag
+
+		e.SetValue(protocol.BodyTarget, "noRegionalBlackoutFlag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebDeliveryAllowedFlag != nil {
+		v := *s.WebDeliveryAllowedFlag
+
+		e.SetValue(protocol.BodyTarget, "webDeliveryAllowedFlag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/Scte35TimeSignalApos
 type Scte35TimeSignalApos struct {
 	_ struct{} `type:"structure"`
@@ -8405,6 +11888,27 @@ func (s *Scte35TimeSignalApos) SetWebDeliveryAllowedFlag(v string) *Scte35TimeSi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Scte35TimeSignalApos) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdAvailOffset != nil {
+		v := *s.AdAvailOffset
+
+		e.SetValue(protocol.BodyTarget, "adAvailOffset", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NoRegionalBlackoutFlag != nil {
+		v := *s.NoRegionalBlackoutFlag
+
+		e.SetValue(protocol.BodyTarget, "noRegionalBlackoutFlag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebDeliveryAllowedFlag != nil {
+		v := *s.WebDeliveryAllowedFlag
+
+		e.SetValue(protocol.BodyTarget, "webDeliveryAllowedFlag", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/SmpteTtDestinationSettings
 type SmpteTtDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -8418,6 +11922,12 @@ func (s SmpteTtDestinationSettings) String() string {
 // GoString returns the string representation
 func (s SmpteTtDestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SmpteTtDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StandardHlsSettings
@@ -8452,6 +11962,22 @@ func (s *StandardHlsSettings) SetAudioRenditionSets(v string) *StandardHlsSettin
 func (s *StandardHlsSettings) SetM3u8Settings(v *M3u8Settings) *StandardHlsSettings {
 	s.M3u8Settings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StandardHlsSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AudioRenditionSets != nil {
+		v := *s.AudioRenditionSets
+
+		e.SetValue(protocol.BodyTarget, "audioRenditionSets", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.M3u8Settings != nil {
+		v := s.M3u8Settings
+
+		e.SetFields(protocol.BodyTarget, "m3u8Settings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StartChannelRequest
@@ -8489,6 +12015,17 @@ func (s *StartChannelInput) Validate() error {
 func (s *StartChannelInput) SetChannelId(v string) *StartChannelInput {
 	s.ChannelId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StartChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StartChannelResponse
@@ -8586,6 +12123,62 @@ func (s *StartChannelOutput) SetState(v string) *StartChannelOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StartChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StaticKeySettings
 type StaticKeySettings struct {
 	_ struct{} `type:"structure"`
@@ -8617,6 +12210,22 @@ func (s *StaticKeySettings) SetKeyProviderServer(v *InputLocation) *StaticKeySet
 func (s *StaticKeySettings) SetStaticKeyValue(v string) *StaticKeySettings {
 	s.StaticKeyValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StaticKeySettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyProviderServer != nil {
+		v := s.KeyProviderServer
+
+		e.SetFields(protocol.BodyTarget, "keyProviderServer", v, protocol.Metadata{})
+	}
+	if s.StaticKeyValue != nil {
+		v := *s.StaticKeyValue
+
+		e.SetValue(protocol.BodyTarget, "staticKeyValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StopChannelRequest
@@ -8654,6 +12263,17 @@ func (s *StopChannelInput) Validate() error {
 func (s *StopChannelInput) SetChannelId(v string) *StopChannelInput {
 	s.ChannelId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StopChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/StopChannelResponse
@@ -8751,6 +12371,62 @@ func (s *StopChannelOutput) SetState(v string) *StopChannelOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StopChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Destinations) > 0 {
+		v := s.Destinations
+
+		e.SetList(protocol.BodyTarget, "destinations", encodeOutputDestinationList(v), protocol.Metadata{})
+	}
+	if len(s.EgressEndpoints) > 0 {
+		v := s.EgressEndpoints
+
+		e.SetList(protocol.BodyTarget, "egressEndpoints", encodeChannelEgressEndpointList(v), protocol.Metadata{})
+	}
+	if s.EncoderSettings != nil {
+		v := s.EncoderSettings
+
+		e.SetFields(protocol.BodyTarget, "encoderSettings", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InputAttachments) > 0 {
+		v := s.InputAttachments
+
+		e.SetList(protocol.BodyTarget, "inputAttachments", encodeInputAttachmentList(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PipelinesRunningCount != nil {
+		v := *s.PipelinesRunningCount
+
+		e.SetValue(protocol.BodyTarget, "pipelinesRunningCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/TeletextDestinationSettings
 type TeletextDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -8764,6 +12440,12 @@ func (s TeletextDestinationSettings) String() string {
 // GoString returns the string representation
 func (s TeletextDestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TeletextDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/TeletextSourceSettings
@@ -8790,6 +12472,17 @@ func (s TeletextSourceSettings) GoString() string {
 func (s *TeletextSourceSettings) SetPageNumber(v string) *TeletextSourceSettings {
 	s.PageNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TeletextSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PageNumber != nil {
+		v := *s.PageNumber
+
+		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/TimecodeConfig
@@ -8833,6 +12526,22 @@ func (s *TimecodeConfig) SetSyncThreshold(v int64) *TimecodeConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TimecodeConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Source != nil {
+		v := *s.Source
+
+		e.SetValue(protocol.BodyTarget, "source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncThreshold != nil {
+		v := *s.SyncThreshold
+
+		e.SetValue(protocol.BodyTarget, "syncThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/TtmlDestinationSettings
 type TtmlDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -8859,6 +12568,17 @@ func (s *TtmlDestinationSettings) SetStyleControl(v string) *TtmlDestinationSett
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TtmlDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StyleControl != nil {
+		v := *s.StyleControl
+
+		e.SetValue(protocol.BodyTarget, "styleControl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UdpContainerSettings
 type UdpContainerSettings struct {
 	_ struct{} `type:"structure"`
@@ -8880,6 +12600,17 @@ func (s UdpContainerSettings) GoString() string {
 func (s *UdpContainerSettings) SetM2tsSettings(v *M2tsSettings) *UdpContainerSettings {
 	s.M2tsSettings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UdpContainerSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.M2tsSettings != nil {
+		v := s.M2tsSettings
+
+		e.SetFields(protocol.BodyTarget, "m2tsSettings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UdpGroupSettings
@@ -8928,6 +12659,27 @@ func (s *UdpGroupSettings) SetTimedMetadataId3Frame(v string) *UdpGroupSettings 
 func (s *UdpGroupSettings) SetTimedMetadataId3Period(v int64) *UdpGroupSettings {
 	s.TimedMetadataId3Period = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UdpGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InputLossAction != nil {
+		v := *s.InputLossAction
+
+		e.SetValue(protocol.BodyTarget, "inputLossAction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Frame != nil {
+		v := *s.TimedMetadataId3Frame
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Frame", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimedMetadataId3Period != nil {
+		v := *s.TimedMetadataId3Period
+
+		e.SetValue(protocol.BodyTarget, "timedMetadataId3Period", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/UdpOutputSettings
@@ -8984,6 +12736,32 @@ func (s *UdpOutputSettings) SetFecOutputSettings(v *FecOutputSettings) *UdpOutpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UdpOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BufferMsec != nil {
+		v := *s.BufferMsec
+
+		e.SetValue(protocol.BodyTarget, "bufferMsec", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContainerSettings != nil {
+		v := s.ContainerSettings
+
+		e.SetFields(protocol.BodyTarget, "containerSettings", v, protocol.Metadata{})
+	}
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "destination", v, protocol.Metadata{})
+	}
+	if s.FecOutputSettings != nil {
+		v := s.FecOutputSettings
+
+		e.SetFields(protocol.BodyTarget, "fecOutputSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ValidationError
 type ValidationError struct {
 	_ struct{} `type:"structure"`
@@ -9015,6 +12793,30 @@ func (s *ValidationError) SetErrorMessage(v string) *ValidationError {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ValidationError) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ElementPath != nil {
+		v := *s.ElementPath
+
+		e.SetValue(protocol.BodyTarget, "elementPath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ErrorMessage != nil {
+		v := *s.ErrorMessage
+
+		e.SetValue(protocol.BodyTarget, "errorMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeValidationErrorList(vs []*ValidationError) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/VideoCodecSettings
 type VideoCodecSettings struct {
 	_ struct{} `type:"structure"`
@@ -9036,6 +12838,17 @@ func (s VideoCodecSettings) GoString() string {
 func (s *VideoCodecSettings) SetH264Settings(v *H264Settings) *VideoCodecSettings {
 	s.H264Settings = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.H264Settings != nil {
+		v := s.H264Settings
+
+		e.SetFields(protocol.BodyTarget, "h264Settings", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Video settings for this stream.
@@ -9128,6 +12941,55 @@ func (s *VideoDescription) SetWidth(v int64) *VideoDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CodecSettings != nil {
+		v := s.CodecSettings
+
+		e.SetFields(protocol.BodyTarget, "codecSettings", v, protocol.Metadata{})
+	}
+	if s.Height != nil {
+		v := *s.Height
+
+		e.SetValue(protocol.BodyTarget, "height", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RespondToAfd != nil {
+		v := *s.RespondToAfd
+
+		e.SetValue(protocol.BodyTarget, "respondToAfd", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ScalingBehavior != nil {
+		v := *s.ScalingBehavior
+
+		e.SetValue(protocol.BodyTarget, "scalingBehavior", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sharpness != nil {
+		v := *s.Sharpness
+
+		e.SetValue(protocol.BodyTarget, "sharpness", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Width != nil {
+		v := *s.Width
+
+		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVideoDescriptionList(vs []*VideoDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Specifies a particular video stream within an input source. An input may
 // have only a single video selector.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/VideoSelector
@@ -9180,6 +13042,27 @@ func (s *VideoSelector) SetSelectorSettings(v *VideoSelectorSettings) *VideoSele
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoSelector) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ColorSpace != nil {
+		v := *s.ColorSpace
+
+		e.SetValue(protocol.BodyTarget, "colorSpace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ColorSpaceUsage != nil {
+		v := *s.ColorSpaceUsage
+
+		e.SetValue(protocol.BodyTarget, "colorSpaceUsage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SelectorSettings != nil {
+		v := s.SelectorSettings
+
+		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/VideoSelectorPid
 type VideoSelectorPid struct {
 	_ struct{} `type:"structure"`
@@ -9202,6 +13085,17 @@ func (s VideoSelectorPid) GoString() string {
 func (s *VideoSelectorPid) SetPid(v int64) *VideoSelectorPid {
 	s.Pid = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoSelectorPid) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Pid != nil {
+		v := *s.Pid
+
+		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/VideoSelectorProgramId
@@ -9228,6 +13122,17 @@ func (s VideoSelectorProgramId) GoString() string {
 func (s *VideoSelectorProgramId) SetProgramId(v int64) *VideoSelectorProgramId {
 	s.ProgramId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoSelectorProgramId) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProgramId != nil {
+		v := *s.ProgramId
+
+		e.SetValue(protocol.BodyTarget, "programId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/VideoSelectorSettings
@@ -9261,6 +13166,22 @@ func (s *VideoSelectorSettings) SetVideoSelectorProgramId(v *VideoSelectorProgra
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VideoSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VideoSelectorPid != nil {
+		v := s.VideoSelectorPid
+
+		e.SetFields(protocol.BodyTarget, "videoSelectorPid", v, protocol.Metadata{})
+	}
+	if s.VideoSelectorProgramId != nil {
+		v := s.VideoSelectorProgramId
+
+		e.SetFields(protocol.BodyTarget, "videoSelectorProgramId", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/WebvttDestinationSettings
 type WebvttDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -9274,6 +13195,12 @@ func (s WebvttDestinationSettings) String() string {
 // GoString returns the string representation
 func (s WebvttDestinationSettings) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WebvttDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 const (

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -1590,7 +1590,6 @@ func (s *AacSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "vbrQuality", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1715,7 +1714,6 @@ func (s *Ac3Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "metadataControl", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1749,7 +1747,6 @@ func (s *ArchiveContainerSettings) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "m2tsSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1801,7 +1798,6 @@ func (s *ArchiveGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "rolloverInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1866,7 +1862,6 @@ func (s *ArchiveOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1887,7 +1882,6 @@ func (s AribDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AribDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1908,7 +1902,6 @@ func (s AribSourceSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AribSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1958,7 +1951,6 @@ func (s *AudioChannelMapping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "outputChannel", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2052,7 +2044,6 @@ func (s *AudioCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "passThroughSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2227,7 +2218,6 @@ func (s *AudioDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2289,7 +2279,6 @@ func (s *AudioLanguageSelection) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "languageSelectionPolicy", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2357,7 +2346,6 @@ func (s *AudioNormalizationSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "targetLkfs", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2436,7 +2424,6 @@ func (s *AudioOnlyHlsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "audioTrackType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2471,7 +2458,6 @@ func (s *AudioPidSelection) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2521,7 +2507,6 @@ func (s *AudioSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2576,7 +2561,6 @@ func (s *AudioSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "audioPidSelection", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2627,7 +2611,6 @@ func (s *AvailBlanking) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2662,7 +2645,6 @@ func (s *AvailConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "availSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2709,7 +2691,6 @@ func (s *AvailSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "scte35TimeSignalApos", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2808,7 +2789,6 @@ func (s *BlackoutSlate) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3109,7 +3089,6 @@ func (s *BurnInDestinationSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3206,7 +3185,6 @@ func (s *CaptionDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3378,7 +3356,6 @@ func (s *CaptionDestinationSettings) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "webvttDestinationSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3444,7 +3421,6 @@ func (s *CaptionLanguageMapping) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "languageDescription", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3520,7 +3496,6 @@ func (s *CaptionSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3627,7 +3602,6 @@ func (s *CaptionSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "teletextSourceSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3788,7 +3762,6 @@ func (s *Channel) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3823,7 +3796,6 @@ func (s *ChannelEgressEndpoint) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sourceIp", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3979,7 +3951,6 @@ func (s *ChannelSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4105,7 +4076,6 @@ func (s *CreateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4139,7 +4109,6 @@ func (s *CreateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "channel", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4244,7 +4213,6 @@ func (s *CreateInputInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4278,7 +4246,6 @@ func (s *CreateInputOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "input", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4312,7 +4279,6 @@ func (s *CreateInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleCidrList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4347,7 +4313,6 @@ func (s *CreateInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "securityGroup", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4395,7 +4360,6 @@ func (s *DeleteChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4546,7 +4510,6 @@ func (s *DeleteChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4594,7 +4557,6 @@ func (s *DeleteInputInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "inputId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4615,7 +4577,6 @@ func (s DeleteInputOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteInputOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4663,7 +4624,6 @@ func (s *DeleteInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "inputSecurityGroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4684,7 +4644,6 @@ func (s DeleteInputSecurityGroupOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4732,7 +4691,6 @@ func (s *DescribeChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4883,7 +4841,6 @@ func (s *DescribeChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4931,7 +4888,6 @@ func (s *DescribeInputInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "inputId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5069,7 +5025,6 @@ func (s *DescribeInputOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5117,7 +5072,6 @@ func (s *DescribeInputSecurityGroupInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "inputSecurityGroupId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5177,7 +5131,6 @@ func (s *DescribeInputSecurityGroupOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5243,7 +5196,6 @@ func (s *DvbNitSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "repInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5329,7 +5281,6 @@ func (s *DvbSdtSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "serviceProviderName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5636,7 +5587,6 @@ func (s *DvbSubDestinationSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "yPosition", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5673,7 +5623,6 @@ func (s *DvbSubSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5710,7 +5659,6 @@ func (s *DvbTdtSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "repInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6024,7 +5972,6 @@ func (s *Eac3Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "surroundMode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6045,7 +5992,6 @@ func (s EmbeddedDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *EmbeddedDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6066,7 +6012,6 @@ func (s EmbeddedPlusScte20DestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *EmbeddedPlusScte20DestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6147,7 +6092,6 @@ func (s *EmbeddedSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "source608TrackNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6291,7 +6235,6 @@ func (s *EncoderSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "videoDescriptions", encodeVideoDescriptionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6361,7 +6304,6 @@ func (s *FecOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "rowLength", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6462,7 +6404,6 @@ func (s *GlobalConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "supportLowFramerateInputs", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7012,7 +6953,6 @@ func (s *H264Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timecodeInsertion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7135,7 +7075,6 @@ func (s *HlsAkamaiSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7215,7 +7154,6 @@ func (s *HlsBasicPutSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7288,7 +7226,6 @@ func (s *HlsCdnSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "hlsWebdavSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7848,7 +7785,6 @@ func (s *HlsGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "tsFileMode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7932,7 +7868,6 @@ func (s *HlsInputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "retryInterval", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8027,7 +7962,6 @@ func (s *HlsMediaStoreSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8092,7 +8026,6 @@ func (s *HlsOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "segmentModifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8139,7 +8072,6 @@ func (s *HlsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "standardHlsSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8233,7 +8165,6 @@ func (s *HlsWebdavSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "restartDelay", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8379,7 +8310,6 @@ func (s *Input) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8436,7 +8366,6 @@ func (s *InputAttachment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "inputSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8494,7 +8423,6 @@ func (s *InputChannelLevel) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "inputChannel", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8567,7 +8495,6 @@ func (s *InputDestination) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8611,7 +8538,6 @@ func (s *InputDestinationRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "streamName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8687,7 +8613,6 @@ func (s *InputLocation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8786,7 +8711,6 @@ func (s *InputLossBehavior) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "repeatFrameMsec", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8850,7 +8774,6 @@ func (s *InputSecurityGroup) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "whitelistRules", encodeInputWhitelistRuleList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9011,7 +8934,6 @@ func (s *InputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoSelector", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9075,7 +8997,6 @@ func (s *InputSource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9147,7 +9068,6 @@ func (s *InputSourceRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9191,7 +9111,6 @@ func (s *InputWhitelistRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "cidr", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9235,7 +9154,6 @@ func (s *InputWhitelistRuleCidr) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "cidr", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9277,7 +9195,6 @@ func (s *KeyProviderSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "staticKeySettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9337,7 +9254,6 @@ func (s *ListChannelsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9384,7 +9300,6 @@ func (s *ListChannelsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9444,7 +9359,6 @@ func (s *ListInputSecurityGroupsInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9491,7 +9405,6 @@ func (s *ListInputSecurityGroupsOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9551,7 +9464,6 @@ func (s *ListInputsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9598,7 +9510,6 @@ func (s *ListInputsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10348,7 +10259,6 @@ func (s *M2tsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "videoPid", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10596,7 +10506,6 @@ func (s *M3u8Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "videoPid", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10660,7 +10569,6 @@ func (s *Mp2Settings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "sampleRate", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10978,7 +10886,6 @@ func (s *MsSmoothGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timestampOffsetMode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11014,7 +10921,6 @@ func (s *MsSmoothOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nameModifier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11070,7 +10976,6 @@ func (s *NetworkInputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "serverValidation", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11162,7 +11067,6 @@ func (s *Output) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "videoDescriptionName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11219,7 +11123,6 @@ func (s *OutputDestination) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "settings", encodeOutputDestinationSettingsList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11290,7 +11193,6 @@ func (s *OutputDestinationSettings) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11363,7 +11265,6 @@ func (s *OutputGroup) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "outputs", encodeOutputList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11444,7 +11345,6 @@ func (s *OutputGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "udpGroupSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11479,7 +11379,6 @@ func (s *OutputLocationRef) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "destinationRefId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11552,7 +11451,6 @@ func (s *OutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "udpOutputSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11573,7 +11471,6 @@ func (s PassThroughSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PassThroughSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11636,7 +11533,6 @@ func (s *RemixSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "channelsOut", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11657,7 +11553,6 @@ func (s Scte20PlusEmbeddedDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *Scte20PlusEmbeddedDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11709,7 +11604,6 @@ func (s *Scte20SourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "source608ChannelNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11730,7 +11624,6 @@ func (s Scte27DestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *Scte27DestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11771,7 +11664,6 @@ func (s *Scte27SourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11838,7 +11730,6 @@ func (s *Scte35SpliceInsert) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "webDeliveryAllowedFlag", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11905,7 +11796,6 @@ func (s *Scte35TimeSignalApos) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "webDeliveryAllowedFlag", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11926,7 +11816,6 @@ func (s SmpteTtDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SmpteTtDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11976,7 +11865,6 @@ func (s *StandardHlsSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "m3u8Settings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12024,7 +11912,6 @@ func (s *StartChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12175,7 +12062,6 @@ func (s *StartChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12224,7 +12110,6 @@ func (s *StaticKeySettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "staticKeyValue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12272,7 +12157,6 @@ func (s *StopChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12423,7 +12307,6 @@ func (s *StopChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12444,7 +12327,6 @@ func (s TeletextDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *TeletextDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -12481,7 +12363,6 @@ func (s *TeletextSourceSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pageNumber", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12538,7 +12419,6 @@ func (s *TimecodeConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "syncThreshold", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12575,7 +12455,6 @@ func (s *TtmlDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "styleControl", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12609,7 +12488,6 @@ func (s *UdpContainerSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "m2tsSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12678,7 +12556,6 @@ func (s *UdpGroupSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "timedMetadataId3Period", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12758,7 +12635,6 @@ func (s *UdpOutputSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "fecOutputSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12805,7 +12681,6 @@ func (s *ValidationError) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "errorMessage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12847,7 +12722,6 @@ func (s *VideoCodecSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "h264Settings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12978,7 +12852,6 @@ func (s *VideoDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "width", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13059,7 +12932,6 @@ func (s *VideoSelector) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "selectorSettings", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13094,7 +12966,6 @@ func (s *VideoSelectorPid) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "pid", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13131,7 +13002,6 @@ func (s *VideoSelectorProgramId) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "programId", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13178,7 +13048,6 @@ func (s *VideoSelectorSettings) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "videoSelectorProgramId", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13199,7 +13068,6 @@ func (s WebvttDestinationSettings) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *WebvttDestinationSettings) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateChannel = "CreateChannel"
@@ -1140,6 +1141,40 @@ func (s *Channel) SetId(v string) *Channel {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Channel) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsIngest != nil {
+		v := s.HlsIngest
+
+		e.SetFields(protocol.BodyTarget, "hlsIngest", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeChannelList(vs []*Channel) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/CreateChannelRequest
 type CreateChannelInput struct {
 	_ struct{} `type:"structure"`
@@ -1183,6 +1218,22 @@ func (s *CreateChannelInput) SetDescription(v string) *CreateChannelInput {
 func (s *CreateChannelInput) SetId(v string) *CreateChannelInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/CreateChannelResponse
@@ -1231,6 +1282,32 @@ func (s *CreateChannelOutput) SetHlsIngest(v *HlsIngest) *CreateChannelOutput {
 func (s *CreateChannelOutput) SetId(v string) *CreateChannelOutput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsIngest != nil {
+		v := s.HlsIngest
+
+		e.SetFields(protocol.BodyTarget, "hlsIngest", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/CreateOriginEndpointRequest
@@ -1364,6 +1441,62 @@ func (s *CreateOriginEndpointInput) SetWhitelist(v []*string) *CreateOriginEndpo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.BodyTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/CreateOriginEndpointResponse
 type CreateOriginEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -1478,6 +1611,72 @@ func (s *CreateOriginEndpointOutput) SetWhitelist(v []*string) *CreateOriginEndp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.BodyTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A Dynamic Adaptive Streaming over HTTP (DASH) encryption configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DashEncryption
 type DashEncryption struct {
@@ -1531,6 +1730,22 @@ func (s *DashEncryption) SetKeyRotationIntervalSeconds(v int64) *DashEncryption 
 func (s *DashEncryption) SetSpekeKeyProvider(v *SpekeKeyProvider) *DashEncryption {
 	s.SpekeKeyProvider = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DashEncryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyRotationIntervalSeconds != nil {
+		v := *s.KeyRotationIntervalSeconds
+
+		e.SetValue(protocol.BodyTarget, "keyRotationIntervalSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A Dynamic Adaptive Streaming over HTTP (DASH) packaging configuration.
@@ -1640,6 +1855,52 @@ func (s *DashPackage) SetSuggestedPresentationDelaySeconds(v int64) *DashPackage
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DashPackage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.ManifestWindowSeconds != nil {
+		v := *s.ManifestWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "manifestWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinBufferTimeSeconds != nil {
+		v := *s.MinBufferTimeSeconds
+
+		e.SetValue(protocol.BodyTarget, "minBufferTimeSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinUpdatePeriodSeconds != nil {
+		v := *s.MinUpdatePeriodSeconds
+
+		e.SetValue(protocol.BodyTarget, "minUpdatePeriodSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Profile != nil {
+		v := *s.Profile
+
+		e.SetValue(protocol.BodyTarget, "profile", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentDurationSeconds != nil {
+		v := *s.SegmentDurationSeconds
+
+		e.SetValue(protocol.BodyTarget, "segmentDurationSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamSelection != nil {
+		v := s.StreamSelection
+
+		e.SetFields(protocol.BodyTarget, "streamSelection", v, protocol.Metadata{})
+	}
+	if s.SuggestedPresentationDelaySeconds != nil {
+		v := *s.SuggestedPresentationDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "suggestedPresentationDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DeleteChannelRequest
 type DeleteChannelInput struct {
 	_ struct{} `type:"structure"`
@@ -1677,6 +1938,17 @@ func (s *DeleteChannelInput) SetId(v string) *DeleteChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DeleteChannelResponse
 type DeleteChannelOutput struct {
 	_ struct{} `type:"structure"`
@@ -1690,6 +1962,12 @@ func (s DeleteChannelOutput) String() string {
 // GoString returns the string representation
 func (s DeleteChannelOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DeleteOriginEndpointRequest
@@ -1729,6 +2007,17 @@ func (s *DeleteOriginEndpointInput) SetId(v string) *DeleteOriginEndpointInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DeleteOriginEndpointResponse
 type DeleteOriginEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -1742,6 +2031,12 @@ func (s DeleteOriginEndpointOutput) String() string {
 // GoString returns the string representation
 func (s DeleteOriginEndpointOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DescribeChannelRequest
@@ -1779,6 +2074,17 @@ func (s *DescribeChannelInput) Validate() error {
 func (s *DescribeChannelInput) SetId(v string) *DescribeChannelInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DescribeChannelResponse
@@ -1829,6 +2135,32 @@ func (s *DescribeChannelOutput) SetId(v string) *DescribeChannelOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsIngest != nil {
+		v := s.HlsIngest
+
+		e.SetFields(protocol.BodyTarget, "hlsIngest", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DescribeOriginEndpointRequest
 type DescribeOriginEndpointInput struct {
 	_ struct{} `type:"structure"`
@@ -1864,6 +2196,17 @@ func (s *DescribeOriginEndpointInput) Validate() error {
 func (s *DescribeOriginEndpointInput) SetId(v string) *DescribeOriginEndpointInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/DescribeOriginEndpointResponse
@@ -1980,6 +2323,72 @@ func (s *DescribeOriginEndpointOutput) SetWhitelist(v []*string) *DescribeOrigin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.BodyTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An HTTP Live Streaming (HLS) encryption configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/HlsEncryption
 type HlsEncryption struct {
@@ -2063,6 +2472,37 @@ func (s *HlsEncryption) SetSpekeKeyProvider(v *SpekeKeyProvider) *HlsEncryption 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsEncryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConstantInitializationVector != nil {
+		v := *s.ConstantInitializationVector
+
+		e.SetValue(protocol.BodyTarget, "constantInitializationVector", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncryptionMethod != nil {
+		v := *s.EncryptionMethod
+
+		e.SetValue(protocol.BodyTarget, "encryptionMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyRotationIntervalSeconds != nil {
+		v := *s.KeyRotationIntervalSeconds
+
+		e.SetValue(protocol.BodyTarget, "keyRotationIntervalSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RepeatExtXKey != nil {
+		v := *s.RepeatExtXKey
+
+		e.SetValue(protocol.BodyTarget, "repeatExtXKey", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An HTTP Live Streaming (HLS) ingest resource configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/HlsIngest
 type HlsIngest struct {
@@ -2086,6 +2526,17 @@ func (s HlsIngest) GoString() string {
 func (s *HlsIngest) SetIngestEndpoints(v []*IngestEndpoint) *HlsIngest {
 	s.IngestEndpoints = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsIngest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.IngestEndpoints) > 0 {
+		v := s.IngestEndpoints
+
+		e.SetList(protocol.BodyTarget, "ingestEndpoints", encodeIngestEndpointList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An HTTP Live Streaming (HLS) packaging configuration.
@@ -2214,6 +2665,57 @@ func (s *HlsPackage) SetUseAudioRenditionGroup(v bool) *HlsPackage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HlsPackage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AdMarkers != nil {
+		v := *s.AdMarkers
+
+		e.SetValue(protocol.BodyTarget, "adMarkers", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.IncludeIframeOnlyStream != nil {
+		v := *s.IncludeIframeOnlyStream
+
+		e.SetValue(protocol.BodyTarget, "includeIframeOnlyStream", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PlaylistType != nil {
+		v := *s.PlaylistType
+
+		e.SetValue(protocol.BodyTarget, "playlistType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PlaylistWindowSeconds != nil {
+		v := *s.PlaylistWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "playlistWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ProgramDateTimeIntervalSeconds != nil {
+		v := *s.ProgramDateTimeIntervalSeconds
+
+		e.SetValue(protocol.BodyTarget, "programDateTimeIntervalSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentDurationSeconds != nil {
+		v := *s.SegmentDurationSeconds
+
+		e.SetValue(protocol.BodyTarget, "segmentDurationSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamSelection != nil {
+		v := s.StreamSelection
+
+		e.SetFields(protocol.BodyTarget, "streamSelection", v, protocol.Metadata{})
+	}
+	if s.UseAudioRenditionGroup != nil {
+		v := *s.UseAudioRenditionGroup
+
+		e.SetValue(protocol.BodyTarget, "useAudioRenditionGroup", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An endpoint for ingesting source content for a Channel.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/IngestEndpoint
 type IngestEndpoint struct {
@@ -2255,6 +2757,35 @@ func (s *IngestEndpoint) SetUrl(v string) *IngestEndpoint {
 func (s *IngestEndpoint) SetUsername(v string) *IngestEndpoint {
 	s.Username = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IngestEndpoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Password != nil {
+		v := *s.Password
+
+		e.SetValue(protocol.BodyTarget, "password", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeIngestEndpointList(vs []*IngestEndpoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/ListChannelsRequest
@@ -2301,6 +2832,22 @@ func (s *ListChannelsInput) SetNextToken(v string) *ListChannelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListChannelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/ListChannelsResponse
 type ListChannelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2330,6 +2877,22 @@ func (s *ListChannelsOutput) SetChannels(v []*Channel) *ListChannelsOutput {
 func (s *ListChannelsOutput) SetNextToken(v string) *ListChannelsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListChannelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Channels) > 0 {
+		v := s.Channels
+
+		e.SetList(protocol.BodyTarget, "channels", encodeChannelList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/ListOriginEndpointsRequest
@@ -2384,6 +2947,27 @@ func (s *ListOriginEndpointsInput) SetNextToken(v string) *ListOriginEndpointsIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOriginEndpointsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.QueryTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/ListOriginEndpointsResponse
 type ListOriginEndpointsOutput struct {
 	_ struct{} `type:"structure"`
@@ -2413,6 +2997,22 @@ func (s *ListOriginEndpointsOutput) SetNextToken(v string) *ListOriginEndpointsO
 func (s *ListOriginEndpointsOutput) SetOriginEndpoints(v []*OriginEndpoint) *ListOriginEndpointsOutput {
 	s.OriginEndpoints = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListOriginEndpointsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.OriginEndpoints) > 0 {
+		v := s.OriginEndpoints
+
+		e.SetList(protocol.BodyTarget, "originEndpoints", encodeOriginEndpointList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A Microsoft Smooth Streaming (MSS) encryption configuration.
@@ -2459,6 +3059,17 @@ func (s *MssEncryption) Validate() error {
 func (s *MssEncryption) SetSpekeKeyProvider(v *SpekeKeyProvider) *MssEncryption {
 	s.SpekeKeyProvider = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MssEncryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SpekeKeyProvider != nil {
+		v := s.SpekeKeyProvider
+
+		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A Microsoft Smooth Streaming (MSS) packaging configuration.
@@ -2526,6 +3137,32 @@ func (s *MssPackage) SetSegmentDurationSeconds(v int64) *MssPackage {
 func (s *MssPackage) SetStreamSelection(v *StreamSelection) *MssPackage {
 	s.StreamSelection = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MssPackage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "encryption", v, protocol.Metadata{})
+	}
+	if s.ManifestWindowSeconds != nil {
+		v := *s.ManifestWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "manifestWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentDurationSeconds != nil {
+		v := *s.SegmentDurationSeconds
+
+		e.SetValue(protocol.BodyTarget, "segmentDurationSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamSelection != nil {
+		v := s.StreamSelection
+
+		e.SetFields(protocol.BodyTarget, "streamSelection", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // An OriginEndpoint resource configuration.
@@ -2654,6 +3291,80 @@ func (s *OriginEndpoint) SetWhitelist(v []*string) *OriginEndpoint {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *OriginEndpoint) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.BodyTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeOriginEndpointList(vs []*OriginEndpoint) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/RotateChannelCredentialsRequest
 type RotateChannelCredentialsInput struct {
 	_ struct{} `type:"structure"`
@@ -2689,6 +3400,17 @@ func (s *RotateChannelCredentialsInput) Validate() error {
 func (s *RotateChannelCredentialsInput) SetId(v string) *RotateChannelCredentialsInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RotateChannelCredentialsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/RotateChannelCredentialsResponse
@@ -2737,6 +3459,32 @@ func (s *RotateChannelCredentialsOutput) SetHlsIngest(v *HlsIngest) *RotateChann
 func (s *RotateChannelCredentialsOutput) SetId(v string) *RotateChannelCredentialsOutput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RotateChannelCredentialsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsIngest != nil {
+		v := s.HlsIngest
+
+		e.SetFields(protocol.BodyTarget, "hlsIngest", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A configuration for accessing an external Secure Packager and Encoder Key
@@ -2823,6 +3571,32 @@ func (s *SpekeKeyProvider) SetUrl(v string) *SpekeKeyProvider {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SpekeKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.BodyTarget, "resourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "roleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SystemIds) > 0 {
+		v := s.SystemIds
+
+		e.SetList(protocol.BodyTarget, "systemIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A StreamSelection configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/StreamSelection
 type StreamSelection struct {
@@ -2864,6 +3638,27 @@ func (s *StreamSelection) SetMinVideoBitsPerSecond(v int64) *StreamSelection {
 func (s *StreamSelection) SetStreamOrder(v string) *StreamSelection {
 	s.StreamOrder = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StreamSelection) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxVideoBitsPerSecond != nil {
+		v := *s.MaxVideoBitsPerSecond
+
+		e.SetValue(protocol.BodyTarget, "maxVideoBitsPerSecond", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MinVideoBitsPerSecond != nil {
+		v := *s.MinVideoBitsPerSecond
+
+		e.SetValue(protocol.BodyTarget, "minVideoBitsPerSecond", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StreamOrder != nil {
+		v := *s.StreamOrder
+
+		e.SetValue(protocol.BodyTarget, "streamOrder", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/UpdateChannelRequest
@@ -2909,6 +3704,22 @@ func (s *UpdateChannelInput) SetDescription(v string) *UpdateChannelInput {
 func (s *UpdateChannelInput) SetId(v string) *UpdateChannelInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/UpdateChannelResponse
@@ -2957,6 +3768,32 @@ func (s *UpdateChannelOutput) SetHlsIngest(v *HlsIngest) *UpdateChannelOutput {
 func (s *UpdateChannelOutput) SetId(v string) *UpdateChannelOutput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsIngest != nil {
+		v := s.HlsIngest
+
+		e.SetFields(protocol.BodyTarget, "hlsIngest", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/UpdateOriginEndpointRequest
@@ -3078,6 +3915,57 @@ func (s *UpdateOriginEndpointInput) SetWhitelist(v []*string) *UpdateOriginEndpo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediapackage-2017-10-12/UpdateOriginEndpointResponse
 type UpdateOriginEndpointOutput struct {
 	_ struct{} `type:"structure"`
@@ -3190,6 +4078,72 @@ func (s *UpdateOriginEndpointOutput) SetUrl(v string) *UpdateOriginEndpointOutpu
 func (s *UpdateOriginEndpointOutput) SetWhitelist(v []*string) *UpdateOriginEndpointOutput {
 	s.Whitelist = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelId != nil {
+		v := *s.ChannelId
+
+		e.SetValue(protocol.BodyTarget, "channelId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DashPackage != nil {
+		v := s.DashPackage
+
+		e.SetFields(protocol.BodyTarget, "dashPackage", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HlsPackage != nil {
+		v := s.HlsPackage
+
+		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ManifestName != nil {
+		v := *s.ManifestName
+
+		e.SetValue(protocol.BodyTarget, "manifestName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MssPackage != nil {
+		v := s.MssPackage
+
+		e.SetFields(protocol.BodyTarget, "mssPackage", v, protocol.Metadata{})
+	}
+	if s.StartoverWindowSeconds != nil {
+		v := *s.StartoverWindowSeconds
+
+		e.SetValue(protocol.BodyTarget, "startoverWindowSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeDelaySeconds != nil {
+		v := *s.TimeDelaySeconds
+
+		e.SetValue(protocol.BodyTarget, "timeDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Whitelist) > 0 {
+		v := s.Whitelist
+
+		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -1163,7 +1163,6 @@ func (s *Channel) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1232,7 +1231,6 @@ func (s *CreateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1306,7 +1304,6 @@ func (s *CreateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1493,7 +1490,6 @@ func (s *CreateOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1673,7 +1669,6 @@ func (s *CreateOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1744,7 +1739,6 @@ func (s *DashEncryption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1897,7 +1891,6 @@ func (s *DashPackage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "suggestedPresentationDelaySeconds", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1945,7 +1938,6 @@ func (s *DeleteChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1966,7 +1958,6 @@ func (s DeleteChannelOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2014,7 +2005,6 @@ func (s *DeleteOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2035,7 +2025,6 @@ func (s DeleteOriginEndpointOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2083,7 +2072,6 @@ func (s *DescribeChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2157,7 +2145,6 @@ func (s *DescribeChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2205,7 +2192,6 @@ func (s *DescribeOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2385,7 +2371,6 @@ func (s *DescribeOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2499,7 +2484,6 @@ func (s *HlsEncryption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2535,7 +2519,6 @@ func (s *HlsIngest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "ingestEndpoints", encodeIngestEndpointList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2712,7 +2695,6 @@ func (s *HlsPackage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "useAudioRenditionGroup", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2776,7 +2758,6 @@ func (s *IngestEndpoint) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2844,7 +2825,6 @@ func (s *ListChannelsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2891,7 +2871,6 @@ func (s *ListChannelsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2964,7 +2943,6 @@ func (s *ListOriginEndpointsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3011,7 +2989,6 @@ func (s *ListOriginEndpointsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "originEndpoints", encodeOriginEndpointList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3068,7 +3045,6 @@ func (s *MssEncryption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "spekeKeyProvider", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3161,7 +3137,6 @@ func (s *MssPackage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "streamSelection", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3353,7 +3328,6 @@ func (s *OriginEndpoint) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3409,7 +3383,6 @@ func (s *RotateChannelCredentialsInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3483,7 +3456,6 @@ func (s *RotateChannelCredentialsOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3593,7 +3565,6 @@ func (s *SpekeKeyProvider) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3657,7 +3628,6 @@ func (s *StreamSelection) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "streamOrder", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3718,7 +3688,6 @@ func (s *UpdateChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3792,7 +3761,6 @@ func (s *UpdateChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3932,11 +3900,6 @@ func (s *UpdateOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "hlsPackage", v, protocol.Metadata{})
 	}
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ManifestName != nil {
 		v := *s.ManifestName
 
@@ -3962,7 +3925,11 @@ func (s *UpdateOriginEndpointInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.PathTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -4142,7 +4109,6 @@ func (s *UpdateOriginEndpointOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "whitelist", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -489,7 +489,6 @@ func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -510,7 +509,6 @@ func (s DeleteObjectOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -564,7 +562,6 @@ func (s *DescribeObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -659,7 +656,6 @@ func (s *DescribeObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -740,17 +736,16 @@ func (s *GetObjectInput) SetRange(v string) *GetObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Path != nil {
-		v := *s.Path
-
-		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Range != nil {
 		v := *s.Range
 
 		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Path != nil {
+		v := *s.Path
 
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -859,7 +854,6 @@ func (s *GetObjectOutput) SetStatusCode(v int64) *GetObjectOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-	// Skipping Body Output type's body not valid.
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -890,8 +884,8 @@ func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
+	// Skipping Body Output type's body not valid.
 	// ignoring invalid encode state, StatusCode. StatusCode
-
 	return nil
 }
 
@@ -997,7 +991,6 @@ func (s *Item) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1083,7 +1076,6 @@ func (s *ListItemsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1132,7 +1124,6 @@ func (s *ListItemsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1260,11 +1251,6 @@ func (s *PutObjectInput) SetStorageClass(v string) *PutObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
-	}
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -1275,17 +1261,21 @@ func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Path != nil {
-		v := *s.Path
-
-		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StorageClass != nil {
 		v := *s.StorageClass
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Path != nil {
+		v := *s.Path
 
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -1348,7 +1338,6 @@ func (s *PutObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opDeleteObject = "DeleteObject"
@@ -481,6 +482,17 @@ func (s *DeleteObjectInput) SetPath(v string) *DeleteObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/DeleteObjectResponse
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -494,6 +506,12 @@ func (s DeleteObjectOutput) String() string {
 // GoString returns the string representation
 func (s DeleteObjectOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/DescribeObjectRequest
@@ -537,6 +555,17 @@ func (s *DescribeObjectInput) Validate() error {
 func (s *DescribeObjectInput) SetPath(v string) *DescribeObjectInput {
 	s.Path = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/DescribeObjectResponse
@@ -601,6 +630,37 @@ func (s *DescribeObjectOutput) SetETag(v string) *DescribeObjectOutput {
 func (s *DescribeObjectOutput) SetLastModified(v time.Time) *DescribeObjectOutput {
 	s.LastModified = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/GetObjectRequest
@@ -676,6 +736,22 @@ func (s *GetObjectInput) SetPath(v string) *GetObjectInput {
 func (s *GetObjectInput) SetRange(v string) *GetObjectInput {
 	s.Range = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/GetObjectResponse
@@ -781,6 +857,44 @@ func (s *GetObjectOutput) SetStatusCode(v int64) *GetObjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping Body Output type's body not valid.
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentRange != nil {
+		v := *s.ContentRange
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	// ignoring invalid encode state, StatusCode. StatusCode
+
+	return nil
+}
+
 // A metadata entry for a folder or object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/Item
 type Item struct {
@@ -851,6 +965,50 @@ func (s *Item) SetType(v string) *Item {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Item) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.BodyTarget, "ContentLength", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "ContentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeItemList(vs []*Item) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/ListItemsRequest
 type ListItemsInput struct {
 	_ struct{} `type:"structure"`
@@ -908,6 +1066,27 @@ func (s *ListItemsInput) SetPath(v string) *ListItemsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListItemsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "MaxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.QueryTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/ListItemsResponse
 type ListItemsOutput struct {
 	_ struct{} `type:"structure"`
@@ -939,6 +1118,22 @@ func (s *ListItemsOutput) SetItems(v []*Item) *ListItemsOutput {
 func (s *ListItemsOutput) SetNextToken(v string) *ListItemsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListItemsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Items) > 0 {
+		v := s.Items
+
+		e.SetList(protocol.BodyTarget, "Items", encodeItemList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/PutObjectRequest
@@ -1063,6 +1258,37 @@ func (s *PutObjectInput) SetStorageClass(v string) *PutObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Path != nil {
+		v := *s.Path
+
+		e.SetValue(protocol.PathTarget, "Path", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mediastore-data-2017-09-01/PutObjectResponse
 type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -1103,6 +1329,27 @@ func (s *PutObjectOutput) SetETag(v string) *PutObjectOutput {
 func (s *PutObjectOutput) SetStorageClass(v string) *PutObjectOutput {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentSHA256 != nil {
+		v := *s.ContentSHA256
+
+		e.SetValue(protocol.BodyTarget, "ContentSHA256", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateProject = "CreateProject"
@@ -1082,6 +1083,50 @@ func (s *BundleDetails) SetVersion(v string) *BundleDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BundleDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AvailablePlatforms) > 0 {
+		v := s.AvailablePlatforms
+
+		e.SetList(protocol.BodyTarget, "availablePlatforms", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IconUrl != nil {
+		v := *s.IconUrl
+
+		e.SetValue(protocol.BodyTarget, "iconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBundleDetailsList(vs []*BundleDetails) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Request structure used to request a project be created.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/CreateProjectRequest
 type CreateProjectInput struct {
@@ -1137,6 +1182,32 @@ func (s *CreateProjectInput) SetSnapshotId(v string) *CreateProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Contents != nil {
+		v := s.Contents
+
+		e.SetStream(protocol.PayloadTarget, "contents", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.QueryTarget, "region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotId != nil {
+		v := *s.SnapshotId
+
+		e.SetValue(protocol.QueryTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used in response to a request to create a project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/CreateProjectResult
 type CreateProjectOutput struct {
@@ -1160,6 +1231,17 @@ func (s CreateProjectOutput) GoString() string {
 func (s *CreateProjectOutput) SetDetails(v *ProjectDetails) *CreateProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request a project be deleted.
@@ -1202,6 +1284,17 @@ func (s *DeleteProjectInput) SetProjectId(v string) *DeleteProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used in response to request to delete a project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DeleteProjectResult
 type DeleteProjectOutput struct {
@@ -1235,6 +1328,22 @@ func (s *DeleteProjectOutput) SetDeletedResources(v []*Resource) *DeleteProjectO
 func (s *DeleteProjectOutput) SetOrphanedResources(v []*Resource) *DeleteProjectOutput {
 	s.OrphanedResources = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DeletedResources) > 0 {
+		v := s.DeletedResources
+
+		e.SetList(protocol.BodyTarget, "deletedResources", encodeResourceList(v), protocol.Metadata{})
+	}
+	if len(s.OrphanedResources) > 0 {
+		v := s.OrphanedResources
+
+		e.SetList(protocol.BodyTarget, "orphanedResources", encodeResourceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure to request the details of a specific bundle.
@@ -1277,6 +1386,17 @@ func (s *DescribeBundleInput) SetBundleId(v string) *DescribeBundleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeBundleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.PathTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure contains the details of the bundle.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DescribeBundleResult
 type DescribeBundleOutput struct {
@@ -1300,6 +1420,17 @@ func (s DescribeBundleOutput) GoString() string {
 func (s *DescribeBundleOutput) SetDetails(v *BundleDetails) *DescribeBundleOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request details about a project.
@@ -1353,6 +1484,22 @@ func (s *DescribeProjectInput) SetSyncFromResources(v bool) *DescribeProjectInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SyncFromResources != nil {
+		v := *s.SyncFromResources
+
+		e.SetValue(protocol.QueryTarget, "syncFromResources", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests of project details.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/DescribeProjectResult
 type DescribeProjectOutput struct {
@@ -1376,6 +1523,17 @@ func (s DescribeProjectOutput) GoString() string {
 func (s *DescribeProjectOutput) SetDetails(v *ProjectDetails) *DescribeProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request generation of custom SDK and tool packages
@@ -1437,6 +1595,27 @@ func (s *ExportBundleInput) SetProjectId(v string) *ExportBundleInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportBundleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.PathTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.QueryTarget, "platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure which contains link to download custom-generated SDK and
 // tool packages used to integrate mobile web or app clients with backed AWS
 // resources.
@@ -1464,6 +1643,17 @@ func (s ExportBundleOutput) GoString() string {
 func (s *ExportBundleOutput) SetDownloadUrl(v string) *ExportBundleOutput {
 	s.DownloadUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DownloadUrl != nil {
+		v := *s.DownloadUrl
+
+		e.SetValue(protocol.BodyTarget, "downloadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used in requests to export project configuration details.
@@ -1504,6 +1694,17 @@ func (s *ExportProjectInput) Validate() error {
 func (s *ExportProjectInput) SetProjectId(v string) *ExportProjectInput {
 	s.ProjectId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Result structure used for requests to export project configuration details.
@@ -1555,6 +1756,27 @@ func (s *ExportProjectOutput) SetSnapshotId(v string) *ExportProjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ExportProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DownloadUrl != nil {
+		v := *s.DownloadUrl
+
+		e.SetValue(protocol.BodyTarget, "downloadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShareUrl != nil {
+		v := *s.ShareUrl
+
+		e.SetValue(protocol.BodyTarget, "shareUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SnapshotId != nil {
+		v := *s.SnapshotId
+
+		e.SetValue(protocol.BodyTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request structure to request all available bundles.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListBundlesRequest
 type ListBundlesInput struct {
@@ -1591,6 +1813,22 @@ func (s *ListBundlesInput) SetNextToken(v string) *ListBundlesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBundlesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure contains a list of all available bundles with details.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListBundlesResult
 type ListBundlesOutput struct {
@@ -1624,6 +1862,22 @@ func (s *ListBundlesOutput) SetBundleList(v []*BundleDetails) *ListBundlesOutput
 func (s *ListBundlesOutput) SetNextToken(v string) *ListBundlesOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBundlesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.BundleList) > 0 {
+		v := s.BundleList
+
+		e.SetList(protocol.BodyTarget, "bundleList", encodeBundleDetailsList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Request structure used to request projects list in AWS Mobile Hub.
@@ -1662,6 +1916,22 @@ func (s *ListProjectsInput) SetNextToken(v string) *ListProjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxResults", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests to list projects in AWS Mobile Hub.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ListProjectsResult
 type ListProjectsOutput struct {
@@ -1696,6 +1966,22 @@ func (s *ListProjectsOutput) SetNextToken(v string) *ListProjectsOutput {
 func (s *ListProjectsOutput) SetProjects(v []*ProjectSummary) *ListProjectsOutput {
 	s.Projects = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListProjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Projects) > 0 {
+		v := s.Projects
+
+		e.SetList(protocol.BodyTarget, "projects", encodeProjectSummaryList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Detailed information about an AWS Mobile Hub project.
@@ -1786,6 +2072,52 @@ func (s *ProjectDetails) SetState(v string) *ProjectDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProjectDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConsoleUrl != nil {
+		v := *s.ConsoleUrl
+
+		e.SetValue(protocol.BodyTarget, "consoleUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedDate != nil {
+		v := *s.CreatedDate
+
+		e.SetValue(protocol.BodyTarget, "createdDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LastUpdatedDate != nil {
+		v := *s.LastUpdatedDate
+
+		e.SetValue(protocol.BodyTarget, "lastUpdatedDate", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.BodyTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Resources) > 0 {
+		v := s.Resources
+
+		e.SetList(protocol.BodyTarget, "resources", encodeResourceList(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Summary information about an AWS Mobile Hub project.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/ProjectSummary
 type ProjectSummary struct {
@@ -1818,6 +2150,30 @@ func (s *ProjectSummary) SetName(v string) *ProjectSummary {
 func (s *ProjectSummary) SetProjectId(v string) *ProjectSummary {
 	s.ProjectId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ProjectSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.BodyTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeProjectSummaryList(vs []*ProjectSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an instance of an AWS resource associated with a project.
@@ -1882,6 +2238,45 @@ func (s *Resource) SetType(v string) *Resource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Arn != nil {
+		v := *s.Arn
+
+		e.SetValue(protocol.BodyTarget, "arn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Feature != nil {
+		v := *s.Feature
+
+		e.SetValue(protocol.BodyTarget, "feature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceList(vs []*Resource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Request structure used for requests to update project configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/UpdateProjectRequest
 type UpdateProjectInput struct {
@@ -1933,6 +2328,22 @@ func (s *UpdateProjectInput) SetProjectId(v string) *UpdateProjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Contents != nil {
+		v := s.Contents
+
+		e.SetStream(protocol.PayloadTarget, "contents", protocol.BytesStream(v), protocol.Metadata{})
+	}
+	if s.ProjectId != nil {
+		v := *s.ProjectId
+
+		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Result structure used for requests to updated project configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/mobile-2017-07-01/UpdateProjectResult
 type UpdateProjectOutput struct {
@@ -1956,6 +2367,17 @@ func (s UpdateProjectOutput) GoString() string {
 func (s *UpdateProjectOutput) SetDetails(v *ProjectDetails) *UpdateProjectOutput {
 	s.Details = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Details != nil {
+		v := s.Details
+
+		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Developer desktop or target mobile app or website platform.

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -1115,7 +1115,6 @@ func (s *BundleDetails) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1204,7 +1203,6 @@ func (s *CreateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1240,7 +1238,6 @@ func (s *CreateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1291,7 +1288,6 @@ func (s *DeleteProjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1342,7 +1338,6 @@ func (s *DeleteProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "orphanedResources", encodeResourceList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1393,7 +1388,6 @@ func (s *DescribeBundleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "bundleId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1429,7 +1423,6 @@ func (s *DescribeBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1496,7 +1489,6 @@ func (s *DescribeProjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "syncFromResources", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1532,7 +1524,6 @@ func (s *DescribeProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1612,7 +1603,6 @@ func (s *ExportBundleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1652,7 +1642,6 @@ func (s *ExportBundleOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "downloadUrl", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1703,7 +1692,6 @@ func (s *ExportProjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1773,7 +1761,6 @@ func (s *ExportProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "snapshotId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1825,7 +1812,6 @@ func (s *ListBundlesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1876,7 +1862,6 @@ func (s *ListBundlesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1928,7 +1913,6 @@ func (s *ListProjectsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "nextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1980,7 +1964,6 @@ func (s *ListProjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "projects", encodeProjectSummaryList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2114,7 +2097,6 @@ func (s *ProjectDetails) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "state", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2164,7 +2146,6 @@ func (s *ProjectSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2265,7 +2246,6 @@ func (s *Resource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2340,7 +2320,6 @@ func (s *UpdateProjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "projectId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2376,7 +2355,6 @@ func (s *UpdateProjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "details", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -200,6 +200,50 @@ func (s *Event) SetVersion(v string) *Event {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Event) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "attributes", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.EventType != nil {
+		v := *s.EventType
+
+		e.SetValue(protocol.BodyTarget, "eventType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.Session != nil {
+		v := s.Session
+
+		e.SetFields(protocol.BodyTarget, "session", v, protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "timestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEventList(vs []*Event) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
 	_ struct{} `type:"structure"`
@@ -273,6 +317,27 @@ func (s *PutEventsInput) SetEvents(v []*Event) *PutEventsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientContext != nil {
+		v := *s.ClientContext
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientContextEncoding != nil {
+		v := *s.ClientContextEncoding
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "events", encodeEventList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 type PutEventsOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -285,6 +350,12 @@ func (s PutEventsOutput) String() string {
 // GoString returns the string representation
 func (s PutEventsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the session. Session information is required on ALL events.
@@ -351,4 +422,30 @@ func (s *Session) SetStartTimestamp(v string) *Session {
 func (s *Session) SetStopTimestamp(v string) *Session {
 	s.StopTimestamp = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Session) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "duration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTimestamp != nil {
+		v := *s.StartTimestamp
+
+		e.SetValue(protocol.BodyTarget, "startTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StopTimestamp != nil {
+		v := *s.StopTimestamp
+
+		e.SetValue(protocol.BodyTarget, "stopTimestamp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -232,7 +232,6 @@ func (s *Event) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -319,6 +318,11 @@ func (s *PutEventsInput) SetEvents(v []*Event) *PutEventsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutEventsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "events", encodeEventList(v), protocol.Metadata{})
+	}
 	if s.ClientContext != nil {
 		v := *s.ClientContext
 
@@ -329,12 +333,6 @@ func (s *PutEventsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-Client-Context-Encoding", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if len(s.Events) > 0 {
-		v := s.Events
-
-		e.SetList(protocol.BodyTarget, "events", encodeEventList(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -354,7 +352,6 @@ func (s PutEventsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutEventsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -446,6 +443,5 @@ func (s *Session) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "stopTimestamp", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opCreateApp = "CreateApp"
@@ -5331,6 +5332,27 @@ func (s *ADMChannelRequest) SetEnabled(v bool) *ADMChannelRequest {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ADMChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientId != nil {
+		v := *s.ClientId
+
+		e.SetValue(protocol.BodyTarget, "ClientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ClientSecret != nil {
+		v := *s.ClientSecret
+
+		e.SetValue(protocol.BodyTarget, "ClientSecret", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Amazon Device Messaging channel definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ADMChannelResponse
 type ADMChannelResponse struct {
@@ -5435,6 +5457,62 @@ func (s *ADMChannelResponse) SetPlatform(v string) *ADMChannelResponse {
 func (s *ADMChannelResponse) SetVersion(v int64) *ADMChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ADMChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // ADM Message.
@@ -5613,6 +5691,97 @@ func (s *ADMMessage) SetUrl(v string) *ADMMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ADMMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConsolidationKey != nil {
+		v := *s.ConsolidationKey
+
+		e.SetValue(protocol.BodyTarget, "ConsolidationKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ExpiresAfter != nil {
+		v := *s.ExpiresAfter
+
+		e.SetValue(protocol.BodyTarget, "ExpiresAfter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IconReference != nil {
+		v := *s.IconReference
+
+		e.SetValue(protocol.BodyTarget, "IconReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MD5 != nil {
+		v := *s.MD5
+
+		e.SetValue(protocol.BodyTarget, "MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SmallImageIconUrl != nil {
+		v := *s.SmallImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "SmallImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple Push Notification Service channel definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/APNSChannelRequest
 type APNSChannelRequest struct {
@@ -5699,6 +5868,52 @@ func (s *APNSChannelRequest) SetTokenKey(v string) *APNSChannelRequest {
 func (s *APNSChannelRequest) SetTokenKeyId(v string) *APNSChannelRequest {
 	s.TokenKeyId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "BundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TeamId != nil {
+		v := *s.TeamId
+
+		e.SetValue(protocol.BodyTarget, "TeamId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKey != nil {
+		v := *s.TokenKey
+
+		e.SetValue(protocol.BodyTarget, "TokenKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKeyId != nil {
+		v := *s.TokenKeyId
+
+		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Apple Distribution Push Notification Service channel definition.
@@ -5823,6 +6038,72 @@ func (s *APNSChannelResponse) SetPlatform(v string) *APNSChannelResponse {
 func (s *APNSChannelResponse) SetVersion(v int64) *APNSChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasTokenKey != nil {
+		v := *s.HasTokenKey
+
+		e.SetValue(protocol.BodyTarget, "HasTokenKey", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // APNS Message.
@@ -6016,6 +6297,102 @@ func (s *APNSMessage) SetUrl(v string) *APNSMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Badge != nil {
+		v := *s.Badge
+
+		e.SetValue(protocol.BodyTarget, "Badge", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Category != nil {
+		v := *s.Category
+
+		e.SetValue(protocol.BodyTarget, "Category", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CollapseId != nil {
+		v := *s.CollapseId
+
+		e.SetValue(protocol.BodyTarget, "CollapseId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MediaUrl != nil {
+		v := *s.MediaUrl
+
+		e.SetValue(protocol.BodyTarget, "MediaUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PreferredAuthenticationMethod != nil {
+		v := *s.PreferredAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "PreferredAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "Priority", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeToLive != nil {
+		v := *s.TimeToLive
+
+		e.SetValue(protocol.BodyTarget, "TimeToLive", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple Development Push Notification Service channel definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/APNSSandboxChannelRequest
 type APNSSandboxChannelRequest struct {
@@ -6102,6 +6479,52 @@ func (s *APNSSandboxChannelRequest) SetTokenKey(v string) *APNSSandboxChannelReq
 func (s *APNSSandboxChannelRequest) SetTokenKeyId(v string) *APNSSandboxChannelRequest {
 	s.TokenKeyId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSSandboxChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "BundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TeamId != nil {
+		v := *s.TeamId
+
+		e.SetValue(protocol.BodyTarget, "TeamId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKey != nil {
+		v := *s.TokenKey
+
+		e.SetValue(protocol.BodyTarget, "TokenKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKeyId != nil {
+		v := *s.TokenKeyId
+
+		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Apple Development Push Notification Service channel definition.
@@ -6228,6 +6651,72 @@ func (s *APNSSandboxChannelResponse) SetVersion(v int64) *APNSSandboxChannelResp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSSandboxChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasTokenKey != nil {
+		v := *s.HasTokenKey
+
+		e.SetValue(protocol.BodyTarget, "HasTokenKey", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple VOIP Push Notification Service channel definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/APNSVoipChannelRequest
 type APNSVoipChannelRequest struct {
@@ -6314,6 +6803,52 @@ func (s *APNSVoipChannelRequest) SetTokenKey(v string) *APNSVoipChannelRequest {
 func (s *APNSVoipChannelRequest) SetTokenKeyId(v string) *APNSVoipChannelRequest {
 	s.TokenKeyId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSVoipChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "BundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TeamId != nil {
+		v := *s.TeamId
+
+		e.SetValue(protocol.BodyTarget, "TeamId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKey != nil {
+		v := *s.TokenKey
+
+		e.SetValue(protocol.BodyTarget, "TokenKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKeyId != nil {
+		v := *s.TokenKeyId
+
+		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Apple VOIP Push Notification Service channel definition.
@@ -6440,6 +6975,72 @@ func (s *APNSVoipChannelResponse) SetVersion(v int64) *APNSVoipChannelResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSVoipChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasTokenKey != nil {
+		v := *s.HasTokenKey
+
+		e.SetValue(protocol.BodyTarget, "HasTokenKey", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Apple VOIP Developer Push Notification Service channel definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/APNSVoipSandboxChannelRequest
 type APNSVoipSandboxChannelRequest struct {
@@ -6526,6 +7127,52 @@ func (s *APNSVoipSandboxChannelRequest) SetTokenKey(v string) *APNSVoipSandboxCh
 func (s *APNSVoipSandboxChannelRequest) SetTokenKeyId(v string) *APNSVoipSandboxChannelRequest {
 	s.TokenKeyId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSVoipSandboxChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BundleId != nil {
+		v := *s.BundleId
+
+		e.SetValue(protocol.BodyTarget, "BundleId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Certificate != nil {
+		v := *s.Certificate
+
+		e.SetValue(protocol.BodyTarget, "Certificate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.PrivateKey != nil {
+		v := *s.PrivateKey
+
+		e.SetValue(protocol.BodyTarget, "PrivateKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TeamId != nil {
+		v := *s.TeamId
+
+		e.SetValue(protocol.BodyTarget, "TeamId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKey != nil {
+		v := *s.TokenKey
+
+		e.SetValue(protocol.BodyTarget, "TokenKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TokenKeyId != nil {
+		v := *s.TokenKeyId
+
+		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Apple VOIP Developer Push Notification Service channel definition.
@@ -6652,6 +7299,72 @@ func (s *APNSVoipSandboxChannelResponse) SetVersion(v int64) *APNSVoipSandboxCha
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *APNSVoipSandboxChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultAuthenticationMethod != nil {
+		v := *s.DefaultAuthenticationMethod
+
+		e.SetValue(protocol.BodyTarget, "DefaultAuthenticationMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasTokenKey != nil {
+		v := *s.HasTokenKey
+
+		e.SetValue(protocol.BodyTarget, "HasTokenKey", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Activities for campaign.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ActivitiesResponse
 type ActivitiesResponse struct {
@@ -6675,6 +7388,17 @@ func (s ActivitiesResponse) GoString() string {
 func (s *ActivitiesResponse) SetItem(v []*ActivityResponse) *ActivitiesResponse {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivitiesResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeActivityResponseList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Activity definition
@@ -6813,6 +7537,85 @@ func (s *ActivityResponse) SetTreatmentId(v string) *ActivityResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivityResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.BodyTarget, "CampaignId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.End != nil {
+		v := *s.End
+
+		e.SetValue(protocol.BodyTarget, "End", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Result != nil {
+		v := *s.Result
+
+		e.SetValue(protocol.BodyTarget, "Result", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ScheduledStart != nil {
+		v := *s.ScheduledStart
+
+		e.SetValue(protocol.BodyTarget, "ScheduledStart", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "Start", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SuccessfulEndpointCount != nil {
+		v := *s.SuccessfulEndpointCount
+
+		e.SetValue(protocol.BodyTarget, "SuccessfulEndpointCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimezonesCompletedCount != nil {
+		v := *s.TimezonesCompletedCount
+
+		e.SetValue(protocol.BodyTarget, "TimezonesCompletedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimezonesTotalCount != nil {
+		v := *s.TimezonesTotalCount
+
+		e.SetValue(protocol.BodyTarget, "TimezonesTotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalEndpointCount != nil {
+		v := *s.TotalEndpointCount
+
+		e.SetValue(protocol.BodyTarget, "TotalEndpointCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentId != nil {
+		v := *s.TreatmentId
+
+		e.SetValue(protocol.BodyTarget, "TreatmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActivityResponseList(vs []*ActivityResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Address configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/AddressConfiguration
 type AddressConfiguration struct {
@@ -6882,6 +7685,55 @@ func (s *AddressConfiguration) SetTitleOverride(v string) *AddressConfiguration 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddressConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BodyOverride != nil {
+		v := *s.BodyOverride
+
+		e.SetValue(protocol.BodyTarget, "BodyOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.TitleOverride != nil {
+		v := *s.TitleOverride
+
+		e.SetValue(protocol.BodyTarget, "TitleOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAddressConfigurationMap(vs map[string]*AddressConfiguration) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Application Response.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ApplicationResponse
 type ApplicationResponse struct {
@@ -6914,6 +7766,30 @@ func (s *ApplicationResponse) SetId(v string) *ApplicationResponse {
 func (s *ApplicationResponse) SetName(v string) *ApplicationResponse {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeApplicationResponseList(vs []*ApplicationResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Application settings.
@@ -6972,6 +7848,32 @@ func (s *ApplicationSettingsResource) SetQuietTime(v *QuietTime) *ApplicationSet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationSettingsResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Get Applications Result.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ApplicationsResponse
 type ApplicationsResponse struct {
@@ -7007,6 +7909,22 @@ func (s *ApplicationsResponse) SetNextToken(v string) *ApplicationsResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ApplicationsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeApplicationResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Custom attibute dimension
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/AttributeDimension
 type AttributeDimension struct {
@@ -7040,6 +7958,30 @@ func (s *AttributeDimension) SetAttributeType(v string) *AttributeDimension {
 func (s *AttributeDimension) SetValues(v []*string) *AttributeDimension {
 	s.Values = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AttributeDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AttributeType != nil {
+		v := *s.AttributeType
+
+		e.SetValue(protocol.BodyTarget, "AttributeType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Values) > 0 {
+		v := s.Values
+
+		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAttributeDimensionMap(vs map[string]*AttributeDimension) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Baidu Cloud Push credentials
@@ -7083,6 +8025,27 @@ func (s *BaiduChannelRequest) SetEnabled(v bool) *BaiduChannelRequest {
 func (s *BaiduChannelRequest) SetSecretKey(v string) *BaiduChannelRequest {
 	s.SecretKey = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BaiduChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.BodyTarget, "ApiKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SecretKey != nil {
+		v := *s.SecretKey
+
+		e.SetValue(protocol.BodyTarget, "SecretKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Baidu Cloud Messaging channel definition
@@ -7198,6 +8161,67 @@ func (s *BaiduChannelResponse) SetPlatform(v string) *BaiduChannelResponse {
 func (s *BaiduChannelResponse) SetVersion(v int64) *BaiduChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BaiduChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credential != nil {
+		v := *s.Credential
+
+		e.SetValue(protocol.BodyTarget, "Credential", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Baidu Message.
@@ -7345,6 +8369,82 @@ func (s *BaiduMessage) SetUrl(v string) *BaiduMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BaiduMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.IconReference != nil {
+		v := *s.IconReference
+
+		e.SetValue(protocol.BodyTarget, "IconReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SmallImageIconUrl != nil {
+		v := *s.SmallImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "SmallImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The email message configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CampaignEmailMessage
 type CampaignEmailMessage struct {
@@ -7396,6 +8496,32 @@ func (s *CampaignEmailMessage) SetHtmlBody(v string) *CampaignEmailMessage {
 func (s *CampaignEmailMessage) SetTitle(v string) *CampaignEmailMessage {
 	s.Title = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignEmailMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HtmlBody != nil {
+		v := *s.HtmlBody
+
+		e.SetValue(protocol.BodyTarget, "HtmlBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Campaign Limits are used to limit the number of messages that can be sent
@@ -7451,6 +8577,32 @@ func (s *CampaignLimits) SetMessagesPerSecond(v int64) *CampaignLimits {
 func (s *CampaignLimits) SetTotal(v int64) *CampaignLimits {
 	s.Total = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignLimits) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Daily != nil {
+		v := *s.Daily
+
+		e.SetValue(protocol.BodyTarget, "Daily", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaximumDuration != nil {
+		v := *s.MaximumDuration
+
+		e.SetValue(protocol.BodyTarget, "MaximumDuration", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MessagesPerSecond != nil {
+		v := *s.MessagesPerSecond
+
+		e.SetValue(protocol.BodyTarget, "MessagesPerSecond", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Total != nil {
+		v := *s.Total
+
+		e.SetValue(protocol.BodyTarget, "Total", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Campaign definition
@@ -7644,6 +8796,115 @@ func (s *CampaignResponse) SetVersion(v int64) *CampaignResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalTreatments) > 0 {
+		v := s.AdditionalTreatments
+
+		e.SetList(protocol.BodyTarget, "AdditionalTreatments", encodeTreatmentResourceList(v), protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DefaultState != nil {
+		v := s.DefaultState
+
+		e.SetFields(protocol.BodyTarget, "DefaultState", v, protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HoldoutPercent != nil {
+		v := *s.HoldoutPercent
+
+		e.SetValue(protocol.BodyTarget, "HoldoutPercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsPaused != nil {
+		v := *s.IsPaused
+
+		e.SetValue(protocol.BodyTarget, "IsPaused", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentVersion != nil {
+		v := *s.SegmentVersion
+
+		e.SetValue(protocol.BodyTarget, "SegmentVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := s.State
+
+		e.SetFields(protocol.BodyTarget, "State", v, protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCampaignResponseList(vs []*CampaignResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // SMS message configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CampaignSmsMessage
 type CampaignSmsMessage struct {
@@ -7687,6 +8948,27 @@ func (s *CampaignSmsMessage) SetSenderId(v string) *CampaignSmsMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignSmsMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageType != nil {
+		v := *s.MessageType
+
+		e.SetValue(protocol.BodyTarget, "MessageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // State of the Campaign
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CampaignState
 type CampaignState struct {
@@ -7712,6 +8994,17 @@ func (s CampaignState) GoString() string {
 func (s *CampaignState) SetCampaignStatus(v string) *CampaignState {
 	s.CampaignStatus = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignState) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignStatus != nil {
+		v := *s.CampaignStatus
+
+		e.SetValue(protocol.BodyTarget, "CampaignStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // List of available campaigns.
@@ -7747,6 +9040,22 @@ func (s *CampaignsResponse) SetItem(v []*CampaignResponse) *CampaignsResponse {
 func (s *CampaignsResponse) SetNextToken(v string) *CampaignsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CampaignsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeCampaignResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateAppRequest
@@ -7788,6 +9097,17 @@ func (s *CreateAppInput) SetCreateApplicationRequest(v *CreateApplicationRequest
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreateApplicationRequest != nil {
+		v := s.CreateApplicationRequest
+
+		e.SetFields(protocol.PayloadTarget, "CreateApplicationRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateAppResponse
 type CreateAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
@@ -7814,6 +9134,17 @@ func (s *CreateAppOutput) SetApplicationResponse(v *ApplicationResponse) *Create
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Application Request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateApplicationRequest
 type CreateApplicationRequest struct {
@@ -7837,6 +9168,17 @@ func (s CreateApplicationRequest) GoString() string {
 func (s *CreateApplicationRequest) SetName(v string) *CreateApplicationRequest {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateApplicationRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateCampaignRequest
@@ -7890,6 +9232,22 @@ func (s *CreateCampaignInput) SetWriteCampaignRequest(v *WriteCampaignRequest) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteCampaignRequest != nil {
+		v := s.WriteCampaignRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateCampaignResponse
 type CreateCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
@@ -7914,6 +9272,17 @@ func (s CreateCampaignOutput) GoString() string {
 func (s *CreateCampaignOutput) SetCampaignResponse(v *CampaignResponse) *CreateCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateImportJobRequest
@@ -7965,6 +9334,22 @@ func (s *CreateImportJobInput) SetImportJobRequest(v *ImportJobRequest) *CreateI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImportJobRequest != nil {
+		v := s.ImportJobRequest
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateImportJobResponse
 type CreateImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
@@ -7987,6 +9372,17 @@ func (s CreateImportJobOutput) GoString() string {
 func (s *CreateImportJobOutput) SetImportJobResponse(v *ImportJobResponse) *CreateImportJobOutput {
 	s.ImportJobResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobResponse != nil {
+		v := s.ImportJobResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateSegmentRequest
@@ -8040,6 +9436,22 @@ func (s *CreateSegmentInput) SetWriteSegmentRequest(v *WriteSegmentRequest) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteSegmentRequest != nil {
+		v := s.WriteSegmentRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateSegmentResponse
 type CreateSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
@@ -8064,6 +9476,17 @@ func (s CreateSegmentOutput) GoString() string {
 func (s *CreateSegmentOutput) SetSegmentResponse(v *SegmentResponse) *CreateSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Default Message across push notification, email, and sms.
@@ -8097,6 +9520,27 @@ func (s *DefaultMessage) SetBody(v string) *DefaultMessage {
 func (s *DefaultMessage) SetSubstitutions(v map[string][]*string) *DefaultMessage {
 	s.Substitutions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Default Push Notification Message.
@@ -8184,6 +9628,52 @@ func (s *DefaultPushNotificationMessage) SetUrl(v string) *DefaultPushNotificati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DefaultPushNotificationMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteAdmChannelRequest
 type DeleteAdmChannelInput struct {
 	_ struct{} `type:"structure"`
@@ -8221,6 +9711,17 @@ func (s *DeleteAdmChannelInput) SetApplicationId(v string) *DeleteAdmChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteAdmChannelResponse
 type DeleteAdmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"ADMChannelResponse"`
@@ -8245,6 +9746,17 @@ func (s DeleteAdmChannelOutput) GoString() string {
 func (s *DeleteAdmChannelOutput) SetADMChannelResponse(v *ADMChannelResponse) *DeleteAdmChannelOutput {
 	s.ADMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMChannelResponse != nil {
+		v := s.ADMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsChannelRequest
@@ -8284,6 +9796,17 @@ func (s *DeleteApnsChannelInput) SetApplicationId(v string) *DeleteApnsChannelIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsChannelResponse
 type DeleteApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
@@ -8308,6 +9831,17 @@ func (s DeleteApnsChannelOutput) GoString() string {
 func (s *DeleteApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *DeleteApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsSandboxChannelRequest
@@ -8347,6 +9881,17 @@ func (s *DeleteApnsSandboxChannelInput) SetApplicationId(v string) *DeleteApnsSa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsSandboxChannelResponse
 type DeleteApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
@@ -8371,6 +9916,17 @@ func (s DeleteApnsSandboxChannelOutput) GoString() string {
 func (s *DeleteApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *DeleteApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipChannelRequest
@@ -8410,6 +9966,17 @@ func (s *DeleteApnsVoipChannelInput) SetApplicationId(v string) *DeleteApnsVoipC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipChannelResponse
 type DeleteApnsVoipChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipChannelResponse"`
@@ -8434,6 +10001,17 @@ func (s DeleteApnsVoipChannelOutput) GoString() string {
 func (s *DeleteApnsVoipChannelOutput) SetAPNSVoipChannelResponse(v *APNSVoipChannelResponse) *DeleteApnsVoipChannelOutput {
 	s.APNSVoipChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipChannelResponse != nil {
+		v := s.APNSVoipChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipSandboxChannelRequest
@@ -8473,6 +10051,17 @@ func (s *DeleteApnsVoipSandboxChannelInput) SetApplicationId(v string) *DeleteAp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipSandboxChannelResponse
 type DeleteApnsVoipSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipSandboxChannelResponse"`
@@ -8497,6 +10086,17 @@ func (s DeleteApnsVoipSandboxChannelOutput) GoString() string {
 func (s *DeleteApnsVoipSandboxChannelOutput) SetAPNSVoipSandboxChannelResponse(v *APNSVoipSandboxChannelResponse) *DeleteApnsVoipSandboxChannelOutput {
 	s.APNSVoipSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipSandboxChannelResponse != nil {
+		v := s.APNSVoipSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteAppRequest
@@ -8536,6 +10136,17 @@ func (s *DeleteAppInput) SetApplicationId(v string) *DeleteAppInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteAppResponse
 type DeleteAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
@@ -8560,6 +10171,17 @@ func (s DeleteAppOutput) GoString() string {
 func (s *DeleteAppOutput) SetApplicationResponse(v *ApplicationResponse) *DeleteAppOutput {
 	s.ApplicationResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteBaiduChannelRequest
@@ -8599,6 +10221,17 @@ func (s *DeleteBaiduChannelInput) SetApplicationId(v string) *DeleteBaiduChannel
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteBaiduChannelResponse
 type DeleteBaiduChannelOutput struct {
 	_ struct{} `type:"structure" payload:"BaiduChannelResponse"`
@@ -8623,6 +10256,17 @@ func (s DeleteBaiduChannelOutput) GoString() string {
 func (s *DeleteBaiduChannelOutput) SetBaiduChannelResponse(v *BaiduChannelResponse) *DeleteBaiduChannelOutput {
 	s.BaiduChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BaiduChannelResponse != nil {
+		v := s.BaiduChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteCampaignRequest
@@ -8674,6 +10318,22 @@ func (s *DeleteCampaignInput) SetCampaignId(v string) *DeleteCampaignInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteCampaignResponse
 type DeleteCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
@@ -8698,6 +10358,17 @@ func (s DeleteCampaignOutput) GoString() string {
 func (s *DeleteCampaignOutput) SetCampaignResponse(v *CampaignResponse) *DeleteCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEmailChannelRequest
@@ -8737,6 +10408,17 @@ func (s *DeleteEmailChannelInput) SetApplicationId(v string) *DeleteEmailChannel
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEmailChannelResponse
 type DeleteEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
@@ -8761,6 +10443,17 @@ func (s DeleteEmailChannelOutput) GoString() string {
 func (s *DeleteEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *DeleteEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEventStreamRequest
@@ -8802,6 +10495,17 @@ func (s *DeleteEventStreamInput) SetApplicationId(v string) *DeleteEventStreamIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEventStreamResponse
 type DeleteEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
@@ -8826,6 +10530,17 @@ func (s DeleteEventStreamOutput) GoString() string {
 func (s *DeleteEventStreamOutput) SetEventStream(v *EventStream) *DeleteEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteGcmChannelRequest
@@ -8865,6 +10580,17 @@ func (s *DeleteGcmChannelInput) SetApplicationId(v string) *DeleteGcmChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteGcmChannelResponse
 type DeleteGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
@@ -8889,6 +10615,17 @@ func (s DeleteGcmChannelOutput) GoString() string {
 func (s *DeleteGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *DeleteGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSegmentRequest
@@ -8940,6 +10677,22 @@ func (s *DeleteSegmentInput) SetSegmentId(v string) *DeleteSegmentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSegmentResponse
 type DeleteSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
@@ -8964,6 +10717,17 @@ func (s DeleteSegmentOutput) GoString() string {
 func (s *DeleteSegmentOutput) SetSegmentResponse(v *SegmentResponse) *DeleteSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSmsChannelRequest
@@ -9003,6 +10767,17 @@ func (s *DeleteSmsChannelInput) SetApplicationId(v string) *DeleteSmsChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSmsChannelResponse
 type DeleteSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
@@ -9027,6 +10802,17 @@ func (s DeleteSmsChannelOutput) GoString() string {
 func (s *DeleteSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *DeleteSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The message configuration.
@@ -9109,6 +10895,47 @@ func (s *DirectMessageConfiguration) SetSMSMessage(v *SMSMessage) *DirectMessage
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DirectMessageConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMMessage != nil {
+		v := s.ADMMessage
+
+		e.SetFields(protocol.BodyTarget, "ADMMessage", v, protocol.Metadata{})
+	}
+	if s.APNSMessage != nil {
+		v := s.APNSMessage
+
+		e.SetFields(protocol.BodyTarget, "APNSMessage", v, protocol.Metadata{})
+	}
+	if s.BaiduMessage != nil {
+		v := s.BaiduMessage
+
+		e.SetFields(protocol.BodyTarget, "BaiduMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultMessage != nil {
+		v := s.DefaultMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultPushNotificationMessage != nil {
+		v := s.DefaultPushNotificationMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultPushNotificationMessage", v, protocol.Metadata{})
+	}
+	if s.GCMMessage != nil {
+		v := s.GCMMessage
+
+		e.SetFields(protocol.BodyTarget, "GCMMessage", v, protocol.Metadata{})
+	}
+	if s.SMSMessage != nil {
+		v := s.SMSMessage
+
+		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Email Channel Request
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EmailChannelRequest
 type EmailChannelRequest struct {
@@ -9160,6 +10987,32 @@ func (s *EmailChannelRequest) SetIdentity(v string) *EmailChannelRequest {
 func (s *EmailChannelRequest) SetRoleArn(v string) *EmailChannelRequest {
 	s.RoleArn = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmailChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Identity != nil {
+		v := *s.Identity
+
+		e.SetValue(protocol.BodyTarget, "Identity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Email Channel Response.
@@ -9296,6 +11149,77 @@ func (s *EmailChannelResponse) SetVersion(v int64) *EmailChannelResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EmailChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FromAddress != nil {
+		v := *s.FromAddress
+
+		e.SetValue(protocol.BodyTarget, "FromAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Identity != nil {
+		v := *s.Identity
+
+		e.SetValue(protocol.BodyTarget, "Identity", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Endpoint update request
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointBatchItem
 type EndpointBatchItem struct {
@@ -9422,6 +11346,85 @@ func (s *EndpointBatchItem) SetUser(v *EndpointUser) *EndpointBatchItem {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointBatchItem) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEndpointBatchItemList(vs []*EndpointBatchItem) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Endpoint batch update request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointBatchRequest
 type EndpointBatchRequest struct {
@@ -9445,6 +11448,17 @@ func (s EndpointBatchRequest) GoString() string {
 func (s *EndpointBatchRequest) SetItem(v []*EndpointBatchItem) *EndpointBatchRequest {
 	s.Item = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointBatchRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeEndpointBatchItemList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint demographic data
@@ -9536,6 +11550,52 @@ func (s *EndpointDemographic) SetTimezone(v string) *EndpointDemographic {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointDemographic) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppVersion != nil {
+		v := *s.AppVersion
+
+		e.SetValue(protocol.BodyTarget, "AppVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Make != nil {
+		v := *s.Make
+
+		e.SetValue(protocol.BodyTarget, "Make", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Model != nil {
+		v := *s.Model
+
+		e.SetValue(protocol.BodyTarget, "Model", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModelVersion != nil {
+		v := *s.ModelVersion
+
+		e.SetValue(protocol.BodyTarget, "ModelVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PlatformVersion != nil {
+		v := *s.PlatformVersion
+
+		e.SetValue(protocol.BodyTarget, "PlatformVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timezone != nil {
+		v := *s.Timezone
+
+		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Endpoint location data
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointLocation
 type EndpointLocation struct {
@@ -9609,6 +11669,42 @@ func (s *EndpointLocation) SetRegion(v string) *EndpointLocation {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.City != nil {
+		v := *s.City
+
+		e.SetValue(protocol.BodyTarget, "City", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Country != nil {
+		v := *s.Country
+
+		e.SetValue(protocol.BodyTarget, "Country", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Latitude != nil {
+		v := *s.Latitude
+
+		e.SetValue(protocol.BodyTarget, "Latitude", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Longitude != nil {
+		v := *s.Longitude
+
+		e.SetValue(protocol.BodyTarget, "Longitude", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.PostalCode != nil {
+		v := *s.PostalCode
+
+		e.SetValue(protocol.BodyTarget, "PostalCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result from sending a message to an endpoint.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointMessageResult
 type EndpointMessageResult struct {
@@ -9668,6 +11764,45 @@ func (s *EndpointMessageResult) SetStatusMessage(v string) *EndpointMessageResul
 func (s *EndpointMessageResult) SetUpdatedToken(v string) *EndpointMessageResult {
 	s.UpdatedToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointMessageResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeliveryStatus != nil {
+		v := *s.DeliveryStatus
+
+		e.SetValue(protocol.BodyTarget, "DeliveryStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "StatusCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdatedToken != nil {
+		v := *s.UpdatedToken
+
+		e.SetValue(protocol.BodyTarget, "UpdatedToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEndpointMessageResultMap(vs map[string]*EndpointMessageResult) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Endpoint update request
@@ -9785,6 +11920,72 @@ func (s *EndpointRequest) SetRequestId(v string) *EndpointRequest {
 func (s *EndpointRequest) SetUser(v *EndpointUser) *EndpointRequest {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Endpoint response
@@ -9945,6 +12146,92 @@ func (s *EndpointResponse) SetUser(v *EndpointUser) *EndpointResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Address != nil {
+		v := *s.Address
+
+		e.SetValue(protocol.BodyTarget, "Address", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.ChannelType != nil {
+		v := *s.ChannelType
+
+		e.SetValue(protocol.BodyTarget, "ChannelType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CohortId != nil {
+		v := *s.CohortId
+
+		e.SetValue(protocol.BodyTarget, "CohortId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.EffectiveDate != nil {
+		v := *s.EffectiveDate
+
+		e.SetValue(protocol.BodyTarget, "EffectiveDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointStatus != nil {
+		v := *s.EndpointStatus
+
+		e.SetValue(protocol.BodyTarget, "EndpointStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.Metrics) > 0 {
+		v := s.Metrics
+
+		e.SetMap(protocol.BodyTarget, "Metrics", protocol.EncodeFloat64Map(v), protocol.Metadata{})
+	}
+	if s.OptOut != nil {
+		v := *s.OptOut
+
+		e.SetValue(protocol.BodyTarget, "OptOut", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Endpoint send configuration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointSendConfiguration
 type EndpointSendConfiguration struct {
@@ -10005,6 +12292,50 @@ func (s *EndpointSendConfiguration) SetTitleOverride(v string) *EndpointSendConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointSendConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BodyOverride != nil {
+		v := *s.BodyOverride
+
+		e.SetValue(protocol.BodyTarget, "BodyOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.TitleOverride != nil {
+		v := *s.TitleOverride
+
+		e.SetValue(protocol.BodyTarget, "TitleOverride", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEndpointSendConfigurationMap(vs map[string]*EndpointSendConfiguration) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
+}
+
 // Endpoint user specific custom userAttributes
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/EndpointUser
 type EndpointUser struct {
@@ -10036,6 +12367,27 @@ func (s *EndpointUser) SetUserAttributes(v map[string][]*string) *EndpointUser {
 func (s *EndpointUser) SetUserId(v string) *EndpointUser {
 	s.UserId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EndpointUser) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.UserAttributes) > 0 {
+		v := s.UserAttributes
+
+		e.SetMap(protocol.BodyTarget, "UserAttributes", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.BodyTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Model for an event publishing subscription export.
@@ -10112,6 +12464,42 @@ func (s *EventStream) SetRoleArn(v string) *EventStream {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EventStream) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DestinationStreamArn != nil {
+		v := *s.DestinationStreamArn
+
+		e.SetValue(protocol.BodyTarget, "DestinationStreamArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastUpdatedBy != nil {
+		v := *s.LastUpdatedBy
+
+		e.SetValue(protocol.BodyTarget, "LastUpdatedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Google Cloud Messaging credentials
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GCMChannelRequest
 type GCMChannelRequest struct {
@@ -10144,6 +12532,22 @@ func (s *GCMChannelRequest) SetApiKey(v string) *GCMChannelRequest {
 func (s *GCMChannelRequest) SetEnabled(v bool) *GCMChannelRequest {
 	s.Enabled = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApiKey != nil {
+		v := *s.ApiKey
+
+		e.SetValue(protocol.BodyTarget, "ApiKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Google Cloud Messaging channel definition
@@ -10259,6 +12663,67 @@ func (s *GCMChannelResponse) SetPlatform(v string) *GCMChannelResponse {
 func (s *GCMChannelResponse) SetVersion(v int64) *GCMChannelResponse {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Credential != nil {
+		v := *s.Credential
+
+		e.SetValue(protocol.BodyTarget, "Credential", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // GCM Message.
@@ -10448,6 +12913,102 @@ func (s *GCMMessage) SetUrl(v string) *GCMMessage {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GCMMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CollapseKey != nil {
+		v := *s.CollapseKey
+
+		e.SetValue(protocol.BodyTarget, "CollapseKey", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Data) > 0 {
+		v := s.Data
+
+		e.SetMap(protocol.BodyTarget, "Data", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.IconReference != nil {
+		v := *s.IconReference
+
+		e.SetValue(protocol.BodyTarget, "IconReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Priority != nil {
+		v := *s.Priority
+
+		e.SetValue(protocol.BodyTarget, "Priority", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestrictedPackageName != nil {
+		v := *s.RestrictedPackageName
+
+		e.SetValue(protocol.BodyTarget, "RestrictedPackageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SmallImageIconUrl != nil {
+		v := *s.SmallImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "SmallImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sound != nil {
+		v := *s.Sound
+
+		e.SetValue(protocol.BodyTarget, "Sound", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.TimeToLive != nil {
+		v := *s.TimeToLive
+
+		e.SetValue(protocol.BodyTarget, "TimeToLive", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAdmChannelRequest
 type GetAdmChannelInput struct {
 	_ struct{} `type:"structure"`
@@ -10485,6 +13046,17 @@ func (s *GetAdmChannelInput) SetApplicationId(v string) *GetAdmChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAdmChannelResponse
 type GetAdmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"ADMChannelResponse"`
@@ -10509,6 +13081,17 @@ func (s GetAdmChannelOutput) GoString() string {
 func (s *GetAdmChannelOutput) SetADMChannelResponse(v *ADMChannelResponse) *GetAdmChannelOutput {
 	s.ADMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMChannelResponse != nil {
+		v := s.ADMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsChannelRequest
@@ -10548,6 +13131,17 @@ func (s *GetApnsChannelInput) SetApplicationId(v string) *GetApnsChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsChannelResponse
 type GetApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
@@ -10572,6 +13166,17 @@ func (s GetApnsChannelOutput) GoString() string {
 func (s *GetApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *GetApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsSandboxChannelRequest
@@ -10611,6 +13216,17 @@ func (s *GetApnsSandboxChannelInput) SetApplicationId(v string) *GetApnsSandboxC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsSandboxChannelResponse
 type GetApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
@@ -10635,6 +13251,17 @@ func (s GetApnsSandboxChannelOutput) GoString() string {
 func (s *GetApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *GetApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipChannelRequest
@@ -10674,6 +13301,17 @@ func (s *GetApnsVoipChannelInput) SetApplicationId(v string) *GetApnsVoipChannel
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipChannelResponse
 type GetApnsVoipChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipChannelResponse"`
@@ -10698,6 +13336,17 @@ func (s GetApnsVoipChannelOutput) GoString() string {
 func (s *GetApnsVoipChannelOutput) SetAPNSVoipChannelResponse(v *APNSVoipChannelResponse) *GetApnsVoipChannelOutput {
 	s.APNSVoipChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipChannelResponse != nil {
+		v := s.APNSVoipChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipSandboxChannelRequest
@@ -10737,6 +13386,17 @@ func (s *GetApnsVoipSandboxChannelInput) SetApplicationId(v string) *GetApnsVoip
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipSandboxChannelResponse
 type GetApnsVoipSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipSandboxChannelResponse"`
@@ -10761,6 +13421,17 @@ func (s GetApnsVoipSandboxChannelOutput) GoString() string {
 func (s *GetApnsVoipSandboxChannelOutput) SetAPNSVoipSandboxChannelResponse(v *APNSVoipSandboxChannelResponse) *GetApnsVoipSandboxChannelOutput {
 	s.APNSVoipSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipSandboxChannelResponse != nil {
+		v := s.APNSVoipSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAppRequest
@@ -10800,6 +13471,17 @@ func (s *GetAppInput) SetApplicationId(v string) *GetAppInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAppResponse
 type GetAppOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationResponse"`
@@ -10824,6 +13506,17 @@ func (s GetAppOutput) GoString() string {
 func (s *GetAppOutput) SetApplicationResponse(v *ApplicationResponse) *GetAppOutput {
 	s.ApplicationResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationResponse != nil {
+		v := s.ApplicationResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApplicationSettingsRequest
@@ -10863,6 +13556,17 @@ func (s *GetApplicationSettingsInput) SetApplicationId(v string) *GetApplication
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApplicationSettingsResponse
 type GetApplicationSettingsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationSettingsResource"`
@@ -10887,6 +13591,17 @@ func (s GetApplicationSettingsOutput) GoString() string {
 func (s *GetApplicationSettingsOutput) SetApplicationSettingsResource(v *ApplicationSettingsResource) *GetApplicationSettingsOutput {
 	s.ApplicationSettingsResource = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationSettingsResource != nil {
+		v := s.ApplicationSettingsResource
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAppsRequest
@@ -10920,6 +13635,22 @@ func (s *GetAppsInput) SetToken(v string) *GetAppsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAppsResponse
 type GetAppsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationsResponse"`
@@ -10944,6 +13675,17 @@ func (s GetAppsOutput) GoString() string {
 func (s *GetAppsOutput) SetApplicationsResponse(v *ApplicationsResponse) *GetAppsOutput {
 	s.ApplicationsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAppsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationsResponse != nil {
+		v := s.ApplicationsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetBaiduChannelRequest
@@ -10983,6 +13725,17 @@ func (s *GetBaiduChannelInput) SetApplicationId(v string) *GetBaiduChannelInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetBaiduChannelResponse
 type GetBaiduChannelOutput struct {
 	_ struct{} `type:"structure" payload:"BaiduChannelResponse"`
@@ -11007,6 +13760,17 @@ func (s GetBaiduChannelOutput) GoString() string {
 func (s *GetBaiduChannelOutput) SetBaiduChannelResponse(v *BaiduChannelResponse) *GetBaiduChannelOutput {
 	s.BaiduChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BaiduChannelResponse != nil {
+		v := s.BaiduChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignActivitiesRequest
@@ -11074,6 +13838,32 @@ func (s *GetCampaignActivitiesInput) SetToken(v string) *GetCampaignActivitiesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignActivitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignActivitiesResponse
 type GetCampaignActivitiesOutput struct {
 	_ struct{} `type:"structure" payload:"ActivitiesResponse"`
@@ -11098,6 +13888,17 @@ func (s GetCampaignActivitiesOutput) GoString() string {
 func (s *GetCampaignActivitiesOutput) SetActivitiesResponse(v *ActivitiesResponse) *GetCampaignActivitiesOutput {
 	s.ActivitiesResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignActivitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ActivitiesResponse != nil {
+		v := s.ActivitiesResponse
+
+		e.SetFields(protocol.PayloadTarget, "ActivitiesResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignRequest
@@ -11149,6 +13950,22 @@ func (s *GetCampaignInput) SetCampaignId(v string) *GetCampaignInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignResponse
 type GetCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
@@ -11173,6 +13990,17 @@ func (s GetCampaignOutput) GoString() string {
 func (s *GetCampaignOutput) SetCampaignResponse(v *CampaignResponse) *GetCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersionRequest
@@ -11236,6 +14064,27 @@ func (s *GetCampaignVersionInput) SetVersion(v string) *GetCampaignVersionInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersionResponse
 type GetCampaignVersionOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
@@ -11260,6 +14109,17 @@ func (s GetCampaignVersionOutput) GoString() string {
 func (s *GetCampaignVersionOutput) SetCampaignResponse(v *CampaignResponse) *GetCampaignVersionOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersionsRequest
@@ -11327,6 +14187,32 @@ func (s *GetCampaignVersionsInput) SetToken(v string) *GetCampaignVersionsInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersionsResponse
 type GetCampaignVersionsOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignsResponse"`
@@ -11351,6 +14237,17 @@ func (s GetCampaignVersionsOutput) GoString() string {
 func (s *GetCampaignVersionsOutput) SetCampaignsResponse(v *CampaignsResponse) *GetCampaignVersionsOutput {
 	s.CampaignsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignsResponse != nil {
+		v := s.CampaignsResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignsRequest
@@ -11406,6 +14303,27 @@ func (s *GetCampaignsInput) SetToken(v string) *GetCampaignsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignsResponse
 type GetCampaignsOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignsResponse"`
@@ -11430,6 +14348,17 @@ func (s GetCampaignsOutput) GoString() string {
 func (s *GetCampaignsOutput) SetCampaignsResponse(v *CampaignsResponse) *GetCampaignsOutput {
 	s.CampaignsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCampaignsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignsResponse != nil {
+		v := s.CampaignsResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEmailChannelRequest
@@ -11469,6 +14398,17 @@ func (s *GetEmailChannelInput) SetApplicationId(v string) *GetEmailChannelInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEmailChannelResponse
 type GetEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
@@ -11493,6 +14433,17 @@ func (s GetEmailChannelOutput) GoString() string {
 func (s *GetEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *GetEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEndpointRequest
@@ -11544,6 +14495,22 @@ func (s *GetEndpointInput) SetEndpointId(v string) *GetEndpointInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointId != nil {
+		v := *s.EndpointId
+
+		e.SetValue(protocol.PathTarget, "endpoint-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEndpointResponse
 type GetEndpointOutput struct {
 	_ struct{} `type:"structure" payload:"EndpointResponse"`
@@ -11568,6 +14535,17 @@ func (s GetEndpointOutput) GoString() string {
 func (s *GetEndpointOutput) SetEndpointResponse(v *EndpointResponse) *GetEndpointOutput {
 	s.EndpointResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndpointResponse != nil {
+		v := s.EndpointResponse
+
+		e.SetFields(protocol.PayloadTarget, "EndpointResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEventStreamRequest
@@ -11609,6 +14587,17 @@ func (s *GetEventStreamInput) SetApplicationId(v string) *GetEventStreamInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEventStreamResponse
 type GetEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
@@ -11633,6 +14622,17 @@ func (s GetEventStreamOutput) GoString() string {
 func (s *GetEventStreamOutput) SetEventStream(v *EventStream) *GetEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetGcmChannelRequest
@@ -11672,6 +14672,17 @@ func (s *GetGcmChannelInput) SetApplicationId(v string) *GetGcmChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetGcmChannelResponse
 type GetGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
@@ -11696,6 +14707,17 @@ func (s GetGcmChannelOutput) GoString() string {
 func (s *GetGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *GetGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJobRequest
@@ -11747,6 +14769,22 @@ func (s *GetImportJobInput) SetJobId(v string) *GetImportJobInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobId != nil {
+		v := *s.JobId
+
+		e.SetValue(protocol.PathTarget, "job-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJobResponse
 type GetImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
@@ -11769,6 +14807,17 @@ func (s GetImportJobOutput) GoString() string {
 func (s *GetImportJobOutput) SetImportJobResponse(v *ImportJobResponse) *GetImportJobOutput {
 	s.ImportJobResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobResponse != nil {
+		v := s.ImportJobResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJobsRequest
@@ -11824,6 +14873,27 @@ func (s *GetImportJobsInput) SetToken(v string) *GetImportJobsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJobsResponse
 type GetImportJobsOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobsResponse"`
@@ -11848,6 +14918,17 @@ func (s GetImportJobsOutput) GoString() string {
 func (s *GetImportJobsOutput) SetImportJobsResponse(v *ImportJobsResponse) *GetImportJobsOutput {
 	s.ImportJobsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetImportJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobsResponse != nil {
+		v := s.ImportJobsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentImportJobsRequest
@@ -11915,6 +14996,32 @@ func (s *GetSegmentImportJobsInput) SetToken(v string) *GetSegmentImportJobsInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentImportJobsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentImportJobsResponse
 type GetSegmentImportJobsOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobsResponse"`
@@ -11939,6 +15046,17 @@ func (s GetSegmentImportJobsOutput) GoString() string {
 func (s *GetSegmentImportJobsOutput) SetImportJobsResponse(v *ImportJobsResponse) *GetSegmentImportJobsOutput {
 	s.ImportJobsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentImportJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ImportJobsResponse != nil {
+		v := s.ImportJobsResponse
+
+		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentRequest
@@ -11990,6 +15108,22 @@ func (s *GetSegmentInput) SetSegmentId(v string) *GetSegmentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentResponse
 type GetSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
@@ -12014,6 +15148,17 @@ func (s GetSegmentOutput) GoString() string {
 func (s *GetSegmentOutput) SetSegmentResponse(v *SegmentResponse) *GetSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersionRequest
@@ -12077,6 +15222,27 @@ func (s *GetSegmentVersionInput) SetVersion(v string) *GetSegmentVersionInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersionResponse
 type GetSegmentVersionOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
@@ -12101,6 +15267,17 @@ func (s GetSegmentVersionOutput) GoString() string {
 func (s *GetSegmentVersionOutput) SetSegmentResponse(v *SegmentResponse) *GetSegmentVersionOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersionsRequest
@@ -12168,6 +15345,32 @@ func (s *GetSegmentVersionsInput) SetToken(v string) *GetSegmentVersionsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersionsResponse
 type GetSegmentVersionsOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentsResponse"`
@@ -12192,6 +15395,17 @@ func (s GetSegmentVersionsOutput) GoString() string {
 func (s *GetSegmentVersionsOutput) SetSegmentsResponse(v *SegmentsResponse) *GetSegmentVersionsOutput {
 	s.SegmentsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentsResponse != nil {
+		v := s.SegmentsResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentsRequest
@@ -12247,6 +15461,27 @@ func (s *GetSegmentsInput) SetToken(v string) *GetSegmentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Token != nil {
+		v := *s.Token
+
+		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentsResponse
 type GetSegmentsOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentsResponse"`
@@ -12271,6 +15506,17 @@ func (s GetSegmentsOutput) GoString() string {
 func (s *GetSegmentsOutput) SetSegmentsResponse(v *SegmentsResponse) *GetSegmentsOutput {
 	s.SegmentsResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentsResponse != nil {
+		v := s.SegmentsResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSmsChannelRequest
@@ -12310,6 +15556,17 @@ func (s *GetSmsChannelInput) SetApplicationId(v string) *GetSmsChannelInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSmsChannelResponse
 type GetSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
@@ -12334,6 +15591,17 @@ func (s GetSmsChannelOutput) GoString() string {
 func (s *GetSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *GetSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ImportJobRequest
@@ -12432,6 +15700,52 @@ func (s *ImportJobRequest) SetSegmentName(v string) *ImportJobRequest {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefineSegment != nil {
+		v := *s.DefineSegment
+
+		e.SetValue(protocol.BodyTarget, "DefineSegment", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegisterEndpoints != nil {
+		v := *s.RegisterEndpoints
+
+		e.SetValue(protocol.BodyTarget, "RegisterEndpoints", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentName != nil {
+		v := *s.SegmentName
+
+		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ImportJobResource
 type ImportJobResource struct {
 	_ struct{} `type:"structure"`
@@ -12526,6 +15840,52 @@ func (s *ImportJobResource) SetSegmentId(v string) *ImportJobResource {
 func (s *ImportJobResource) SetSegmentName(v string) *ImportJobResource {
 	s.SegmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DefineSegment != nil {
+		v := *s.DefineSegment
+
+		e.SetValue(protocol.BodyTarget, "DefineSegment", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RegisterEndpoints != nil {
+		v := *s.RegisterEndpoints
+
+		e.SetValue(protocol.BodyTarget, "RegisterEndpoints", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentName != nil {
+		v := *s.SegmentName
+
+		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ImportJobResponse
@@ -12664,6 +16024,85 @@ func (s *ImportJobResponse) SetType(v string) *ImportJobResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CompletedPieces != nil {
+		v := *s.CompletedPieces
+
+		e.SetValue(protocol.BodyTarget, "CompletedPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.CompletionDate != nil {
+		v := *s.CompletionDate
+
+		e.SetValue(protocol.BodyTarget, "CompletionDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Definition != nil {
+		v := s.Definition
+
+		e.SetFields(protocol.BodyTarget, "Definition", v, protocol.Metadata{})
+	}
+	if s.FailedPieces != nil {
+		v := *s.FailedPieces
+
+		e.SetValue(protocol.BodyTarget, "FailedPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Failures) > 0 {
+		v := s.Failures
+
+		e.SetList(protocol.BodyTarget, "Failures", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JobStatus != nil {
+		v := *s.JobStatus
+
+		e.SetValue(protocol.BodyTarget, "JobStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TotalFailures != nil {
+		v := *s.TotalFailures
+
+		e.SetValue(protocol.BodyTarget, "TotalFailures", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalPieces != nil {
+		v := *s.TotalPieces
+
+		e.SetValue(protocol.BodyTarget, "TotalPieces", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalProcessed != nil {
+		v := *s.TotalProcessed
+
+		e.SetValue(protocol.BodyTarget, "TotalProcessed", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeImportJobResponseList(vs []*ImportJobResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Import job list.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/ImportJobsResponse
 type ImportJobsResponse struct {
@@ -12697,6 +16136,22 @@ func (s *ImportJobsResponse) SetItem(v []*ImportJobResponse) *ImportJobsResponse
 func (s *ImportJobsResponse) SetNextToken(v string) *ImportJobsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ImportJobsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeImportJobResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/Message
@@ -12823,6 +16278,67 @@ func (s *Message) SetUrl(v string) *Message {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageIconUrl != nil {
+		v := *s.ImageIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageSmallIconUrl != nil {
+		v := *s.ImageSmallIconUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageSmallIconUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImageUrl != nil {
+		v := *s.ImageUrl
+
+		e.SetValue(protocol.BodyTarget, "ImageUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.JsonBody != nil {
+		v := *s.JsonBody
+
+		e.SetValue(protocol.BodyTarget, "JsonBody", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MediaUrl != nil {
+		v := *s.MediaUrl
+
+		e.SetValue(protocol.BodyTarget, "MediaUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RawContent != nil {
+		v := *s.RawContent
+
+		e.SetValue(protocol.BodyTarget, "RawContent", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SilentPush != nil {
+		v := *s.SilentPush
+
+		e.SetValue(protocol.BodyTarget, "SilentPush", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Title != nil {
+		v := *s.Title
+
+		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Url != nil {
+		v := *s.Url
+
+		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Simple message object.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/MessageBody
 type MessageBody struct {
@@ -12855,6 +16371,22 @@ func (s *MessageBody) SetMessage(v string) *MessageBody {
 func (s *MessageBody) SetRequestID(v string) *MessageBody {
 	s.RequestID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageBody) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestID != nil {
+		v := *s.RequestID
+
+		e.SetValue(protocol.BodyTarget, "RequestID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Message configuration for a campaign.
@@ -12940,6 +16472,47 @@ func (s *MessageConfiguration) SetSMSMessage(v *CampaignSmsMessage) *MessageConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMMessage != nil {
+		v := s.ADMMessage
+
+		e.SetFields(protocol.BodyTarget, "ADMMessage", v, protocol.Metadata{})
+	}
+	if s.APNSMessage != nil {
+		v := s.APNSMessage
+
+		e.SetFields(protocol.BodyTarget, "APNSMessage", v, protocol.Metadata{})
+	}
+	if s.BaiduMessage != nil {
+		v := s.BaiduMessage
+
+		e.SetFields(protocol.BodyTarget, "BaiduMessage", v, protocol.Metadata{})
+	}
+	if s.DefaultMessage != nil {
+		v := s.DefaultMessage
+
+		e.SetFields(protocol.BodyTarget, "DefaultMessage", v, protocol.Metadata{})
+	}
+	if s.EmailMessage != nil {
+		v := s.EmailMessage
+
+		e.SetFields(protocol.BodyTarget, "EmailMessage", v, protocol.Metadata{})
+	}
+	if s.GCMMessage != nil {
+		v := s.GCMMessage
+
+		e.SetFields(protocol.BodyTarget, "GCMMessage", v, protocol.Metadata{})
+	}
+	if s.SMSMessage != nil {
+		v := s.SMSMessage
+
+		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Send message request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/MessageRequest
 type MessageRequest struct {
@@ -12991,6 +16564,32 @@ func (s *MessageRequest) SetEndpoints(v map[string]*EndpointSendConfiguration) *
 func (s *MessageRequest) SetMessageConfiguration(v *DirectMessageConfiguration) *MessageRequest {
 	s.MessageConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Addresses) > 0 {
+		v := s.Addresses
+
+		e.SetMap(protocol.BodyTarget, "Addresses", encodeAddressConfigurationMap(v), protocol.Metadata{})
+	}
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if len(s.Endpoints) > 0 {
+		v := s.Endpoints
+
+		e.SetMap(protocol.BodyTarget, "Endpoints", encodeEndpointSendConfigurationMap(v), protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send message response.
@@ -13048,6 +16647,32 @@ func (s *MessageResponse) SetResult(v map[string]*MessageResult) *MessageRespons
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.EndpointResult) > 0 {
+		v := s.EndpointResult
+
+		e.SetMap(protocol.BodyTarget, "EndpointResult", encodeEndpointMessageResultMap(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Result) > 0 {
+		v := s.Result
+
+		e.SetMap(protocol.BodyTarget, "Result", encodeMessageResultMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The result from sending a message to an address.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/MessageResult
 type MessageResult struct {
@@ -13098,6 +16723,40 @@ func (s *MessageResult) SetStatusMessage(v string) *MessageResult {
 func (s *MessageResult) SetUpdatedToken(v string) *MessageResult {
 	s.UpdatedToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MessageResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeliveryStatus != nil {
+		v := *s.DeliveryStatus
+
+		e.SetValue(protocol.BodyTarget, "DeliveryStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusCode != nil {
+		v := *s.StatusCode
+
+		e.SetValue(protocol.BodyTarget, "StatusCode", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UpdatedToken != nil {
+		v := *s.UpdatedToken
+
+		e.SetValue(protocol.BodyTarget, "UpdatedToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMessageResultMap(vs map[string]*MessageResult) func(protocol.MapEncoder) {
+	return func(me protocol.MapEncoder) {
+		for k, v := range vs {
+			me.MapSetFields(k, v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/PutEventStreamRequest
@@ -13153,6 +16812,22 @@ func (s *PutEventStreamInput) SetWriteEventStream(v *WriteEventStream) *PutEvent
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteEventStream != nil {
+		v := s.WriteEventStream
+
+		e.SetFields(protocol.PayloadTarget, "WriteEventStream", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/PutEventStreamResponse
 type PutEventStreamOutput struct {
 	_ struct{} `type:"structure" payload:"EventStream"`
@@ -13177,6 +16852,17 @@ func (s PutEventStreamOutput) GoString() string {
 func (s *PutEventStreamOutput) SetEventStream(v *EventStream) *PutEventStreamOutput {
 	s.EventStream = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EventStream != nil {
+		v := s.EventStream
+
+		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Quiet Time
@@ -13211,6 +16897,22 @@ func (s *QuietTime) SetEnd(v string) *QuietTime {
 func (s *QuietTime) SetStart(v string) *QuietTime {
 	s.Start = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QuietTime) MarshalFields(e protocol.FieldEncoder) error {
+	if s.End != nil {
+		v := *s.End
+
+		e.SetValue(protocol.BodyTarget, "End", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Start != nil {
+		v := *s.Start
+
+		e.SetValue(protocol.BodyTarget, "Start", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Define how a segment based on recency of use.
@@ -13248,6 +16950,22 @@ func (s *RecencyDimension) SetDuration(v string) *RecencyDimension {
 func (s *RecencyDimension) SetRecencyType(v string) *RecencyDimension {
 	s.RecencyType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RecencyDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecencyType != nil {
+		v := *s.RecencyType
+
+		e.SetValue(protocol.BodyTarget, "RecencyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // SMS Channel Request
@@ -13291,6 +17009,27 @@ func (s *SMSChannelRequest) SetSenderId(v string) *SMSChannelRequest {
 func (s *SMSChannelRequest) SetShortCode(v string) *SMSChannelRequest {
 	s.ShortCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShortCode != nil {
+		v := *s.ShortCode
+
+		e.SetValue(protocol.BodyTarget, "ShortCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // SMS Channel Response.
@@ -13417,6 +17156,72 @@ func (s *SMSChannelResponse) SetVersion(v int64) *SMSChannelResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Enabled != nil {
+		v := *s.Enabled
+
+		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasCredential != nil {
+		v := *s.HasCredential
+
+		e.SetValue(protocol.BodyTarget, "HasCredential", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsArchived != nil {
+		v := *s.IsArchived
+
+		e.SetValue(protocol.BodyTarget, "IsArchived", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedBy != nil {
+		v := *s.LastModifiedBy
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedBy", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := *s.Platform
+
+		e.SetValue(protocol.BodyTarget, "Platform", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShortCode != nil {
+		v := *s.ShortCode
+
+		e.SetValue(protocol.BodyTarget, "ShortCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // SMS Message.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SMSMessage
 type SMSMessage struct {
@@ -13466,6 +17271,37 @@ func (s *SMSMessage) SetSenderId(v string) *SMSMessage {
 func (s *SMSMessage) SetSubstitutions(v map[string][]*string) *SMSMessage {
 	s.Substitutions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SMSMessage) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := *s.Body
+
+		e.SetValue(protocol.BodyTarget, "Body", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageType != nil {
+		v := *s.MessageType
+
+		e.SetValue(protocol.BodyTarget, "MessageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SenderId != nil {
+		v := *s.SenderId
+
+		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Substitutions) > 0 {
+		v := s.Substitutions
+
+		e.SetMap(protocol.BodyTarget, "Substitutions", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, protocol.EncodeStringList(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Shcedule that defines when a campaign is run.
@@ -13541,6 +17377,42 @@ func (s *Schedule) SetTimezone(v string) *Schedule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Schedule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Frequency != nil {
+		v := *s.Frequency
+
+		e.SetValue(protocol.BodyTarget, "Frequency", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsLocalTime != nil {
+		v := *s.IsLocalTime
+
+		e.SetValue(protocol.BodyTarget, "IsLocalTime", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Timezone != nil {
+		v := *s.Timezone
+
+		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment behavior dimensions
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SegmentBehaviors
 type SegmentBehaviors struct {
@@ -13564,6 +17436,17 @@ func (s SegmentBehaviors) GoString() string {
 func (s *SegmentBehaviors) SetRecency(v *RecencyDimension) *SegmentBehaviors {
 	s.Recency = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentBehaviors) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Recency != nil {
+		v := s.Recency
+
+		e.SetFields(protocol.BodyTarget, "Recency", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment demographic dimensions
@@ -13636,6 +17519,42 @@ func (s *SegmentDemographics) SetPlatform(v *SetDimension) *SegmentDemographics 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentDemographics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AppVersion != nil {
+		v := s.AppVersion
+
+		e.SetFields(protocol.BodyTarget, "AppVersion", v, protocol.Metadata{})
+	}
+	if s.Channel != nil {
+		v := s.Channel
+
+		e.SetFields(protocol.BodyTarget, "Channel", v, protocol.Metadata{})
+	}
+	if s.DeviceType != nil {
+		v := s.DeviceType
+
+		e.SetFields(protocol.BodyTarget, "DeviceType", v, protocol.Metadata{})
+	}
+	if s.Make != nil {
+		v := s.Make
+
+		e.SetFields(protocol.BodyTarget, "Make", v, protocol.Metadata{})
+	}
+	if s.Model != nil {
+		v := s.Model
+
+		e.SetFields(protocol.BodyTarget, "Model", v, protocol.Metadata{})
+	}
+	if s.Platform != nil {
+		v := s.Platform
+
+		e.SetFields(protocol.BodyTarget, "Platform", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment dimensions
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SegmentDimensions
 type SegmentDimensions struct {
@@ -13695,6 +17614,37 @@ func (s *SegmentDimensions) SetLocation(v *SegmentLocation) *SegmentDimensions {
 func (s *SegmentDimensions) SetUserAttributes(v map[string]*AttributeDimension) *SegmentDimensions {
 	s.UserAttributes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentDimensions) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Attributes) > 0 {
+		v := s.Attributes
+
+		e.SetMap(protocol.BodyTarget, "Attributes", encodeAttributeDimensionMap(v), protocol.Metadata{})
+	}
+	if s.Behavior != nil {
+		v := s.Behavior
+
+		e.SetFields(protocol.BodyTarget, "Behavior", v, protocol.Metadata{})
+	}
+	if s.Demographic != nil {
+		v := s.Demographic
+
+		e.SetFields(protocol.BodyTarget, "Demographic", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := s.Location
+
+		e.SetFields(protocol.BodyTarget, "Location", v, protocol.Metadata{})
+	}
+	if len(s.UserAttributes) > 0 {
+		v := s.UserAttributes
+
+		e.SetMap(protocol.BodyTarget, "UserAttributes", encodeAttributeDimensionMap(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment import definition.
@@ -13770,6 +17720,42 @@ func (s *SegmentImportResource) SetSize(v int64) *SegmentImportResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentImportResource) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ChannelCounts) > 0 {
+		v := s.ChannelCounts
+
+		e.SetMap(protocol.BodyTarget, "ChannelCounts", protocol.EncodeInt64Map(v), protocol.Metadata{})
+	}
+	if s.ExternalId != nil {
+		v := *s.ExternalId
+
+		e.SetValue(protocol.BodyTarget, "ExternalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.S3Url != nil {
+		v := *s.S3Url
+
+		e.SetValue(protocol.BodyTarget, "S3Url", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment location dimensions
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SegmentLocation
 type SegmentLocation struct {
@@ -13793,6 +17779,17 @@ func (s SegmentLocation) GoString() string {
 func (s *SegmentLocation) SetCountry(v *SetDimension) *SegmentLocation {
 	s.Country = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Country != nil {
+		v := s.Country
+
+		e.SetFields(protocol.BodyTarget, "Country", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Segment definition.
@@ -13898,6 +17895,65 @@ func (s *SegmentResponse) SetVersion(v int64) *SegmentResponse {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Dimensions != nil {
+		v := s.Dimensions
+
+		e.SetFields(protocol.BodyTarget, "Dimensions", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ImportDefinition != nil {
+		v := s.ImportDefinition
+
+		e.SetFields(protocol.BodyTarget, "ImportDefinition", v, protocol.Metadata{})
+	}
+	if s.LastModifiedDate != nil {
+		v := *s.LastModifiedDate
+
+		e.SetValue(protocol.BodyTarget, "LastModifiedDate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentType != nil {
+		v := *s.SegmentType
+
+		e.SetValue(protocol.BodyTarget, "SegmentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSegmentResponseList(vs []*SegmentResponse) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Segments in your account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SegmentsResponse
 type SegmentsResponse struct {
@@ -13931,6 +17987,22 @@ func (s *SegmentsResponse) SetItem(v []*SegmentResponse) *SegmentsResponse {
 func (s *SegmentsResponse) SetNextToken(v string) *SegmentsResponse {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SegmentsResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Item) > 0 {
+		v := s.Item
+
+		e.SetList(protocol.BodyTarget, "Item", encodeSegmentResponseList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendMessagesRequest
@@ -13984,6 +18056,22 @@ func (s *SendMessagesInput) SetMessageRequest(v *MessageRequest) *SendMessagesIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendMessagesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageRequest != nil {
+		v := s.MessageRequest
+
+		e.SetFields(protocol.PayloadTarget, "MessageRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendMessagesResponse
 type SendMessagesOutput struct {
 	_ struct{} `type:"structure" payload:"MessageResponse"`
@@ -14008,6 +18096,17 @@ func (s SendMessagesOutput) GoString() string {
 func (s *SendMessagesOutput) SetMessageResponse(v *MessageResponse) *SendMessagesOutput {
 	s.MessageResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendMessagesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageResponse != nil {
+		v := s.MessageResponse
+
+		e.SetFields(protocol.PayloadTarget, "MessageResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Send message request.
@@ -14053,6 +18152,27 @@ func (s *SendUsersMessageRequest) SetUsers(v map[string]*EndpointSendConfigurati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendUsersMessageRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Context) > 0 {
+		v := s.Context
+
+		e.SetMap(protocol.BodyTarget, "Context", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetMap(protocol.BodyTarget, "Users", encodeEndpointSendConfigurationMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // User send message response.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendUsersMessageResponse
 type SendUsersMessageResponse struct {
@@ -14094,6 +18214,32 @@ func (s *SendUsersMessageResponse) SetRequestId(v string) *SendUsersMessageRespo
 func (s *SendUsersMessageResponse) SetResult(v map[string]map[string]*EndpointMessageResult) *SendUsersMessageResponse {
 	s.Result = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendUsersMessageResponse) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.BodyTarget, "ApplicationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestId != nil {
+		v := *s.RequestId
+
+		e.SetValue(protocol.BodyTarget, "RequestId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Result) > 0 {
+		v := s.Result
+
+		e.SetMap(protocol.BodyTarget, "Result", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetMap(k, encodeEndpointMessageResultMap(v))
+			}
+		}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendUsersMessagesRequest
@@ -14147,6 +18293,22 @@ func (s *SendUsersMessagesInput) SetSendUsersMessageRequest(v *SendUsersMessageR
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendUsersMessagesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SendUsersMessageRequest != nil {
+		v := s.SendUsersMessageRequest
+
+		e.SetFields(protocol.PayloadTarget, "SendUsersMessageRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendUsersMessagesResponse
 type SendUsersMessagesOutput struct {
 	_ struct{} `type:"structure" payload:"SendUsersMessageResponse"`
@@ -14171,6 +18333,17 @@ func (s SendUsersMessagesOutput) GoString() string {
 func (s *SendUsersMessagesOutput) SetSendUsersMessageResponse(v *SendUsersMessageResponse) *SendUsersMessagesOutput {
 	s.SendUsersMessageResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SendUsersMessagesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SendUsersMessageResponse != nil {
+		v := s.SendUsersMessageResponse
+
+		e.SetFields(protocol.PayloadTarget, "SendUsersMessageResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Dimension specification of a segment.
@@ -14206,6 +18379,22 @@ func (s *SetDimension) SetDimensionType(v string) *SetDimension {
 func (s *SetDimension) SetValues(v []*string) *SetDimension {
 	s.Values = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SetDimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DimensionType != nil {
+		v := *s.DimensionType
+
+		e.SetValue(protocol.BodyTarget, "DimensionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Values) > 0 {
+		v := s.Values
+
+		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Treatment resource
@@ -14287,6 +18476,55 @@ func (s *TreatmentResource) SetTreatmentName(v string) *TreatmentResource {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SizePercent != nil {
+		v := *s.SizePercent
+
+		e.SetValue(protocol.BodyTarget, "SizePercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := s.State
+
+		e.SetFields(protocol.BodyTarget, "State", v, protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTreatmentResourceList(vs []*TreatmentResource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateAdmChannelRequest
 type UpdateAdmChannelInput struct {
 	_ struct{} `type:"structure" payload:"ADMChannelRequest"`
@@ -14338,6 +18576,22 @@ func (s *UpdateAdmChannelInput) SetApplicationId(v string) *UpdateAdmChannelInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMChannelRequest != nil {
+		v := s.ADMChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "ADMChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateAdmChannelResponse
 type UpdateAdmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"ADMChannelResponse"`
@@ -14362,6 +18616,17 @@ func (s UpdateAdmChannelOutput) GoString() string {
 func (s *UpdateAdmChannelOutput) SetADMChannelResponse(v *ADMChannelResponse) *UpdateAdmChannelOutput {
 	s.ADMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ADMChannelResponse != nil {
+		v := s.ADMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsChannelRequest
@@ -14415,6 +18680,22 @@ func (s *UpdateApnsChannelInput) SetApplicationId(v string) *UpdateApnsChannelIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelRequest != nil {
+		v := s.APNSChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsChannelResponse
 type UpdateApnsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSChannelResponse"`
@@ -14439,6 +18720,17 @@ func (s UpdateApnsChannelOutput) GoString() string {
 func (s *UpdateApnsChannelOutput) SetAPNSChannelResponse(v *APNSChannelResponse) *UpdateApnsChannelOutput {
 	s.APNSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSChannelResponse != nil {
+		v := s.APNSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsSandboxChannelRequest
@@ -14492,6 +18784,22 @@ func (s *UpdateApnsSandboxChannelInput) SetApplicationId(v string) *UpdateApnsSa
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelRequest != nil {
+		v := s.APNSSandboxChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsSandboxChannelResponse
 type UpdateApnsSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSSandboxChannelResponse"`
@@ -14516,6 +18824,17 @@ func (s UpdateApnsSandboxChannelOutput) GoString() string {
 func (s *UpdateApnsSandboxChannelOutput) SetAPNSSandboxChannelResponse(v *APNSSandboxChannelResponse) *UpdateApnsSandboxChannelOutput {
 	s.APNSSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSSandboxChannelResponse != nil {
+		v := s.APNSSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipChannelRequest
@@ -14569,6 +18888,22 @@ func (s *UpdateApnsVoipChannelInput) SetApplicationId(v string) *UpdateApnsVoipC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipChannelRequest != nil {
+		v := s.APNSVoipChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipChannelResponse
 type UpdateApnsVoipChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipChannelResponse"`
@@ -14593,6 +18928,17 @@ func (s UpdateApnsVoipChannelOutput) GoString() string {
 func (s *UpdateApnsVoipChannelOutput) SetAPNSVoipChannelResponse(v *APNSVoipChannelResponse) *UpdateApnsVoipChannelOutput {
 	s.APNSVoipChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipChannelResponse != nil {
+		v := s.APNSVoipChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipSandboxChannelRequest
@@ -14646,6 +18992,22 @@ func (s *UpdateApnsVoipSandboxChannelInput) SetApplicationId(v string) *UpdateAp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipSandboxChannelRequest != nil {
+		v := s.APNSVoipSandboxChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelRequest", v, protocol.Metadata{})
+	}
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipSandboxChannelResponse
 type UpdateApnsVoipSandboxChannelOutput struct {
 	_ struct{} `type:"structure" payload:"APNSVoipSandboxChannelResponse"`
@@ -14670,6 +19032,17 @@ func (s UpdateApnsVoipSandboxChannelOutput) GoString() string {
 func (s *UpdateApnsVoipSandboxChannelOutput) SetAPNSVoipSandboxChannelResponse(v *APNSVoipSandboxChannelResponse) *UpdateApnsVoipSandboxChannelOutput {
 	s.APNSVoipSandboxChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.APNSVoipSandboxChannelResponse != nil {
+		v := s.APNSVoipSandboxChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApplicationSettingsRequest
@@ -14723,6 +19096,22 @@ func (s *UpdateApplicationSettingsInput) SetWriteApplicationSettingsRequest(v *W
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteApplicationSettingsRequest != nil {
+		v := s.WriteApplicationSettingsRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteApplicationSettingsRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApplicationSettingsResponse
 type UpdateApplicationSettingsOutput struct {
 	_ struct{} `type:"structure" payload:"ApplicationSettingsResource"`
@@ -14747,6 +19136,17 @@ func (s UpdateApplicationSettingsOutput) GoString() string {
 func (s *UpdateApplicationSettingsOutput) SetApplicationSettingsResource(v *ApplicationSettingsResource) *UpdateApplicationSettingsOutput {
 	s.ApplicationSettingsResource = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationSettingsResource != nil {
+		v := s.ApplicationSettingsResource
+
+		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateBaiduChannelRequest
@@ -14800,6 +19200,22 @@ func (s *UpdateBaiduChannelInput) SetBaiduChannelRequest(v *BaiduChannelRequest)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BaiduChannelRequest != nil {
+		v := s.BaiduChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "BaiduChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateBaiduChannelResponse
 type UpdateBaiduChannelOutput struct {
 	_ struct{} `type:"structure" payload:"BaiduChannelResponse"`
@@ -14824,6 +19240,17 @@ func (s UpdateBaiduChannelOutput) GoString() string {
 func (s *UpdateBaiduChannelOutput) SetBaiduChannelResponse(v *BaiduChannelResponse) *UpdateBaiduChannelOutput {
 	s.BaiduChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BaiduChannelResponse != nil {
+		v := s.BaiduChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateCampaignRequest
@@ -14889,6 +19316,27 @@ func (s *UpdateCampaignInput) SetWriteCampaignRequest(v *WriteCampaignRequest) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CampaignId != nil {
+		v := *s.CampaignId
+
+		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteCampaignRequest != nil {
+		v := s.WriteCampaignRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateCampaignResponse
 type UpdateCampaignOutput struct {
 	_ struct{} `type:"structure" payload:"CampaignResponse"`
@@ -14913,6 +19361,17 @@ func (s UpdateCampaignOutput) GoString() string {
 func (s *UpdateCampaignOutput) SetCampaignResponse(v *CampaignResponse) *UpdateCampaignOutput {
 	s.CampaignResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CampaignResponse != nil {
+		v := s.CampaignResponse
+
+		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEmailChannelRequest
@@ -14966,6 +19425,22 @@ func (s *UpdateEmailChannelInput) SetEmailChannelRequest(v *EmailChannelRequest)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailChannelRequest != nil {
+		v := s.EmailChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEmailChannelResponse
 type UpdateEmailChannelOutput struct {
 	_ struct{} `type:"structure" payload:"EmailChannelResponse"`
@@ -14990,6 +19465,17 @@ func (s UpdateEmailChannelOutput) GoString() string {
 func (s *UpdateEmailChannelOutput) SetEmailChannelResponse(v *EmailChannelResponse) *UpdateEmailChannelOutput {
 	s.EmailChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailChannelResponse != nil {
+		v := s.EmailChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpointRequest
@@ -15055,6 +19541,27 @@ func (s *UpdateEndpointInput) SetEndpointRequest(v *EndpointRequest) *UpdateEndp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointId != nil {
+		v := *s.EndpointId
+
+		e.SetValue(protocol.PathTarget, "endpoint-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointRequest != nil {
+		v := s.EndpointRequest
+
+		e.SetFields(protocol.PayloadTarget, "EndpointRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpointResponse
 type UpdateEndpointOutput struct {
 	_ struct{} `type:"structure" payload:"MessageBody"`
@@ -15079,6 +19586,17 @@ func (s UpdateEndpointOutput) GoString() string {
 func (s *UpdateEndpointOutput) SetMessageBody(v *MessageBody) *UpdateEndpointOutput {
 	s.MessageBody = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageBody != nil {
+		v := s.MessageBody
+
+		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpointsBatchRequest
@@ -15132,6 +19650,22 @@ func (s *UpdateEndpointsBatchInput) SetEndpointBatchRequest(v *EndpointBatchRequ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointsBatchInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndpointBatchRequest != nil {
+		v := s.EndpointBatchRequest
+
+		e.SetFields(protocol.PayloadTarget, "EndpointBatchRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpointsBatchResponse
 type UpdateEndpointsBatchOutput struct {
 	_ struct{} `type:"structure" payload:"MessageBody"`
@@ -15156,6 +19690,17 @@ func (s UpdateEndpointsBatchOutput) GoString() string {
 func (s *UpdateEndpointsBatchOutput) SetMessageBody(v *MessageBody) *UpdateEndpointsBatchOutput {
 	s.MessageBody = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateEndpointsBatchOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageBody != nil {
+		v := s.MessageBody
+
+		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateGcmChannelRequest
@@ -15209,6 +19754,22 @@ func (s *UpdateGcmChannelInput) SetGCMChannelRequest(v *GCMChannelRequest) *Upda
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GCMChannelRequest != nil {
+		v := s.GCMChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateGcmChannelResponse
 type UpdateGcmChannelOutput struct {
 	_ struct{} `type:"structure" payload:"GCMChannelResponse"`
@@ -15233,6 +19794,17 @@ func (s UpdateGcmChannelOutput) GoString() string {
 func (s *UpdateGcmChannelOutput) SetGCMChannelResponse(v *GCMChannelResponse) *UpdateGcmChannelOutput {
 	s.GCMChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GCMChannelResponse != nil {
+		v := s.GCMChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSegmentRequest
@@ -15298,6 +19870,27 @@ func (s *UpdateSegmentInput) SetWriteSegmentRequest(v *WriteSegmentRequest) *Upd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WriteSegmentRequest != nil {
+		v := s.WriteSegmentRequest
+
+		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSegmentResponse
 type UpdateSegmentOutput struct {
 	_ struct{} `type:"structure" payload:"SegmentResponse"`
@@ -15322,6 +19915,17 @@ func (s UpdateSegmentOutput) GoString() string {
 func (s *UpdateSegmentOutput) SetSegmentResponse(v *SegmentResponse) *UpdateSegmentOutput {
 	s.SegmentResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SegmentResponse != nil {
+		v := s.SegmentResponse
+
+		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSmsChannelRequest
@@ -15375,6 +19979,22 @@ func (s *UpdateSmsChannelInput) SetSMSChannelRequest(v *SMSChannelRequest) *Upda
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplicationId != nil {
+		v := *s.ApplicationId
+
+		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SMSChannelRequest != nil {
+		v := s.SMSChannelRequest
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelRequest", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSmsChannelResponse
 type UpdateSmsChannelOutput struct {
 	_ struct{} `type:"structure" payload:"SMSChannelResponse"`
@@ -15399,6 +20019,17 @@ func (s UpdateSmsChannelOutput) GoString() string {
 func (s *UpdateSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *UpdateSmsChannelOutput {
 	s.SMSChannelResponse = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SMSChannelResponse != nil {
+		v := s.SMSChannelResponse
+
+		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Creating application setting request
@@ -15437,6 +20068,22 @@ func (s *WriteApplicationSettingsRequest) SetLimits(v *CampaignLimits) *WriteApp
 func (s *WriteApplicationSettingsRequest) SetQuietTime(v *QuietTime) *WriteApplicationSettingsRequest {
 	s.QuietTime = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteApplicationSettingsRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.QuietTime != nil {
+		v := s.QuietTime
+
+		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Used to create a campaign.
@@ -15565,6 +20212,72 @@ func (s *WriteCampaignRequest) SetTreatmentName(v string) *WriteCampaignRequest 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteCampaignRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AdditionalTreatments) > 0 {
+		v := s.AdditionalTreatments
+
+		e.SetList(protocol.BodyTarget, "AdditionalTreatments", encodeWriteTreatmentResourceList(v), protocol.Metadata{})
+	}
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HoldoutPercent != nil {
+		v := *s.HoldoutPercent
+
+		e.SetValue(protocol.BodyTarget, "HoldoutPercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IsPaused != nil {
+		v := *s.IsPaused
+
+		e.SetValue(protocol.BodyTarget, "IsPaused", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Limits != nil {
+		v := s.Limits
+
+		e.SetFields(protocol.BodyTarget, "Limits", v, protocol.Metadata{})
+	}
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SegmentId != nil {
+		v := *s.SegmentId
+
+		e.SetValue(protocol.BodyTarget, "SegmentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SegmentVersion != nil {
+		v := *s.SegmentVersion
+
+		e.SetValue(protocol.BodyTarget, "SegmentVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to save an EventStream.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/WriteEventStream
 type WriteEventStream struct {
@@ -15602,6 +20315,22 @@ func (s *WriteEventStream) SetRoleArn(v string) *WriteEventStream {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteEventStream) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DestinationStreamArn != nil {
+		v := *s.DestinationStreamArn
+
+		e.SetValue(protocol.BodyTarget, "DestinationStreamArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RoleArn != nil {
+		v := *s.RoleArn
+
+		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Segment definition.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/WriteSegmentRequest
 type WriteSegmentRequest struct {
@@ -15634,6 +20363,22 @@ func (s *WriteSegmentRequest) SetDimensions(v *SegmentDimensions) *WriteSegmentR
 func (s *WriteSegmentRequest) SetName(v string) *WriteSegmentRequest {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteSegmentRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Dimensions != nil {
+		v := s.Dimensions
+
+		e.SetFields(protocol.BodyTarget, "Dimensions", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Used to create a campaign treatment.
@@ -15695,6 +20440,45 @@ func (s *WriteTreatmentResource) SetTreatmentDescription(v string) *WriteTreatme
 func (s *WriteTreatmentResource) SetTreatmentName(v string) *WriteTreatmentResource {
 	s.TreatmentName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WriteTreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MessageConfiguration != nil {
+		v := s.MessageConfiguration
+
+		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+	if s.SizePercent != nil {
+		v := *s.SizePercent
+
+		e.SetValue(protocol.BodyTarget, "SizePercent", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TreatmentDescription != nil {
+		v := *s.TreatmentDescription
+
+		e.SetValue(protocol.BodyTarget, "TreatmentDescription", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TreatmentName != nil {
+		v := *s.TreatmentName
+
+		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeWriteTreatmentResourceList(vs []*WriteTreatmentResource) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -5349,7 +5349,6 @@ func (s *ADMChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5511,7 +5510,6 @@ func (s *ADMChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5778,7 +5776,6 @@ func (s *ADMMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5912,7 +5909,6 @@ func (s *APNSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6102,7 +6098,6 @@ func (s *APNSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6389,7 +6384,6 @@ func (s *APNSMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6523,7 +6517,6 @@ func (s *APNSSandboxChannelRequest) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6713,7 +6706,6 @@ func (s *APNSSandboxChannelResponse) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6847,7 +6839,6 @@ func (s *APNSVoipChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7037,7 +7028,6 @@ func (s *APNSVoipChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7171,7 +7161,6 @@ func (s *APNSVoipSandboxChannelRequest) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "TokenKeyId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7361,7 +7350,6 @@ func (s *APNSVoipSandboxChannelResponse) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7397,7 +7385,6 @@ func (s *ActivitiesResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Item", encodeActivityResponseList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7604,7 +7591,6 @@ func (s *ActivityResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TreatmentId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7722,7 +7708,6 @@ func (s *AddressConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TitleOverride", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7780,7 +7765,6 @@ func (s *ApplicationResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7870,7 +7854,6 @@ func (s *ApplicationSettingsResource) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7921,7 +7904,6 @@ func (s *ApplicationsResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7972,7 +7954,6 @@ func (s *AttributeDimension) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8044,7 +8025,6 @@ func (s *BaiduChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SecretKey", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8220,7 +8200,6 @@ func (s *BaiduChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8441,7 +8420,6 @@ func (s *BaiduMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8520,7 +8498,6 @@ func (s *CampaignEmailMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Title", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8601,7 +8578,6 @@ func (s *CampaignLimits) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Total", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8893,7 +8869,6 @@ func (s *CampaignResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8965,7 +8940,6 @@ func (s *CampaignSmsMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SenderId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9003,7 +8977,6 @@ func (s *CampaignState) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "CampaignStatus", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9054,7 +9027,6 @@ func (s *CampaignsResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9104,7 +9076,6 @@ func (s *CreateAppInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CreateApplicationRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9141,7 +9112,6 @@ func (s *CreateAppOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9177,7 +9147,6 @@ func (s *CreateApplicationRequest) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9244,7 +9213,6 @@ func (s *CreateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9281,7 +9249,6 @@ func (s *CreateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9346,7 +9313,6 @@ func (s *CreateImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ImportJobRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9381,7 +9347,6 @@ func (s *CreateImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9448,7 +9413,6 @@ func (s *CreateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9485,7 +9449,6 @@ func (s *CreateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9539,7 +9502,6 @@ func (s *DefaultMessage) MarshalFields(e protocol.FieldEncoder) error {
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9670,7 +9632,6 @@ func (s *DefaultPushNotificationMessage) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9718,7 +9679,6 @@ func (s *DeleteAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9755,7 +9715,6 @@ func (s *DeleteAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9803,7 +9762,6 @@ func (s *DeleteApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9840,7 +9798,6 @@ func (s *DeleteApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9888,7 +9845,6 @@ func (s *DeleteApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9925,7 +9881,6 @@ func (s *DeleteApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9973,7 +9928,6 @@ func (s *DeleteApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10010,7 +9964,6 @@ func (s *DeleteApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10058,7 +10011,6 @@ func (s *DeleteApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10095,7 +10047,6 @@ func (s *DeleteApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10143,7 +10094,6 @@ func (s *DeleteAppInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10180,7 +10130,6 @@ func (s *DeleteAppOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10228,7 +10177,6 @@ func (s *DeleteBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10265,7 +10213,6 @@ func (s *DeleteBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10330,7 +10277,6 @@ func (s *DeleteCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10367,7 +10313,6 @@ func (s *DeleteCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10415,7 +10360,6 @@ func (s *DeleteEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10452,7 +10396,6 @@ func (s *DeleteEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10502,7 +10445,6 @@ func (s *DeleteEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10539,7 +10481,6 @@ func (s *DeleteEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10587,7 +10528,6 @@ func (s *DeleteGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10624,7 +10564,6 @@ func (s *DeleteGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10689,7 +10628,6 @@ func (s *DeleteSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10726,7 +10664,6 @@ func (s *DeleteSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10774,7 +10711,6 @@ func (s *DeleteSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10811,7 +10747,6 @@ func (s *DeleteSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10932,7 +10867,6 @@ func (s *DirectMessageConfiguration) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11011,7 +10945,6 @@ func (s *EmailChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11216,7 +11149,6 @@ func (s *EmailChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11413,7 +11345,6 @@ func (s *EndpointBatchItem) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11457,7 +11388,6 @@ func (s *EndpointBatchRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Item", encodeEndpointBatchItemList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11592,7 +11522,6 @@ func (s *EndpointDemographic) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11701,7 +11630,6 @@ func (s *EndpointLocation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11793,7 +11721,6 @@ func (s *EndpointMessageResult) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UpdatedToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11984,7 +11911,6 @@ func (s *EndpointRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12228,7 +12154,6 @@ func (s *EndpointResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12324,7 +12249,6 @@ func (s *EndpointSendConfiguration) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "TitleOverride", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12386,7 +12310,6 @@ func (s *EndpointUser) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12496,7 +12419,6 @@ func (s *EventStream) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12546,7 +12468,6 @@ func (s *GCMChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Enabled", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12722,7 +12643,6 @@ func (s *GCMChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13005,7 +12925,6 @@ func (s *GCMMessage) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13053,7 +12972,6 @@ func (s *GetAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13090,7 +13008,6 @@ func (s *GetAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13138,7 +13055,6 @@ func (s *GetApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13175,7 +13091,6 @@ func (s *GetApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13223,7 +13138,6 @@ func (s *GetApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13260,7 +13174,6 @@ func (s *GetApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13308,7 +13221,6 @@ func (s *GetApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13345,7 +13257,6 @@ func (s *GetApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13393,7 +13304,6 @@ func (s *GetApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13430,7 +13340,6 @@ func (s *GetApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13478,7 +13387,6 @@ func (s *GetAppInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13515,7 +13423,6 @@ func (s *GetAppOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13563,7 +13470,6 @@ func (s *GetApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13600,7 +13506,6 @@ func (s *GetApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13647,7 +13552,6 @@ func (s *GetAppsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13684,7 +13588,6 @@ func (s *GetAppsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13732,7 +13635,6 @@ func (s *GetBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13769,7 +13671,6 @@ func (s *GetBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13860,7 +13761,6 @@ func (s *GetCampaignActivitiesInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13897,7 +13797,6 @@ func (s *GetCampaignActivitiesOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.PayloadTarget, "ActivitiesResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13962,7 +13861,6 @@ func (s *GetCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "campaign-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13999,7 +13897,6 @@ func (s *GetCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14081,7 +13978,6 @@ func (s *GetCampaignVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14118,7 +14014,6 @@ func (s *GetCampaignVersionOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14209,7 +14104,6 @@ func (s *GetCampaignVersionsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14246,7 +14140,6 @@ func (s *GetCampaignVersionsOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14320,7 +14213,6 @@ func (s *GetCampaignsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14357,7 +14249,6 @@ func (s *GetCampaignsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CampaignsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14405,7 +14296,6 @@ func (s *GetEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14442,7 +14332,6 @@ func (s *GetEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14507,7 +14396,6 @@ func (s *GetEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "endpoint-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14544,7 +14432,6 @@ func (s *GetEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EndpointResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14594,7 +14481,6 @@ func (s *GetEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14631,7 +14517,6 @@ func (s *GetEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14679,7 +14564,6 @@ func (s *GetGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14716,7 +14600,6 @@ func (s *GetGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14781,7 +14664,6 @@ func (s *GetImportJobInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "job-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14816,7 +14698,6 @@ func (s *GetImportJobOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ImportJobResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14890,7 +14771,6 @@ func (s *GetImportJobsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14927,7 +14807,6 @@ func (s *GetImportJobsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15003,22 +14882,21 @@ func (s *GetSegmentImportJobsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PageSize != nil {
-		v := *s.PageSize
-
-		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.SegmentId != nil {
 		v := *s.SegmentId
 
 		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Token != nil {
 		v := *s.Token
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15055,7 +14933,6 @@ func (s *GetSegmentImportJobsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "ImportJobsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15120,7 +14997,6 @@ func (s *GetSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15157,7 +15033,6 @@ func (s *GetSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15239,7 +15114,6 @@ func (s *GetSegmentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "version", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15276,7 +15150,6 @@ func (s *GetSegmentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15352,22 +15225,21 @@ func (s *GetSegmentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PageSize != nil {
-		v := *s.PageSize
-
-		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.SegmentId != nil {
 		v := *s.SegmentId
 
 		e.SetValue(protocol.PathTarget, "segment-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PageSize != nil {
+		v := *s.PageSize
+
+		e.SetValue(protocol.QueryTarget, "page-size", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Token != nil {
 		v := *s.Token
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15404,7 +15276,6 @@ func (s *GetSegmentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15478,7 +15349,6 @@ func (s *GetSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15515,7 +15385,6 @@ func (s *GetSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentsResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15563,7 +15432,6 @@ func (s *GetSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15600,7 +15468,6 @@ func (s *GetSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15742,7 +15609,6 @@ func (s *ImportJobRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15884,7 +15750,6 @@ func (s *ImportJobResource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SegmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16091,7 +15956,6 @@ func (s *ImportJobResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16150,7 +16014,6 @@ func (s *ImportJobsResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16335,7 +16198,6 @@ func (s *Message) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Url", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16385,7 +16247,6 @@ func (s *MessageBody) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RequestID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16509,7 +16370,6 @@ func (s *MessageConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SMSMessage", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16588,7 +16448,6 @@ func (s *MessageRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "MessageConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16669,7 +16528,6 @@ func (s *MessageResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Result", encodeMessageResultMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16747,7 +16605,6 @@ func (s *MessageResult) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UpdatedToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16824,7 +16681,6 @@ func (s *PutEventStreamInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WriteEventStream", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16861,7 +16717,6 @@ func (s *PutEventStreamOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EventStream", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16911,7 +16766,6 @@ func (s *QuietTime) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Start", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16964,7 +16818,6 @@ func (s *RecencyDimension) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RecencyType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17028,7 +16881,6 @@ func (s *SMSChannelRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ShortCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17218,7 +17070,6 @@ func (s *SMSChannelResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17300,7 +17151,6 @@ func (s *SMSMessage) MarshalFields(e protocol.FieldEncoder) error {
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17409,7 +17259,6 @@ func (s *Schedule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Timezone", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17445,7 +17294,6 @@ func (s *SegmentBehaviors) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Recency", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17551,7 +17399,6 @@ func (s *SegmentDemographics) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Platform", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17643,7 +17490,6 @@ func (s *SegmentDimensions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "UserAttributes", encodeAttributeDimensionMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17752,7 +17598,6 @@ func (s *SegmentImportResource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17788,7 +17633,6 @@ func (s *SegmentLocation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Country", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17942,7 +17786,6 @@ func (s *SegmentResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18001,7 +17844,6 @@ func (s *SegmentsResponse) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18068,7 +17910,6 @@ func (s *SendMessagesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "MessageRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18105,7 +17946,6 @@ func (s *SendMessagesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "MessageResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18169,7 +18009,6 @@ func (s *SendUsersMessageRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Users", encodeEndpointSendConfigurationMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18238,7 +18077,6 @@ func (s *SendUsersMessageResponse) MarshalFields(e protocol.FieldEncoder) error 
 			}
 		}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18305,7 +18143,6 @@ func (s *SendUsersMessagesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SendUsersMessageRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18342,7 +18179,6 @@ func (s *SendUsersMessagesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SendUsersMessageResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18393,7 +18229,6 @@ func (s *SetDimension) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Values", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18513,7 +18348,6 @@ func (s *TreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18578,17 +18412,16 @@ func (s *UpdateAdmChannelInput) SetApplicationId(v string) *UpdateAdmChannelInpu
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateAdmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ADMChannelRequest != nil {
-		v := s.ADMChannelRequest
-
-		e.SetFields(protocol.PayloadTarget, "ADMChannelRequest", v, protocol.Metadata{})
-	}
 	if s.ApplicationId != nil {
 		v := *s.ApplicationId
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ADMChannelRequest != nil {
+		v := s.ADMChannelRequest
 
+		e.SetFields(protocol.PayloadTarget, "ADMChannelRequest", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18625,7 +18458,6 @@ func (s *UpdateAdmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "ADMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18682,17 +18514,16 @@ func (s *UpdateApnsChannelInput) SetApplicationId(v string) *UpdateApnsChannelIn
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateApnsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.APNSChannelRequest != nil {
-		v := s.APNSChannelRequest
-
-		e.SetFields(protocol.PayloadTarget, "APNSChannelRequest", v, protocol.Metadata{})
-	}
 	if s.ApplicationId != nil {
 		v := *s.ApplicationId
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.APNSChannelRequest != nil {
+		v := s.APNSChannelRequest
 
+		e.SetFields(protocol.PayloadTarget, "APNSChannelRequest", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18729,7 +18560,6 @@ func (s *UpdateApnsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "APNSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18786,17 +18616,16 @@ func (s *UpdateApnsSandboxChannelInput) SetApplicationId(v string) *UpdateApnsSa
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateApnsSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.APNSSandboxChannelRequest != nil {
-		v := s.APNSSandboxChannelRequest
-
-		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelRequest", v, protocol.Metadata{})
-	}
 	if s.ApplicationId != nil {
 		v := *s.ApplicationId
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.APNSSandboxChannelRequest != nil {
+		v := s.APNSSandboxChannelRequest
 
+		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelRequest", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18833,7 +18662,6 @@ func (s *UpdateApnsSandboxChannelOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.PayloadTarget, "APNSSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18890,17 +18718,16 @@ func (s *UpdateApnsVoipChannelInput) SetApplicationId(v string) *UpdateApnsVoipC
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateApnsVoipChannelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.APNSVoipChannelRequest != nil {
-		v := s.APNSVoipChannelRequest
-
-		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelRequest", v, protocol.Metadata{})
-	}
 	if s.ApplicationId != nil {
 		v := *s.ApplicationId
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.APNSVoipChannelRequest != nil {
+		v := s.APNSVoipChannelRequest
 
+		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelRequest", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18937,7 +18764,6 @@ func (s *UpdateApnsVoipChannelOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18994,17 +18820,16 @@ func (s *UpdateApnsVoipSandboxChannelInput) SetApplicationId(v string) *UpdateAp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateApnsVoipSandboxChannelInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.APNSVoipSandboxChannelRequest != nil {
-		v := s.APNSVoipSandboxChannelRequest
-
-		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelRequest", v, protocol.Metadata{})
-	}
 	if s.ApplicationId != nil {
 		v := *s.ApplicationId
 
 		e.SetValue(protocol.PathTarget, "application-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.APNSVoipSandboxChannelRequest != nil {
+		v := s.APNSVoipSandboxChannelRequest
 
+		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelRequest", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -19041,7 +18866,6 @@ func (s *UpdateApnsVoipSandboxChannelOutput) MarshalFields(e protocol.FieldEncod
 
 		e.SetFields(protocol.PayloadTarget, "APNSVoipSandboxChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19108,7 +18932,6 @@ func (s *UpdateApplicationSettingsInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.PayloadTarget, "WriteApplicationSettingsRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19145,7 +18968,6 @@ func (s *UpdateApplicationSettingsOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.PayloadTarget, "ApplicationSettingsResource", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19212,7 +19034,6 @@ func (s *UpdateBaiduChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "BaiduChannelRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19249,7 +19070,6 @@ func (s *UpdateBaiduChannelOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "BaiduChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19333,7 +19153,6 @@ func (s *UpdateCampaignInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WriteCampaignRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19370,7 +19189,6 @@ func (s *UpdateCampaignOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CampaignResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19437,7 +19255,6 @@ func (s *UpdateEmailChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EmailChannelRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19474,7 +19291,6 @@ func (s *UpdateEmailChannelOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "EmailChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19558,7 +19374,6 @@ func (s *UpdateEndpointInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "EndpointRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19595,7 +19410,6 @@ func (s *UpdateEndpointOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19662,7 +19476,6 @@ func (s *UpdateEndpointsBatchInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.PayloadTarget, "EndpointBatchRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19699,7 +19512,6 @@ func (s *UpdateEndpointsBatchOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "MessageBody", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19766,7 +19578,6 @@ func (s *UpdateGcmChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "GCMChannelRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19803,7 +19614,6 @@ func (s *UpdateGcmChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "GCMChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19887,7 +19697,6 @@ func (s *UpdateSegmentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WriteSegmentRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19924,7 +19733,6 @@ func (s *UpdateSegmentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SegmentResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19991,7 +19799,6 @@ func (s *UpdateSmsChannelInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SMSChannelRequest", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20028,7 +19835,6 @@ func (s *UpdateSmsChannelOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "SMSChannelResponse", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20082,7 +19888,6 @@ func (s *WriteApplicationSettingsRequest) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.BodyTarget, "QuietTime", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20274,7 +20079,6 @@ func (s *WriteCampaignRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20327,7 +20131,6 @@ func (s *WriteEventStream) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RoleArn", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20377,7 +20180,6 @@ func (s *WriteSegmentRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20469,7 +20271,6 @@ func (s *WriteTreatmentResource) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TreatmentName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opDeleteLexicon = "DeleteLexicon"
@@ -627,6 +628,17 @@ func (s *DeleteLexiconInput) SetName(v string) *DeleteLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DeleteLexiconOutput
 type DeleteLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -640,6 +652,12 @@ func (s DeleteLexiconOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLexiconOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DescribeVoicesInput
@@ -678,6 +696,22 @@ func (s *DescribeVoicesInput) SetNextToken(v string) *DescribeVoicesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVoicesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.QueryTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/DescribeVoicesOutput
 type DescribeVoicesOutput struct {
 	_ struct{} `type:"structure"`
@@ -710,6 +744,22 @@ func (s *DescribeVoicesOutput) SetNextToken(v string) *DescribeVoicesOutput {
 func (s *DescribeVoicesOutput) SetVoices(v []*Voice) *DescribeVoicesOutput {
 	s.Voices = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeVoicesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Voices) > 0 {
+		v := s.Voices
+
+		e.SetList(protocol.BodyTarget, "Voices", encodeVoiceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/GetLexiconInput
@@ -751,6 +801,17 @@ func (s *GetLexiconInput) SetName(v string) *GetLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/GetLexiconOutput
 type GetLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -784,6 +845,22 @@ func (s *GetLexiconOutput) SetLexicon(v *Lexicon) *GetLexiconOutput {
 func (s *GetLexiconOutput) SetLexiconAttributes(v *LexiconAttributes) *GetLexiconOutput {
 	s.LexiconAttributes = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Lexicon != nil {
+		v := s.Lexicon
+
+		e.SetFields(protocol.BodyTarget, "Lexicon", v, protocol.Metadata{})
+	}
+	if s.LexiconAttributes != nil {
+		v := s.LexiconAttributes
+
+		e.SetFields(protocol.BodyTarget, "LexiconAttributes", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Provides lexicon name and lexicon content in string format. For more information,
@@ -820,6 +897,22 @@ func (s *Lexicon) SetContent(v string) *Lexicon {
 func (s *Lexicon) SetName(v string) *Lexicon {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Lexicon) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "Content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains metadata describing the lexicon such as the number of lexemes, language
@@ -895,6 +988,42 @@ func (s *LexiconAttributes) SetSize(v int64) *LexiconAttributes {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LexiconAttributes) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Alphabet != nil {
+		v := *s.Alphabet
+
+		e.SetValue(protocol.BodyTarget, "Alphabet", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.LexemesCount != nil {
+		v := *s.LexemesCount
+
+		e.SetValue(protocol.BodyTarget, "LexemesCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.LexiconArn != nil {
+		v := *s.LexiconArn
+
+		e.SetValue(protocol.BodyTarget, "LexiconArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the content of the lexicon.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/LexiconDescription
 type LexiconDescription struct {
@@ -929,6 +1058,30 @@ func (s *LexiconDescription) SetName(v string) *LexiconDescription {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LexiconDescription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Attributes != nil {
+		v := s.Attributes
+
+		e.SetFields(protocol.BodyTarget, "Attributes", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLexiconDescriptionList(vs []*LexiconDescription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/ListLexiconsInput
 type ListLexiconsInput struct {
 	_ struct{} `type:"structure"`
@@ -952,6 +1105,17 @@ func (s ListLexiconsInput) GoString() string {
 func (s *ListLexiconsInput) SetNextToken(v string) *ListLexiconsInput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLexiconsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/ListLexiconsOutput
@@ -986,6 +1150,22 @@ func (s *ListLexiconsOutput) SetLexicons(v []*LexiconDescription) *ListLexiconsO
 func (s *ListLexiconsOutput) SetNextToken(v string) *ListLexiconsOutput {
 	s.NextToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListLexiconsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Lexicons) > 0 {
+		v := s.Lexicons
+
+		e.SetList(protocol.BodyTarget, "Lexicons", encodeLexiconDescriptionList(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/PutLexiconInput
@@ -1043,6 +1223,22 @@ func (s *PutLexiconInput) SetName(v string) *PutLexiconInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Content != nil {
+		v := *s.Content
+
+		e.SetValue(protocol.BodyTarget, "Content", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/PutLexiconOutput
 type PutLexiconOutput struct {
 	_ struct{} `type:"structure"`
@@ -1056,6 +1252,12 @@ func (s PutLexiconOutput) String() string {
 // GoString returns the string representation
 func (s PutLexiconOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/SynthesizeSpeechInput
@@ -1174,6 +1376,47 @@ func (s *SynthesizeSpeechInput) SetVoiceId(v string) *SynthesizeSpeechInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SynthesizeSpeechInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LexiconNames) > 0 {
+		v := s.LexiconNames
+
+		e.SetList(protocol.BodyTarget, "LexiconNames", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.OutputFormat != nil {
+		v := *s.OutputFormat
+
+		e.SetValue(protocol.BodyTarget, "OutputFormat", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SampleRate != nil {
+		v := *s.SampleRate
+
+		e.SetValue(protocol.BodyTarget, "SampleRate", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.SpeechMarkTypes) > 0 {
+		v := s.SpeechMarkTypes
+
+		e.SetList(protocol.BodyTarget, "SpeechMarkTypes", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TextType != nil {
+		v := *s.TextType
+
+		e.SetValue(protocol.BodyTarget, "TextType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VoiceId != nil {
+		v := *s.VoiceId
+
+		e.SetValue(protocol.BodyTarget, "VoiceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/polly-2016-06-10/SynthesizeSpeechOutput
 type SynthesizeSpeechOutput struct {
 	_ struct{} `type:"structure" payload:"AudioStream"`
@@ -1228,6 +1471,23 @@ func (s *SynthesizeSpeechOutput) SetContentType(v string) *SynthesizeSpeechOutpu
 func (s *SynthesizeSpeechOutput) SetRequestCharacters(v int64) *SynthesizeSpeechOutput {
 	s.RequestCharacters = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SynthesizeSpeechOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping AudioStream Output type's body not valid.
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharacters != nil {
+		v := *s.RequestCharacters
+
+		e.SetValue(protocol.HeaderTarget, "x-amzn-RequestCharacters", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Description of the voice.
@@ -1291,6 +1551,45 @@ func (s *Voice) SetLanguageName(v string) *Voice {
 func (s *Voice) SetName(v string) *Voice {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Voice) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Gender != nil {
+		v := *s.Gender
+
+		e.SetValue(protocol.BodyTarget, "Gender", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageCode != nil {
+		v := *s.LanguageCode
+
+		e.SetValue(protocol.BodyTarget, "LanguageCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LanguageName != nil {
+		v := *s.LanguageName
+
+		e.SetValue(protocol.BodyTarget, "LanguageName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVoiceList(vs []*Voice) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -635,7 +635,6 @@ func (s *DeleteLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -656,7 +655,6 @@ func (s DeleteLexiconOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -708,7 +706,6 @@ func (s *DescribeVoicesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -758,7 +755,6 @@ func (s *DescribeVoicesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Voices", encodeVoiceList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -808,7 +804,6 @@ func (s *GetLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -859,7 +854,6 @@ func (s *GetLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "LexiconAttributes", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -911,7 +905,6 @@ func (s *Lexicon) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1020,7 +1013,6 @@ func (s *LexiconAttributes) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1070,7 +1062,6 @@ func (s *LexiconDescription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1114,7 +1105,6 @@ func (s *ListLexiconsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1164,7 +1154,6 @@ func (s *ListLexiconsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1235,7 +1224,6 @@ func (s *PutLexiconInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "LexiconName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1256,7 +1244,6 @@ func (s PutLexiconOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutLexiconOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -1413,7 +1400,6 @@ func (s *SynthesizeSpeechInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VoiceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1475,7 +1461,6 @@ func (s *SynthesizeSpeechOutput) SetRequestCharacters(v int64) *SynthesizeSpeech
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SynthesizeSpeechOutput) MarshalFields(e protocol.FieldEncoder) error {
-	// Skipping AudioStream Output type's body not valid.
 	if s.ContentType != nil {
 		v := *s.ContentType
 
@@ -1486,7 +1471,7 @@ func (s *SynthesizeSpeechOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amzn-RequestCharacters", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
+	// Skipping AudioStream Output type's body not valid.
 	return nil
 }
 
@@ -1580,7 +1565,6 @@ func (s *Voice) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -5792,7 +5792,6 @@ func (s *AccountLimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5877,7 +5876,6 @@ func (s *AlarmIdentifier) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6143,7 +6141,6 @@ func (s *AliasTarget) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6223,22 +6220,24 @@ func (s *AssociateVPCWithHostedZoneInput) SetVPC(v *VPC) *AssociateVPCWithHosted
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AssociateVPCWithHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "AssociateVPCWithHostedZoneRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.VPC != nil {
+			v := s.VPC
+
+			e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HostedZoneId != nil {
 		v := *s.HostedZoneId
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VPC != nil {
-		v := s.VPC
-
-		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6277,7 +6276,6 @@ func (s *AssociateVPCWithHostedZoneOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6367,7 +6365,6 @@ func (s *Change) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ResourceRecordSet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6453,7 +6450,6 @@ func (s *ChangeBatch) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6546,7 +6542,6 @@ func (s *ChangeInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubmittedAt", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6612,17 +6607,19 @@ func (s *ChangeResourceRecordSetsInput) SetHostedZoneId(v string) *ChangeResourc
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ChangeResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.ChangeBatch != nil {
-		v := s.ChangeBatch
+	e.SetFields(protocol.BodyTarget, "ChangeResourceRecordSetsRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.ChangeBatch != nil {
+			v := s.ChangeBatch
 
-		e.SetFields(protocol.BodyTarget, "ChangeBatch", v, protocol.Metadata{})
-	}
+			e.SetFields(protocol.BodyTarget, "ChangeBatch", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HostedZoneId != nil {
 		v := *s.HostedZoneId
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6664,7 +6661,6 @@ func (s *ChangeResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6758,16 +6754,19 @@ func (s *ChangeTagsForResourceInput) SetResourceType(v string) *ChangeTagsForRes
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ChangeTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.AddTags) > 0 {
-		v := s.AddTags
+	e.SetFields(protocol.BodyTarget, "ChangeTagsForResourceRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.AddTags) > 0 {
+			v := s.AddTags
 
-		e.SetList(protocol.BodyTarget, "AddTags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
-	}
-	if len(s.RemoveTagKeys) > 0 {
-		v := s.RemoveTagKeys
+			e.SetList(protocol.BodyTarget, "AddTags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+		}
+		if len(s.RemoveTagKeys) > 0 {
+			v := s.RemoveTagKeys
 
-		e.SetList(protocol.BodyTarget, "RemoveTagKeys", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
-	}
+			e.SetList(protocol.BodyTarget, "RemoveTagKeys", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
@@ -6778,7 +6777,6 @@ func (s *ChangeTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6800,7 +6798,6 @@ func (s ChangeTagsForResourceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ChangeTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6959,7 +6956,6 @@ func (s *CloudWatchAlarmConfiguration) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Threshold", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7046,17 +7042,19 @@ func (s *CreateHealthCheckInput) SetHealthCheckConfig(v *HealthCheckConfig) *Cre
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CallerReference != nil {
-		v := *s.CallerReference
+	e.SetFields(protocol.BodyTarget, "CreateHealthCheckRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.CallerReference != nil {
+			v := *s.CallerReference
 
-		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.HealthCheckConfig != nil {
-		v := s.HealthCheckConfig
+			e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.HealthCheckConfig != nil {
+			v := s.HealthCheckConfig
 
-		e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7110,7 +7108,6 @@ func (s *CreateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7234,32 +7231,34 @@ func (s *CreateHostedZoneInput) SetVPC(v *VPC) *CreateHostedZoneInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CallerReference != nil {
-		v := *s.CallerReference
+	e.SetFields(protocol.BodyTarget, "CreateHostedZoneRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.CallerReference != nil {
+			v := *s.CallerReference
 
-		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DelegationSetId != nil {
-		v := *s.DelegationSetId
+			e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.DelegationSetId != nil {
+			v := *s.DelegationSetId
 
-		e.SetValue(protocol.BodyTarget, "DelegationSetId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.HostedZoneConfig != nil {
-		v := s.HostedZoneConfig
+			e.SetValue(protocol.BodyTarget, "DelegationSetId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.HostedZoneConfig != nil {
+			v := s.HostedZoneConfig
 
-		e.SetFields(protocol.BodyTarget, "HostedZoneConfig", v, protocol.Metadata{})
-	}
-	if s.Name != nil {
-		v := *s.Name
+			e.SetFields(protocol.BodyTarget, "HostedZoneConfig", v, protocol.Metadata{})
+		}
+		if s.Name != nil {
+			v := *s.Name
 
-		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.VPC != nil {
-		v := s.VPC
+			e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.VPC != nil {
+			v := s.VPC
 
-		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
-	}
-
+			e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7350,17 +7349,16 @@ func (s *CreateHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
 	}
-	if s.Location != nil {
-		v := *s.Location
-
-		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.VPC != nil {
 		v := s.VPC
 
 		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
 	}
+	if s.Location != nil {
+		v := *s.Location
 
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7428,17 +7426,19 @@ func (s *CreateQueryLoggingConfigInput) SetHostedZoneId(v string) *CreateQueryLo
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CloudWatchLogsLogGroupArn != nil {
-		v := *s.CloudWatchLogsLogGroupArn
+	e.SetFields(protocol.BodyTarget, "CreateQueryLoggingConfigRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.CloudWatchLogsLogGroupArn != nil {
+			v := *s.CloudWatchLogsLogGroupArn
 
-		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.HostedZoneId != nil {
-		v := *s.HostedZoneId
+			e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.HostedZoneId != nil {
+			v := *s.HostedZoneId
 
-		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7483,17 +7483,16 @@ func (s *CreateQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingCo
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Location != nil {
-		v := *s.Location
-
-		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.QueryLoggingConfig != nil {
 		v := s.QueryLoggingConfig
 
 		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
 	}
+	if s.Location != nil {
+		v := *s.Location
 
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7555,17 +7554,19 @@ func (s *CreateReusableDelegationSetInput) SetHostedZoneId(v string) *CreateReus
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CallerReference != nil {
-		v := *s.CallerReference
+	e.SetFields(protocol.BodyTarget, "CreateReusableDelegationSetRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.CallerReference != nil {
+			v := *s.CallerReference
 
-		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.HostedZoneId != nil {
-		v := *s.HostedZoneId
+			e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.HostedZoneId != nil {
+			v := *s.HostedZoneId
 
-		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7618,7 +7619,6 @@ func (s *CreateReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7689,22 +7689,24 @@ func (s *CreateTrafficPolicyInput) SetName(v string) *CreateTrafficPolicyInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "CreateTrafficPolicyRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Document != nil {
-		v := *s.Document
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Document != nil {
+			v := *s.Document
 
-		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Name != nil {
-		v := *s.Name
+			e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Name != nil {
+			v := *s.Name
 
-		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7819,32 +7821,34 @@ func (s *CreateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Cre
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.HostedZoneId != nil {
-		v := *s.HostedZoneId
+	e.SetFields(protocol.BodyTarget, "CreateTrafficPolicyInstanceRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.HostedZoneId != nil {
+			v := *s.HostedZoneId
 
-		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Name != nil {
-		v := *s.Name
+			e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Name != nil {
+			v := *s.Name
 
-		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.TTL != nil {
-		v := *s.TTL
+			e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.TTL != nil {
+			v := *s.TTL
 
-		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.TrafficPolicyId != nil {
-		v := *s.TrafficPolicyId
+			e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.TrafficPolicyId != nil {
+			v := *s.TrafficPolicyId
 
-		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.TrafficPolicyVersion != nil {
-		v := *s.TrafficPolicyVersion
+			e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.TrafficPolicyVersion != nil {
+			v := *s.TrafficPolicyVersion
 
-		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	return nil
 }
 
@@ -7889,17 +7893,16 @@ func (s *CreateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficP
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Location != nil {
-		v := *s.Location
-
-		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TrafficPolicyInstance != nil {
 		v := s.TrafficPolicyInstance
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
 	}
+	if s.Location != nil {
+		v := *s.Location
 
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -7944,17 +7947,16 @@ func (s *CreateTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTr
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Location != nil {
-		v := *s.Location
-
-		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TrafficPolicy != nil {
 		v := s.TrafficPolicy
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
 	}
+	if s.Location != nil {
+		v := *s.Location
 
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8030,22 +8032,24 @@ func (s *CreateTrafficPolicyVersionInput) SetId(v string) *CreateTrafficPolicyVe
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "CreateTrafficPolicyVersionRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Document != nil {
-		v := *s.Document
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Document != nil {
+			v := *s.Document
 
-		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8091,17 +8095,16 @@ func (s *CreateTrafficPolicyVersionOutput) SetTrafficPolicy(v *TrafficPolicy) *C
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateTrafficPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Location != nil {
-		v := *s.Location
-
-		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.TrafficPolicy != nil {
 		v := s.TrafficPolicy
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
 	}
+	if s.Location != nil {
+		v := *s.Location
 
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8170,17 +8173,19 @@ func (s *CreateVPCAssociationAuthorizationInput) SetVPC(v *VPC) *CreateVPCAssoci
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	e.SetFields(protocol.BodyTarget, "CreateVPCAssociationAuthorizationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.VPC != nil {
+			v := s.VPC
+
+			e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HostedZoneId != nil {
 		v := *s.HostedZoneId
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VPC != nil {
-		v := s.VPC
-
-		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -8235,7 +8240,6 @@ func (s *CreateVPCAssociationAuthorizationOutput) MarshalFields(e protocol.Field
 
 		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8304,7 +8308,6 @@ func (s *DelegationSet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "NameServers", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NameServer"})
 	}
-
 	return nil
 }
 
@@ -8363,7 +8366,6 @@ func (s *DeleteHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8385,7 +8387,6 @@ func (s DeleteHealthCheckOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8436,7 +8437,6 @@ func (s *DeleteHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8475,7 +8475,6 @@ func (s *DeleteHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8528,7 +8527,6 @@ func (s *DeleteQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8549,7 +8547,6 @@ func (s DeleteQueryLoggingConfigOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8600,7 +8597,6 @@ func (s *DeleteReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8622,7 +8618,6 @@ func (s DeleteReusableDelegationSetOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8698,7 +8693,6 @@ func (s *DeleteTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8756,7 +8750,6 @@ func (s *DeleteTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8778,7 +8771,6 @@ func (s DeleteTrafficPolicyInstanceOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8800,7 +8792,6 @@ func (s DeleteTrafficPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8871,17 +8862,19 @@ func (s *DeleteVPCAssociationAuthorizationInput) SetVPC(v *VPC) *DeleteVPCAssoci
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	e.SetFields(protocol.BodyTarget, "DeleteVPCAssociationAuthorizationRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.VPC != nil {
+			v := s.VPC
+
+			e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HostedZoneId != nil {
 		v := *s.HostedZoneId
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VPC != nil {
-		v := s.VPC
-
-		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -8903,7 +8896,6 @@ func (s DeleteVPCAssociationAuthorizationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteVPCAssociationAuthorizationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -8960,7 +8952,6 @@ func (s *Dimension) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9044,22 +9035,24 @@ func (s *DisassociateVPCFromHostedZoneInput) SetVPC(v *VPC) *DisassociateVPCFrom
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DisassociateVPCFromHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "DisassociateVPCFromHostedZoneRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.VPC != nil {
+			v := s.VPC
+
+			e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HostedZoneId != nil {
 		v := *s.HostedZoneId
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VPC != nil {
-		v := s.VPC
-
-		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -9099,7 +9092,6 @@ func (s *DisassociateVPCFromHostedZoneOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9188,7 +9180,6 @@ func (s *GeoLocation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9297,7 +9288,6 @@ func (s *GeoLocationDetails) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubdivisionName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9374,7 +9364,6 @@ func (s *GetAccountLimitInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9434,7 +9423,6 @@ func (s *GetAccountLimitOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9487,7 +9475,6 @@ func (s *GetChangeInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9525,7 +9512,6 @@ func (s *GetChangeOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9546,7 +9532,6 @@ func (s GetCheckerIpRangesInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetCheckerIpRangesInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9581,7 +9566,6 @@ func (s *GetCheckerIpRangesOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "CheckerIpRanges", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9683,7 +9667,6 @@ func (s *GetGeoLocationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "subdivisioncode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9723,7 +9706,6 @@ func (s *GetGeoLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "GeoLocationDetails", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9746,7 +9728,6 @@ func (s GetHealthCheckCountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetHealthCheckCountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9784,7 +9765,6 @@ func (s *GetHealthCheckCountOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "HealthCheckCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9838,7 +9818,6 @@ func (s *GetHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9891,7 +9870,6 @@ func (s *GetHealthCheckLastFailureReasonInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9931,7 +9909,6 @@ func (s *GetHealthCheckLastFailureReasonOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
 	}
-
 	return nil
 }
 
@@ -9970,7 +9947,6 @@ func (s *GetHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10027,7 +10003,6 @@ func (s *GetHealthCheckStatusInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10066,7 +10041,6 @@ func (s *GetHealthCheckStatusOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
 	}
-
 	return nil
 }
 
@@ -10089,7 +10063,6 @@ func (s GetHostedZoneCountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetHostedZoneCountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10128,7 +10101,6 @@ func (s *GetHostedZoneCountOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "HostedZoneCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10179,7 +10151,6 @@ func (s *GetHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10256,7 +10227,6 @@ func (s *GetHostedZoneLimitInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10316,7 +10286,6 @@ func (s *GetHostedZoneLimitOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10385,7 +10354,6 @@ func (s *GetHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
 	}
-
 	return nil
 }
 
@@ -10439,7 +10407,6 @@ func (s *GetQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10477,7 +10444,6 @@ func (s *GetQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10529,7 +10495,6 @@ func (s *GetReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10602,7 +10567,6 @@ func (s *GetReusableDelegationSetLimitInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10658,7 +10622,6 @@ func (s *GetReusableDelegationSetLimitOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10697,7 +10660,6 @@ func (s *GetReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10774,7 +10736,6 @@ func (s *GetTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10797,7 +10758,6 @@ func (s GetTrafficPolicyInstanceCountInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetTrafficPolicyInstanceCountInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10837,7 +10797,6 @@ func (s *GetTrafficPolicyInstanceCountOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10891,7 +10850,6 @@ func (s *GetTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10930,7 +10888,6 @@ func (s *GetTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10968,7 +10925,6 @@ func (s *GetTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11091,7 +11047,6 @@ func (s *HealthCheck) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "LinkedService", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11596,7 +11551,6 @@ func (s *HealthCheckConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11664,7 +11618,6 @@ func (s *HealthCheckObservation) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "StatusReport", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11794,7 +11747,6 @@ func (s *HostedZone) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResourceRecordSetCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11854,7 +11806,6 @@ func (s *HostedZoneConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PrivateZone", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11915,7 +11866,6 @@ func (s *HostedZoneLimit) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11973,7 +11923,6 @@ func (s *LinkedService) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ServicePrincipal", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12095,7 +12044,6 @@ func (s *ListGeoLocationsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "startsubdivisioncode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12218,7 +12166,6 @@ func (s *ListGeoLocationsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextSubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12280,7 +12227,6 @@ func (s *ListHealthChecksInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12388,7 +12334,6 @@ func (s *ListHealthChecksOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12470,7 +12415,6 @@ func (s *ListHostedZonesByNameInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12614,7 +12558,6 @@ func (s *ListHostedZonesByNameOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "NextHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12693,7 +12636,6 @@ func (s *ListHostedZonesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12802,7 +12744,6 @@ func (s *ListHostedZonesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12881,7 +12822,6 @@ func (s *ListQueryLoggingConfigsInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12940,7 +12880,6 @@ func (s *ListQueryLoggingConfigsOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetList(protocol.BodyTarget, "QueryLoggingConfigs", encodeQueryLoggingConfigList(v), protocol.Metadata{ListLocationName: "QueryLoggingConfig"})
 	}
-
 	return nil
 }
 
@@ -13083,7 +13022,6 @@ func (s *ListResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13203,7 +13141,6 @@ func (s *ListResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "ResourceRecordSets", encodeResourceRecordSetList(v), protocol.Metadata{ListLocationName: "ResourceRecordSet"})
 	}
-
 	return nil
 }
 
@@ -13265,7 +13202,6 @@ func (s *ListReusableDelegationSetsInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13373,7 +13309,6 @@ func (s *ListReusableDelegationSetsOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13448,7 +13383,6 @@ func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13487,7 +13421,6 @@ func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.BodyTarget, "ResourceTagSet", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13556,17 +13489,19 @@ func (s *ListTagsForResourcesInput) SetResourceType(v string) *ListTagsForResour
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListTagsForResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
-	if len(s.ResourceIds) > 0 {
-		v := s.ResourceIds
+	e.SetFields(protocol.BodyTarget, "ListTagsForResourcesRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if len(s.ResourceIds) > 0 {
+			v := s.ResourceIds
 
-		e.SetList(protocol.BodyTarget, "ResourceIds", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResourceId"})
-	}
+			e.SetList(protocol.BodyTarget, "ResourceIds", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResourceId"})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.ResourceType != nil {
 		v := *s.ResourceType
 
 		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13604,7 +13539,6 @@ func (s *ListTagsForResourcesOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "ResourceTagSets", encodeResourceTagSetList(v), protocol.Metadata{ListLocationName: "ResourceTagSet"})
 	}
-
 	return nil
 }
 
@@ -13679,7 +13613,6 @@ func (s *ListTrafficPoliciesInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "trafficpolicyid", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13771,7 +13704,6 @@ func (s *ListTrafficPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "TrafficPolicySummaries", encodeTrafficPolicySummaryList(v), protocol.Metadata{ListLocationName: "TrafficPolicySummary"})
 	}
-
 	return nil
 }
 
@@ -13887,7 +13819,6 @@ func (s *ListTrafficPolicyInstancesByHostedZoneInput) MarshalFields(e protocol.F
 
 		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13994,7 +13925,6 @@ func (s *ListTrafficPolicyInstancesByHostedZoneOutput) MarshalFields(e protocol.
 
 		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
 	}
-
 	return nil
 }
 
@@ -14161,7 +14091,6 @@ func (s *ListTrafficPolicyInstancesByPolicyInput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.QueryTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14285,7 +14214,6 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) MarshalFields(e protocol.Fiel
 
 		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
 	}
-
 	return nil
 }
 
@@ -14393,7 +14321,6 @@ func (s *ListTrafficPolicyInstancesInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14518,7 +14445,6 @@ func (s *ListTrafficPolicyInstancesOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
 	}
-
 	return nil
 }
 
@@ -14614,7 +14540,6 @@ func (s *ListTrafficPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.QueryTarget, "trafficpolicyversion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14710,7 +14635,6 @@ func (s *ListTrafficPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersionMarker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14797,7 +14721,6 @@ func (s *ListVPCAssociationAuthorizationsInput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14870,7 +14793,6 @@ func (s *ListVPCAssociationAuthorizationsOutput) MarshalFields(e protocol.FieldE
 
 		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
 	}
-
 	return nil
 }
 
@@ -14942,7 +14864,6 @@ func (s *QueryLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15012,7 +14933,6 @@ func (s *ResourceRecord) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15623,7 +15543,6 @@ func (s *ResourceRecordSet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Weight", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15699,7 +15618,6 @@ func (s *ResourceTagSet) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
 	}
-
 	return nil
 }
 
@@ -15764,7 +15682,6 @@ func (s *ReusableDelegationSetLimit) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15819,7 +15736,6 @@ func (s *StatusReport) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15887,7 +15803,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16040,7 +15955,6 @@ func (s *TestDNSAnswerInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "resolverip", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16164,7 +16078,6 @@ func (s *TestDNSAnswerOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResponseCode", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16285,7 +16198,6 @@ func (s *TrafficPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16477,7 +16389,6 @@ func (s *TrafficPolicyInstance) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16590,7 +16501,6 @@ func (s *TrafficPolicySummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16995,87 +16905,89 @@ func (s *UpdateHealthCheckInput) SetSearchString(v string) *UpdateHealthCheckInp
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AlarmIdentifier != nil {
-		v := s.AlarmIdentifier
+	e.SetFields(protocol.BodyTarget, "UpdateHealthCheckRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.AlarmIdentifier != nil {
+			v := s.AlarmIdentifier
 
-		e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
-	}
-	if len(s.ChildHealthChecks) > 0 {
-		v := s.ChildHealthChecks
+			e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
+		}
+		if len(s.ChildHealthChecks) > 0 {
+			v := s.ChildHealthChecks
 
-		e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
-	}
-	if s.EnableSNI != nil {
-		v := *s.EnableSNI
+			e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
+		}
+		if s.EnableSNI != nil {
+			v := *s.EnableSNI
 
-		e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
-	}
-	if s.FailureThreshold != nil {
-		v := *s.FailureThreshold
+			e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
+		}
+		if s.FailureThreshold != nil {
+			v := *s.FailureThreshold
 
-		e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.FullyQualifiedDomainName != nil {
-		v := *s.FullyQualifiedDomainName
+			e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.FullyQualifiedDomainName != nil {
+			v := *s.FullyQualifiedDomainName
 
-		e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.HealthCheckVersion != nil {
+			v := *s.HealthCheckVersion
+
+			e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.HealthThreshold != nil {
+			v := *s.HealthThreshold
+
+			e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.IPAddress != nil {
+			v := *s.IPAddress
+
+			e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.InsufficientDataHealthStatus != nil {
+			v := *s.InsufficientDataHealthStatus
+
+			e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.Inverted != nil {
+			v := *s.Inverted
+
+			e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
+		}
+		if s.Port != nil {
+			v := *s.Port
+
+			e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if len(s.Regions) > 0 {
+			v := s.Regions
+
+			e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
+		}
+		if len(s.ResetElements) > 0 {
+			v := s.ResetElements
+
+			e.SetList(protocol.BodyTarget, "ResetElements", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResettableElementName"})
+		}
+		if s.ResourcePath != nil {
+			v := *s.ResourcePath
+
+			e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.SearchString != nil {
+			v := *s.SearchString
+
+			e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.HealthCheckId != nil {
 		v := *s.HealthCheckId
 
 		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.HealthCheckVersion != nil {
-		v := *s.HealthCheckVersion
-
-		e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.HealthThreshold != nil {
-		v := *s.HealthThreshold
-
-		e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.IPAddress != nil {
-		v := *s.IPAddress
-
-		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.InsufficientDataHealthStatus != nil {
-		v := *s.InsufficientDataHealthStatus
-
-		e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Inverted != nil {
-		v := *s.Inverted
-
-		e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
-	}
-	if s.Port != nil {
-		v := *s.Port
-
-		e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if len(s.Regions) > 0 {
-		v := s.Regions
-
-		e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
-	}
-	if len(s.ResetElements) > 0 {
-		v := s.ResetElements
-
-		e.SetList(protocol.BodyTarget, "ResetElements", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResettableElementName"})
-	}
-	if s.ResourcePath != nil {
-		v := *s.ResourcePath
-
-		e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SearchString != nil {
-		v := *s.SearchString
-
-		e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -17113,7 +17025,6 @@ func (s *UpdateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17169,17 +17080,19 @@ func (s *UpdateHostedZoneCommentInput) SetId(v string) *UpdateHostedZoneCommentI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateHostedZoneCommentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "UpdateHostedZoneCommentRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17218,7 +17131,6 @@ func (s *UpdateHostedZoneCommentOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17301,11 +17213,14 @@ func (s *UpdateTrafficPolicyCommentInput) SetVersion(v int64) *UpdateTrafficPoli
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateTrafficPolicyCommentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Comment != nil {
-		v := *s.Comment
+	e.SetFields(protocol.BodyTarget, "UpdateTrafficPolicyCommentRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.Comment != nil {
+			v := *s.Comment
 
-		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
-	}
+			e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.Id != nil {
 		v := *s.Id
 
@@ -17316,7 +17231,6 @@ func (s *UpdateTrafficPolicyCommentInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17354,7 +17268,6 @@ func (s *UpdateTrafficPolicyCommentOutput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17455,27 +17368,29 @@ func (s *UpdateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Upd
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	e.SetFields(protocol.BodyTarget, "UpdateTrafficPolicyInstanceRequest", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.TTL != nil {
+			v := *s.TTL
+
+			e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		if s.TrafficPolicyId != nil {
+			v := *s.TrafficPolicyId
+
+			e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		if s.TrafficPolicyVersion != nil {
+			v := *s.TrafficPolicyVersion
+
+			e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{XMLNamespaceURI: "https://route53.amazonaws.com/doc/2013-04-01/"})
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.TTL != nil {
-		v := *s.TTL
-
-		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
-	}
-	if s.TrafficPolicyId != nil {
-		v := *s.TrafficPolicyId
-
-		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.TrafficPolicyVersion != nil {
-		v := *s.TrafficPolicyVersion
-
-		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -17514,7 +17429,6 @@ func (s *UpdateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17578,7 +17492,6 @@ func (s *VPC) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VPCRegion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opAssociateVPCWithHostedZone = "AssociateVPCWithHostedZone"
@@ -5779,6 +5780,22 @@ func (s *AccountLimit) SetValue(v int64) *AccountLimit {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccountLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that identifies the CloudWatch alarm that you want Amazon
 // Route 53 health checkers to use to determine whether this health check is
 // healthy.
@@ -5846,6 +5863,22 @@ func (s *AlarmIdentifier) SetName(v string) *AlarmIdentifier {
 func (s *AlarmIdentifier) SetRegion(v string) *AlarmIdentifier {
 	s.Region = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AlarmIdentifier) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Alias resource record sets only: Information about the CloudFront distribution,
@@ -6093,6 +6126,27 @@ func (s *AliasTarget) SetHostedZoneId(v string) *AliasTarget {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AliasTarget) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.BodyTarget, "DNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EvaluateTargetHealth != nil {
+		v := *s.EvaluateTargetHealth
+
+		e.SetValue(protocol.BodyTarget, "EvaluateTargetHealth", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the request to associate a
 // VPC with a private hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/AssociateVPCWithHostedZoneRequest
@@ -6167,6 +6221,27 @@ func (s *AssociateVPCWithHostedZoneInput) SetVPC(v *VPC) *AssociateVPCWithHosted
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateVPCWithHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the AssociateVPCWithHostedZone
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/AssociateVPCWithHostedZoneResponse
@@ -6193,6 +6268,17 @@ func (s AssociateVPCWithHostedZoneOutput) GoString() string {
 func (s *AssociateVPCWithHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *AssociateVPCWithHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AssociateVPCWithHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // The information for each resource record set that you want to change.
@@ -6269,6 +6355,30 @@ func (s *Change) SetResourceRecordSet(v *ResourceRecordSet) *Change {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Change) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Action != nil {
+		v := *s.Action
+
+		e.SetValue(protocol.BodyTarget, "Action", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceRecordSet != nil {
+		v := s.ResourceRecordSet
+
+		e.SetFields(protocol.BodyTarget, "ResourceRecordSet", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeChangeList(vs []*Change) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // The information for a change request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeBatch
 type ChangeBatch struct {
@@ -6329,6 +6439,22 @@ func (s *ChangeBatch) SetChanges(v []*Change) *ChangeBatch {
 func (s *ChangeBatch) SetComment(v string) *ChangeBatch {
 	s.Comment = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeBatch) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Changes) > 0 {
+		v := s.Changes
+
+		e.SetList(protocol.BodyTarget, "Changes", encodeChangeList(v), protocol.Metadata{ListLocationName: "Change"})
+	}
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that describes change information about changes made to your
@@ -6398,6 +6524,32 @@ func (s *ChangeInfo) SetSubmittedAt(v time.Time) *ChangeInfo {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubmittedAt != nil {
+		v := *s.SubmittedAt
+
+		e.SetValue(protocol.BodyTarget, "SubmittedAt", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains change information for the resource record set.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeResourceRecordSetsRequest
 type ChangeResourceRecordSetsInput struct {
@@ -6458,6 +6610,22 @@ func (s *ChangeResourceRecordSetsInput) SetHostedZoneId(v string) *ChangeResourc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeBatch != nil {
+		v := s.ChangeBatch
+
+		e.SetFields(protocol.BodyTarget, "ChangeBatch", v, protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeResourceRecordSetsResponse
 type ChangeResourceRecordSetsOutput struct {
@@ -6487,6 +6655,17 @@ func (s ChangeResourceRecordSetsOutput) GoString() string {
 func (s *ChangeResourceRecordSetsOutput) SetChangeInfo(v *ChangeInfo) *ChangeResourceRecordSetsOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the tags that you want to
@@ -6577,6 +6756,32 @@ func (s *ChangeTagsForResourceInput) SetResourceType(v string) *ChangeTagsForRes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AddTags) > 0 {
+		v := s.AddTags
+
+		e.SetList(protocol.BodyTarget, "AddTags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+	if len(s.RemoveTagKeys) > 0 {
+		v := s.RemoveTagKeys
+
+		e.SetList(protocol.BodyTarget, "RemoveTagKeys", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Key"})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Empty response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ChangeTagsForResourceResponse
 type ChangeTagsForResourceOutput struct {
@@ -6591,6 +6796,12 @@ func (s ChangeTagsForResourceOutput) String() string {
 // GoString returns the string representation
 func (s ChangeTagsForResourceOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ChangeTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the CloudWatch alarm that
@@ -6706,6 +6917,52 @@ func (s *CloudWatchAlarmConfiguration) SetThreshold(v float64) *CloudWatchAlarmC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudWatchAlarmConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ComparisonOperator != nil {
+		v := *s.ComparisonOperator
+
+		e.SetValue(protocol.BodyTarget, "ComparisonOperator", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Dimensions) > 0 {
+		v := s.Dimensions
+
+		e.SetList(protocol.BodyTarget, "Dimensions", encodeDimensionList(v), protocol.Metadata{ListLocationName: "Dimension"})
+	}
+	if s.EvaluationPeriods != nil {
+		v := *s.EvaluationPeriods
+
+		e.SetValue(protocol.BodyTarget, "EvaluationPeriods", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MetricName != nil {
+		v := *s.MetricName
+
+		e.SetValue(protocol.BodyTarget, "MetricName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Namespace != nil {
+		v := *s.Namespace
+
+		e.SetValue(protocol.BodyTarget, "Namespace", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Period != nil {
+		v := *s.Period
+
+		e.SetValue(protocol.BodyTarget, "Period", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Statistic != nil {
+		v := *s.Statistic
+
+		e.SetValue(protocol.BodyTarget, "Statistic", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Threshold != nil {
+		v := *s.Threshold
+
+		e.SetValue(protocol.BodyTarget, "Threshold", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the health check request information.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHealthCheckRequest
 type CreateHealthCheckInput struct {
@@ -6787,6 +7044,22 @@ func (s *CreateHealthCheckInput) SetHealthCheckConfig(v *HealthCheckConfig) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckConfig != nil {
+		v := s.HealthCheckConfig
+
+		e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the new health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHealthCheckResponse
 type CreateHealthCheckOutput struct {
@@ -6823,6 +7096,22 @@ func (s *CreateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *CreateHealthCh
 func (s *CreateHealthCheckOutput) SetLocation(v string) *CreateHealthCheckOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to create a hosted
@@ -6943,6 +7232,37 @@ func (s *CreateHostedZoneInput) SetVPC(v *VPC) *CreateHostedZoneInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DelegationSetId != nil {
+		v := *s.DelegationSetId
+
+		e.SetValue(protocol.BodyTarget, "DelegationSetId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneConfig != nil {
+		v := s.HostedZoneConfig
+
+		e.SetFields(protocol.BodyTarget, "HostedZoneConfig", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateHostedZoneResponse
 type CreateHostedZoneOutput struct {
@@ -7013,6 +7333,37 @@ func (s *CreateHostedZoneOutput) SetVPC(v *VPC) *CreateHostedZoneOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateQueryLoggingConfigRequest
 type CreateQueryLoggingConfigInput struct {
 	_ struct{} `locationName:"CreateQueryLoggingConfigRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
@@ -7075,6 +7426,22 @@ func (s *CreateQueryLoggingConfigInput) SetHostedZoneId(v string) *CreateQueryLo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudWatchLogsLogGroupArn != nil {
+		v := *s.CloudWatchLogsLogGroupArn
+
+		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateQueryLoggingConfigResponse
 type CreateQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -7112,6 +7479,22 @@ func (s *CreateQueryLoggingConfigOutput) SetLocation(v string) *CreateQueryLoggi
 func (s *CreateQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfig) *CreateQueryLoggingConfigOutput {
 	s.QueryLoggingConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueryLoggingConfig != nil {
+		v := s.QueryLoggingConfig
+
+		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateReusableDelegationSetRequest
@@ -7170,6 +7553,22 @@ func (s *CreateReusableDelegationSetInput) SetHostedZoneId(v string) *CreateReus
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateReusableDelegationSetResponse
 type CreateReusableDelegationSetOutput struct {
 	_ struct{} `type:"structure"`
@@ -7205,6 +7604,22 @@ func (s *CreateReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *
 func (s *CreateReusableDelegationSetOutput) SetLocation(v string) *CreateReusableDelegationSetOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -7270,6 +7685,27 @@ func (s *CreateTrafficPolicyInput) SetDocument(v string) *CreateTrafficPolicyInp
 func (s *CreateTrafficPolicyInput) SetName(v string) *CreateTrafficPolicyInput {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -7381,6 +7817,37 @@ func (s *CreateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyInstance
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyInstanceResponse
@@ -7420,6 +7887,22 @@ func (s *CreateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicy
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyResponse
@@ -7457,6 +7940,22 @@ func (s *CreateTrafficPolicyOutput) SetLocation(v string) *CreateTrafficPolicyOu
 func (s *CreateTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -7529,6 +8028,27 @@ func (s *CreateTrafficPolicyVersionInput) SetId(v string) *CreateTrafficPolicyVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the CreateTrafficPolicyVersion
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateTrafficPolicyVersionResponse
@@ -7567,6 +8087,22 @@ func (s *CreateTrafficPolicyVersionOutput) SetLocation(v string) *CreateTrafficP
 func (s *CreateTrafficPolicyVersionOutput) SetTrafficPolicy(v *TrafficPolicy) *CreateTrafficPolicyVersionOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateTrafficPolicyVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to authorize associating
@@ -7632,6 +8168,22 @@ func (s *CreateVPCAssociationAuthorizationInput) SetVPC(v *VPC) *CreateVPCAssoci
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information from a CreateVPCAssociationAuthorization
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/CreateVPCAssociationAuthorizationResponse
@@ -7669,6 +8221,22 @@ func (s *CreateVPCAssociationAuthorizationOutput) SetHostedZoneId(v string) *Cre
 func (s *CreateVPCAssociationAuthorizationOutput) SetVPC(v *VPC) *CreateVPCAssociationAuthorizationOutput {
 	s.VPC = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateVPCAssociationAuthorizationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that lists the name servers in a delegation set, as well as
@@ -7719,6 +8287,35 @@ func (s *DelegationSet) SetNameServers(v []*string) *DelegationSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DelegationSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.NameServers) > 0 {
+		v := s.NameServers
+
+		e.SetList(protocol.BodyTarget, "NameServers", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "NameServer"})
+	}
+
+	return nil
+}
+
+func encodeDelegationSetList(vs []*DelegationSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // This action deletes a health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHealthCheckRequest
 type DeleteHealthCheckInput struct {
@@ -7759,6 +8356,17 @@ func (s *DeleteHealthCheckInput) SetHealthCheckId(v string) *DeleteHealthCheckIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHealthCheckResponse
 type DeleteHealthCheckOutput struct {
@@ -7773,6 +8381,12 @@ func (s DeleteHealthCheckOutput) String() string {
 // GoString returns the string representation
 func (s DeleteHealthCheckOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a hosted zone.
@@ -7815,6 +8429,17 @@ func (s *DeleteHostedZoneInput) SetId(v string) *DeleteHostedZoneInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a DeleteHostedZone request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteHostedZoneResponse
 type DeleteHostedZoneOutput struct {
@@ -7841,6 +8466,17 @@ func (s DeleteHostedZoneOutput) GoString() string {
 func (s *DeleteHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DeleteHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteQueryLoggingConfigRequest
@@ -7885,6 +8521,17 @@ func (s *DeleteQueryLoggingConfigInput) SetId(v string) *DeleteQueryLoggingConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteQueryLoggingConfigResponse
 type DeleteQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -7898,6 +8545,12 @@ func (s DeleteQueryLoggingConfigOutput) String() string {
 // GoString returns the string representation
 func (s DeleteQueryLoggingConfigOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a reusable delegation set.
@@ -7940,6 +8593,17 @@ func (s *DeleteReusableDelegationSetInput) SetId(v string) *DeleteReusableDelega
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteReusableDelegationSetResponse
 type DeleteReusableDelegationSetOutput struct {
@@ -7954,6 +8618,12 @@ func (s DeleteReusableDelegationSetOutput) String() string {
 // GoString returns the string representation
 func (s DeleteReusableDelegationSetOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A request to delete a specified traffic policy version.
@@ -8016,6 +8686,22 @@ func (s *DeleteTrafficPolicyInput) SetVersion(v int64) *DeleteTrafficPolicyInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to delete a specified traffic policy instance.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyInstanceRequest
 type DeleteTrafficPolicyInstanceInput struct {
@@ -8063,6 +8749,17 @@ func (s *DeleteTrafficPolicyInstanceInput) SetId(v string) *DeleteTrafficPolicyI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyInstanceResponse
 type DeleteTrafficPolicyInstanceOutput struct {
@@ -8079,6 +8776,12 @@ func (s DeleteTrafficPolicyInstanceOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // An empty element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteTrafficPolicyResponse
 type DeleteTrafficPolicyOutput struct {
@@ -8093,6 +8796,12 @@ func (s DeleteTrafficPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteTrafficPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the request to remove authorization
@@ -8160,6 +8869,22 @@ func (s *DeleteVPCAssociationAuthorizationInput) SetVPC(v *VPC) *DeleteVPCAssoci
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVPCAssociationAuthorizationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Empty response for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DeleteVPCAssociationAuthorizationResponse
 type DeleteVPCAssociationAuthorizationOutput struct {
@@ -8174,6 +8899,12 @@ func (s DeleteVPCAssociationAuthorizationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteVPCAssociationAuthorizationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteVPCAssociationAuthorizationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // For the metric that the CloudWatch alarm is associated with, a complex type
@@ -8215,6 +8946,30 @@ func (s *Dimension) SetName(v string) *Dimension {
 func (s *Dimension) SetValue(v string) *Dimension {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Dimension) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDimensionList(vs []*Dimension) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about the VPC that you want to disassociate
@@ -8287,6 +9042,27 @@ func (s *DisassociateVPCFromHostedZoneInput) SetVPC(v *VPC) *DisassociateVPCFrom
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateVPCFromHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPC != nil {
+		v := s.VPC
+
+		e.SetFields(protocol.BodyTarget, "VPC", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the disassociate
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/DisassociateVPCFromHostedZoneResponse
@@ -8314,6 +9090,17 @@ func (s DisassociateVPCFromHostedZoneOutput) GoString() string {
 func (s *DisassociateVPCFromHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DisassociateVPCFromHostedZoneOutput {
 	s.ChangeInfo = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DisassociateVPCFromHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a geo location.
@@ -8382,6 +9169,27 @@ func (s *GeoLocation) SetCountryCode(v string) *GeoLocation {
 func (s *GeoLocation) SetSubdivisionCode(v string) *GeoLocation {
 	s.SubdivisionCode = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoLocation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.BodyTarget, "ContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.BodyTarget, "CountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the codes and full continent, country, and subdivision
@@ -8457,6 +9265,50 @@ func (s *GeoLocationDetails) SetSubdivisionName(v string) *GeoLocationDetails {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GeoLocationDetails) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.BodyTarget, "ContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinentName != nil {
+		v := *s.ContinentName
+
+		e.SetValue(protocol.BodyTarget, "ContinentName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.BodyTarget, "CountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryName != nil {
+		v := *s.CountryName
+
+		e.SetValue(protocol.BodyTarget, "CountryName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionName != nil {
+		v := *s.SubdivisionName
+
+		e.SetValue(protocol.BodyTarget, "SubdivisionName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGeoLocationDetailsList(vs []*GeoLocationDetails) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains information about the request to create a hosted
 // zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetAccountLimitRequest
@@ -8515,6 +9367,17 @@ func (s *GetAccountLimitInput) SetType(v string) *GetAccountLimitInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountLimitInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the requested limit.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetAccountLimitResponse
 type GetAccountLimitOutput struct {
@@ -8559,6 +9422,22 @@ func (s *GetAccountLimitOutput) SetLimit(v *AccountLimit) *GetAccountLimitOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetAccountLimitOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := s.Limit
+
+		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // The input for a GetChange request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetChangeRequest
 type GetChangeInput struct {
@@ -8601,6 +9480,17 @@ func (s *GetChangeInput) SetId(v string) *GetChangeInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetChangeInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the ChangeInfo element.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetChangeResponse
 type GetChangeOutput struct {
@@ -8628,6 +9518,17 @@ func (s *GetChangeOutput) SetChangeInfo(v *ChangeInfo) *GetChangeOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetChangeOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ChangeInfo != nil {
+		v := s.ChangeInfo
+
+		e.SetFields(protocol.BodyTarget, "ChangeInfo", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetCheckerIpRangesRequest
 type GetCheckerIpRangesInput struct {
 	_ struct{} `type:"structure"`
@@ -8641,6 +9542,12 @@ func (s GetCheckerIpRangesInput) String() string {
 // GoString returns the string representation
 func (s GetCheckerIpRangesInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCheckerIpRangesInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetCheckerIpRangesResponse
@@ -8665,6 +9572,17 @@ func (s GetCheckerIpRangesOutput) GoString() string {
 func (s *GetCheckerIpRangesOutput) SetCheckerIpRanges(v []*string) *GetCheckerIpRangesOutput {
 	s.CheckerIpRanges = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCheckerIpRangesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CheckerIpRanges) > 0 {
+		v := s.CheckerIpRanges
+
+		e.SetList(protocol.BodyTarget, "CheckerIpRanges", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request for information about whether a specified geographic location is
@@ -8748,6 +9666,27 @@ func (s *GetGeoLocationInput) SetSubdivisionCode(v string) *GetGeoLocationInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGeoLocationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinentCode != nil {
+		v := *s.ContinentCode
+
+		e.SetValue(protocol.QueryTarget, "continentcode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CountryCode != nil {
+		v := *s.CountryCode
+
+		e.SetValue(protocol.QueryTarget, "countrycode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubdivisionCode != nil {
+		v := *s.SubdivisionCode
+
+		e.SetValue(protocol.QueryTarget, "subdivisioncode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the specified geolocation
 // code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetGeoLocationResponse
@@ -8777,6 +9716,17 @@ func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *Get
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetGeoLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.GeoLocationDetails != nil {
+		v := s.GeoLocationDetails
+
+		e.SetFields(protocol.BodyTarget, "GeoLocationDetails", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for the number of health checks that are associated with the current
 // AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckCountRequest
@@ -8792,6 +9742,12 @@ func (s GetHealthCheckCountInput) String() string {
 // GoString returns the string representation
 func (s GetHealthCheckCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains the response to a GetHealthCheckCount request.
@@ -8819,6 +9775,17 @@ func (s GetHealthCheckCountOutput) GoString() string {
 func (s *GetHealthCheckCountOutput) SetHealthCheckCount(v int64) *GetHealthCheckCountOutput {
 	s.HealthCheckCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckCount != nil {
+		v := *s.HealthCheckCount
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified health check.
@@ -8864,6 +9831,17 @@ func (s *GetHealthCheckInput) SetHealthCheckId(v string) *GetHealthCheckInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request for the reason that a health check failed most recently.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckLastFailureReasonRequest
 type GetHealthCheckLastFailureReasonInput struct {
@@ -8906,6 +9884,17 @@ func (s *GetHealthCheckLastFailureReasonInput) SetHealthCheckId(v string) *GetHe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckLastFailureReasonInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheckLastFailureReason
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckLastFailureReasonResponse
@@ -8935,6 +9924,17 @@ func (s *GetHealthCheckLastFailureReasonOutput) SetHealthCheckObservations(v []*
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckLastFailureReasonOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthCheckObservations) > 0 {
+		v := s.HealthCheckObservations
+
+		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckResponse
 type GetHealthCheckOutput struct {
@@ -8961,6 +9961,17 @@ func (s GetHealthCheckOutput) GoString() string {
 func (s *GetHealthCheckOutput) SetHealthCheck(v *HealthCheck) *GetHealthCheckOutput {
 	s.HealthCheck = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get the status for a health check.
@@ -9009,6 +10020,17 @@ func (s *GetHealthCheckStatusInput) SetHealthCheckId(v string) *GetHealthCheckSt
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckStatusInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a GetHealthCheck request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHealthCheckStatusResponse
 type GetHealthCheckStatusOutput struct {
@@ -9037,6 +10059,17 @@ func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHealthCheckStatusOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthCheckObservations) > 0 {
+		v := s.HealthCheckObservations
+
+		e.SetList(protocol.BodyTarget, "HealthCheckObservations", encodeHealthCheckObservationList(v), protocol.Metadata{ListLocationName: "HealthCheckObservation"})
+	}
+
+	return nil
+}
+
 // A request to retrieve a count of all the hosted zones that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHostedZoneCountRequest
@@ -9052,6 +10085,12 @@ func (s GetHostedZoneCountInput) String() string {
 // GoString returns the string representation
 func (s GetHostedZoneCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains the response to a GetHostedZoneCount request.
@@ -9080,6 +10119,17 @@ func (s GetHostedZoneCountOutput) GoString() string {
 func (s *GetHostedZoneCountOutput) SetHostedZoneCount(v int64) *GetHostedZoneCountOutput {
 	s.HostedZoneCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneCount != nil {
+		v := *s.HostedZoneCount
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified hosted zone.
@@ -9120,6 +10170,17 @@ func (s *GetHostedZoneInput) Validate() error {
 func (s *GetHostedZoneInput) SetId(v string) *GetHostedZoneInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to create a hosted
@@ -9183,6 +10244,22 @@ func (s *GetHostedZoneLimitInput) SetType(v string) *GetHostedZoneLimitInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneLimitInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the requested limit.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetHostedZoneLimitResponse
 type GetHostedZoneLimitOutput struct {
@@ -9225,6 +10302,22 @@ func (s *GetHostedZoneLimitOutput) SetCount(v int64) *GetHostedZoneLimitOutput {
 func (s *GetHostedZoneLimitOutput) SetLimit(v *HostedZoneLimit) *GetHostedZoneLimitOutput {
 	s.Limit = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneLimitOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := s.Limit
+
+		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contain the response to a GetHostedZone request.
@@ -9275,6 +10368,27 @@ func (s *GetHostedZoneOutput) SetVPCs(v []*VPC) *GetHostedZoneOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+	if len(s.VPCs) > 0 {
+		v := s.VPCs
+
+		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetQueryLoggingConfigRequest
 type GetQueryLoggingConfigInput struct {
 	_ struct{} `type:"structure"`
@@ -9318,6 +10432,17 @@ func (s *GetQueryLoggingConfigInput) SetId(v string) *GetQueryLoggingConfigInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueryLoggingConfigInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetQueryLoggingConfigResponse
 type GetQueryLoggingConfigOutput struct {
 	_ struct{} `type:"structure"`
@@ -9343,6 +10468,17 @@ func (s GetQueryLoggingConfigOutput) GoString() string {
 func (s *GetQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfig) *GetQueryLoggingConfigOutput {
 	s.QueryLoggingConfig = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetQueryLoggingConfigOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.QueryLoggingConfig != nil {
+		v := s.QueryLoggingConfig
+
+		e.SetFields(protocol.BodyTarget, "QueryLoggingConfig", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get information about a specified reusable delegation set.
@@ -9384,6 +10520,17 @@ func (s *GetReusableDelegationSetInput) Validate() error {
 func (s *GetReusableDelegationSetInput) SetId(v string) *GetReusableDelegationSetInput {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the request to create a hosted
@@ -9443,6 +10590,22 @@ func (s *GetReusableDelegationSetLimitInput) SetType(v string) *GetReusableDeleg
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetLimitInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSetId != nil {
+		v := *s.DelegationSetId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.PathTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the requested limit.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetReusableDelegationSetLimitResponse
 type GetReusableDelegationSetLimitOutput struct {
@@ -9483,6 +10646,22 @@ func (s *GetReusableDelegationSetLimitOutput) SetLimit(v *ReusableDelegationSetL
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetLimitOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := s.Limit
+
+		e.SetFields(protocol.BodyTarget, "Limit", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to the GetReusableDelegationSet
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetReusableDelegationSetResponse
@@ -9509,6 +10688,17 @@ func (s GetReusableDelegationSetOutput) GoString() string {
 func (s *GetReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *GetReusableDelegationSetOutput {
 	s.DelegationSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetReusableDelegationSetOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSet != nil {
+		v := s.DelegationSet
+
+		e.SetFields(protocol.BodyTarget, "DelegationSet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets information about a specific traffic policy version.
@@ -9572,6 +10762,22 @@ func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Request to get the number of traffic policy instances that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyInstanceCountRequest
@@ -9587,6 +10793,12 @@ func (s GetTrafficPolicyInstanceCountInput) String() string {
 // GoString returns the string representation
 func (s GetTrafficPolicyInstanceCountInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceCountInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -9616,6 +10828,17 @@ func (s GetTrafficPolicyInstanceCountOutput) GoString() string {
 func (s *GetTrafficPolicyInstanceCountOutput) SetTrafficPolicyInstanceCount(v int64) *GetTrafficPolicyInstanceCountOutput {
 	s.TrafficPolicyInstanceCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceCountOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstanceCount != nil {
+		v := *s.TrafficPolicyInstanceCount
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Gets information about a specified traffic policy instance.
@@ -9661,6 +10884,17 @@ func (s *GetTrafficPolicyInstanceInput) SetId(v string) *GetTrafficPolicyInstanc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyInstanceResponse
@@ -9689,6 +10923,17 @@ func (s *GetTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/GetTrafficPolicyResponse
 type GetTrafficPolicyOutput struct {
@@ -9714,6 +10959,17 @@ func (s GetTrafficPolicyOutput) GoString() string {
 func (s *GetTrafficPolicyOutput) SetTrafficPolicy(v *TrafficPolicy) *GetTrafficPolicyOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTrafficPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about one health check that is associated
@@ -9801,6 +11057,50 @@ func (s *HealthCheck) SetId(v string) *HealthCheck {
 func (s *HealthCheck) SetLinkedService(v *LinkedService) *HealthCheck {
 	s.LinkedService = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheck) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CloudWatchAlarmConfiguration != nil {
+		v := s.CloudWatchAlarmConfiguration
+
+		e.SetFields(protocol.BodyTarget, "CloudWatchAlarmConfiguration", v, protocol.Metadata{})
+	}
+	if s.HealthCheckConfig != nil {
+		v := s.HealthCheckConfig
+
+		e.SetFields(protocol.BodyTarget, "HealthCheckConfig", v, protocol.Metadata{})
+	}
+	if s.HealthCheckVersion != nil {
+		v := *s.HealthCheckVersion
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkedService != nil {
+		v := s.LinkedService
+
+		e.SetFields(protocol.BodyTarget, "LinkedService", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHealthCheckList(vs []*HealthCheck) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about the health check.
@@ -10214,6 +11514,92 @@ func (s *HealthCheckConfig) SetType(v string) *HealthCheckConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheckConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmIdentifier != nil {
+		v := s.AlarmIdentifier
+
+		e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
+	}
+	if len(s.ChildHealthChecks) > 0 {
+		v := s.ChildHealthChecks
+
+		e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
+	}
+	if s.EnableSNI != nil {
+		v := *s.EnableSNI
+
+		e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FailureThreshold != nil {
+		v := *s.FailureThreshold
+
+		e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FullyQualifiedDomainName != nil {
+		v := *s.FullyQualifiedDomainName
+
+		e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthThreshold != nil {
+		v := *s.HealthThreshold
+
+		e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InsufficientDataHealthStatus != nil {
+		v := *s.InsufficientDataHealthStatus
+
+		e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Inverted != nil {
+		v := *s.Inverted
+
+		e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MeasureLatency != nil {
+		v := *s.MeasureLatency
+
+		e.SetValue(protocol.BodyTarget, "MeasureLatency", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Port != nil {
+		v := *s.Port
+
+		e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Regions) > 0 {
+		v := s.Regions
+
+		e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
+	}
+	if s.RequestInterval != nil {
+		v := *s.RequestInterval
+
+		e.SetValue(protocol.BodyTarget, "RequestInterval", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ResourcePath != nil {
+		v := *s.ResourcePath
+
+		e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SearchString != nil {
+		v := *s.SearchString
+
+		e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the last failure reason as reported by one Amazon
 // Route 53 health checker.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/HealthCheckObservation
@@ -10259,6 +11645,35 @@ func (s *HealthCheckObservation) SetRegion(v string) *HealthCheckObservation {
 func (s *HealthCheckObservation) SetStatusReport(v *StatusReport) *HealthCheckObservation {
 	s.StatusReport = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HealthCheckObservation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusReport != nil {
+		v := s.StatusReport
+
+		e.SetFields(protocol.BodyTarget, "StatusReport", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHealthCheckObservationList(vs []*HealthCheckObservation) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains general information about the hosted zone.
@@ -10347,6 +11762,50 @@ func (s *HostedZone) SetResourceRecordSetCount(v int64) *HostedZone {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HostedZone) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CallerReference != nil {
+		v := *s.CallerReference
+
+		e.SetValue(protocol.BodyTarget, "CallerReference", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Config != nil {
+		v := s.Config
+
+		e.SetFields(protocol.BodyTarget, "Config", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LinkedService != nil {
+		v := s.LinkedService
+
+		e.SetFields(protocol.BodyTarget, "LinkedService", v, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceRecordSetCount != nil {
+		v := *s.ResourceRecordSetCount
+
+		e.SetValue(protocol.BodyTarget, "ResourceRecordSetCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHostedZoneList(vs []*HostedZone) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains an optional comment about your hosted zone.
 // If you don't want to specify a comment, omit both the HostedZoneConfig and
 // Comment elements.
@@ -10381,6 +11840,22 @@ func (s *HostedZoneConfig) SetComment(v string) *HostedZoneConfig {
 func (s *HostedZoneConfig) SetPrivateZone(v bool) *HostedZoneConfig {
 	s.PrivateZone = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HostedZoneConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrivateZone != nil {
+		v := *s.PrivateZone
+
+		e.SetValue(protocol.BodyTarget, "PrivateZone", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the type of limit that you specified in the
@@ -10428,6 +11903,22 @@ func (s *HostedZoneLimit) SetValue(v int64) *HostedZoneLimit {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HostedZoneLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // If a health check or hosted zone was created by another service, LinkedService
 // is a complex type that describes the service that created the resource. When
 // a resource is created by another service, you can't edit or delete it using
@@ -10468,6 +11959,22 @@ func (s *LinkedService) SetDescription(v string) *LinkedService {
 func (s *LinkedService) SetServicePrincipal(v string) *LinkedService {
 	s.ServicePrincipal = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LinkedService) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Description != nil {
+		v := *s.Description
+
+		e.SetValue(protocol.BodyTarget, "Description", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServicePrincipal != nil {
+		v := *s.ServicePrincipal
+
+		e.SetValue(protocol.BodyTarget, "ServicePrincipal", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to get a list of geographic locations that Amazon Route 53 supports
@@ -10566,6 +12073,32 @@ func (s *ListGeoLocationsInput) SetStartSubdivisionCode(v string) *ListGeoLocati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGeoLocationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartContinentCode != nil {
+		v := *s.StartContinentCode
+
+		e.SetValue(protocol.QueryTarget, "startcontinentcode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartCountryCode != nil {
+		v := *s.StartCountryCode
+
+		e.SetValue(protocol.QueryTarget, "startcountrycode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartSubdivisionCode != nil {
+		v := *s.StartSubdivisionCode
+
+		e.SetValue(protocol.QueryTarget, "startsubdivisioncode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListGeoLocationsResponse
 type ListGeoLocationsOutput struct {
@@ -10653,6 +12186,42 @@ func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListGeoLocationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.GeoLocationDetailsList) > 0 {
+		v := s.GeoLocationDetailsList
+
+		e.SetList(protocol.BodyTarget, "GeoLocationDetailsList", encodeGeoLocationDetailsList(v), protocol.Metadata{ListLocationName: "GeoLocationDetails"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextContinentCode != nil {
+		v := *s.NextContinentCode
+
+		e.SetValue(protocol.BodyTarget, "NextContinentCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextCountryCode != nil {
+		v := *s.NextCountryCode
+
+		e.SetValue(protocol.BodyTarget, "NextCountryCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextSubdivisionCode != nil {
+		v := *s.NextSubdivisionCode
+
+		e.SetValue(protocol.BodyTarget, "NextSubdivisionCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to retrieve a list of the health checks that are associated with
 // the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHealthChecksRequest
@@ -10697,6 +12266,22 @@ func (s *ListHealthChecksInput) SetMarker(v string) *ListHealthChecksInput {
 func (s *ListHealthChecksInput) SetMaxItems(v string) *ListHealthChecksInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHealthChecksInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response to a ListHealthChecks request.
@@ -10776,6 +12361,37 @@ func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHealthChecksOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HealthChecks) > 0 {
+		v := s.HealthChecks
+
+		e.SetList(protocol.BodyTarget, "HealthChecks", encodeHealthCheckList(v), protocol.Metadata{ListLocationName: "HealthCheck"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Retrieves a list of the public and private hosted zones that are associated
 // with the current AWS account in ASCII order by domain name.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesByNameRequest
@@ -10835,6 +12451,27 @@ func (s *ListHostedZonesByNameInput) SetHostedZoneId(v string) *ListHostedZonesB
 func (s *ListHostedZonesByNameInput) SetMaxItems(v string) *ListHostedZonesByNameInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesByNameInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.QueryTarget, "dnsname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -10940,6 +12577,47 @@ func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZ
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesByNameOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DNSName != nil {
+		v := *s.DNSName
+
+		e.SetValue(protocol.BodyTarget, "DNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.HostedZones) > 0 {
+		v := s.HostedZones
+
+		e.SetList(protocol.BodyTarget, "HostedZones", encodeHostedZoneList(v), protocol.Metadata{ListLocationName: "HostedZone"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextDNSName != nil {
+		v := *s.NextDNSName
+
+		e.SetValue(protocol.BodyTarget, "NextDNSName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextHostedZoneId != nil {
+		v := *s.NextHostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "NextHostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A request to retrieve a list of the public and private hosted zones that
 // are associated with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesRequest
@@ -10996,6 +12674,27 @@ func (s *ListHostedZonesInput) SetMarker(v string) *ListHostedZonesInput {
 func (s *ListHostedZonesInput) SetMaxItems(v string) *ListHostedZonesInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DelegationSetId != nil {
+		v := *s.DelegationSetId
+
+		e.SetValue(protocol.QueryTarget, "delegationsetid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListHostedZonesResponse
@@ -11076,6 +12775,37 @@ func (s *ListHostedZonesOutput) SetNextMarker(v string) *ListHostedZonesOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListHostedZonesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.HostedZones) > 0 {
+		v := s.HostedZones
+
+		e.SetList(protocol.BodyTarget, "HostedZones", encodeHostedZoneList(v), protocol.Metadata{ListLocationName: "HostedZone"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListQueryLoggingConfigsRequest
 type ListQueryLoggingConfigsInput struct {
 	_ struct{} `type:"structure"`
@@ -11134,6 +12864,27 @@ func (s *ListQueryLoggingConfigsInput) SetNextToken(v string) *ListQueryLoggingC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueryLoggingConfigsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxresults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListQueryLoggingConfigsResponse
 type ListQueryLoggingConfigsOutput struct {
 	_ struct{} `type:"structure"`
@@ -11175,6 +12926,22 @@ func (s *ListQueryLoggingConfigsOutput) SetNextToken(v string) *ListQueryLogging
 func (s *ListQueryLoggingConfigsOutput) SetQueryLoggingConfigs(v []*QueryLoggingConfig) *ListQueryLoggingConfigsOutput {
 	s.QueryLoggingConfigs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListQueryLoggingConfigsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.QueryLoggingConfigs) > 0 {
+		v := s.QueryLoggingConfigs
+
+		e.SetList(protocol.BodyTarget, "QueryLoggingConfigs", encodeQueryLoggingConfigList(v), protocol.Metadata{ListLocationName: "QueryLoggingConfig"})
+	}
+
+	return nil
 }
 
 // A request for the resource record sets that are associated with a specified
@@ -11289,6 +13056,37 @@ func (s *ListResourceRecordSetsInput) SetStartRecordType(v string) *ListResource
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListResourceRecordSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordIdentifier != nil {
+		v := *s.StartRecordIdentifier
+
+		e.SetValue(protocol.QueryTarget, "identifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordName != nil {
+		v := *s.StartRecordName
+
+		e.SetValue(protocol.QueryTarget, "name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartRecordType != nil {
+		v := *s.StartRecordType
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains list information for the resource record set.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListResourceRecordSetsResponse
 type ListResourceRecordSetsOutput struct {
@@ -11373,6 +13171,42 @@ func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecord
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListResourceRecordSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordIdentifier != nil {
+		v := *s.NextRecordIdentifier
+
+		e.SetValue(protocol.BodyTarget, "NextRecordIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordName != nil {
+		v := *s.NextRecordName
+
+		e.SetValue(protocol.BodyTarget, "NextRecordName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextRecordType != nil {
+		v := *s.NextRecordType
+
+		e.SetValue(protocol.BodyTarget, "NextRecordType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceRecordSets) > 0 {
+		v := s.ResourceRecordSets
+
+		e.SetList(protocol.BodyTarget, "ResourceRecordSets", encodeResourceRecordSetList(v), protocol.Metadata{ListLocationName: "ResourceRecordSet"})
+	}
+
+	return nil
+}
+
 // A request to get a list of the reusable delegation sets that are associated
 // with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListReusableDelegationSetsRequest
@@ -11417,6 +13251,22 @@ func (s *ListReusableDelegationSetsInput) SetMarker(v string) *ListReusableDeleg
 func (s *ListReusableDelegationSetsInput) SetMaxItems(v string) *ListReusableDelegationSetsInput {
 	s.MaxItems = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListReusableDelegationSetsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the reusable delegation sets
@@ -11496,6 +13346,37 @@ func (s *ListReusableDelegationSetsOutput) SetNextMarker(v string) *ListReusable
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListReusableDelegationSetsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DelegationSets) > 0 {
+		v := s.DelegationSets
+
+		e.SetList(protocol.BodyTarget, "DelegationSets", encodeDelegationSetList(v), protocol.Metadata{ListLocationName: "DelegationSet"})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourceRequest
@@ -11555,6 +13436,22 @@ func (s *ListTagsForResourceInput) SetResourceType(v string) *ListTagsForResourc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the health checks or hosted
 // zones for which you want to list tags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourceResponse
@@ -11581,6 +13478,17 @@ func (s ListTagsForResourceOutput) GoString() string {
 func (s *ListTagsForResourceOutput) SetResourceTagSet(v *ResourceTagSet) *ListTagsForResourceOutput {
 	s.ResourceTagSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceTagSet != nil {
+		v := s.ResourceTagSet
+
+		e.SetFields(protocol.BodyTarget, "ResourceTagSet", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the health checks or hosted
@@ -11646,6 +13554,22 @@ func (s *ListTagsForResourcesInput) SetResourceType(v string) *ListTagsForResour
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourcesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResourceIds) > 0 {
+		v := s.ResourceIds
+
+		e.SetList(protocol.BodyTarget, "ResourceIds", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResourceId"})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.PathTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type containing tags for the specified resources.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTagsForResourcesResponse
 type ListTagsForResourcesOutput struct {
@@ -11671,6 +13595,17 @@ func (s ListTagsForResourcesOutput) GoString() string {
 func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *ListTagsForResourcesOutput {
 	s.ResourceTagSets = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTagsForResourcesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ResourceTagSets) > 0 {
+		v := s.ResourceTagSets
+
+		e.SetList(protocol.BodyTarget, "ResourceTagSets", encodeResourceTagSetList(v), protocol.Metadata{ListLocationName: "ResourceTagSet"})
+	}
+
+	return nil
 }
 
 // A complex type that contains the information about the request to list the
@@ -11730,6 +13665,22 @@ func (s *ListTrafficPoliciesInput) SetMaxItems(v string) *ListTrafficPoliciesInp
 func (s *ListTrafficPoliciesInput) SetTrafficPolicyIdMarker(v string) *ListTrafficPoliciesInput {
 	s.TrafficPolicyIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPoliciesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyIdMarker != nil {
+		v := *s.TrafficPolicyIdMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -11796,6 +13747,32 @@ func (s *ListTrafficPoliciesOutput) SetTrafficPolicyIdMarker(v string) *ListTraf
 func (s *ListTrafficPoliciesOutput) SetTrafficPolicySummaries(v []*TrafficPolicySummary) *ListTrafficPoliciesOutput {
 	s.TrafficPolicySummaries = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPoliciesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyIdMarker != nil {
+		v := *s.TrafficPolicyIdMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicySummaries) > 0 {
+		v := s.TrafficPolicySummaries
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicySummaries", encodeTrafficPolicySummaryList(v), protocol.Metadata{ListLocationName: "TrafficPolicySummary"})
+	}
+
+	return nil
 }
 
 // A request for the traffic policy instances that you created in a specified
@@ -11888,6 +13865,32 @@ func (s *ListTrafficPolicyInstancesByHostedZoneInput) SetTrafficPolicyInstanceTy
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByHostedZoneInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesByHostedZoneResponse
 type ListTrafficPolicyInstancesByHostedZoneOutput struct {
@@ -11962,6 +13965,37 @@ func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstanceT
 func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstances(v []*TrafficPolicyInstance) *ListTrafficPolicyInstancesByHostedZoneOutput {
 	s.TrafficPolicyInstances = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByHostedZoneOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
 }
 
 // A complex type that contains the information about the request to list your
@@ -12095,6 +14129,42 @@ func (s *ListTrafficPolicyInstancesByPolicyInput) SetTrafficPolicyVersion(v int6
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.QueryTarget, "version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesByPolicyResponse
 type ListTrafficPolicyInstancesByPolicyOutput struct {
@@ -12183,6 +14253,42 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v [
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesByPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
+}
+
 // A request to get information about the traffic policy instances that you
 // created by using the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyInstancesRequest
@@ -12263,6 +14369,32 @@ func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceNameMarker(v s
 func (s *ListTrafficPolicyInstancesInput) SetTrafficPolicyInstanceTypeMarker(v string) *ListTrafficPolicyInstancesInput {
 	s.TrafficPolicyInstanceTypeMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancename", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyinstancetype", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains the response information for the request.
@@ -12354,6 +14486,42 @@ func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstances(v []*Traffi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyInstancesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneIdMarker != nil {
+		v := *s.HostedZoneIdMarker
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceNameMarker != nil {
+		v := *s.TrafficPolicyInstanceNameMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceNameMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceTypeMarker != nil {
+		v := *s.TrafficPolicyInstanceTypeMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceTypeMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicyInstances) > 0 {
+		v := s.TrafficPolicyInstances
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicyInstances", encodeTrafficPolicyInstanceList(v), protocol.Metadata{ListLocationName: "TrafficPolicyInstance"})
+	}
+
+	return nil
+}
+
 // A complex type that contains the information about the request to list your
 // traffic policies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyVersionsRequest
@@ -12429,6 +14597,27 @@ func (s *ListTrafficPolicyVersionsInput) SetTrafficPolicyVersionMarker(v string)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.QueryTarget, "maxitems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersionMarker != nil {
+		v := *s.TrafficPolicyVersionMarker
+
+		e.SetValue(protocol.QueryTarget, "trafficpolicyversion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListTrafficPolicyVersionsResponse
 type ListTrafficPolicyVersionsOutput struct {
@@ -12499,6 +14688,32 @@ func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicyVersionMarker(v string
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListTrafficPolicyVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxItems != nil {
+		v := *s.MaxItems
+
+		e.SetValue(protocol.BodyTarget, "MaxItems", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TrafficPolicies) > 0 {
+		v := s.TrafficPolicies
+
+		e.SetList(protocol.BodyTarget, "TrafficPolicies", encodeTrafficPolicyList(v), protocol.Metadata{ListLocationName: "TrafficPolicy"})
+	}
+	if s.TrafficPolicyVersionMarker != nil {
+		v := *s.TrafficPolicyVersionMarker
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersionMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about that can be associated with
 // your hosted zone.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListVPCAssociationAuthorizationsRequest
@@ -12565,6 +14780,27 @@ func (s *ListVPCAssociationAuthorizationsInput) SetNextToken(v string) *ListVPCA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVPCAssociationAuthorizationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxResults != nil {
+		v := *s.MaxResults
+
+		e.SetValue(protocol.QueryTarget, "maxresults", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.QueryTarget, "nexttoken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ListVPCAssociationAuthorizationsResponse
 type ListVPCAssociationAuthorizationsOutput struct {
@@ -12615,6 +14851,27 @@ func (s *ListVPCAssociationAuthorizationsOutput) SetNextToken(v string) *ListVPC
 func (s *ListVPCAssociationAuthorizationsOutput) SetVPCs(v []*VPC) *ListVPCAssociationAuthorizationsOutput {
 	s.VPCs = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListVPCAssociationAuthorizationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.VPCs) > 0 {
+		v := s.VPCs
+
+		e.SetList(protocol.BodyTarget, "VPCs", encodeVPCList(v), protocol.Metadata{ListLocationName: "VPC"})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a configuration for DNS query
@@ -12668,6 +14925,35 @@ func (s *QueryLoggingConfig) SetId(v string) *QueryLoggingConfig {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueryLoggingConfig) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudWatchLogsLogGroupArn != nil {
+		v := *s.CloudWatchLogsLogGroupArn
+
+		e.SetValue(protocol.BodyTarget, "CloudWatchLogsLogGroupArn", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeQueryLoggingConfigList(vs []*QueryLoggingConfig) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information specific to the resource record.
 //
 // If you're creating an alias resource record set, omit ResourceRecord.
@@ -12717,6 +15003,25 @@ func (s *ResourceRecord) Validate() error {
 func (s *ResourceRecord) SetValue(v string) *ResourceRecord {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceRecord) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceRecordList(vs []*ResourceRecord) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about the resource record set to create or delete.
@@ -13251,6 +15556,85 @@ func (s *ResourceRecordSet) SetWeight(v int64) *ResourceRecordSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceRecordSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AliasTarget != nil {
+		v := s.AliasTarget
+
+		e.SetFields(protocol.BodyTarget, "AliasTarget", v, protocol.Metadata{})
+	}
+	if s.Failover != nil {
+		v := *s.Failover
+
+		e.SetValue(protocol.BodyTarget, "Failover", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GeoLocation != nil {
+		v := s.GeoLocation
+
+		e.SetFields(protocol.BodyTarget, "GeoLocation", v, protocol.Metadata{})
+	}
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultiValueAnswer != nil {
+		v := *s.MultiValueAnswer
+
+		e.SetValue(protocol.BodyTarget, "MultiValueAnswer", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Region != nil {
+		v := *s.Region
+
+		e.SetValue(protocol.BodyTarget, "Region", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.ResourceRecords) > 0 {
+		v := s.ResourceRecords
+
+		e.SetList(protocol.BodyTarget, "ResourceRecords", encodeResourceRecordList(v), protocol.Metadata{ListLocationName: "ResourceRecord"})
+	}
+	if s.SetIdentifier != nil {
+		v := *s.SetIdentifier
+
+		e.SetValue(protocol.BodyTarget, "SetIdentifier", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyInstanceId != nil {
+		v := *s.TrafficPolicyInstanceId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyInstanceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Weight != nil {
+		v := *s.Weight
+
+		e.SetValue(protocol.BodyTarget, "Weight", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourceRecordSetList(vs []*ResourceRecordSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type containing a resource and its associated tags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ResourceTagSet
 type ResourceTagSet struct {
@@ -13298,6 +15682,35 @@ func (s *ResourceTagSet) SetTags(v []*Tag) *ResourceTagSet {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceTagSet) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.BodyTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceType != nil {
+		v := *s.ResourceType
+
+		e.SetValue(protocol.BodyTarget, "ResourceType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tags", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
+}
+
+func encodeResourceTagSetList(vs []*ResourceTagSet) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains the type of limit that you specified in the
 // request and the current value for that limit.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/ReusableDelegationSetLimit
@@ -13339,6 +15752,22 @@ func (s *ReusableDelegationSetLimit) SetValue(v int64) *ReusableDelegationSetLim
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReusableDelegationSetLimit) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the status that one Amazon Route 53 health checker
 // reports and the time of the health check.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/StatusReport
@@ -13376,6 +15805,22 @@ func (s *StatusReport) SetCheckedTime(v time.Time) *StatusReport {
 func (s *StatusReport) SetStatus(v string) *StatusReport {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StatusReport) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CheckedTime != nil {
+		v := *s.CheckedTime
+
+		e.SetValue(protocol.BodyTarget, "CheckedTime", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about a tag that you want to add
@@ -13428,6 +15873,30 @@ func (s *Tag) SetKey(v string) *Tag {
 func (s *Tag) SetValue(v string) *Tag {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Gets the value that Amazon Route 53 returns in response to a DNS request
@@ -13539,6 +16008,42 @@ func (s *TestDNSAnswerInput) SetResolverIP(v string) *TestDNSAnswerInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestDNSAnswerInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EDNS0ClientSubnetIP != nil {
+		v := *s.EDNS0ClientSubnetIP
+
+		e.SetValue(protocol.QueryTarget, "edns0clientsubnetip", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EDNS0ClientSubnetMask != nil {
+		v := *s.EDNS0ClientSubnetMask
+
+		e.SetValue(protocol.QueryTarget, "edns0clientsubnetmask", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.QueryTarget, "hostedzoneid", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordName != nil {
+		v := *s.RecordName
+
+		e.SetValue(protocol.QueryTarget, "recordname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordType != nil {
+		v := *s.RecordType
+
+		e.SetValue(protocol.QueryTarget, "recordtype", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResolverIP != nil {
+		v := *s.ResolverIP
+
+		e.SetValue(protocol.QueryTarget, "resolverip", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to a TestDNSAnswer request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TestDNSAnswerResponse
 type TestDNSAnswerOutput struct {
@@ -13627,6 +16132,42 @@ func (s *TestDNSAnswerOutput) SetResponseCode(v string) *TestDNSAnswerOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TestDNSAnswerOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Nameserver != nil {
+		v := *s.Nameserver
+
+		e.SetValue(protocol.BodyTarget, "Nameserver", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.RecordData) > 0 {
+		v := s.RecordData
+
+		e.SetList(protocol.BodyTarget, "RecordData", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "RecordDataEntry"})
+	}
+	if s.RecordName != nil {
+		v := *s.RecordName
+
+		e.SetValue(protocol.BodyTarget, "RecordName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecordType != nil {
+		v := *s.RecordType
+
+		e.SetValue(protocol.BodyTarget, "RecordType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCode != nil {
+		v := *s.ResponseCode
+
+		e.SetValue(protocol.BodyTarget, "ResponseCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains settings for a traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TrafficPolicy
 type TrafficPolicy struct {
@@ -13710,6 +16251,50 @@ func (s *TrafficPolicy) SetType(v string) *TrafficPolicy {
 func (s *TrafficPolicy) SetVersion(v int64) *TrafficPolicy {
 	s.Version = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.BodyTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicyList(vs []*TrafficPolicy) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains settings for the new traffic policy instance.
@@ -13845,6 +16430,65 @@ func (s *TrafficPolicyInstance) SetTrafficPolicyVersion(v int64) *TrafficPolicyI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicyInstance) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZoneId != nil {
+		v := *s.HostedZoneId
+
+		e.SetValue(protocol.BodyTarget, "HostedZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyType != nil {
+		v := *s.TrafficPolicyType
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicyInstanceList(vs []*TrafficPolicyInstance) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A complex type that contains information about the latest version of one
 // traffic policy that is associated with the current AWS account.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/TrafficPolicySummary
@@ -13917,6 +16561,45 @@ func (s *TrafficPolicySummary) SetTrafficPolicyCount(v int64) *TrafficPolicySumm
 func (s *TrafficPolicySummary) SetType(v string) *TrafficPolicySummary {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TrafficPolicySummary) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LatestVersion != nil {
+		v := *s.LatestVersion
+
+		e.SetValue(protocol.BodyTarget, "LatestVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyCount != nil {
+		v := *s.TrafficPolicyCount
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTrafficPolicySummaryList(vs []*TrafficPolicySummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // A complex type that contains information about a request to update a health
@@ -14310,6 +16993,92 @@ func (s *UpdateHealthCheckInput) SetSearchString(v string) *UpdateHealthCheckInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHealthCheckInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AlarmIdentifier != nil {
+		v := s.AlarmIdentifier
+
+		e.SetFields(protocol.BodyTarget, "AlarmIdentifier", v, protocol.Metadata{})
+	}
+	if len(s.ChildHealthChecks) > 0 {
+		v := s.ChildHealthChecks
+
+		e.SetList(protocol.BodyTarget, "ChildHealthChecks", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ChildHealthCheck"})
+	}
+	if s.EnableSNI != nil {
+		v := *s.EnableSNI
+
+		e.SetValue(protocol.BodyTarget, "EnableSNI", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.FailureThreshold != nil {
+		v := *s.FailureThreshold
+
+		e.SetValue(protocol.BodyTarget, "FailureThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.FullyQualifiedDomainName != nil {
+		v := *s.FullyQualifiedDomainName
+
+		e.SetValue(protocol.BodyTarget, "FullyQualifiedDomainName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckId != nil {
+		v := *s.HealthCheckId
+
+		e.SetValue(protocol.PathTarget, "HealthCheckId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HealthCheckVersion != nil {
+		v := *s.HealthCheckVersion
+
+		e.SetValue(protocol.BodyTarget, "HealthCheckVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HealthThreshold != nil {
+		v := *s.HealthThreshold
+
+		e.SetValue(protocol.BodyTarget, "HealthThreshold", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.IPAddress != nil {
+		v := *s.IPAddress
+
+		e.SetValue(protocol.BodyTarget, "IPAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InsufficientDataHealthStatus != nil {
+		v := *s.InsufficientDataHealthStatus
+
+		e.SetValue(protocol.BodyTarget, "InsufficientDataHealthStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Inverted != nil {
+		v := *s.Inverted
+
+		e.SetValue(protocol.BodyTarget, "Inverted", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Port != nil {
+		v := *s.Port
+
+		e.SetValue(protocol.BodyTarget, "Port", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Regions) > 0 {
+		v := s.Regions
+
+		e.SetList(protocol.BodyTarget, "Regions", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Region"})
+	}
+	if len(s.ResetElements) > 0 {
+		v := s.ResetElements
+
+		e.SetList(protocol.BodyTarget, "ResetElements", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "ResettableElementName"})
+	}
+	if s.ResourcePath != nil {
+		v := *s.ResourcePath
+
+		e.SetValue(protocol.BodyTarget, "ResourcePath", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SearchString != nil {
+		v := *s.SearchString
+
+		e.SetValue(protocol.BodyTarget, "SearchString", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateHealthCheckResponse
 type UpdateHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
@@ -14335,6 +17104,17 @@ func (s UpdateHealthCheckOutput) GoString() string {
 func (s *UpdateHealthCheckOutput) SetHealthCheck(v *HealthCheck) *UpdateHealthCheckOutput {
 	s.HealthCheck = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHealthCheckOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HealthCheck != nil {
+		v := s.HealthCheck
+
+		e.SetFields(protocol.BodyTarget, "HealthCheck", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A request to update the comment for a hosted zone.
@@ -14387,6 +17167,22 @@ func (s *UpdateHostedZoneCommentInput) SetId(v string) *UpdateHostedZoneCommentI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHostedZoneCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response to the UpdateHostedZoneComment
 // request.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateHostedZoneCommentResponse
@@ -14413,6 +17209,17 @@ func (s UpdateHostedZoneCommentOutput) GoString() string {
 func (s *UpdateHostedZoneCommentOutput) SetHostedZone(v *HostedZone) *UpdateHostedZoneCommentOutput {
 	s.HostedZone = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateHostedZoneCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostedZone != nil {
+		v := s.HostedZone
+
+		e.SetFields(protocol.BodyTarget, "HostedZone", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the traffic policy that you
@@ -14492,6 +17299,27 @@ func (s *UpdateTrafficPolicyCommentInput) SetVersion(v int64) *UpdateTrafficPoli
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := *s.Comment
+
+		e.SetValue(protocol.BodyTarget, "Comment", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Version != nil {
+		v := *s.Version
+
+		e.SetValue(protocol.PathTarget, "Version", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains the response information for the traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateTrafficPolicyCommentResponse
 type UpdateTrafficPolicyCommentOutput struct {
@@ -14517,6 +17345,17 @@ func (s UpdateTrafficPolicyCommentOutput) GoString() string {
 func (s *UpdateTrafficPolicyCommentOutput) SetTrafficPolicy(v *TrafficPolicy) *UpdateTrafficPolicyCommentOutput {
 	s.TrafficPolicy = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicy != nil {
+		v := s.TrafficPolicy
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicy", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A complex type that contains information about the resource record sets that
@@ -14614,6 +17453,32 @@ func (s *UpdateTrafficPolicyInstanceInput) SetTrafficPolicyVersion(v int64) *Upd
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyInstanceInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.PathTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TTL != nil {
+		v := *s.TTL
+
+		e.SetValue(protocol.BodyTarget, "TTL", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyId != nil {
+		v := *s.TrafficPolicyId
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TrafficPolicyVersion != nil {
+		v := *s.TrafficPolicyVersion
+
+		e.SetValue(protocol.BodyTarget, "TrafficPolicyVersion", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // A complex type that contains information about the resource record sets that
 // Amazon Route 53 created based on a specified traffic policy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53-2013-04-01/UpdateTrafficPolicyInstanceResponse
@@ -14640,6 +17505,17 @@ func (s UpdateTrafficPolicyInstanceOutput) GoString() string {
 func (s *UpdateTrafficPolicyInstanceOutput) SetTrafficPolicyInstance(v *TrafficPolicyInstance) *UpdateTrafficPolicyInstanceOutput {
 	s.TrafficPolicyInstance = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateTrafficPolicyInstanceOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TrafficPolicyInstance != nil {
+		v := s.TrafficPolicyInstance
+
+		e.SetFields(protocol.BodyTarget, "TrafficPolicyInstance", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // (Private hosted zones only) A complex type that contains information about
@@ -14688,6 +17564,30 @@ func (s *VPC) SetVPCId(v string) *VPC {
 func (s *VPC) SetVPCRegion(v string) *VPC {
 	s.VPCRegion = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VPC) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VPCId != nil {
+		v := *s.VPCId
+
+		e.SetValue(protocol.BodyTarget, "VPCId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VPCRegion != nil {
+		v := *s.VPCRegion
+
+		e.SetValue(protocol.BodyTarget, "VPCRegion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeVPCList(vs []*VPC) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 const (

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -6198,6 +6198,17 @@ func (s *AbortIncompleteMultipartUpload) SetDaysAfterInitiation(v int64) *AbortI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortIncompleteMultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DaysAfterInitiation != nil {
+		v := *s.DaysAfterInitiation
+
+		e.SetValue(protocol.BodyTarget, "DaysAfterInitiation", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AbortMultipartUploadRequest
 type AbortMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
@@ -6281,6 +6292,32 @@ func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AbortMultipartUploadOutput
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -6306,6 +6343,17 @@ func (s *AbortMultipartUploadOutput) SetRequestCharged(v string) *AbortMultipart
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccelerateConfiguration
 type AccelerateConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -6328,6 +6376,17 @@ func (s AccelerateConfiguration) GoString() string {
 func (s *AccelerateConfiguration) SetStatus(v string) *AccelerateConfiguration {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccelerateConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccessControlPolicy
@@ -6382,6 +6441,22 @@ func (s *AccessControlPolicy) SetOwner(v *Owner) *AccessControlPolicy {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessControlPolicy) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for information regarding the access control for replicas.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AccessControlTranslation
 type AccessControlTranslation struct {
@@ -6420,6 +6495,17 @@ func (s *AccessControlTranslation) Validate() error {
 func (s *AccessControlTranslation) SetOwner(v string) *AccessControlTranslation {
 	s.Owner = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AccessControlTranslation) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Owner != nil {
+		v := *s.Owner
+
+		e.SetValue(protocol.BodyTarget, "Owner", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsAndOperator
@@ -6473,6 +6559,22 @@ func (s *AnalyticsAndOperator) SetPrefix(v string) *AnalyticsAndOperator {
 func (s *AnalyticsAndOperator) SetTags(v []*Tag) *AnalyticsAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsConfiguration
@@ -6550,6 +6652,35 @@ func (s *AnalyticsConfiguration) SetStorageClassAnalysis(v *StorageClassAnalysis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClassAnalysis != nil {
+		v := s.StorageClassAnalysis
+
+		e.SetFields(protocol.BodyTarget, "StorageClassAnalysis", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAnalyticsConfigurationList(vs []*AnalyticsConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsExportDestination
 type AnalyticsExportDestination struct {
 	_ struct{} `type:"structure"`
@@ -6592,6 +6723,17 @@ func (s *AnalyticsExportDestination) Validate() error {
 func (s *AnalyticsExportDestination) SetS3BucketDestination(v *AnalyticsS3BucketDestination) *AnalyticsExportDestination {
 	s.S3BucketDestination = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsExportDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3BucketDestination != nil {
+		v := s.S3BucketDestination
+
+		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsFilter
@@ -6655,6 +6797,27 @@ func (s *AnalyticsFilter) SetPrefix(v string) *AnalyticsFilter {
 func (s *AnalyticsFilter) SetTag(v *Tag) *AnalyticsFilter {
 	s.Tag = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/AnalyticsS3BucketDestination
@@ -6737,6 +6900,32 @@ func (s *AnalyticsS3BucketDestination) SetPrefix(v string) *AnalyticsS3BucketDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnalyticsS3BucketDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BucketAccountId != nil {
+		v := *s.BucketAccountId
+
+		e.SetValue(protocol.BodyTarget, "BucketAccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Bucket
 type Bucket struct {
 	_ struct{} `type:"structure"`
@@ -6768,6 +6957,30 @@ func (s *Bucket) SetCreationDate(v time.Time) *Bucket {
 func (s *Bucket) SetName(v string) *Bucket {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreationDate != nil {
+		v := *s.CreationDate
+
+		e.SetValue(protocol.BodyTarget, "CreationDate", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeBucketList(vs []*Bucket) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketLifecycleConfiguration
@@ -6817,6 +7030,17 @@ func (s *BucketLifecycleConfiguration) SetRules(v []*LifecycleRule) *BucketLifec
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketLifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/BucketLoggingStatus
 type BucketLoggingStatus struct {
 	_ struct{} `type:"structure"`
@@ -6853,6 +7077,17 @@ func (s *BucketLoggingStatus) Validate() error {
 func (s *BucketLoggingStatus) SetLoggingEnabled(v *LoggingEnabled) *BucketLoggingStatus {
 	s.LoggingEnabled = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BucketLoggingStatus) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingEnabled != nil {
+		v := s.LoggingEnabled
+
+		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CORSConfiguration
@@ -6900,6 +7135,17 @@ func (s *CORSConfiguration) Validate() error {
 func (s *CORSConfiguration) SetCORSRules(v []*CORSRule) *CORSConfiguration {
 	s.CORSRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CORSConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CORSRules) > 0 {
+		v := s.CORSRules
+
+		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CORSRule
@@ -6986,6 +7232,45 @@ func (s *CORSRule) SetMaxAgeSeconds(v int64) *CORSRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CORSRule) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AllowedHeaders) > 0 {
+		v := s.AllowedHeaders
+
+		e.SetList(protocol.BodyTarget, "AllowedHeader", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.AllowedMethods) > 0 {
+		v := s.AllowedMethods
+
+		e.SetList(protocol.BodyTarget, "AllowedMethod", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.AllowedOrigins) > 0 {
+		v := s.AllowedOrigins
+
+		e.SetList(protocol.BodyTarget, "AllowedOrigin", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.ExposeHeaders) > 0 {
+		v := s.ExposeHeaders
+
+		e.SetList(protocol.BodyTarget, "ExposeHeader", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.MaxAgeSeconds != nil {
+		v := *s.MaxAgeSeconds
+
+		e.SetValue(protocol.BodyTarget, "MaxAgeSeconds", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCORSRuleList(vs []*CORSRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CloudFunctionConfiguration
 type CloudFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -7044,6 +7329,37 @@ func (s *CloudFunctionConfiguration) SetInvocationRole(v string) *CloudFunctionC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CloudFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFunction != nil {
+		v := *s.CloudFunction
+
+		e.SetValue(protocol.BodyTarget, "CloudFunction", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InvocationRole != nil {
+		v := *s.InvocationRole
+
+		e.SetValue(protocol.BodyTarget, "InvocationRole", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CommonPrefix
 type CommonPrefix struct {
 	_ struct{} `type:"structure"`
@@ -7065,6 +7381,25 @@ func (s CommonPrefix) GoString() string {
 func (s *CommonPrefix) SetPrefix(v string) *CommonPrefix {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CommonPrefix) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCommonPrefixList(vs []*CommonPrefix) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompleteMultipartUploadRequest
@@ -7156,6 +7491,37 @@ func (s *CompleteMultipartUploadInput) SetRequestPayer(v string) *CompleteMultip
 func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartUploadInput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MultipartUpload != nil {
+		v := s.MultipartUpload
+
+		e.SetFields(protocol.PayloadTarget, "CompleteMultipartUpload", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompleteMultipartUploadOutput
@@ -7262,6 +7628,57 @@ func (s *CompleteMultipartUploadOutput) SetVersionId(v string) *CompleteMultipar
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompleteMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.BodyTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompletedMultipartUpload
 type CompletedMultipartUpload struct {
 	_ struct{} `type:"structure"`
@@ -7283,6 +7700,17 @@ func (s CompletedMultipartUpload) GoString() string {
 func (s *CompletedMultipartUpload) SetParts(v []*CompletedPart) *CompletedMultipartUpload {
 	s.Parts = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompletedMultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Part", encodeCompletedPartList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CompletedPart
@@ -7317,6 +7745,30 @@ func (s *CompletedPart) SetETag(v string) *CompletedPart {
 func (s *CompletedPart) SetPartNumber(v int64) *CompletedPart {
 	s.PartNumber = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CompletedPart) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.BodyTarget, "PartNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCompletedPartList(vs []*CompletedPart) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Condition
@@ -7360,6 +7812,22 @@ func (s *Condition) SetHttpErrorCodeReturnedEquals(v string) *Condition {
 func (s *Condition) SetKeyPrefixEquals(v string) *Condition {
 	s.KeyPrefixEquals = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Condition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HttpErrorCodeReturnedEquals != nil {
+		v := *s.HttpErrorCodeReturnedEquals
+
+		e.SetValue(protocol.BodyTarget, "HttpErrorCodeReturnedEquals", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyPrefixEquals != nil {
+		v := *s.KeyPrefixEquals
+
+		e.SetValue(protocol.BodyTarget, "KeyPrefixEquals", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectRequest
@@ -7746,6 +8214,177 @@ func (s *CopyObjectInput) SetWebsiteRedirectLocation(v string) *CopyObjectInput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySource != nil {
+		v := *s.CopySource
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfMatch != nil {
+		v := *s.CopySourceIfMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfModifiedSince != nil {
+		v := *s.CopySourceIfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-modified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceIfNoneMatch != nil {
+		v := *s.CopySourceIfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-none-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfUnmodifiedSince != nil {
+		v := *s.CopySourceIfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-unmodified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerAlgorithm != nil {
+		v := *s.CopySourceSSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKey != nil {
+		v := *s.CopySourceSSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKeyMD5 != nil {
+		v := *s.CopySourceSSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MetadataDirective != nil {
+		v := *s.MetadataDirective
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-metadata-directive", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TaggingDirective != nil {
+		v := *s.TaggingDirective
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging-directive", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectOutput
 type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
@@ -7847,6 +8486,57 @@ func (s *CopyObjectOutput) SetVersionId(v string) *CopyObjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CopyObjectResult != nil {
+		v := s.CopyObjectResult
+
+		e.SetFields(protocol.PayloadTarget, "CopyObjectResult", v, protocol.Metadata{})
+	}
+	if s.CopySourceVersionId != nil {
+		v := *s.CopySourceVersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyObjectResult
 type CopyObjectResult struct {
 	_ struct{} `type:"structure"`
@@ -7876,6 +8566,22 @@ func (s *CopyObjectResult) SetETag(v string) *CopyObjectResult {
 func (s *CopyObjectResult) SetLastModified(v time.Time) *CopyObjectResult {
 	s.LastModified = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyObjectResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CopyPartResult
@@ -7911,6 +8617,22 @@ func (s *CopyPartResult) SetLastModified(v time.Time) *CopyPartResult {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CopyPartResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketConfiguration
 type CreateBucketConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -7934,6 +8656,17 @@ func (s CreateBucketConfiguration) GoString() string {
 func (s *CreateBucketConfiguration) SetLocationConstraint(v string) *CreateBucketConfiguration {
 	s.LocationConstraint = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LocationConstraint != nil {
+		v := *s.LocationConstraint
+
+		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketRequest
@@ -8043,6 +8776,52 @@ func (s *CreateBucketInput) SetGrantWriteACP(v string) *CreateBucketInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreateBucketConfiguration != nil {
+		v := s.CreateBucketConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "CreateBucketConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucketOutput
 type CreateBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -8064,6 +8843,17 @@ func (s CreateBucketOutput) GoString() string {
 func (s *CreateBucketOutput) SetLocation(v string) *CreateBucketOutput {
 	s.Location = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Location != nil {
+		v := *s.Location
+
+		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateMultipartUploadRequest
@@ -8338,6 +9128,127 @@ func (s *CreateMultipartUploadInput) SetWebsiteRedirectLocation(v string) *Creat
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateMultipartUploadOutput
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -8458,6 +9369,62 @@ func (s *CreateMultipartUploadOutput) SetUploadId(v string) *CreateMultipartUplo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortDate != nil {
+		v := *s.AbortDate
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Delete
 type Delete struct {
 	_ struct{} `type:"structure"`
@@ -8513,6 +9480,22 @@ func (s *Delete) SetObjects(v []*ObjectIdentifier) *Delete {
 func (s *Delete) SetQuiet(v bool) *Delete {
 	s.Quiet = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Delete) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Objects) > 0 {
+		v := s.Objects
+
+		e.SetList(protocol.BodyTarget, "Object", encodeObjectIdentifierList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Quiet != nil {
+		v := *s.Quiet
+
+		e.SetValue(protocol.BodyTarget, "Quiet", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketAnalyticsConfigurationRequest
@@ -8575,6 +9558,22 @@ func (s *DeleteBucketAnalyticsConfigurationInput) SetId(v string) *DeleteBucketA
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketAnalyticsConfigurationOutput
 type DeleteBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8588,6 +9587,12 @@ func (s DeleteBucketAnalyticsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketAnalyticsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketCorsRequest
@@ -8634,6 +9639,17 @@ func (s *DeleteBucketCorsInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketCorsOutput
 type DeleteBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8647,6 +9663,12 @@ func (s DeleteBucketCorsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketCorsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryptionRequest
@@ -8696,6 +9718,17 @@ func (s *DeleteBucketEncryptionInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketEncryptionOutput
 type DeleteBucketEncryptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8709,6 +9742,12 @@ func (s DeleteBucketEncryptionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketEncryptionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketRequest
@@ -8753,6 +9792,17 @@ func (s *DeleteBucketInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketInventoryConfigurationRequest
@@ -8815,6 +9865,22 @@ func (s *DeleteBucketInventoryConfigurationInput) SetId(v string) *DeleteBucketI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketInventoryConfigurationOutput
 type DeleteBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8828,6 +9894,12 @@ func (s DeleteBucketInventoryConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketInventoryConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketLifecycleRequest
@@ -8874,6 +9946,17 @@ func (s *DeleteBucketLifecycleInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketLifecycleOutput
 type DeleteBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -8887,6 +9970,12 @@ func (s DeleteBucketLifecycleOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketLifecycleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketMetricsConfigurationRequest
@@ -8949,6 +10038,22 @@ func (s *DeleteBucketMetricsConfigurationInput) SetId(v string) *DeleteBucketMet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketMetricsConfigurationOutput
 type DeleteBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -8964,6 +10069,12 @@ func (s DeleteBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketOutput
 type DeleteBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -8977,6 +10088,12 @@ func (s DeleteBucketOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketPolicyRequest
@@ -9023,6 +10140,17 @@ func (s *DeleteBucketPolicyInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketPolicyOutput
 type DeleteBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -9036,6 +10164,12 @@ func (s DeleteBucketPolicyOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketReplicationRequest
@@ -9082,6 +10216,17 @@ func (s *DeleteBucketReplicationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketReplicationOutput
 type DeleteBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -9095,6 +10240,12 @@ func (s DeleteBucketReplicationOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketReplicationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketTaggingRequest
@@ -9141,6 +10292,17 @@ func (s *DeleteBucketTaggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketTaggingOutput
 type DeleteBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -9154,6 +10316,12 @@ func (s DeleteBucketTaggingOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketTaggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketWebsiteRequest
@@ -9200,6 +10368,17 @@ func (s *DeleteBucketWebsiteInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteBucketWebsiteOutput
 type DeleteBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -9213,6 +10392,12 @@ func (s DeleteBucketWebsiteOutput) String() string {
 // GoString returns the string representation
 func (s DeleteBucketWebsiteOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteMarkerEntry
@@ -9273,6 +10458,45 @@ func (s *DeleteMarkerEntry) SetOwner(v *Owner) *DeleteMarkerEntry {
 func (s *DeleteMarkerEntry) SetVersionId(v string) *DeleteMarkerEntry {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteMarkerEntry) MarshalFields(e protocol.FieldEncoder) error {
+	if s.IsLatest != nil {
+		v := *s.IsLatest
+
+		e.SetValue(protocol.BodyTarget, "IsLatest", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeleteMarkerEntryList(vs []*DeleteMarkerEntry) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectRequest
@@ -9365,6 +10589,37 @@ func (s *DeleteObjectInput) SetVersionId(v string) *DeleteObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectOutput
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -9408,6 +10663,27 @@ func (s *DeleteObjectOutput) SetRequestCharged(v string) *DeleteObjectOutput {
 func (s *DeleteObjectOutput) SetVersionId(v string) *DeleteObjectOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectTaggingRequest
@@ -9478,6 +10754,27 @@ func (s *DeleteObjectTaggingInput) SetVersionId(v string) *DeleteObjectTaggingIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectTaggingOutput
 type DeleteObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -9500,6 +10797,17 @@ func (s DeleteObjectTaggingOutput) GoString() string {
 func (s *DeleteObjectTaggingOutput) SetVersionId(v string) *DeleteObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectsRequest
@@ -9585,6 +10893,32 @@ func (s *DeleteObjectsInput) SetRequestPayer(v string) *DeleteObjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delete != nil {
+		v := s.Delete
+
+		e.SetFields(protocol.PayloadTarget, "Delete", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeleteObjectsOutput
 type DeleteObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -9624,6 +10958,27 @@ func (s *DeleteObjectsOutput) SetErrors(v []*Error) *DeleteObjectsOutput {
 func (s *DeleteObjectsOutput) SetRequestCharged(v string) *DeleteObjectsOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Deleted) > 0 {
+		v := s.Deleted
+
+		e.SetList(protocol.BodyTarget, "Deleted", encodeDeletedObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Errors) > 0 {
+		v := s.Errors
+
+		e.SetList(protocol.BodyTarget, "Error", encodeErrorList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/DeletedObject
@@ -9671,6 +11026,40 @@ func (s *DeletedObject) SetKey(v string) *DeletedObject {
 func (s *DeletedObject) SetVersionId(v string) *DeletedObject {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeletedObject) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.BodyTarget, "DeleteMarker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarkerVersionId != nil {
+		v := *s.DeleteMarkerVersionId
+
+		e.SetValue(protocol.BodyTarget, "DeleteMarkerVersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDeletedObjectList(vs []*DeletedObject) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for replication destination information.
@@ -9763,6 +11152,37 @@ func (s *Destination) SetStorageClass(v string) *Destination {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Destination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccessControlTranslation != nil {
+		v := s.AccessControlTranslation
+
+		e.SetFields(protocol.BodyTarget, "AccessControlTranslation", v, protocol.Metadata{})
+	}
+	if s.Account != nil {
+		v := *s.Account
+
+		e.SetValue(protocol.BodyTarget, "Account", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncryptionConfiguration != nil {
+		v := s.EncryptionConfiguration
+
+		e.SetFields(protocol.BodyTarget, "EncryptionConfiguration", v, protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for information regarding encryption based configuration for replicas.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/EncryptionConfiguration
 type EncryptionConfiguration struct {
@@ -9786,6 +11206,17 @@ func (s EncryptionConfiguration) GoString() string {
 func (s *EncryptionConfiguration) SetReplicaKmsKeyID(v string) *EncryptionConfiguration {
 	s.ReplicaKmsKeyID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EncryptionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ReplicaKmsKeyID != nil {
+		v := *s.ReplicaKmsKeyID
+
+		e.SetValue(protocol.BodyTarget, "ReplicaKmsKeyID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Error
@@ -9835,6 +11266,40 @@ func (s *Error) SetVersionId(v string) *Error {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Error) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Code != nil {
+		v := *s.Code
+
+		e.SetValue(protocol.BodyTarget, "Code", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeErrorList(vs []*Error) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ErrorDocument
 type ErrorDocument struct {
 	_ struct{} `type:"structure"`
@@ -9877,6 +11342,17 @@ func (s *ErrorDocument) SetKey(v string) *ErrorDocument {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorDocument) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for key value pair that defines the criteria for the filter rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/FilterRule
 type FilterRule struct {
@@ -9911,6 +11387,30 @@ func (s *FilterRule) SetName(v string) *FilterRule {
 func (s *FilterRule) SetValue(v string) *FilterRule {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FilterRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFilterRuleList(vs []*FilterRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAccelerateConfigurationRequest
@@ -9959,6 +11459,17 @@ func (s *GetBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAccelerateConfigurationOutput
 type GetBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -9981,6 +11492,17 @@ func (s GetBucketAccelerateConfigurationOutput) GoString() string {
 func (s *GetBucketAccelerateConfigurationOutput) SetStatus(v string) *GetBucketAccelerateConfigurationOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAclRequest
@@ -10027,6 +11549,17 @@ func (s *GetBucketAclInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAclOutput
 type GetBucketAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -10057,6 +11590,22 @@ func (s *GetBucketAclOutput) SetGrants(v []*Grant) *GetBucketAclOutput {
 func (s *GetBucketAclOutput) SetOwner(v *Owner) *GetBucketAclOutput {
 	s.Owner = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAnalyticsConfigurationRequest
@@ -10119,6 +11668,22 @@ func (s *GetBucketAnalyticsConfigurationInput) SetId(v string) *GetBucketAnalyti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketAnalyticsConfigurationOutput
 type GetBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
@@ -10141,6 +11706,17 @@ func (s GetBucketAnalyticsConfigurationOutput) GoString() string {
 func (s *GetBucketAnalyticsConfigurationOutput) SetAnalyticsConfiguration(v *AnalyticsConfiguration) *GetBucketAnalyticsConfigurationOutput {
 	s.AnalyticsConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnalyticsConfiguration != nil {
+		v := s.AnalyticsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketCorsRequest
@@ -10187,6 +11763,17 @@ func (s *GetBucketCorsInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketCorsOutput
 type GetBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -10208,6 +11795,17 @@ func (s GetBucketCorsOutput) GoString() string {
 func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
 	s.CORSRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CORSRules) > 0 {
+		v := s.CORSRules
+
+		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryptionRequest
@@ -10257,6 +11855,17 @@ func (s *GetBucketEncryptionInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketEncryptionOutput
 type GetBucketEncryptionOutput struct {
 	_ struct{} `type:"structure" payload:"ServerSideEncryptionConfiguration"`
@@ -10280,6 +11889,17 @@ func (s GetBucketEncryptionOutput) GoString() string {
 func (s *GetBucketEncryptionOutput) SetServerSideEncryptionConfiguration(v *ServerSideEncryptionConfiguration) *GetBucketEncryptionOutput {
 	s.ServerSideEncryptionConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ServerSideEncryptionConfiguration != nil {
+		v := s.ServerSideEncryptionConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ServerSideEncryptionConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketInventoryConfigurationRequest
@@ -10342,6 +11962,22 @@ func (s *GetBucketInventoryConfigurationInput) SetId(v string) *GetBucketInvento
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketInventoryConfigurationOutput
 type GetBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
@@ -10364,6 +12000,17 @@ func (s GetBucketInventoryConfigurationOutput) GoString() string {
 func (s *GetBucketInventoryConfigurationOutput) SetInventoryConfiguration(v *InventoryConfiguration) *GetBucketInventoryConfigurationOutput {
 	s.InventoryConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.InventoryConfiguration != nil {
+		v := s.InventoryConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleConfigurationRequest
@@ -10410,6 +12057,17 @@ func (s *GetBucketLifecycleConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleConfigurationOutput
 type GetBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -10431,6 +12089,17 @@ func (s GetBucketLifecycleConfigurationOutput) GoString() string {
 func (s *GetBucketLifecycleConfigurationOutput) SetRules(v []*LifecycleRule) *GetBucketLifecycleConfigurationOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleRequest
@@ -10477,6 +12146,17 @@ func (s *GetBucketLifecycleInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLifecycleOutput
 type GetBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -10498,6 +12178,17 @@ func (s GetBucketLifecycleOutput) GoString() string {
 func (s *GetBucketLifecycleOutput) SetRules(v []*Rule) *GetBucketLifecycleOutput {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationRequest
@@ -10544,6 +12235,17 @@ func (s *GetBucketLocationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLocationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLocationOutput
 type GetBucketLocationOutput struct {
 	_ struct{} `type:"structure"`
@@ -10565,6 +12267,17 @@ func (s GetBucketLocationOutput) GoString() string {
 func (s *GetBucketLocationOutput) SetLocationConstraint(v string) *GetBucketLocationOutput {
 	s.LocationConstraint = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LocationConstraint != nil {
+		v := *s.LocationConstraint
+
+		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLoggingRequest
@@ -10611,6 +12324,17 @@ func (s *GetBucketLoggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketLoggingOutput
 type GetBucketLoggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -10632,6 +12356,17 @@ func (s GetBucketLoggingOutput) GoString() string {
 func (s *GetBucketLoggingOutput) SetLoggingEnabled(v *LoggingEnabled) *GetBucketLoggingOutput {
 	s.LoggingEnabled = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.LoggingEnabled != nil {
+		v := s.LoggingEnabled
+
+		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketMetricsConfigurationRequest
@@ -10694,6 +12429,22 @@ func (s *GetBucketMetricsConfigurationInput) SetId(v string) *GetBucketMetricsCo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketMetricsConfigurationOutput
 type GetBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
@@ -10716,6 +12467,17 @@ func (s GetBucketMetricsConfigurationOutput) GoString() string {
 func (s *GetBucketMetricsConfigurationOutput) SetMetricsConfiguration(v *MetricsConfiguration) *GetBucketMetricsConfigurationOutput {
 	s.MetricsConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MetricsConfiguration != nil {
+		v := s.MetricsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketNotificationConfigurationRequest
@@ -10764,6 +12526,17 @@ func (s *GetBucketNotificationConfigurationRequest) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketNotificationConfigurationRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketPolicyRequest
 type GetBucketPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -10808,6 +12581,17 @@ func (s *GetBucketPolicyInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketPolicyOutput
 type GetBucketPolicyOutput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
@@ -10830,6 +12614,17 @@ func (s GetBucketPolicyOutput) GoString() string {
 func (s *GetBucketPolicyOutput) SetPolicy(v string) *GetBucketPolicyOutput {
 	s.Policy = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketReplicationRequest
@@ -10876,6 +12671,17 @@ func (s *GetBucketReplicationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketReplicationOutput
 type GetBucketReplicationOutput struct {
 	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
@@ -10899,6 +12705,17 @@ func (s GetBucketReplicationOutput) GoString() string {
 func (s *GetBucketReplicationOutput) SetReplicationConfiguration(v *ReplicationConfiguration) *GetBucketReplicationOutput {
 	s.ReplicationConfiguration = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ReplicationConfiguration != nil {
+		v := s.ReplicationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketRequestPaymentRequest
@@ -10945,6 +12762,17 @@ func (s *GetBucketRequestPaymentInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketRequestPaymentOutput
 type GetBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -10967,6 +12795,17 @@ func (s GetBucketRequestPaymentOutput) GoString() string {
 func (s *GetBucketRequestPaymentOutput) SetPayer(v string) *GetBucketRequestPaymentOutput {
 	s.Payer = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payer != nil {
+		v := *s.Payer
+
+		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketTaggingRequest
@@ -11013,6 +12852,17 @@ func (s *GetBucketTaggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketTaggingOutput
 type GetBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -11035,6 +12885,17 @@ func (s GetBucketTaggingOutput) GoString() string {
 func (s *GetBucketTaggingOutput) SetTagSet(v []*Tag) *GetBucketTaggingOutput {
 	s.TagSet = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketVersioningRequest
@@ -11081,6 +12942,17 @@ func (s *GetBucketVersioningInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketVersioningOutput
 type GetBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
@@ -11114,6 +12986,22 @@ func (s *GetBucketVersioningOutput) SetMFADelete(v string) *GetBucketVersioningO
 func (s *GetBucketVersioningOutput) SetStatus(v string) *GetBucketVersioningOutput {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MFADelete != nil {
+		v := *s.MFADelete
+
+		e.SetValue(protocol.BodyTarget, "MfaDelete", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketWebsiteRequest
@@ -11158,6 +13046,17 @@ func (s *GetBucketWebsiteInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetBucketWebsiteOutput
@@ -11205,6 +13104,32 @@ func (s *GetBucketWebsiteOutput) SetRedirectAllRequestsTo(v *RedirectAllRequests
 func (s *GetBucketWebsiteOutput) SetRoutingRules(v []*RoutingRule) *GetBucketWebsiteOutput {
 	s.RoutingRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorDocument != nil {
+		v := s.ErrorDocument
+
+		e.SetFields(protocol.BodyTarget, "ErrorDocument", v, protocol.Metadata{})
+	}
+	if s.IndexDocument != nil {
+		v := s.IndexDocument
+
+		e.SetFields(protocol.BodyTarget, "IndexDocument", v, protocol.Metadata{})
+	}
+	if s.RedirectAllRequestsTo != nil {
+		v := s.RedirectAllRequestsTo
+
+		e.SetFields(protocol.BodyTarget, "RedirectAllRequestsTo", v, protocol.Metadata{})
+	}
+	if len(s.RoutingRules) > 0 {
+		v := s.RoutingRules
+
+		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectAclRequest
@@ -11287,6 +13212,32 @@ func (s *GetObjectAclInput) SetVersionId(v string) *GetObjectAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectAclOutput
 type GetObjectAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -11327,6 +13278,27 @@ func (s *GetObjectAclOutput) SetOwner(v *Owner) *GetObjectAclOutput {
 func (s *GetObjectAclOutput) SetRequestCharged(v string) *GetObjectAclOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Grants) > 0 {
+		v := s.Grants
+
+		e.SetList(protocol.BodyTarget, "AccessControlList", encodeGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectRequest
@@ -11562,6 +13534,107 @@ func (s *GetObjectInput) SetSSECustomerKeyMD5(v string) *GetObjectInput {
 func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfModifiedSince != nil {
+		v := *s.IfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Modified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.IfNoneMatch != nil {
+		v := *s.IfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-None-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfUnmodifiedSince != nil {
+		v := *s.IfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseCacheControl != nil {
+		v := *s.ResponseCacheControl
+
+		e.SetValue(protocol.QueryTarget, "response-cache-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentDisposition != nil {
+		v := *s.ResponseContentDisposition
+
+		e.SetValue(protocol.QueryTarget, "response-content-disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentEncoding != nil {
+		v := *s.ResponseContentEncoding
+
+		e.SetValue(protocol.QueryTarget, "response-content-encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentLanguage != nil {
+		v := *s.ResponseContentLanguage
+
+		e.SetValue(protocol.QueryTarget, "response-content-language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseContentType != nil {
+		v := *s.ResponseContentType
+
+		e.SetValue(protocol.QueryTarget, "response-content-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResponseExpires != nil {
+		v := *s.ResponseExpires
+
+		e.SetValue(protocol.QueryTarget, "response-expires", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectOutput
@@ -11848,6 +13921,148 @@ func (s *GetObjectOutput) SetWebsiteRedirectLocation(v string) *GetObjectOutput 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "accept-ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Body Output type's body not valid.
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentRange != nil {
+		v := *s.ContentRange
+
+		e.SetValue(protocol.HeaderTarget, "Content-Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MissingMeta != nil {
+		v := *s.MissingMeta
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-missing-meta", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartsCount != nil {
+		v := *s.PartsCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mp-parts-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ReplicationStatus != nil {
+		v := *s.ReplicationStatus
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-replication-status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restore != nil {
+		v := *s.Restore
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-restore", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TagCount != nil {
+		v := *s.TagCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTaggingRequest
 type GetObjectTaggingInput struct {
 	_ struct{} `type:"structure"`
@@ -11915,6 +14130,27 @@ func (s *GetObjectTaggingInput) SetVersionId(v string) *GetObjectTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTaggingOutput
 type GetObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -11945,6 +14181,22 @@ func (s *GetObjectTaggingOutput) SetTagSet(v []*Tag) *GetObjectTaggingOutput {
 func (s *GetObjectTaggingOutput) SetVersionId(v string) *GetObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTorrentRequest
@@ -12018,6 +14270,27 @@ func (s *GetObjectTorrentInput) SetRequestPayer(v string) *GetObjectTorrentInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTorrentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GetObjectTorrentOutput
 type GetObjectTorrentOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
@@ -12049,6 +14322,18 @@ func (s *GetObjectTorrentOutput) SetBody(v io.ReadCloser) *GetObjectTorrentOutpu
 func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetObjectTorrentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	// Skipping Body Output type's body not valid.
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/GlacierJobParameters
@@ -12088,6 +14373,17 @@ func (s *GlacierJobParameters) Validate() error {
 func (s *GlacierJobParameters) SetTier(v string) *GlacierJobParameters {
 	s.Tier = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GlacierJobParameters) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Tier != nil {
+		v := *s.Tier
+
+		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Grant
@@ -12135,6 +14431,35 @@ func (s *Grant) SetGrantee(v *Grantee) *Grant {
 func (s *Grant) SetPermission(v string) *Grant {
 	s.Permission = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Grant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+	if s.Permission != nil {
+		v := *s.Permission
+
+		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGrantList(vs []*Grant) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Grantee
@@ -12212,6 +14537,33 @@ func (s *Grantee) SetURI(v string) *Grantee {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Grantee) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	// Skipping Type XML Attribute.
+	if s.URI != nil {
+		v := *s.URI
+
+		e.SetValue(protocol.BodyTarget, "URI", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadBucketRequest
 type HeadBucketInput struct {
 	_ struct{} `type:"structure"`
@@ -12256,6 +14608,17 @@ func (s *HeadBucketInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadBucketInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadBucketOutput
 type HeadBucketOutput struct {
 	_ struct{} `type:"structure"`
@@ -12269,6 +14632,12 @@ func (s HeadBucketOutput) String() string {
 // GoString returns the string representation
 func (s HeadBucketOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadObjectRequest
@@ -12451,6 +14820,77 @@ func (s *HeadObjectInput) SetSSECustomerKeyMD5(v string) *HeadObjectInput {
 func (s *HeadObjectInput) SetVersionId(v string) *HeadObjectInput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfMatch != nil {
+		v := *s.IfMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfModifiedSince != nil {
+		v := *s.IfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Modified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.IfNoneMatch != nil {
+		v := *s.IfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "If-None-Match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IfUnmodifiedSince != nil {
+		v := *s.IfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Range != nil {
+		v := *s.Range
+
+		e.SetValue(protocol.HeaderTarget, "Range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/HeadObjectOutput
@@ -12710,6 +15150,137 @@ func (s *HeadObjectOutput) SetWebsiteRedirectLocation(v string) *HeadObjectOutpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HeadObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AcceptRanges != nil {
+		v := *s.AcceptRanges
+
+		e.SetValue(protocol.HeaderTarget, "accept-ranges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteMarker != nil {
+		v := *s.DeleteMarker
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-delete-marker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.MissingMeta != nil {
+		v := *s.MissingMeta
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-missing-meta", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartsCount != nil {
+		v := *s.PartsCount
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mp-parts-count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ReplicationStatus != nil {
+		v := *s.ReplicationStatus
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-replication-status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Restore != nil {
+		v := *s.Restore
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-restore", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/IndexDocument
 type IndexDocument struct {
 	_ struct{} `type:"structure"`
@@ -12752,6 +15323,17 @@ func (s *IndexDocument) SetSuffix(v string) *IndexDocument {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *IndexDocument) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Suffix != nil {
+		v := *s.Suffix
+
+		e.SetValue(protocol.BodyTarget, "Suffix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Initiator
 type Initiator struct {
 	_ struct{} `type:"structure"`
@@ -12784,6 +15366,22 @@ func (s *Initiator) SetDisplayName(v string) *Initiator {
 func (s *Initiator) SetID(v string) *Initiator {
 	s.ID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Initiator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryConfiguration
@@ -12915,6 +15513,55 @@ func (s *InventoryConfiguration) SetSchedule(v *InventorySchedule) *InventoryCon
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludedObjectVersions != nil {
+		v := *s.IncludedObjectVersions
+
+		e.SetValue(protocol.BodyTarget, "IncludedObjectVersions", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsEnabled != nil {
+		v := *s.IsEnabled
+
+		e.SetValue(protocol.BodyTarget, "IsEnabled", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.OptionalFields) > 0 {
+		v := s.OptionalFields
+
+		e.SetList(protocol.BodyTarget, "OptionalFields", protocol.EncodeStringList(v), protocol.Metadata{ListLocationName: "Field"})
+	}
+	if s.Schedule != nil {
+		v := s.Schedule
+
+		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeInventoryConfigurationList(vs []*InventoryConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryDestination
 type InventoryDestination struct {
 	_ struct{} `type:"structure"`
@@ -12958,6 +15605,17 @@ func (s *InventoryDestination) Validate() error {
 func (s *InventoryDestination) SetS3BucketDestination(v *InventoryS3BucketDestination) *InventoryDestination {
 	s.S3BucketDestination = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.S3BucketDestination != nil {
+		v := s.S3BucketDestination
+
+		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Contains the type of server-side encryption used to encrypt the inventory
@@ -13010,6 +15668,22 @@ func (s *InventoryEncryption) SetSSES3(v *SSES3) *InventoryEncryption {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryEncryption) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SSEKMS != nil {
+		v := s.SSEKMS
+
+		e.SetFields(protocol.BodyTarget, "SSE-KMS", v, protocol.Metadata{})
+	}
+	if s.SSES3 != nil {
+		v := s.SSES3
+
+		e.SetFields(protocol.BodyTarget, "SSE-S3", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryFilter
 type InventoryFilter struct {
 	_ struct{} `type:"structure"`
@@ -13047,6 +15721,17 @@ func (s *InventoryFilter) Validate() error {
 func (s *InventoryFilter) SetPrefix(v string) *InventoryFilter {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventoryS3BucketDestination
@@ -13143,6 +15828,37 @@ func (s *InventoryS3BucketDestination) SetPrefix(v string) *InventoryS3BucketDes
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventoryS3BucketDestination) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Encryption != nil {
+		v := s.Encryption
+
+		e.SetFields(protocol.BodyTarget, "Encryption", v, protocol.Metadata{})
+	}
+	if s.Format != nil {
+		v := *s.Format
+
+		e.SetValue(protocol.BodyTarget, "Format", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/InventorySchedule
 type InventorySchedule struct {
 	_ struct{} `type:"structure"`
@@ -13182,6 +15898,17 @@ func (s *InventorySchedule) SetFrequency(v string) *InventorySchedule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InventorySchedule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Frequency != nil {
+		v := *s.Frequency
+
+		e.SetValue(protocol.BodyTarget, "Frequency", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for object key name prefix and suffix filtering rules.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/S3KeyFilter
 type KeyFilter struct {
@@ -13206,6 +15933,17 @@ func (s KeyFilter) GoString() string {
 func (s *KeyFilter) SetFilterRules(v []*FilterRule) *KeyFilter {
 	s.FilterRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *KeyFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.FilterRules) > 0 {
+		v := s.FilterRules
+
+		e.SetList(protocol.BodyTarget, "FilterRule", encodeFilterRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Container for specifying the AWS Lambda notification configuration.
@@ -13281,6 +16019,40 @@ func (s *LambdaFunctionConfiguration) SetLambdaFunctionArn(v string) *LambdaFunc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LambdaFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LambdaFunctionArn != nil {
+		v := *s.LambdaFunctionArn
+
+		e.SetValue(protocol.BodyTarget, "CloudFunction", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeLambdaFunctionConfigurationList(vs []*LambdaFunctionConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleConfiguration
 type LifecycleConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -13328,6 +16100,17 @@ func (s *LifecycleConfiguration) SetRules(v []*Rule) *LifecycleConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleExpiration
 type LifecycleExpiration struct {
 	_ struct{} `type:"structure"`
@@ -13373,6 +16156,27 @@ func (s *LifecycleExpiration) SetDays(v int64) *LifecycleExpiration {
 func (s *LifecycleExpiration) SetExpiredObjectDeleteMarker(v bool) *LifecycleExpiration {
 	s.ExpiredObjectDeleteMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleExpiration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Date != nil {
+		v := *s.Date
+
+		e.SetValue(protocol.BodyTarget, "Date", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ExpiredObjectDeleteMarker != nil {
+		v := *s.ExpiredObjectDeleteMarker
+
+		e.SetValue(protocol.BodyTarget, "ExpiredObjectDeleteMarker", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LifecycleRule
@@ -13496,6 +16300,65 @@ func (s *LifecycleRule) SetTransitions(v []*Transition) *LifecycleRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortIncompleteMultipartUpload != nil {
+		v := s.AbortIncompleteMultipartUpload
+
+		e.SetFields(protocol.BodyTarget, "AbortIncompleteMultipartUpload", v, protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := s.Expiration
+
+		e.SetFields(protocol.BodyTarget, "Expiration", v, protocol.Metadata{})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NoncurrentVersionExpiration != nil {
+		v := s.NoncurrentVersionExpiration
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionExpiration", v, protocol.Metadata{})
+	}
+	if len(s.NoncurrentVersionTransitions) > 0 {
+		v := s.NoncurrentVersionTransitions
+
+		e.SetList(protocol.BodyTarget, "NoncurrentVersionTransition", encodeNoncurrentVersionTransitionList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Transitions) > 0 {
+		v := s.Transitions
+
+		e.SetList(protocol.BodyTarget, "Transition", encodeTransitionList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
+func encodeLifecycleRuleList(vs []*LifecycleRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // This is used in a Lifecycle Rule Filter to apply a logical AND to two or
 // more predicates. The Lifecycle Rule will apply to any object matching all
 // of the predicates configured inside the And operator.
@@ -13550,6 +16413,22 @@ func (s *LifecycleRuleAndOperator) SetPrefix(v string) *LifecycleRuleAndOperator
 func (s *LifecycleRuleAndOperator) SetTags(v []*Tag) *LifecycleRuleAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRuleAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // The Filter is used to identify objects that a Lifecycle Rule applies to.
@@ -13618,6 +16497,27 @@ func (s *LifecycleRuleFilter) SetTag(v *Tag) *LifecycleRuleFilter {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LifecycleRuleFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketAnalyticsConfigurationsRequest
 type ListBucketAnalyticsConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -13674,6 +16574,22 @@ func (s *ListBucketAnalyticsConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketAnalyticsConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketAnalyticsConfigurationsOutput
 type ListBucketAnalyticsConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13727,6 +16643,32 @@ func (s *ListBucketAnalyticsConfigurationsOutput) SetIsTruncated(v bool) *ListBu
 func (s *ListBucketAnalyticsConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketAnalyticsConfigurationsOutput {
 	s.NextContinuationToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketAnalyticsConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.AnalyticsConfigurationList) > 0 {
+		v := s.AnalyticsConfigurationList
+
+		e.SetList(protocol.BodyTarget, "AnalyticsConfiguration", encodeAnalyticsConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketInventoryConfigurationsRequest
@@ -13787,6 +16729,22 @@ func (s *ListBucketInventoryConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketInventoryConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketInventoryConfigurationsOutput
 type ListBucketInventoryConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13840,6 +16798,32 @@ func (s *ListBucketInventoryConfigurationsOutput) SetIsTruncated(v bool) *ListBu
 func (s *ListBucketInventoryConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketInventoryConfigurationsOutput {
 	s.NextContinuationToken = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketInventoryConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.InventoryConfigurationList) > 0 {
+		v := s.InventoryConfigurationList
+
+		e.SetList(protocol.BodyTarget, "InventoryConfiguration", encodeInventoryConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketMetricsConfigurationsRequest
@@ -13900,6 +16884,22 @@ func (s *ListBucketMetricsConfigurationsInput) SetContinuationToken(v string) *L
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketMetricsConfigurationsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketMetricsConfigurationsOutput
 type ListBucketMetricsConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -13957,6 +16957,32 @@ func (s *ListBucketMetricsConfigurationsOutput) SetNextContinuationToken(v strin
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketMetricsConfigurationsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.MetricsConfigurationList) > 0 {
+		v := s.MetricsConfigurationList
+
+		e.SetList(protocol.BodyTarget, "MetricsConfiguration", encodeMetricsConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketsInput
 type ListBucketsInput struct {
 	_ struct{} `type:"structure"`
@@ -13970,6 +16996,12 @@ func (s ListBucketsInput) String() string {
 // GoString returns the string representation
 func (s ListBucketsInput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketsInput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListBucketsOutput
@@ -14001,6 +17033,22 @@ func (s *ListBucketsOutput) SetBuckets(v []*Bucket) *ListBucketsOutput {
 func (s *ListBucketsOutput) SetOwner(v *Owner) *ListBucketsOutput {
 	s.Owner = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListBucketsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Buckets) > 0 {
+		v := s.Buckets
+
+		e.SetList(protocol.BodyTarget, "Buckets", encodeBucketList(v), protocol.Metadata{ListLocationName: "Bucket"})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListMultipartUploadsRequest
@@ -14110,6 +17158,47 @@ func (s *ListMultipartUploadsInput) SetPrefix(v string) *ListMultipartUploadsInp
 func (s *ListMultipartUploadsInput) SetUploadIdMarker(v string) *ListMultipartUploadsInput {
 	s.UploadIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.QueryTarget, "key-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxUploads != nil {
+		v := *s.MaxUploads
+
+		e.SetValue(protocol.QueryTarget, "max-uploads", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadIdMarker != nil {
+		v := *s.UploadIdMarker
+
+		e.SetValue(protocol.QueryTarget, "upload-id-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListMultipartUploadsOutput
@@ -14246,6 +17335,72 @@ func (s *ListMultipartUploadsOutput) SetUploads(v []*MultipartUpload) *ListMulti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.BodyTarget, "KeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxUploads != nil {
+		v := *s.MaxUploads
+
+		e.SetValue(protocol.BodyTarget, "MaxUploads", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextKeyMarker != nil {
+		v := *s.NextKeyMarker
+
+		e.SetValue(protocol.BodyTarget, "NextKeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextUploadIdMarker != nil {
+		v := *s.NextUploadIdMarker
+
+		e.SetValue(protocol.BodyTarget, "NextUploadIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadIdMarker != nil {
+		v := *s.UploadIdMarker
+
+		e.SetValue(protocol.BodyTarget, "UploadIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Uploads) > 0 {
+		v := s.Uploads
+
+		e.SetList(protocol.BodyTarget, "Upload", encodeMultipartUploadList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectVersionsRequest
 type ListObjectVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -14348,6 +17503,47 @@ func (s *ListObjectVersionsInput) SetPrefix(v string) *ListObjectVersionsInput {
 func (s *ListObjectVersionsInput) SetVersionIdMarker(v string) *ListObjectVersionsInput {
 	s.VersionIdMarker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.QueryTarget, "key-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionIdMarker != nil {
+		v := *s.VersionIdMarker
+
+		e.SetValue(protocol.QueryTarget, "version-id-marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectVersionsOutput
@@ -14478,6 +17674,77 @@ func (s *ListObjectVersionsOutput) SetVersions(v []*ObjectVersion) *ListObjectVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.DeleteMarkers) > 0 {
+		v := s.DeleteMarkers
+
+		e.SetList(protocol.BodyTarget, "DeleteMarker", encodeDeleteMarkerEntryList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyMarker != nil {
+		v := *s.KeyMarker
+
+		e.SetValue(protocol.BodyTarget, "KeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextKeyMarker != nil {
+		v := *s.NextKeyMarker
+
+		e.SetValue(protocol.BodyTarget, "NextKeyMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextVersionIdMarker != nil {
+		v := *s.NextVersionIdMarker
+
+		e.SetValue(protocol.BodyTarget, "NextVersionIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionIdMarker != nil {
+		v := *s.VersionIdMarker
+
+		e.SetValue(protocol.BodyTarget, "VersionIdMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Versions) > 0 {
+		v := s.Versions
+
+		e.SetList(protocol.BodyTarget, "Version", encodeObjectVersionList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsRequest
 type ListObjectsInput struct {
 	_ struct{} `type:"structure"`
@@ -14584,6 +17851,47 @@ func (s *ListObjectsInput) SetRequestPayer(v string) *ListObjectsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsOutput
 type ListObjectsOutput struct {
 	_ struct{} `type:"structure"`
@@ -14687,6 +17995,62 @@ func (s *ListObjectsOutput) SetNextMarker(v string) *ListObjectsOutput {
 func (s *ListObjectsOutput) SetPrefix(v string) *ListObjectsOutput {
 	s.Prefix = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Contents) > 0 {
+		v := s.Contents
+
+		e.SetList(protocol.BodyTarget, "Contents", encodeObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextMarker != nil {
+		v := *s.NextMarker
+
+		e.SetValue(protocol.BodyTarget, "NextMarker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsV2Request
@@ -14813,6 +18177,57 @@ func (s *ListObjectsV2Input) SetRequestPayer(v string) *ListObjectsV2Input {
 func (s *ListObjectsV2Input) SetStartAfter(v string) *ListObjectsV2Input {
 	s.StartAfter = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsV2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.QueryTarget, "delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.QueryTarget, "encoding-type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FetchOwner != nil {
+		v := *s.FetchOwner
+
+		e.SetValue(protocol.QueryTarget, "fetch-owner", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.QueryTarget, "max-keys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartAfter != nil {
+		v := *s.StartAfter
+
+		e.SetValue(protocol.QueryTarget, "start-after", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListObjectsV2Output
@@ -14949,6 +18364,72 @@ func (s *ListObjectsV2Output) SetStartAfter(v string) *ListObjectsV2Output {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListObjectsV2Output) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CommonPrefixes) > 0 {
+		v := s.CommonPrefixes
+
+		e.SetList(protocol.BodyTarget, "CommonPrefixes", encodeCommonPrefixList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.Contents) > 0 {
+		v := s.Contents
+
+		e.SetList(protocol.BodyTarget, "Contents", encodeObjectList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.ContinuationToken != nil {
+		v := *s.ContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "ContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delimiter != nil {
+		v := *s.Delimiter
+
+		e.SetValue(protocol.BodyTarget, "Delimiter", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EncodingType != nil {
+		v := *s.EncodingType
+
+		e.SetValue(protocol.BodyTarget, "EncodingType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.KeyCount != nil {
+		v := *s.KeyCount
+
+		e.SetValue(protocol.BodyTarget, "KeyCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.MaxKeys != nil {
+		v := *s.MaxKeys
+
+		e.SetValue(protocol.BodyTarget, "MaxKeys", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextContinuationToken != nil {
+		v := *s.NextContinuationToken
+
+		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartAfter != nil {
+		v := *s.StartAfter
+
+		e.SetValue(protocol.BodyTarget, "StartAfter", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListPartsRequest
 type ListPartsInput struct {
 	_ struct{} `type:"structure"`
@@ -15051,6 +18532,42 @@ func (s *ListPartsInput) SetRequestPayer(v string) *ListPartsInput {
 func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
 	s.UploadId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxParts != nil {
+		v := *s.MaxParts
+
+		e.SetValue(protocol.QueryTarget, "max-parts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.PartNumberMarker != nil {
+		v := *s.PartNumberMarker
+
+		e.SetValue(protocol.QueryTarget, "part-number-marker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ListPartsOutput
@@ -15203,6 +18720,82 @@ func (s *ListPartsOutput) SetUploadId(v string) *ListPartsOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortDate != nil {
+		v := *s.AbortDate
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.BodyTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.IsTruncated != nil {
+		v := *s.IsTruncated
+
+		e.SetValue(protocol.BodyTarget, "IsTruncated", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MaxParts != nil {
+		v := *s.MaxParts
+
+		e.SetValue(protocol.BodyTarget, "MaxParts", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.NextPartNumberMarker != nil {
+		v := *s.NextPartNumberMarker
+
+		e.SetValue(protocol.BodyTarget, "NextPartNumberMarker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.PartNumberMarker != nil {
+		v := *s.PartNumberMarker
+
+		e.SetValue(protocol.BodyTarget, "PartNumberMarker", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Parts) > 0 {
+		v := s.Parts
+
+		e.SetList(protocol.BodyTarget, "Part", encodePartList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/LoggingEnabled
 type LoggingEnabled struct {
 	_ struct{} `type:"structure"`
@@ -15270,6 +18863,27 @@ func (s *LoggingEnabled) SetTargetPrefix(v string) *LoggingEnabled {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *LoggingEnabled) MarshalFields(e protocol.FieldEncoder) error {
+	if s.TargetBucket != nil {
+		v := *s.TargetBucket
+
+		e.SetValue(protocol.BodyTarget, "TargetBucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TargetGrants) > 0 {
+		v := s.TargetGrants
+
+		e.SetList(protocol.BodyTarget, "TargetGrants", encodeTargetGrantList(v), protocol.Metadata{ListLocationName: "Grant"})
+	}
+	if s.TargetPrefix != nil {
+		v := *s.TargetPrefix
+
+		e.SetValue(protocol.BodyTarget, "TargetPrefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsAndOperator
 type MetricsAndOperator struct {
 	_ struct{} `type:"structure"`
@@ -15321,6 +18935,22 @@ func (s *MetricsAndOperator) SetPrefix(v string) *MetricsAndOperator {
 func (s *MetricsAndOperator) SetTags(v []*Tag) *MetricsAndOperator {
 	s.Tags = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Tags) > 0 {
+		v := s.Tags
+
+		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsConfiguration
@@ -15376,6 +19006,30 @@ func (s *MetricsConfiguration) SetFilter(v *MetricsFilter) *MetricsConfiguration
 func (s *MetricsConfiguration) SetId(v string) *MetricsConfiguration {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMetricsConfigurationList(vs []*MetricsConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MetricsFilter
@@ -15440,6 +19094,27 @@ func (s *MetricsFilter) SetPrefix(v string) *MetricsFilter {
 func (s *MetricsFilter) SetTag(v *Tag) *MetricsFilter {
 	s.Tag = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MetricsFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.And != nil {
+		v := s.And
+
+		e.SetFields(protocol.BodyTarget, "And", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tag != nil {
+		v := s.Tag
+
+		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/MultipartUpload
@@ -15510,6 +19185,50 @@ func (s *MultipartUpload) SetUploadId(v string) *MultipartUpload {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *MultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Initiated != nil {
+		v := *s.Initiated
+
+		e.SetValue(protocol.BodyTarget, "Initiated", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeMultipartUploadList(vs []*MultipartUpload) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Specifies when noncurrent object versions expire. Upon expiration, Amazon
 // S3 permanently deletes the noncurrent object versions. You set this lifecycle
 // configuration action on a bucket that has versioning enabled (or suspended)
@@ -15540,6 +19259,17 @@ func (s NoncurrentVersionExpiration) GoString() string {
 func (s *NoncurrentVersionExpiration) SetNoncurrentDays(v int64) *NoncurrentVersionExpiration {
 	s.NoncurrentDays = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoncurrentVersionExpiration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoncurrentDays != nil {
+		v := *s.NoncurrentDays
+
+		e.SetValue(protocol.BodyTarget, "NoncurrentDays", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for the transition rule that describes when noncurrent objects
@@ -15581,6 +19311,30 @@ func (s *NoncurrentVersionTransition) SetNoncurrentDays(v int64) *NoncurrentVers
 func (s *NoncurrentVersionTransition) SetStorageClass(v string) *NoncurrentVersionTransition {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NoncurrentVersionTransition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NoncurrentDays != nil {
+		v := *s.NoncurrentDays
+
+		e.SetValue(protocol.BodyTarget, "NoncurrentDays", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeNoncurrentVersionTransitionList(vs []*NoncurrentVersionTransition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for specifying the notification configuration of the bucket. If
@@ -15664,6 +19418,27 @@ func (s *NotificationConfiguration) SetTopicConfigurations(v []*TopicConfigurati
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.LambdaFunctionConfigurations) > 0 {
+		v := s.LambdaFunctionConfigurations
+
+		e.SetList(protocol.BodyTarget, "CloudFunctionConfiguration", encodeLambdaFunctionConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.QueueConfigurations) > 0 {
+		v := s.QueueConfigurations
+
+		e.SetList(protocol.BodyTarget, "QueueConfiguration", encodeQueueConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+	if len(s.TopicConfigurations) > 0 {
+		v := s.TopicConfigurations
+
+		e.SetList(protocol.BodyTarget, "TopicConfiguration", encodeTopicConfigurationList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NotificationConfigurationDeprecated
 type NotificationConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -15703,6 +19478,27 @@ func (s *NotificationConfigurationDeprecated) SetTopicConfiguration(v *TopicConf
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CloudFunctionConfiguration != nil {
+		v := s.CloudFunctionConfiguration
+
+		e.SetFields(protocol.BodyTarget, "CloudFunctionConfiguration", v, protocol.Metadata{})
+	}
+	if s.QueueConfiguration != nil {
+		v := s.QueueConfiguration
+
+		e.SetFields(protocol.BodyTarget, "QueueConfiguration", v, protocol.Metadata{})
+	}
+	if s.TopicConfiguration != nil {
+		v := s.TopicConfiguration
+
+		e.SetFields(protocol.BodyTarget, "TopicConfiguration", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for object key name filtering rules. For information about key
 // name filtering, go to Configuring Event Notifications (http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/NotificationConfigurationFilter
@@ -15727,6 +19523,17 @@ func (s NotificationConfigurationFilter) GoString() string {
 func (s *NotificationConfigurationFilter) SetKey(v *KeyFilter) *NotificationConfigurationFilter {
 	s.Key = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationConfigurationFilter) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := s.Key
+
+		e.SetFields(protocol.BodyTarget, "S3Key", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Object
@@ -15793,6 +19600,50 @@ func (s *Object) SetStorageClass(v string) *Object {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Object) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectList(vs []*Object) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectIdentifier
 type ObjectIdentifier struct {
 	_ struct{} `type:"structure"`
@@ -15842,6 +19693,30 @@ func (s *ObjectIdentifier) SetKey(v string) *ObjectIdentifier {
 func (s *ObjectIdentifier) SetVersionId(v string) *ObjectIdentifier {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectIdentifier) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectIdentifierList(vs []*ObjectIdentifier) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ObjectVersion
@@ -15930,6 +19805,60 @@ func (s *ObjectVersion) SetVersionId(v string) *ObjectVersion {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ObjectVersion) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsLatest != nil {
+		v := *s.IsLatest
+
+		e.SetValue(protocol.BodyTarget, "IsLatest", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeObjectVersionList(vs []*ObjectVersion) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Owner
 type Owner struct {
 	_ struct{} `type:"structure"`
@@ -15959,6 +19888,22 @@ func (s *Owner) SetDisplayName(v string) *Owner {
 func (s *Owner) SetID(v string) *Owner {
 	s.ID = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Owner) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DisplayName != nil {
+		v := *s.DisplayName
+
+		e.SetValue(protocol.BodyTarget, "DisplayName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Part
@@ -16011,6 +19956,40 @@ func (s *Part) SetPartNumber(v int64) *Part {
 func (s *Part) SetSize(v int64) *Part {
 	s.Size = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Part) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LastModified != nil {
+		v := *s.LastModified
+
+		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.BodyTarget, "PartNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePartList(vs []*Part) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAccelerateConfigurationRequest
@@ -16073,6 +20052,22 @@ func (s *PutBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccelerateConfiguration != nil {
+		v := s.AccelerateConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AccelerateConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAccelerateConfigurationOutput
 type PutBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16086,6 +20081,12 @@ func (s PutBucketAccelerateConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAccelerateConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAclRequest
@@ -16200,6 +20201,52 @@ func (s *PutBucketAclInput) SetGrantWriteACP(v string) *PutBucketAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
+
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAclOutput
 type PutBucketAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -16213,6 +20260,12 @@ func (s PutBucketAclOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAclOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAnalyticsConfigurationRequest
@@ -16294,6 +20347,27 @@ func (s *PutBucketAnalyticsConfigurationInput) SetId(v string) *PutBucketAnalyti
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnalyticsConfiguration != nil {
+		v := s.AnalyticsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketAnalyticsConfigurationOutput
 type PutBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16307,6 +20381,12 @@ func (s PutBucketAnalyticsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketAnalyticsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketCorsRequest
@@ -16370,6 +20450,22 @@ func (s *PutBucketCorsInput) SetCORSConfiguration(v *CORSConfiguration) *PutBuck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CORSConfiguration != nil {
+		v := s.CORSConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "CORSConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketCorsOutput
 type PutBucketCorsOutput struct {
 	_ struct{} `type:"structure"`
@@ -16383,6 +20479,12 @@ func (s PutBucketCorsOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketCorsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryptionRequest
@@ -16452,6 +20554,22 @@ func (s *PutBucketEncryptionInput) SetServerSideEncryptionConfiguration(v *Serve
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryptionConfiguration != nil {
+		v := s.ServerSideEncryptionConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ServerSideEncryptionConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketEncryptionOutput
 type PutBucketEncryptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -16465,6 +20583,12 @@ func (s PutBucketEncryptionOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketEncryptionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketInventoryConfigurationRequest
@@ -16546,6 +20670,27 @@ func (s *PutBucketInventoryConfigurationInput) SetInventoryConfiguration(v *Inve
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.InventoryConfiguration != nil {
+		v := s.InventoryConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketInventoryConfigurationOutput
 type PutBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16559,6 +20704,12 @@ func (s PutBucketInventoryConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketInventoryConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleConfigurationRequest
@@ -16618,6 +20769,22 @@ func (s *PutBucketLifecycleConfigurationInput) SetLifecycleConfiguration(v *Buck
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifecycleConfiguration != nil {
+		v := s.LifecycleConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleConfigurationOutput
 type PutBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16631,6 +20798,12 @@ func (s PutBucketLifecycleConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLifecycleConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleRequest
@@ -16690,6 +20863,22 @@ func (s *PutBucketLifecycleInput) SetLifecycleConfiguration(v *LifecycleConfigur
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.LifecycleConfiguration != nil {
+		v := s.LifecycleConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLifecycleOutput
 type PutBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
@@ -16703,6 +20892,12 @@ func (s PutBucketLifecycleOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLifecycleOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLoggingRequest
@@ -16766,6 +20961,22 @@ func (s *PutBucketLoggingInput) SetBucketLoggingStatus(v *BucketLoggingStatus) *
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.BucketLoggingStatus != nil {
+		v := s.BucketLoggingStatus
+
+		e.SetFields(protocol.PayloadTarget, "BucketLoggingStatus", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketLoggingOutput
 type PutBucketLoggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -16779,6 +20990,12 @@ func (s PutBucketLoggingOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketLoggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketMetricsConfigurationRequest
@@ -16860,6 +21077,27 @@ func (s *PutBucketMetricsConfigurationInput) SetMetricsConfiguration(v *MetricsC
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MetricsConfiguration != nil {
+		v := s.MetricsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketMetricsConfigurationOutput
 type PutBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16873,6 +21111,12 @@ func (s PutBucketMetricsConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationConfigurationRequest
@@ -16939,6 +21183,22 @@ func (s *PutBucketNotificationConfigurationInput) SetNotificationConfiguration(v
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotificationConfiguration != nil {
+		v := s.NotificationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationConfigurationOutput
 type PutBucketNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
@@ -16952,6 +21212,12 @@ func (s PutBucketNotificationConfigurationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketNotificationConfigurationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationRequest
@@ -17010,6 +21276,22 @@ func (s *PutBucketNotificationInput) SetNotificationConfiguration(v *Notificatio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotificationConfiguration != nil {
+		v := s.NotificationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketNotificationOutput
 type PutBucketNotificationOutput struct {
 	_ struct{} `type:"structure"`
@@ -17023,6 +21305,12 @@ func (s PutBucketNotificationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketNotificationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketNotificationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketPolicyRequest
@@ -17093,6 +21381,27 @@ func (s *PutBucketPolicyInput) SetPolicy(v string) *PutBucketPolicyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ConfirmRemoveSelfBucketAccess != nil {
+		v := *s.ConfirmRemoveSelfBucketAccess
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-confirm-remove-self-bucket-access", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Policy != nil {
+		v := *s.Policy
+
+		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketPolicyOutput
 type PutBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -17106,6 +21415,12 @@ func (s PutBucketPolicyOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketPolicyOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketReplicationRequest
@@ -17172,6 +21487,22 @@ func (s *PutBucketReplicationInput) SetReplicationConfiguration(v *ReplicationCo
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplicationConfiguration != nil {
+		v := s.ReplicationConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketReplicationOutput
 type PutBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -17185,6 +21516,12 @@ func (s PutBucketReplicationOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketReplicationOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketRequestPaymentRequest
@@ -17248,6 +21585,22 @@ func (s *PutBucketRequestPaymentInput) SetRequestPaymentConfiguration(v *Request
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPaymentConfiguration != nil {
+		v := s.RequestPaymentConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "RequestPaymentConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketRequestPaymentOutput
 type PutBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
@@ -17261,6 +21614,12 @@ func (s PutBucketRequestPaymentOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketRequestPaymentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketTaggingRequest
@@ -17324,6 +21683,22 @@ func (s *PutBucketTaggingInput) SetTagging(v *Tagging) *PutBucketTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := s.Tagging
+
+		e.SetFields(protocol.PayloadTarget, "Tagging", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketTaggingOutput
 type PutBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -17337,6 +21712,12 @@ func (s PutBucketTaggingOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketTaggingOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketVersioningRequest
@@ -17405,6 +21786,27 @@ func (s *PutBucketVersioningInput) SetVersioningConfiguration(v *VersioningConfi
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.MFA != nil {
+		v := *s.MFA
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersioningConfiguration != nil {
+		v := s.VersioningConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "VersioningConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketVersioningOutput
 type PutBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
@@ -17418,6 +21820,12 @@ func (s PutBucketVersioningOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketVersioningOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketWebsiteRequest
@@ -17481,6 +21889,22 @@ func (s *PutBucketWebsiteInput) SetWebsiteConfiguration(v *WebsiteConfiguration)
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteConfiguration != nil {
+		v := s.WebsiteConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "WebsiteConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutBucketWebsiteOutput
 type PutBucketWebsiteOutput struct {
 	_ struct{} `type:"structure"`
@@ -17494,6 +21918,12 @@ func (s PutBucketWebsiteOutput) String() string {
 // GoString returns the string representation
 func (s PutBucketWebsiteOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectAclRequest
@@ -17644,6 +22074,67 @@ func (s *PutObjectAclInput) SetVersionId(v string) *PutObjectAclInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
+
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWrite != nil {
+		v := *s.GrantWrite
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectAclOutput
 type PutObjectAclOutput struct {
 	_ struct{} `type:"structure"`
@@ -17667,6 +22158,17 @@ func (s PutObjectAclOutput) GoString() string {
 func (s *PutObjectAclOutput) SetRequestCharged(v string) *PutObjectAclOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectRequest
@@ -17973,6 +22475,142 @@ func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ACL != nil {
+		v := *s.ACL
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CacheControl != nil {
+		v := *s.CacheControl
+
+		e.SetValue(protocol.HeaderTarget, "Cache-Control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentDisposition != nil {
+		v := *s.ContentDisposition
+
+		e.SetValue(protocol.HeaderTarget, "Content-Disposition", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentEncoding != nil {
+		v := *s.ContentEncoding
+
+		e.SetValue(protocol.HeaderTarget, "Content-Encoding", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLanguage != nil {
+		v := *s.ContentLanguage
+
+		e.SetValue(protocol.HeaderTarget, "Content-Language", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentMD5 != nil {
+		v := *s.ContentMD5
+
+		e.SetValue(protocol.HeaderTarget, "Content-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.HeaderTarget, "Content-Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expires != nil {
+		v := *s.Expires
+
+		e.SetValue(protocol.HeaderTarget, "Expires", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.GrantFullControl != nil {
+		v := *s.GrantFullControl
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-full-control", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantRead != nil {
+		v := *s.GrantRead
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantReadACP != nil {
+		v := *s.GrantReadACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-read-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantWriteACP != nil {
+		v := *s.GrantWriteACP
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
+
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-storage-class", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := *s.Tagging
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-tagging", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.WebsiteRedirectLocation != nil {
+		v := *s.WebsiteRedirectLocation
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectOutput
 type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -18068,6 +22706,52 @@ func (s *PutObjectOutput) SetVersionId(v string) *PutObjectOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectTaggingRequest
 type PutObjectTaggingInput struct {
 	_ struct{} `type:"structure" payload:"Tagging"`
@@ -18152,6 +22836,32 @@ func (s *PutObjectTaggingInput) SetVersionId(v string) *PutObjectTaggingInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Tagging != nil {
+		v := s.Tagging
+
+		e.SetFields(protocol.PayloadTarget, "Tagging", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/PutObjectTaggingOutput
 type PutObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
@@ -18173,6 +22883,17 @@ func (s PutObjectTaggingOutput) GoString() string {
 func (s *PutObjectTaggingOutput) SetVersionId(v string) *PutObjectTaggingOutput {
 	s.VersionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for specifying an configuration when you want Amazon S3 to publish
@@ -18249,6 +22970,40 @@ func (s *QueueConfiguration) SetQueueArn(v string) *QueueConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueueConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.QueueArn != nil {
+		v := *s.QueueArn
+
+		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeQueueConfigurationList(vs []*QueueConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/QueueConfigurationDeprecated
 type QueueConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -18297,6 +23052,32 @@ func (s *QueueConfigurationDeprecated) SetId(v string) *QueueConfigurationDeprec
 func (s *QueueConfigurationDeprecated) SetQueue(v string) *QueueConfigurationDeprecated {
 	s.Queue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *QueueConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Queue != nil {
+		v := *s.Queue
+
+		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Redirect
@@ -18368,6 +23149,37 @@ func (s *Redirect) SetReplaceKeyWith(v string) *Redirect {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Redirect) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostName != nil {
+		v := *s.HostName
+
+		e.SetValue(protocol.BodyTarget, "HostName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpRedirectCode != nil {
+		v := *s.HttpRedirectCode
+
+		e.SetValue(protocol.BodyTarget, "HttpRedirectCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplaceKeyPrefixWith != nil {
+		v := *s.ReplaceKeyPrefixWith
+
+		e.SetValue(protocol.BodyTarget, "ReplaceKeyPrefixWith", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ReplaceKeyWith != nil {
+		v := *s.ReplaceKeyWith
+
+		e.SetValue(protocol.BodyTarget, "ReplaceKeyWith", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RedirectAllRequestsTo
 type RedirectAllRequestsTo struct {
 	_ struct{} `type:"structure"`
@@ -18415,6 +23227,22 @@ func (s *RedirectAllRequestsTo) SetHostName(v string) *RedirectAllRequestsTo {
 func (s *RedirectAllRequestsTo) SetProtocol(v string) *RedirectAllRequestsTo {
 	s.Protocol = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RedirectAllRequestsTo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.HostName != nil {
+		v := *s.HostName
+
+		e.SetValue(protocol.BodyTarget, "HostName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for replication rules. You can add as many as 1,000 rules. Total
@@ -18482,6 +23310,22 @@ func (s *ReplicationConfiguration) SetRole(v string) *ReplicationConfiguration {
 func (s *ReplicationConfiguration) SetRules(v []*ReplicationRule) *ReplicationConfiguration {
 	s.Rules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplicationConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeReplicationRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
 }
 
 // Container for information about a particular replication rule.
@@ -18582,6 +23426,45 @@ func (s *ReplicationRule) SetStatus(v string) *ReplicationRule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ReplicationRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SourceSelectionCriteria != nil {
+		v := s.SourceSelectionCriteria
+
+		e.SetFields(protocol.BodyTarget, "SourceSelectionCriteria", v, protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeReplicationRuleList(vs []*ReplicationRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RequestPaymentConfiguration
 type RequestPaymentConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -18619,6 +23502,17 @@ func (s *RequestPaymentConfiguration) Validate() error {
 func (s *RequestPaymentConfiguration) SetPayer(v string) *RequestPaymentConfiguration {
 	s.Payer = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RequestPaymentConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Payer != nil {
+		v := *s.Payer
+
+		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreObjectRequest
@@ -18713,6 +23607,37 @@ func (s *RestoreObjectInput) SetVersionId(v string) *RestoreObjectInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RestoreRequest != nil {
+		v := s.RestoreRequest
+
+		e.SetFields(protocol.PayloadTarget, "RestoreRequest", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreObjectOutput
 type RestoreObjectOutput struct {
 	_ struct{} `type:"structure"`
@@ -18736,6 +23661,17 @@ func (s RestoreObjectOutput) GoString() string {
 func (s *RestoreObjectOutput) SetRequestCharged(v string) *RestoreObjectOutput {
 	s.RequestCharged = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RestoreRequest
@@ -18791,6 +23727,22 @@ func (s *RestoreRequest) SetGlacierJobParameters(v *GlacierJobParameters) *Resto
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RestoreRequest) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.GlacierJobParameters != nil {
+		v := s.GlacierJobParameters
+
+		e.SetFields(protocol.BodyTarget, "GlacierJobParameters", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/RoutingRule
 type RoutingRule struct {
 	_ struct{} `type:"structure"`
@@ -18842,6 +23794,30 @@ func (s *RoutingRule) SetCondition(v *Condition) *RoutingRule {
 func (s *RoutingRule) SetRedirect(v *Redirect) *RoutingRule {
 	s.Redirect = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RoutingRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Condition != nil {
+		v := s.Condition
+
+		e.SetFields(protocol.BodyTarget, "Condition", v, protocol.Metadata{})
+	}
+	if s.Redirect != nil {
+		v := s.Redirect
+
+		e.SetFields(protocol.BodyTarget, "Redirect", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRoutingRuleList(vs []*RoutingRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Rule
@@ -18959,6 +23935,60 @@ func (s *Rule) SetTransition(v *Transition) *Rule {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AbortIncompleteMultipartUpload != nil {
+		v := s.AbortIncompleteMultipartUpload
+
+		e.SetFields(protocol.BodyTarget, "AbortIncompleteMultipartUpload", v, protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := s.Expiration
+
+		e.SetFields(protocol.BodyTarget, "Expiration", v, protocol.Metadata{})
+	}
+	if s.ID != nil {
+		v := *s.ID
+
+		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NoncurrentVersionExpiration != nil {
+		v := s.NoncurrentVersionExpiration
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionExpiration", v, protocol.Metadata{})
+	}
+	if s.NoncurrentVersionTransition != nil {
+		v := s.NoncurrentVersionTransition
+
+		e.SetFields(protocol.BodyTarget, "NoncurrentVersionTransition", v, protocol.Metadata{})
+	}
+	if s.Prefix != nil {
+		v := *s.Prefix
+
+		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Transition != nil {
+		v := s.Transition
+
+		e.SetFields(protocol.BodyTarget, "Transition", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeRuleList(vs []*Rule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Specifies the use of SSE-KMS to encrypt delievered Inventory reports.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SSEKMS
 type SSEKMS struct {
@@ -19000,6 +24030,17 @@ func (s *SSEKMS) SetKeyId(v string) *SSEKMS {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SSEKMS) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KeyId != nil {
+		v := *s.KeyId
+
+		e.SetValue(protocol.BodyTarget, "KeyId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Specifies the use of SSE-S3 to encrypt delievered Inventory reports.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SSES3
 type SSES3 struct {
@@ -19014,6 +24055,12 @@ func (s SSES3) String() string {
 // GoString returns the string representation
 func (s SSES3) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SSES3) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the default server-side encryption to apply to new objects in the
@@ -19068,6 +24115,22 @@ func (s *ServerSideEncryptionByDefault) SetSSEAlgorithm(v string) *ServerSideEnc
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServerSideEncryptionByDefault) MarshalFields(e protocol.FieldEncoder) error {
+	if s.KMSMasterKeyID != nil {
+		v := *s.KMSMasterKeyID
+
+		e.SetValue(protocol.BodyTarget, "KMSMasterKeyID", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEAlgorithm != nil {
+		v := *s.SSEAlgorithm
+
+		e.SetValue(protocol.BodyTarget, "SSEAlgorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Container for server-side encryption configuration rules. Currently S3 supports
 // one rule only.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ServerSideEncryptionConfiguration
@@ -19120,6 +24183,17 @@ func (s *ServerSideEncryptionConfiguration) SetRules(v []*ServerSideEncryptionRu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServerSideEncryptionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Rules) > 0 {
+		v := s.Rules
+
+		e.SetList(protocol.BodyTarget, "Rule", encodeServerSideEncryptionRuleList(v), protocol.Metadata{Flatten: true})
+	}
+
+	return nil
+}
+
 // Container for information about a particular server-side encryption configuration
 // rule.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/ServerSideEncryptionRule
@@ -19163,6 +24237,25 @@ func (s *ServerSideEncryptionRule) SetApplyServerSideEncryptionByDefault(v *Serv
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServerSideEncryptionRule) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApplyServerSideEncryptionByDefault != nil {
+		v := s.ApplyServerSideEncryptionByDefault
+
+		e.SetFields(protocol.BodyTarget, "ApplyServerSideEncryptionByDefault", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeServerSideEncryptionRuleList(vs []*ServerSideEncryptionRule) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Container for filters that define which source objects should be replicated.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/SourceSelectionCriteria
 type SourceSelectionCriteria struct {
@@ -19201,6 +24294,17 @@ func (s *SourceSelectionCriteria) Validate() error {
 func (s *SourceSelectionCriteria) SetSseKmsEncryptedObjects(v *SseKmsEncryptedObjects) *SourceSelectionCriteria {
 	s.SseKmsEncryptedObjects = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SourceSelectionCriteria) MarshalFields(e protocol.FieldEncoder) error {
+	if s.SseKmsEncryptedObjects != nil {
+		v := s.SseKmsEncryptedObjects
+
+		e.SetFields(protocol.BodyTarget, "SseKmsEncryptedObjects", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Container for filter information of selection of KMS Encrypted S3 objects.
@@ -19244,6 +24348,17 @@ func (s *SseKmsEncryptedObjects) SetStatus(v string) *SseKmsEncryptedObjects {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SseKmsEncryptedObjects) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/StorageClassAnalysis
 type StorageClassAnalysis struct {
 	_ struct{} `type:"structure"`
@@ -19282,6 +24397,17 @@ func (s *StorageClassAnalysis) Validate() error {
 func (s *StorageClassAnalysis) SetDataExport(v *StorageClassAnalysisDataExport) *StorageClassAnalysis {
 	s.DataExport = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageClassAnalysis) MarshalFields(e protocol.FieldEncoder) error {
+	if s.DataExport != nil {
+		v := s.DataExport
+
+		e.SetFields(protocol.BodyTarget, "DataExport", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/StorageClassAnalysisDataExport
@@ -19342,6 +24468,22 @@ func (s *StorageClassAnalysisDataExport) SetOutputSchemaVersion(v string) *Stora
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageClassAnalysisDataExport) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Destination != nil {
+		v := s.Destination
+
+		e.SetFields(protocol.BodyTarget, "Destination", v, protocol.Metadata{})
+	}
+	if s.OutputSchemaVersion != nil {
+		v := *s.OutputSchemaVersion
+
+		e.SetValue(protocol.BodyTarget, "OutputSchemaVersion", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Tag
 type Tag struct {
 	_ struct{} `type:"structure"`
@@ -19398,6 +24540,30 @@ func (s *Tag) SetValue(v string) *Tag {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTagList(vs []*Tag) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Tagging
 type Tagging struct {
 	_ struct{} `type:"structure"`
@@ -19445,6 +24611,17 @@ func (s *Tagging) SetTagSet(v []*Tag) *Tagging {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Tagging) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TagSet) > 0 {
+		v := s.TagSet
+
+		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/TargetGrant
 type TargetGrant struct {
 	_ struct{} `type:"structure"`
@@ -19490,6 +24667,35 @@ func (s *TargetGrant) SetGrantee(v *Grantee) *TargetGrant {
 func (s *TargetGrant) SetPermission(v string) *TargetGrant {
 	s.Permission = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TargetGrant) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Grantee != nil {
+		v := s.Grantee
+		attrs := make([]protocol.Attribute, 0, 1)
+
+		if s.Grantee.Type != nil {
+			v := *s.Grantee.Type
+			attrs = append(attrs, protocol.Attribute{Name: "xsi:type", Value: protocol.StringValue(v), Meta: protocol.Metadata{}})
+		}
+		e.SetFields(protocol.BodyTarget, "Grantee", v, protocol.Metadata{Attributes: attrs, XMLNamespacePrefix: "xsi", XMLNamespaceURI: "http://www.w3.org/2001/XMLSchema-instance"})
+	}
+	if s.Permission != nil {
+		v := *s.Permission
+
+		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTargetGrantList(vs []*TargetGrant) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Container for specifying the configuration when you want Amazon S3 to publish
@@ -19566,6 +24772,40 @@ func (s *TopicConfiguration) SetTopicArn(v string) *TopicConfiguration {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Filter != nil {
+		v := s.Filter
+
+		e.SetFields(protocol.BodyTarget, "Filter", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TopicArn != nil {
+		v := *s.TopicArn
+
+		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTopicConfigurationList(vs []*TopicConfiguration) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/TopicConfigurationDeprecated
 type TopicConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
@@ -19618,6 +24858,32 @@ func (s *TopicConfigurationDeprecated) SetTopic(v string) *TopicConfigurationDep
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TopicConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Event != nil {
+		v := *s.Event
+
+		e.SetValue(protocol.BodyTarget, "Event", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Events) > 0 {
+		v := s.Events
+
+		e.SetList(protocol.BodyTarget, "Event", protocol.EncodeStringList(v), protocol.Metadata{Flatten: true})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Topic != nil {
+		v := *s.Topic
+
+		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/Transition
 type Transition struct {
 	_ struct{} `type:"structure"`
@@ -19660,6 +24926,35 @@ func (s *Transition) SetDays(v int64) *Transition {
 func (s *Transition) SetStorageClass(v string) *Transition {
 	s.StorageClass = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Transition) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Date != nil {
+		v := *s.Date
+
+		e.SetValue(protocol.BodyTarget, "Date", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
+	}
+	if s.Days != nil {
+		v := *s.Days
+
+		e.SetValue(protocol.BodyTarget, "Days", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageClass != nil {
+		v := *s.StorageClass
+
+		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTransitionList(vs []*Transition) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartCopyRequest
@@ -19906,6 +25201,97 @@ func (s *UploadPartCopyInput) SetUploadId(v string) *UploadPartCopyInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartCopyInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySource != nil {
+		v := *s.CopySource
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfMatch != nil {
+		v := *s.CopySourceIfMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfModifiedSince != nil {
+		v := *s.CopySourceIfModifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-modified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceIfNoneMatch != nil {
+		v := *s.CopySourceIfNoneMatch
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-none-match", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceIfUnmodifiedSince != nil {
+		v := *s.CopySourceIfUnmodifiedSince
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-if-unmodified-since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.CopySourceRange != nil {
+		v := *s.CopySourceRange
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-range", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerAlgorithm != nil {
+		v := *s.CopySourceSSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKey != nil {
+		v := *s.CopySourceSSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CopySourceSSECustomerKeyMD5 != nil {
+		v := *s.CopySourceSSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartCopyOutput
 type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
@@ -19989,6 +25375,47 @@ func (s *UploadPartCopyOutput) SetSSEKMSKeyId(v string) *UploadPartCopyOutput {
 func (s *UploadPartCopyOutput) SetServerSideEncryption(v string) *UploadPartCopyOutput {
 	s.ServerSideEncryption = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartCopyOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CopyPartResult != nil {
+		v := s.CopyPartResult
+
+		e.SetFields(protocol.PayloadTarget, "CopyPartResult", v, protocol.Metadata{})
+	}
+	if s.CopySourceVersionId != nil {
+		v := *s.CopySourceVersionId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-version-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartRequest
@@ -20164,6 +25591,67 @@ func (s *UploadPartInput) SetUploadId(v string) *UploadPartInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentLength != nil {
+		v := *s.ContentLength
+
+		e.SetValue(protocol.HeaderTarget, "Content-Length", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ContentMD5 != nil {
+		v := *s.ContentMD5
+
+		e.SetValue(protocol.HeaderTarget, "Content-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/UploadPartOutput
 type UploadPartOutput struct {
 	_ struct{} `type:"structure"`
@@ -20240,6 +25728,42 @@ func (s *UploadPartOutput) SetServerSideEncryption(v string) *UploadPartOutput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadPartOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ETag != nil {
+		v := *s.ETag
+
+		e.SetValue(protocol.HeaderTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSEKMSKeyId != nil {
+		v := *s.SSEKMSKeyId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-aws-kms-key-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ServerSideEncryption != nil {
+		v := *s.ServerSideEncryption
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/VersioningConfiguration
 type VersioningConfiguration struct {
 	_ struct{} `type:"structure"`
@@ -20273,6 +25797,22 @@ func (s *VersioningConfiguration) SetMFADelete(v string) *VersioningConfiguratio
 func (s *VersioningConfiguration) SetStatus(v string) *VersioningConfiguration {
 	s.Status = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *VersioningConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.MFADelete != nil {
+		v := *s.MFADelete
+
+		e.SetValue(protocol.BodyTarget, "MfaDelete", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/WebsiteConfiguration
@@ -20355,6 +25895,32 @@ func (s *WebsiteConfiguration) SetRedirectAllRequestsTo(v *RedirectAllRequestsTo
 func (s *WebsiteConfiguration) SetRoutingRules(v []*RoutingRule) *WebsiteConfiguration {
 	s.RoutingRules = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *WebsiteConfiguration) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorDocument != nil {
+		v := s.ErrorDocument
+
+		e.SetFields(protocol.BodyTarget, "ErrorDocument", v, protocol.Metadata{})
+	}
+	if s.IndexDocument != nil {
+		v := s.IndexDocument
+
+		e.SetFields(protocol.BodyTarget, "IndexDocument", v, protocol.Metadata{})
+	}
+	if s.RedirectAllRequestsTo != nil {
+		v := s.RedirectAllRequestsTo
+
+		e.SetFields(protocol.BodyTarget, "RedirectAllRequestsTo", v, protocol.Metadata{})
+	}
+	if len(s.RoutingRules) > 0 {
+		v := s.RoutingRules
+
+		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
+	}
+
+	return nil
 }
 
 const (

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -6205,7 +6205,6 @@ func (s *AbortIncompleteMultipartUpload) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "DaysAfterInitiation", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6294,6 +6293,11 @@ func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadI
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -6304,17 +6308,11 @@ func (s *AbortMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
 		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6350,7 +6348,6 @@ func (s *AbortMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6385,7 +6382,6 @@ func (s *AccelerateConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6453,7 +6449,6 @@ func (s *AccessControlPolicy) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6504,7 +6499,6 @@ func (s *AccessControlTranslation) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.BodyTarget, "Owner", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6573,7 +6567,6 @@ func (s *AnalyticsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -6669,7 +6662,6 @@ func (s *AnalyticsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "StorageClassAnalysis", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6732,7 +6724,6 @@ func (s *AnalyticsExportDestination) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6816,7 +6807,6 @@ func (s *AnalyticsFilter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6922,7 +6912,6 @@ func (s *AnalyticsS3BucketDestination) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6971,7 +6960,6 @@ func (s *Bucket) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7037,7 +7025,6 @@ func (s *BucketLifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -7086,7 +7073,6 @@ func (s *BucketLoggingStatus) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7144,7 +7130,6 @@ func (s *CORSConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -7259,7 +7244,6 @@ func (s *CORSRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "MaxAgeSeconds", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7356,7 +7340,6 @@ func (s *CloudFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.BodyTarget, "InvocationRole", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7390,7 +7373,6 @@ func (s *CommonPrefix) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7495,6 +7477,11 @@ func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartU
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -7510,17 +7497,11 @@ func (s *CompleteMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.PayloadTarget, "CompleteMultipartUpload", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
 		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7640,11 +7621,6 @@ func (s *CompleteMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "ETag", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Expiration != nil {
-		v := *s.Expiration
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Key != nil {
 		v := *s.Key
 
@@ -7654,6 +7630,11 @@ func (s *CompleteMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) e
 		v := *s.Location
 
 		e.SetValue(protocol.BodyTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Expiration != nil {
+		v := *s.Expiration
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-expiration", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RequestCharged != nil {
 		v := *s.RequestCharged
@@ -7675,7 +7656,6 @@ func (s *CompleteMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7709,7 +7689,6 @@ func (s *CompletedMultipartUpload) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "Part", encodeCompletedPartList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -7759,7 +7738,6 @@ func (s *CompletedPart) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "PartNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7826,7 +7804,6 @@ func (s *Condition) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "KeyPrefixEquals", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8221,11 +8198,6 @@ func (s *CopyObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -8316,16 +8288,6 @@ func (s *CopyObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if len(s.Metadata) > 0 {
-		v := s.Metadata
-
-		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.MetadataDirective != nil {
 		v := *s.MetadataDirective
 
@@ -8381,7 +8343,21 @@ func (s *CopyObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
 
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8488,11 +8464,6 @@ func (s *CopyObjectOutput) SetVersionId(v string) *CopyObjectOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CopyObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CopyObjectResult != nil {
-		v := s.CopyObjectResult
-
-		e.SetFields(protocol.PayloadTarget, "CopyObjectResult", v, protocol.Metadata{})
-	}
 	if s.CopySourceVersionId != nil {
 		v := *s.CopySourceVersionId
 
@@ -8533,7 +8504,11 @@ func (s *CopyObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CopyObjectResult != nil {
+		v := s.CopyObjectResult
 
+		e.SetFields(protocol.PayloadTarget, "CopyObjectResult", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -8580,7 +8555,6 @@ func (s *CopyObjectResult) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8629,7 +8603,6 @@ func (s *CopyPartResult) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "LastModified", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8665,7 +8638,6 @@ func (s *CreateBucketConfiguration) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8783,16 +8755,6 @@ func (s *CreateBucketInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.CreateBucketConfiguration != nil {
-		v := s.CreateBucketConfiguration
-
-		e.SetFields(protocol.PayloadTarget, "CreateBucketConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
 	if s.GrantFullControl != nil {
 		v := *s.GrantFullControl
 
@@ -8818,7 +8780,16 @@ func (s *CreateBucketInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
 
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreateBucketConfiguration != nil {
+		v := s.CreateBucketConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "CreateBucketConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
 	return nil
 }
 
@@ -8852,7 +8823,6 @@ func (s *CreateBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Location", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9135,11 +9105,6 @@ func (s *CreateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -9190,16 +9155,6 @@ func (s *CreateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if len(s.Metadata) > 0 {
-		v := s.Metadata
-
-		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.RequestPayer != nil {
 		v := *s.RequestPayer
 
@@ -9245,7 +9200,21 @@ func (s *CreateMultipartUploadInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
 
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -9371,16 +9340,6 @@ func (s *CreateMultipartUploadOutput) SetUploadId(v string) *CreateMultipartUplo
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AbortDate != nil {
-		v := *s.AbortDate
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
-	}
-	if s.AbortRuleId != nil {
-		v := *s.AbortRuleId
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -9390,6 +9349,21 @@ func (s *CreateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) err
 		v := *s.Key
 
 		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UploadId != nil {
+		v := *s.UploadId
+
+		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AbortDate != nil {
+		v := *s.AbortDate
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RequestCharged != nil {
 		v := *s.RequestCharged
@@ -9416,12 +9390,6 @@ func (s *CreateMultipartUploadOutput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.UploadId != nil {
-		v := *s.UploadId
-
-		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -9494,7 +9462,6 @@ func (s *Delete) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Quiet", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9570,7 +9537,6 @@ func (s *DeleteBucketAnalyticsConfigurationInput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9591,7 +9557,6 @@ func (s DeleteBucketAnalyticsConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9646,7 +9611,6 @@ func (s *DeleteBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9667,7 +9631,6 @@ func (s DeleteBucketCorsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9725,7 +9688,6 @@ func (s *DeleteBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9746,7 +9708,6 @@ func (s DeleteBucketEncryptionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9801,7 +9762,6 @@ func (s *DeleteBucketInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9877,7 +9837,6 @@ func (s *DeleteBucketInventoryConfigurationInput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9898,7 +9857,6 @@ func (s DeleteBucketInventoryConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -9953,7 +9911,6 @@ func (s *DeleteBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9974,7 +9931,6 @@ func (s DeleteBucketLifecycleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10050,7 +10006,6 @@ func (s *DeleteBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10071,7 +10026,6 @@ func (s DeleteBucketMetricsConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10092,7 +10046,6 @@ func (s DeleteBucketOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10147,7 +10100,6 @@ func (s *DeleteBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10168,7 +10120,6 @@ func (s DeleteBucketPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10223,7 +10174,6 @@ func (s *DeleteBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10244,7 +10194,6 @@ func (s DeleteBucketReplicationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10299,7 +10248,6 @@ func (s *DeleteBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10320,7 +10268,6 @@ func (s DeleteBucketTaggingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10375,7 +10322,6 @@ func (s *DeleteBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10396,7 +10342,6 @@ func (s DeleteBucketWebsiteOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10487,7 +10432,6 @@ func (s *DeleteMarkerEntry) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10591,16 +10535,6 @@ func (s *DeleteObjectInput) SetVersionId(v string) *DeleteObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MFA != nil {
 		v := *s.MFA
 
@@ -10611,12 +10545,21 @@ func (s *DeleteObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10682,7 +10625,6 @@ func (s *DeleteObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10771,7 +10713,6 @@ func (s *DeleteObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10806,7 +10747,6 @@ func (s *DeleteObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10895,16 +10835,6 @@ func (s *DeleteObjectsInput) SetRequestPayer(v string) *DeleteObjectsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Delete != nil {
-		v := s.Delete
-
-		e.SetFields(protocol.PayloadTarget, "Delete", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
 	if s.MFA != nil {
 		v := *s.MFA
 
@@ -10915,7 +10845,16 @@ func (s *DeleteObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
 
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Delete != nil {
+		v := s.Delete
+
+		e.SetFields(protocol.PayloadTarget, "Delete", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
 	return nil
 }
 
@@ -10977,7 +10916,6 @@ func (s *DeleteObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11050,7 +10988,6 @@ func (s *DeletedObject) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11179,7 +11116,6 @@ func (s *Destination) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11215,7 +11151,6 @@ func (s *EncryptionConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ReplicaKmsKeyID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11288,7 +11223,6 @@ func (s *Error) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11349,7 +11283,6 @@ func (s *ErrorDocument) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11401,7 +11334,6 @@ func (s *FilterRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11466,7 +11398,6 @@ func (s *GetBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11501,7 +11432,6 @@ func (s *GetBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11556,7 +11486,6 @@ func (s *GetBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11604,7 +11533,6 @@ func (s *GetBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11680,7 +11608,6 @@ func (s *GetBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11715,7 +11642,6 @@ func (s *GetBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11770,7 +11696,6 @@ func (s *GetBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11804,7 +11729,6 @@ func (s *GetBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "CORSRule", encodeCORSRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -11862,7 +11786,6 @@ func (s *GetBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11898,7 +11821,6 @@ func (s *GetBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.PayloadTarget, "ServerSideEncryptionConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11974,7 +11896,6 @@ func (s *GetBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12009,7 +11930,6 @@ func (s *GetBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12064,7 +11984,6 @@ func (s *GetBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12098,7 +12017,6 @@ func (s *GetBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeLifecycleRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -12153,7 +12071,6 @@ func (s *GetBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12187,7 +12104,6 @@ func (s *GetBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -12242,7 +12158,6 @@ func (s *GetBucketLocationInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12276,7 +12191,6 @@ func (s *GetBucketLocationOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "LocationConstraint", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12331,7 +12245,6 @@ func (s *GetBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12365,7 +12278,6 @@ func (s *GetBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "LoggingEnabled", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12441,7 +12353,6 @@ func (s *GetBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12476,7 +12387,6 @@ func (s *GetBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12533,7 +12443,6 @@ func (s *GetBucketNotificationConfigurationRequest) MarshalFields(e protocol.Fie
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12588,7 +12497,6 @@ func (s *GetBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12623,7 +12531,6 @@ func (s *GetBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12678,7 +12585,6 @@ func (s *GetBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12714,7 +12620,6 @@ func (s *GetBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12769,7 +12674,6 @@ func (s *GetBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12804,7 +12708,6 @@ func (s *GetBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12859,7 +12762,6 @@ func (s *GetBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12894,7 +12796,6 @@ func (s *GetBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
 	}
-
 	return nil
 }
 
@@ -12949,7 +12850,6 @@ func (s *GetBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13000,7 +12900,6 @@ func (s *GetBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13055,7 +12954,6 @@ func (s *GetBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13128,7 +13026,6 @@ func (s *GetBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
 	}
-
 	return nil
 }
 
@@ -13214,6 +13111,11 @@ func (s *GetObjectAclInput) SetVersionId(v string) *GetObjectAclInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -13224,17 +13126,11 @@ func (s *GetObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13297,7 +13193,6 @@ func (s *GetObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13538,11 +13433,6 @@ func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
@@ -13563,16 +13453,6 @@ func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.PartNumber != nil {
-		v := *s.PartNumber
-
-		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.Range != nil {
 		v := *s.Range
 
@@ -13582,6 +13462,36 @@ func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.RequestPayer
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerAlgorithm != nil {
+		v := *s.SSECustomerAlgorithm
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKey != nil {
+		v := *s.SSECustomerKey
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SSECustomerKeyMD5 != nil {
+		v := *s.SSECustomerKeyMD5
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.ResponseCacheControl != nil {
 		v := *s.ResponseCacheControl
@@ -13613,27 +13523,11 @@ func (s *GetObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "response-expires", protocol.TimeValue{V: v, Format: protocol.ISO8601TimeFormat}, protocol.Metadata{})
 	}
-	if s.SSECustomerAlgorithm != nil {
-		v := *s.SSECustomerAlgorithm
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-algorithm", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SSECustomerKey != nil {
-		v := *s.SSECustomerKey
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.SSECustomerKeyMD5 != nil {
-		v := *s.SSECustomerKeyMD5
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -13928,7 +13822,6 @@ func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "accept-ranges", protocol.StringValue(v), protocol.Metadata{})
 	}
-	// Skipping Body Output type's body not valid.
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -13988,11 +13881,6 @@ func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.LastModified
 
 		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
-	}
-	if len(s.Metadata) > 0 {
-		v := s.Metadata
-
-		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
 	if s.MissingMeta != nil {
 		v := *s.MissingMeta
@@ -14059,7 +13947,12 @@ func (s *GetObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
 
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	// Skipping Body Output type's body not valid.
 	return nil
 }
 
@@ -14147,7 +14040,6 @@ func (s *GetObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14195,7 +14087,6 @@ func (s *GetObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14272,6 +14163,11 @@ func (s *GetObjectTorrentInput) SetRequestPayer(v string) *GetObjectTorrentInput
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectTorrentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -14282,12 +14178,6 @@ func (s *GetObjectTorrentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -14326,13 +14216,12 @@ func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOu
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *GetObjectTorrentOutput) MarshalFields(e protocol.FieldEncoder) error {
-	// Skipping Body Output type's body not valid.
 	if s.RequestCharged != nil {
 		v := *s.RequestCharged
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
+	// Skipping Body Output type's body not valid.
 	return nil
 }
 
@@ -14382,7 +14271,6 @@ func (s *GlacierJobParameters) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Tier", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14450,7 +14338,6 @@ func (s *Grant) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14560,7 +14447,6 @@ func (s *Grantee) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "URI", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14615,7 +14501,6 @@ func (s *HeadBucketInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -14636,7 +14521,6 @@ func (s HeadBucketOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *HeadBucketOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -14824,11 +14708,6 @@ func (s *HeadObjectInput) SetVersionId(v string) *HeadObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *HeadObjectInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.IfMatch != nil {
 		v := *s.IfMatch
 
@@ -14848,16 +14727,6 @@ func (s *HeadObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.IfUnmodifiedSince
 
 		e.SetValue(protocol.HeaderTarget, "If-Unmodified-Since", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
-	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.PartNumber != nil {
-		v := *s.PartNumber
-
-		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.Range != nil {
 		v := *s.Range
@@ -14884,12 +14753,26 @@ func (s *HeadObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15212,11 +15095,6 @@ func (s *HeadObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Last-Modified", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
 	}
-	if len(s.Metadata) > 0 {
-		v := s.Metadata
-
-		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.MissingMeta != nil {
 		v := *s.MissingMeta
 
@@ -15277,7 +15155,11 @@ func (s *HeadObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
 
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -15330,7 +15212,6 @@ func (s *IndexDocument) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Suffix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15380,7 +15261,6 @@ func (s *Initiator) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15550,7 +15430,6 @@ func (s *InventoryConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Schedule", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15614,7 +15493,6 @@ func (s *InventoryDestination) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "S3BucketDestination", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15680,7 +15558,6 @@ func (s *InventoryEncryption) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SSE-S3", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15730,7 +15607,6 @@ func (s *InventoryFilter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15855,7 +15731,6 @@ func (s *InventoryS3BucketDestination) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15905,7 +15780,6 @@ func (s *InventorySchedule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Frequency", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -15942,7 +15816,6 @@ func (s *KeyFilter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "FilterRule", encodeFilterRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -16041,7 +15914,6 @@ func (s *LambdaFunctionConfiguration) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "CloudFunction", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16107,7 +15979,6 @@ func (s *LifecycleConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -16175,7 +16046,6 @@ func (s *LifecycleExpiration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ExpiredObjectDeleteMarker", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16347,7 +16217,6 @@ func (s *LifecycleRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Transition", encodeTransitionList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -16427,7 +16296,6 @@ func (s *LifecycleRuleAndOperator) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -16514,7 +16382,6 @@ func (s *LifecycleRuleFilter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16586,7 +16453,6 @@ func (s *ListBucketAnalyticsConfigurationsInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16667,7 +16533,6 @@ func (s *ListBucketAnalyticsConfigurationsOutput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16741,7 +16606,6 @@ func (s *ListBucketInventoryConfigurationsInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16822,7 +16686,6 @@ func (s *ListBucketInventoryConfigurationsOutput) MarshalFields(e protocol.Field
 
 		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16896,7 +16759,6 @@ func (s *ListBucketMetricsConfigurationsInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.QueryTarget, "continuation-token", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -16979,7 +16841,6 @@ func (s *ListBucketMetricsConfigurationsOutput) MarshalFields(e protocol.FieldEn
 
 		e.SetValue(protocol.BodyTarget, "NextContinuationToken", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17000,7 +16861,6 @@ func (s ListBucketsInput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListBucketsInput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -17047,7 +16907,6 @@ func (s *ListBucketsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17197,7 +17056,6 @@ func (s *ListMultipartUploadsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "upload-id-marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17397,7 +17255,6 @@ func (s *ListMultipartUploadsOutput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetList(protocol.BodyTarget, "Upload", encodeMultipartUploadList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -17542,7 +17399,6 @@ func (s *ListObjectVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "version-id-marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -17741,7 +17597,6 @@ func (s *ListObjectVersionsOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "Version", encodeObjectVersionList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -17853,6 +17708,11 @@ func (s *ListObjectsInput) SetRequestPayer(v string) *ListObjectsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -17883,12 +17743,6 @@ func (s *ListObjectsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -18049,7 +17903,6 @@ func (s *ListObjectsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18181,6 +18034,11 @@ func (s *ListObjectsV2Input) SetStartAfter(v string) *ListObjectsV2Input {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListObjectsV2Input) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -18216,17 +18074,11 @@ func (s *ListObjectsV2Input) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "prefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StartAfter != nil {
 		v := *s.StartAfter
 
 		e.SetValue(protocol.QueryTarget, "start-after", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18426,7 +18278,6 @@ func (s *ListObjectsV2Output) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StartAfter", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18536,6 +18387,11 @@ func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -18556,17 +18412,11 @@ func (s *ListPartsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "part-number-marker", protocol.Int64Value(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
 		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18722,16 +18572,6 @@ func (s *ListPartsOutput) SetUploadId(v string) *ListPartsOutput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AbortDate != nil {
-		v := *s.AbortDate
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
-	}
-	if s.AbortRuleId != nil {
-		v := *s.AbortRuleId
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -18777,11 +18617,6 @@ func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Part", encodePartList(v), protocol.Metadata{Flatten: true})
 	}
-	if s.RequestCharged != nil {
-		v := *s.RequestCharged
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.StorageClass != nil {
 		v := *s.StorageClass
 
@@ -18792,7 +18627,21 @@ func (s *ListPartsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AbortDate != nil {
+		v := *s.AbortDate
 
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-date", protocol.TimeValue{V: v, Format: protocol.RFC822TimeFromat}, protocol.Metadata{})
+	}
+	if s.AbortRuleId != nil {
+		v := *s.AbortRuleId
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-abort-rule-id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RequestCharged != nil {
+		v := *s.RequestCharged
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -18880,7 +18729,6 @@ func (s *LoggingEnabled) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TargetPrefix", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -18949,7 +18797,6 @@ func (s *MetricsAndOperator) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Tag", encodeTagList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -19020,7 +18867,6 @@ func (s *MetricsConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19113,7 +18959,6 @@ func (s *MetricsFilter) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Tag", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19217,7 +19062,6 @@ func (s *MultipartUpload) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19268,7 +19112,6 @@ func (s *NoncurrentVersionExpiration) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "NoncurrentDays", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19325,7 +19168,6 @@ func (s *NoncurrentVersionTransition) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19435,7 +19277,6 @@ func (s *NotificationConfiguration) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.BodyTarget, "TopicConfiguration", encodeTopicConfigurationList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -19495,7 +19336,6 @@ func (s *NotificationConfigurationDeprecated) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.BodyTarget, "TopicConfiguration", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19532,7 +19372,6 @@ func (s *NotificationConfigurationFilter) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetFields(protocol.BodyTarget, "S3Key", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19632,7 +19471,6 @@ func (s *Object) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19707,7 +19545,6 @@ func (s *ObjectIdentifier) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19847,7 +19684,6 @@ func (s *ObjectVersion) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19902,7 +19738,6 @@ func (s *Owner) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ID", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -19980,7 +19815,6 @@ func (s *Part) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20054,17 +19888,16 @@ func (s *PutBucketAccelerateConfigurationInput) getBucket() (v string) {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketAccelerateConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AccelerateConfiguration != nil {
-		v := s.AccelerateConfiguration
-
-		e.SetFields(protocol.PayloadTarget, "AccelerateConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AccelerateConfiguration != nil {
+		v := s.AccelerateConfiguration
 
+		e.SetFields(protocol.PayloadTarget, "AccelerateConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
 	return nil
 }
 
@@ -20085,7 +19918,6 @@ func (s PutBucketAccelerateConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketAccelerateConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20208,16 +20040,6 @@ func (s *PutBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.AccessControlPolicy != nil {
-		v := s.AccessControlPolicy
-
-		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.GrantFullControl != nil {
 		v := *s.GrantFullControl
 
@@ -20243,7 +20065,16 @@ func (s *PutBucketAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
 
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
+
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
+	}
 	return nil
 }
 
@@ -20264,7 +20095,6 @@ func (s PutBucketAclOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketAclOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20349,22 +20179,21 @@ func (s *PutBucketAnalyticsConfigurationInput) SetId(v string) *PutBucketAnalyti
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketAnalyticsConfigurationInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AnalyticsConfiguration != nil {
-		v := s.AnalyticsConfiguration
-
-		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.AnalyticsConfiguration != nil {
+		v := s.AnalyticsConfiguration
+
+		e.SetFields(protocol.PayloadTarget, "AnalyticsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
 	if s.Id != nil {
 		v := *s.Id
 
 		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -20385,7 +20214,6 @@ func (s PutBucketAnalyticsConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketAnalyticsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20462,7 +20290,6 @@ func (s *PutBucketCorsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "CORSConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -20483,7 +20310,6 @@ func (s PutBucketCorsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketCorsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20566,7 +20392,6 @@ func (s *PutBucketEncryptionInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.PayloadTarget, "ServerSideEncryptionConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -20587,7 +20412,6 @@ func (s PutBucketEncryptionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketEncryptionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20677,17 +20501,16 @@ func (s *PutBucketInventoryConfigurationInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.InventoryConfiguration != nil {
 		v := s.InventoryConfiguration
 
 		e.SetFields(protocol.PayloadTarget, "InventoryConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -20708,7 +20531,6 @@ func (s PutBucketInventoryConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketInventoryConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20781,7 +20603,6 @@ func (s *PutBucketLifecycleConfigurationInput) MarshalFields(e protocol.FieldEnc
 
 		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -20802,7 +20623,6 @@ func (s PutBucketLifecycleConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketLifecycleConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20875,7 +20695,6 @@ func (s *PutBucketLifecycleInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "LifecycleConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -20896,7 +20715,6 @@ func (s PutBucketLifecycleOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketLifecycleOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -20973,7 +20791,6 @@ func (s *PutBucketLoggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "BucketLoggingStatus", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -20994,7 +20811,6 @@ func (s PutBucketLoggingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketLoggingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21084,17 +20900,16 @@ func (s *PutBucketMetricsConfigurationInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Id != nil {
-		v := *s.Id
-
-		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MetricsConfiguration != nil {
 		v := s.MetricsConfiguration
 
 		e.SetFields(protocol.PayloadTarget, "MetricsConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
+	if s.Id != nil {
+		v := *s.Id
 
+		e.SetValue(protocol.QueryTarget, "id", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -21115,7 +20930,6 @@ func (s PutBucketMetricsConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketMetricsConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21195,7 +21009,6 @@ func (s *PutBucketNotificationConfigurationInput) MarshalFields(e protocol.Field
 
 		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21216,7 +21029,6 @@ func (s PutBucketNotificationConfigurationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketNotificationConfigurationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21288,7 +21100,6 @@ func (s *PutBucketNotificationInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetFields(protocol.PayloadTarget, "NotificationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21309,7 +21120,6 @@ func (s PutBucketNotificationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketNotificationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21383,22 +21193,21 @@ func (s *PutBucketPolicyInput) SetPolicy(v string) *PutBucketPolicyInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketPolicyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ConfirmRemoveSelfBucketAccess != nil {
 		v := *s.ConfirmRemoveSelfBucketAccess
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-confirm-remove-self-bucket-access", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Policy != nil {
 		v := *s.Policy
 
 		e.SetStream(protocol.PayloadTarget, "Policy", protocol.StringStream(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -21419,7 +21228,6 @@ func (s PutBucketPolicyOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketPolicyOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21499,7 +21307,6 @@ func (s *PutBucketReplicationInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetFields(protocol.PayloadTarget, "ReplicationConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21520,7 +21327,6 @@ func (s PutBucketReplicationOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketReplicationOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21597,7 +21403,6 @@ func (s *PutBucketRequestPaymentInput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetFields(protocol.PayloadTarget, "RequestPaymentConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21618,7 +21423,6 @@ func (s PutBucketRequestPaymentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketRequestPaymentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21695,7 +21499,6 @@ func (s *PutBucketTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "Tagging", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21716,7 +21519,6 @@ func (s PutBucketTaggingOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21788,22 +21590,21 @@ func (s *PutBucketVersioningInput) SetVersioningConfiguration(v *VersioningConfi
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketVersioningInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.MFA != nil {
 		v := *s.MFA
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-mfa", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.VersioningConfiguration != nil {
 		v := s.VersioningConfiguration
 
 		e.SetFields(protocol.PayloadTarget, "VersioningConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21824,7 +21625,6 @@ func (s PutBucketVersioningOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketVersioningOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -21901,7 +21701,6 @@ func (s *PutBucketWebsiteInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.PayloadTarget, "WebsiteConfiguration", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
-
 	return nil
 }
 
@@ -21922,7 +21721,6 @@ func (s PutBucketWebsiteOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutBucketWebsiteOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -22081,16 +21879,6 @@ func (s *PutObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.AccessControlPolicy != nil {
-		v := s.AccessControlPolicy
-
-		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
-	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.GrantFullControl != nil {
 		v := *s.GrantFullControl
 
@@ -22116,22 +21904,31 @@ func (s *PutObjectAclInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Key != nil {
 		v := *s.Key
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
+	if s.AccessControlPolicy != nil {
+		v := s.AccessControlPolicy
 
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+		e.SetFields(protocol.PayloadTarget, "AccessControlPolicy", v, protocol.Metadata{XMLNamespaceURI: "http://s3.amazonaws.com/doc/2006-03-01/"})
 	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22167,7 +21964,6 @@ func (s *PutObjectAclOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22482,16 +22278,6 @@ func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-acl", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
-	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.CacheControl != nil {
 		v := *s.CacheControl
 
@@ -22552,16 +22338,6 @@ func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-grant-write-acp", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if len(s.Metadata) > 0 {
-		v := s.Metadata
-
-		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
-	}
 	if s.RequestPayer != nil {
 		v := *s.RequestPayer
 
@@ -22607,7 +22383,26 @@ func (s *PutObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-website-redirect-location", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if len(s.Metadata) > 0 {
+		v := s.Metadata
 
+		e.SetMap(protocol.HeadersTarget, "x-amz-meta-", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -22748,7 +22543,6 @@ func (s *PutObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22858,7 +22652,6 @@ func (s *PutObjectTaggingInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22892,7 +22685,6 @@ func (s *PutObjectTaggingOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-version-id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -22992,7 +22784,6 @@ func (s *QueueConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23076,7 +22867,6 @@ func (s *QueueConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Queue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23176,7 +22966,6 @@ func (s *Redirect) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ReplaceKeyWith", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23241,7 +23030,6 @@ func (s *RedirectAllRequestsTo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23324,7 +23112,6 @@ func (s *ReplicationConfiguration) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeReplicationRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -23453,7 +23240,6 @@ func (s *ReplicationRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23511,7 +23297,6 @@ func (s *RequestPaymentConfiguration) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.BodyTarget, "Payer", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23609,6 +23394,11 @@ func (s *RestoreObjectInput) SetVersionId(v string) *RestoreObjectInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RestoreObjectInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.RequestPayer != nil {
+		v := *s.RequestPayer
+
+		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Bucket != nil {
 		v := *s.Bucket
 
@@ -23618,11 +23408,6 @@ func (s *RestoreObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.Key
 
 		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.RequestPayer != nil {
-		v := *s.RequestPayer
-
-		e.SetValue(protocol.HeaderTarget, "x-amz-request-payer", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.RestoreRequest != nil {
 		v := s.RestoreRequest
@@ -23634,7 +23419,6 @@ func (s *RestoreObjectInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23670,7 +23454,6 @@ func (s *RestoreObjectOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-request-charged", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23739,7 +23522,6 @@ func (s *RestoreRequest) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "GlacierJobParameters", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23808,7 +23590,6 @@ func (s *RoutingRule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Redirect", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -23977,7 +23758,6 @@ func (s *Rule) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Transition", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24032,12 +23812,14 @@ func (s *SSEKMS) SetKeyId(v string) *SSEKMS {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SSEKMS) MarshalFields(e protocol.FieldEncoder) error {
-	if s.KeyId != nil {
-		v := *s.KeyId
+	e.SetFields(protocol.BodyTarget, "SSE-KMS", protocol.FieldMarshalerFunc(func(e protocol.FieldEncoder) error {
+		if s.KeyId != nil {
+			v := *s.KeyId
 
-		e.SetValue(protocol.BodyTarget, "KeyId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
+			e.SetValue(protocol.BodyTarget, "KeyId", protocol.StringValue(v), protocol.Metadata{})
+		}
+		return nil
+	}), protocol.Metadata{})
 	return nil
 }
 
@@ -24059,7 +23841,6 @@ func (s SSES3) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *SSES3) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -24127,7 +23908,6 @@ func (s *ServerSideEncryptionByDefault) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.BodyTarget, "SSEAlgorithm", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24190,7 +23970,6 @@ func (s *ServerSideEncryptionConfiguration) MarshalFields(e protocol.FieldEncode
 
 		e.SetList(protocol.BodyTarget, "Rule", encodeServerSideEncryptionRuleList(v), protocol.Metadata{Flatten: true})
 	}
-
 	return nil
 }
 
@@ -24244,7 +24023,6 @@ func (s *ServerSideEncryptionRule) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "ApplyServerSideEncryptionByDefault", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24303,7 +24081,6 @@ func (s *SourceSelectionCriteria) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SseKmsEncryptedObjects", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24355,7 +24132,6 @@ func (s *SseKmsEncryptedObjects) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24406,7 +24182,6 @@ func (s *StorageClassAnalysis) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "DataExport", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24480,7 +24255,6 @@ func (s *StorageClassAnalysisDataExport) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "OutputSchemaVersion", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24552,7 +24326,6 @@ func (s *Tag) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24618,7 +24391,6 @@ func (s *Tagging) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TagSet", encodeTagList(v), protocol.Metadata{ListLocationName: "Tag"})
 	}
-
 	return nil
 }
 
@@ -24686,7 +24458,6 @@ func (s *TargetGrant) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Permission", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24794,7 +24565,6 @@ func (s *TopicConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24880,7 +24650,6 @@ func (s *TopicConfigurationDeprecated) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Topic", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -24945,7 +24714,6 @@ func (s *Transition) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageClass", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25203,11 +24971,6 @@ func (s *UploadPartCopyInput) SetUploadId(v string) *UploadPartCopyInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UploadPartCopyInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.CopySource != nil {
 		v := *s.CopySource
 
@@ -25253,16 +25016,6 @@ func (s *UploadPartCopyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-copy-source-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.PartNumber != nil {
-		v := *s.PartNumber
-
-		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
-	}
 	if s.RequestPayer != nil {
 		v := *s.RequestPayer
 
@@ -25283,12 +25036,26 @@ func (s *UploadPartCopyInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
 		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25379,11 +25146,6 @@ func (s *UploadPartCopyOutput) SetServerSideEncryption(v string) *UploadPartCopy
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UploadPartCopyOutput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.CopyPartResult != nil {
-		v := s.CopyPartResult
-
-		e.SetFields(protocol.PayloadTarget, "CopyPartResult", v, protocol.Metadata{})
-	}
 	if s.CopySourceVersionId != nil {
 		v := *s.CopySourceVersionId
 
@@ -25414,7 +25176,11 @@ func (s *UploadPartCopyOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.CopyPartResult != nil {
+		v := s.CopyPartResult
 
+		e.SetFields(protocol.PayloadTarget, "CopyPartResult", v, protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -25593,16 +25359,6 @@ func (s *UploadPartInput) SetUploadId(v string) *UploadPartInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UploadPartInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.Body != nil {
-		v := s.Body
-
-		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
-	}
-	if s.Bucket != nil {
-		v := *s.Bucket
-
-		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ContentLength != nil {
 		v := *s.ContentLength
 
@@ -25612,16 +25368,6 @@ func (s *UploadPartInput) MarshalFields(e protocol.FieldEncoder) error {
 		v := *s.ContentMD5
 
 		e.SetValue(protocol.HeaderTarget, "Content-MD5", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.Key != nil {
-		v := *s.Key
-
-		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.PartNumber != nil {
-		v := *s.PartNumber
-
-		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
 	}
 	if s.RequestPayer != nil {
 		v := *s.RequestPayer
@@ -25643,12 +25389,31 @@ func (s *UploadPartInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption-customer-key-MD5", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.Bucket != nil {
+		v := *s.Bucket
+
+		e.SetValue(protocol.PathTarget, "Bucket", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Key != nil {
+		v := *s.Key
+
+		e.SetValue(protocol.PathTarget, "Key", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Body != nil {
+		v := s.Body
+
+		e.SetStream(protocol.PayloadTarget, "Body", protocol.ReadSeekerStream{V: v}, protocol.Metadata{})
+	}
+	if s.PartNumber != nil {
+		v := *s.PartNumber
+
+		e.SetValue(protocol.QueryTarget, "partNumber", protocol.Int64Value(v), protocol.Metadata{})
+	}
 	if s.UploadId != nil {
 		v := *s.UploadId
 
 		e.SetValue(protocol.QueryTarget, "uploadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25760,7 +25525,6 @@ func (s *UploadPartOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "x-amz-server-side-encryption", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25811,7 +25575,6 @@ func (s *VersioningConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -25919,7 +25682,6 @@ func (s *WebsiteConfiguration) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "RoutingRules", encodeRoutingRuleList(v), protocol.Metadata{ListLocationName: "RoutingRule"})
 	}
-
 	return nil
 }
 

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4159,6 +4159,27 @@ func (s *AbortDocumentVersionUploadInput) SetVersionId(v string) *AbortDocumentV
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AbortDocumentVersionUploadOutput
 type AbortDocumentVersionUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -4172,6 +4193,12 @@ func (s AbortDocumentVersionUploadOutput) String() string {
 // GoString returns the string representation
 func (s AbortDocumentVersionUploadOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AbortDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ActivateUserRequest
@@ -4229,6 +4256,22 @@ func (s *ActivateUserInput) SetUserId(v string) *ActivateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ActivateUserResponse
 type ActivateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -4251,6 +4294,17 @@ func (s ActivateUserOutput) GoString() string {
 func (s *ActivateUserOutput) SetUser(v *User) *ActivateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ActivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the activity information.
@@ -4345,6 +4399,60 @@ func (s *Activity) SetType(v string) *Activity {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Activity) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentMetadata != nil {
+		v := s.CommentMetadata
+
+		e.SetFields(protocol.BodyTarget, "CommentMetadata", v, protocol.Metadata{})
+	}
+	if s.Initiator != nil {
+		v := s.Initiator
+
+		e.SetFields(protocol.BodyTarget, "Initiator", v, protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginalParent != nil {
+		v := s.OriginalParent
+
+		e.SetFields(protocol.BodyTarget, "OriginalParent", v, protocol.Metadata{})
+	}
+	if s.Participants != nil {
+		v := s.Participants
+
+		e.SetFields(protocol.BodyTarget, "Participants", v, protocol.Metadata{})
+	}
+	if s.ResourceMetadata != nil {
+		v := s.ResourceMetadata
+
+		e.SetFields(protocol.BodyTarget, "ResourceMetadata", v, protocol.Metadata{})
+	}
+	if s.TimeStamp != nil {
+		v := *s.TimeStamp
+
+		e.SetValue(protocol.BodyTarget, "TimeStamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeActivityList(vs []*Activity) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AddResourcePermissionsRequest
 type AddResourcePermissionsInput struct {
 	_ struct{} `type:"structure"`
@@ -4433,6 +4541,32 @@ func (s *AddResourcePermissionsInput) SetResourceId(v string) *AddResourcePermis
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotificationOptions != nil {
+		v := s.NotificationOptions
+
+		e.SetFields(protocol.BodyTarget, "NotificationOptions", v, protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "Principals", encodeSharePrincipalList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/AddResourcePermissionsResponse
 type AddResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -4455,6 +4589,17 @@ func (s AddResourcePermissionsOutput) GoString() string {
 func (s *AddResourcePermissionsOutput) SetShareResults(v []*ShareResult) *AddResourcePermissionsOutput {
 	s.ShareResults = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AddResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ShareResults) > 0 {
+		v := s.ShareResults
+
+		e.SetList(protocol.BodyTarget, "ShareResults", encodeShareResultList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a comment.
@@ -4559,6 +4704,65 @@ func (s *Comment) SetVisibility(v string) *Comment {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Comment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.BodyTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Contributor != nil {
+		v := s.Contributor
+
+		e.SetFields(protocol.BodyTarget, "Contributor", v, protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecipientId != nil {
+		v := *s.RecipientId
+
+		e.SetValue(protocol.BodyTarget, "RecipientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Visibility != nil {
+		v := *s.Visibility
+
+		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeCommentList(vs []*Comment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the metadata of a comment.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CommentMetadata
 type CommentMetadata struct {
@@ -4618,6 +4822,37 @@ func (s *CommentMetadata) SetCreatedTimestamp(v time.Time) *CommentMetadata {
 func (s *CommentMetadata) SetRecipientId(v string) *CommentMetadata {
 	s.RecipientId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CommentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.BodyTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CommentStatus != nil {
+		v := *s.CommentStatus
+
+		e.SetValue(protocol.BodyTarget, "CommentStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Contributor != nil {
+		v := s.Contributor
+
+		e.SetFields(protocol.BodyTarget, "Contributor", v, protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.RecipientId != nil {
+		v := *s.RecipientId
+
+		e.SetValue(protocol.BodyTarget, "RecipientId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCommentRequest
@@ -4754,6 +4989,52 @@ func (s *CreateCommentInput) SetVisibility(v string) *CreateCommentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NotifyCollaborators != nil {
+		v := *s.NotifyCollaborators
+
+		e.SetValue(protocol.BodyTarget, "NotifyCollaborators", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Text != nil {
+		v := *s.Text
+
+		e.SetValue(protocol.BodyTarget, "Text", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ThreadId != nil {
+		v := *s.ThreadId
+
+		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Visibility != nil {
+		v := *s.Visibility
+
+		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCommentResponse
 type CreateCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -4776,6 +5057,17 @@ func (s CreateCommentOutput) GoString() string {
 func (s *CreateCommentOutput) SetComment(v *Comment) *CreateCommentOutput {
 	s.Comment = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Comment != nil {
+		v := s.Comment
+
+		e.SetFields(protocol.BodyTarget, "Comment", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCustomMetadataRequest
@@ -4863,6 +5155,32 @@ func (s *CreateCustomMetadataInput) SetVersionId(v string) *CreateCustomMetadata
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionid", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateCustomMetadataResponse
 type CreateCustomMetadataOutput struct {
 	_ struct{} `type:"structure"`
@@ -4876,6 +5194,12 @@ func (s CreateCustomMetadataOutput) String() string {
 // GoString returns the string representation
 func (s CreateCustomMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateFolderRequest
@@ -4945,6 +5269,27 @@ func (s *CreateFolderInput) SetParentFolderId(v string) *CreateFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateFolderResponse
 type CreateFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -4967,6 +5312,17 @@ func (s CreateFolderOutput) GoString() string {
 func (s *CreateFolderOutput) SetMetadata(v *FolderMetadata) *CreateFolderOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateLabelsRequest
@@ -5038,6 +5394,27 @@ func (s *CreateLabelsInput) SetResourceId(v string) *CreateLabelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateLabelsResponse
 type CreateLabelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5051,6 +5428,12 @@ func (s CreateLabelsOutput) String() string {
 // GoString returns the string representation
 func (s CreateLabelsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateNotificationSubscriptionRequest
@@ -5142,6 +5525,32 @@ func (s *CreateNotificationSubscriptionInput) SetSubscriptionType(v string) *Cre
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateNotificationSubscriptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Endpoint != nil {
+		v := *s.Endpoint
+
+		e.SetValue(protocol.BodyTarget, "Endpoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionType != nil {
+		v := *s.SubscriptionType
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateNotificationSubscriptionResponse
 type CreateNotificationSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5164,6 +5573,17 @@ func (s CreateNotificationSubscriptionOutput) GoString() string {
 func (s *CreateNotificationSubscriptionOutput) SetSubscription(v *Subscription) *CreateNotificationSubscriptionOutput {
 	s.Subscription = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Subscription != nil {
+		v := s.Subscription
+
+		e.SetFields(protocol.BodyTarget, "Subscription", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateUserRequest
@@ -5317,6 +5737,57 @@ func (s *CreateUserInput) SetUsername(v string) *CreateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Password != nil {
+		v := *s.Password
+
+		e.SetValue(protocol.BodyTarget, "Password", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/CreateUserResponse
 type CreateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5339,6 +5810,17 @@ func (s CreateUserOutput) GoString() string {
 func (s *CreateUserOutput) SetUser(v *User) *CreateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *CreateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeactivateUserRequest
@@ -5396,6 +5878,22 @@ func (s *DeactivateUserInput) SetUserId(v string) *DeactivateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeactivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeactivateUserOutput
 type DeactivateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -5409,6 +5907,12 @@ func (s DeactivateUserOutput) String() string {
 // GoString returns the string representation
 func (s DeactivateUserOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeactivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCommentRequest
@@ -5500,6 +6004,32 @@ func (s *DeleteCommentInput) SetVersionId(v string) *DeleteCommentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCommentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CommentId != nil {
+		v := *s.CommentId
+
+		e.SetValue(protocol.PathTarget, "CommentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCommentOutput
 type DeleteCommentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5513,6 +6043,12 @@ func (s DeleteCommentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCommentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCustomMetadataRequest
@@ -5602,6 +6138,37 @@ func (s *DeleteCustomMetadataInput) SetVersionId(v string) *DeleteCustomMetadata
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteAll != nil {
+		v := *s.DeleteAll
+
+		e.SetValue(protocol.QueryTarget, "deleteAll", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Keys) > 0 {
+		v := s.Keys
+
+		e.SetList(protocol.QueryTarget, "keys", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteCustomMetadataResponse
 type DeleteCustomMetadataOutput struct {
 	_ struct{} `type:"structure"`
@@ -5615,6 +6182,12 @@ func (s DeleteCustomMetadataOutput) String() string {
 // GoString returns the string representation
 func (s DeleteCustomMetadataOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteDocumentRequest
@@ -5672,6 +6245,22 @@ func (s *DeleteDocumentInput) SetDocumentId(v string) *DeleteDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteDocumentOutput
 type DeleteDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -5685,6 +6274,12 @@ func (s DeleteDocumentOutput) String() string {
 // GoString returns the string representation
 func (s DeleteDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderContentsRequest
@@ -5742,6 +6337,22 @@ func (s *DeleteFolderContentsInput) SetFolderId(v string) *DeleteFolderContentsI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderContentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderContentsOutput
 type DeleteFolderContentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5755,6 +6366,12 @@ func (s DeleteFolderContentsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFolderContentsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderRequest
@@ -5812,6 +6429,22 @@ func (s *DeleteFolderInput) SetFolderId(v string) *DeleteFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteFolderOutput
 type DeleteFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -5825,6 +6458,12 @@ func (s DeleteFolderOutput) String() string {
 // GoString returns the string representation
 func (s DeleteFolderOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteLabelsRequest
@@ -5900,6 +6539,32 @@ func (s *DeleteLabelsInput) SetResourceId(v string) *DeleteLabelsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DeleteAll != nil {
+		v := *s.DeleteAll
+
+		e.SetValue(protocol.QueryTarget, "deleteAll", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.QueryTarget, "labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteLabelsResponse
 type DeleteLabelsOutput struct {
 	_ struct{} `type:"structure"`
@@ -5913,6 +6578,12 @@ func (s DeleteLabelsOutput) String() string {
 // GoString returns the string representation
 func (s DeleteLabelsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteNotificationSubscriptionRequest
@@ -5974,6 +6645,22 @@ func (s *DeleteNotificationSubscriptionInput) SetSubscriptionId(v string) *Delet
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteNotificationSubscriptionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionId != nil {
+		v := *s.SubscriptionId
+
+		e.SetValue(protocol.PathTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteNotificationSubscriptionOutput
 type DeleteNotificationSubscriptionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5987,6 +6674,12 @@ func (s DeleteNotificationSubscriptionOutput) String() string {
 // GoString returns the string representation
 func (s DeleteNotificationSubscriptionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteUserRequest
@@ -6044,6 +6737,22 @@ func (s *DeleteUserInput) SetUserId(v string) *DeleteUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DeleteUserOutput
 type DeleteUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -6057,6 +6766,12 @@ func (s DeleteUserOutput) String() string {
 // GoString returns the string representation
 func (s DeleteUserOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DeleteUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesRequest
@@ -6168,6 +6883,47 @@ func (s *DescribeActivitiesInput) SetUserId(v string) *DescribeActivitiesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeActivitiesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.QueryTarget, "endTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.QueryTarget, "organizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.QueryTarget, "startTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.QueryTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeActivitiesResponse
 type DescribeActivitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6199,6 +6955,22 @@ func (s *DescribeActivitiesOutput) SetMarker(v string) *DescribeActivitiesOutput
 func (s *DescribeActivitiesOutput) SetUserActivities(v []*Activity) *DescribeActivitiesOutput {
 	s.UserActivities = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeActivitiesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.UserActivities) > 0 {
+		v := s.UserActivities
+
+		e.SetList(protocol.BodyTarget, "UserActivities", encodeActivityList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeCommentsRequest
@@ -6298,6 +7070,37 @@ func (s *DescribeCommentsInput) SetVersionId(v string) *DescribeCommentsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCommentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeCommentsResponse
 type DescribeCommentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6330,6 +7133,22 @@ func (s *DescribeCommentsOutput) SetComments(v []*Comment) *DescribeCommentsOutp
 func (s *DescribeCommentsOutput) SetMarker(v string) *DescribeCommentsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeCommentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Comments) > 0 {
+		v := s.Comments
+
+		e.SetList(protocol.BodyTarget, "Comments", encodeCommentList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeDocumentVersionsRequest
@@ -6438,6 +7257,42 @@ func (s *DescribeDocumentVersionsInput) SetMarker(v string) *DescribeDocumentVer
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDocumentVersionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeDocumentVersionsResponse
 type DescribeDocumentVersionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6470,6 +7325,22 @@ func (s *DescribeDocumentVersionsOutput) SetDocumentVersions(v []*DocumentVersio
 func (s *DescribeDocumentVersionsOutput) SetMarker(v string) *DescribeDocumentVersionsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeDocumentVersionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.DocumentVersions) > 0 {
+		v := s.DocumentVersions
+
+		e.SetList(protocol.BodyTarget, "DocumentVersions", encodeDocumentVersionMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeFolderContentsRequest
@@ -6591,6 +7462,52 @@ func (s *DescribeFolderContentsInput) SetType(v string) *DescribeFolderContentsI
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFolderContentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeFolderContentsResponse
 type DescribeFolderContentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6632,6 +7549,27 @@ func (s *DescribeFolderContentsOutput) SetFolders(v []*FolderMetadata) *Describe
 func (s *DescribeFolderContentsOutput) SetMarker(v string) *DescribeFolderContentsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Documents) > 0 {
+		v := s.Documents
+
+		e.SetList(protocol.BodyTarget, "Documents", encodeDocumentMetadataList(v), protocol.Metadata{})
+	}
+	if len(s.Folders) > 0 {
+		v := s.Folders
+
+		e.SetList(protocol.BodyTarget, "Folders", encodeFolderMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeGroupsRequest
@@ -6726,6 +7664,37 @@ func (s *DescribeGroupsInput) SetSearchQuery(v string) *DescribeGroupsInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.QueryTarget, "organizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SearchQuery != nil {
+		v := *s.SearchQuery
+
+		e.SetValue(protocol.QueryTarget, "searchQuery", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeGroupsResponse
 type DescribeGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6758,6 +7727,22 @@ func (s *DescribeGroupsOutput) SetGroups(v []*GroupMetadata) *DescribeGroupsOutp
 func (s *DescribeGroupsOutput) SetMarker(v string) *DescribeGroupsOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Groups) > 0 {
+		v := s.Groups
+
+		e.SetList(protocol.BodyTarget, "Groups", encodeGroupMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeNotificationSubscriptionsRequest
@@ -6827,6 +7812,27 @@ func (s *DescribeNotificationSubscriptionsInput) SetOrganizationId(v string) *De
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeNotificationSubscriptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeNotificationSubscriptionsResponse
 type DescribeNotificationSubscriptionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6859,6 +7865,22 @@ func (s *DescribeNotificationSubscriptionsOutput) SetMarker(v string) *DescribeN
 func (s *DescribeNotificationSubscriptionsOutput) SetSubscriptions(v []*Subscription) *DescribeNotificationSubscriptionsOutput {
 	s.Subscriptions = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeNotificationSubscriptionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Subscriptions) > 0 {
+		v := s.Subscriptions
+
+		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeResourcePermissionsRequest
@@ -6953,6 +7975,37 @@ func (s *DescribeResourcePermissionsInput) SetResourceId(v string) *DescribeReso
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.QueryTarget, "principalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeResourcePermissionsResponse
 type DescribeResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6985,6 +8038,22 @@ func (s *DescribeResourcePermissionsOutput) SetMarker(v string) *DescribeResourc
 func (s *DescribeResourcePermissionsOutput) SetPrincipals(v []*Principal) *DescribeResourcePermissionsOutput {
 	s.Principals = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Principals) > 0 {
+		v := s.Principals
+
+		e.SetList(protocol.BodyTarget, "Principals", encodePrincipalList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersRequest
@@ -7055,6 +8124,27 @@ func (s *DescribeRootFoldersInput) SetMarker(v string) *DescribeRootFoldersInput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeRootFoldersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeRootFoldersResponse
 type DescribeRootFoldersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7086,6 +8176,22 @@ func (s *DescribeRootFoldersOutput) SetFolders(v []*FolderMetadata) *DescribeRoo
 func (s *DescribeRootFoldersOutput) SetMarker(v string) *DescribeRootFoldersOutput {
 	s.Marker = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeRootFoldersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Folders) > 0 {
+		v := s.Folders
+
+		e.SetList(protocol.BodyTarget, "Folders", encodeFolderMetadataList(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeUsersRequest
@@ -7227,6 +8333,62 @@ func (s *DescribeUsersInput) SetUserIds(v string) *DescribeUsersInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeUsersInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Include != nil {
+		v := *s.Include
+
+		e.SetValue(protocol.QueryTarget, "include", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Order != nil {
+		v := *s.Order
+
+		e.SetValue(protocol.QueryTarget, "order", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.QueryTarget, "organizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Query != nil {
+		v := *s.Query
+
+		e.SetValue(protocol.QueryTarget, "query", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sort != nil {
+		v := *s.Sort
+
+		e.SetValue(protocol.QueryTarget, "sort", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserIds != nil {
+		v := *s.UserIds
+
+		e.SetValue(protocol.QueryTarget, "userIds", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/DescribeUsersResponse
 type DescribeUsersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7268,6 +8430,27 @@ func (s *DescribeUsersOutput) SetTotalNumberOfUsers(v int64) *DescribeUsersOutpu
 func (s *DescribeUsersOutput) SetUsers(v []*User) *DescribeUsersOutput {
 	s.Users = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DescribeUsersOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TotalNumberOfUsers != nil {
+		v := *s.TotalNumberOfUsers
+
+		e.SetValue(protocol.BodyTarget, "TotalNumberOfUsers", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeUserList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the document.
@@ -7356,6 +8539,60 @@ func (s *DocumentMetadata) SetParentFolderId(v string) *DocumentMetadata {
 func (s *DocumentMetadata) SetResourceState(v string) *DocumentMetadata {
 	s.ResourceState = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.LatestVersionMetadata != nil {
+		v := s.LatestVersionMetadata
+
+		e.SetFields(protocol.BodyTarget, "LatestVersionMetadata", v, protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentMetadataList(vs []*DocumentMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a version of a document.
@@ -7491,6 +8728,85 @@ func (s *DocumentVersionMetadata) SetThumbnail(v map[string]*string) *DocumentVe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *DocumentVersionMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ContentCreatedTimestamp != nil {
+		v := *s.ContentCreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentCreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentModifiedTimestamp != nil {
+		v := *s.ContentModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "ContentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "Signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.Source) > 0 {
+		v := s.Source
+
+		e.SetMap(protocol.BodyTarget, "Source", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Thumbnail) > 0 {
+		v := s.Thumbnail
+
+		e.SetMap(protocol.BodyTarget, "Thumbnail", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeDocumentVersionMetadataList(vs []*DocumentVersionMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes a folder.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/FolderMetadata
 type FolderMetadata struct {
@@ -7606,6 +8922,75 @@ func (s *FolderMetadata) SetSize(v int64) *FolderMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FolderMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.CreatorId != nil {
+		v := *s.CreatorId
+
+		e.SetValue(protocol.BodyTarget, "CreatorId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Labels) > 0 {
+		v := s.Labels
+
+		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.LatestVersionSize != nil {
+		v := *s.LatestVersionSize
+
+		e.SetValue(protocol.BodyTarget, "LatestVersionSize", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Signature != nil {
+		v := *s.Signature
+
+		e.SetValue(protocol.BodyTarget, "Signature", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Size != nil {
+		v := *s.Size
+
+		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeFolderMetadataList(vs []*FolderMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserRequest
 type GetCurrentUserInput struct {
 	_ struct{} `type:"structure"`
@@ -7649,6 +9034,17 @@ func (s *GetCurrentUserInput) SetAuthenticationToken(v string) *GetCurrentUserIn
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCurrentUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetCurrentUserResponse
 type GetCurrentUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -7671,6 +9067,17 @@ func (s GetCurrentUserOutput) GoString() string {
 func (s *GetCurrentUserOutput) SetUser(v *User) *GetCurrentUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetCurrentUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentRequest
@@ -7737,6 +9144,27 @@ func (s *GetDocumentInput) SetIncludeCustomMetadata(v bool) *GetDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentResponse
 type GetDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -7768,6 +9196,22 @@ func (s *GetDocumentOutput) SetCustomMetadata(v map[string]*string) *GetDocument
 func (s *GetDocumentOutput) SetMetadata(v *DocumentMetadata) *GetDocumentOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentPathRequest
@@ -7862,6 +9306,37 @@ func (s *GetDocumentPathInput) SetMarker(v string) *GetDocumentPathInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentPathInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentPathResponse
 type GetDocumentPathOutput struct {
 	_ struct{} `type:"structure"`
@@ -7884,6 +9359,17 @@ func (s GetDocumentPathOutput) GoString() string {
 func (s *GetDocumentPathOutput) SetPath(v *ResourcePath) *GetDocumentPathOutput {
 	s.Path = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentPathOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := s.Path
+
+		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentVersionRequest
@@ -7980,6 +9466,37 @@ func (s *GetDocumentVersionInput) SetVersionId(v string) *GetDocumentVersionInpu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetDocumentVersionResponse
 type GetDocumentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8011,6 +9528,22 @@ func (s *GetDocumentVersionOutput) SetCustomMetadata(v map[string]*string) *GetD
 func (s *GetDocumentVersionOutput) SetMetadata(v *DocumentVersionMetadata) *GetDocumentVersionOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderRequest
@@ -8077,6 +9610,27 @@ func (s *GetFolderInput) SetIncludeCustomMetadata(v bool) *GetFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IncludeCustomMetadata != nil {
+		v := *s.IncludeCustomMetadata
+
+		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderResponse
 type GetFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -8108,6 +9662,22 @@ func (s *GetFolderOutput) SetCustomMetadata(v map[string]*string) *GetFolderOutp
 func (s *GetFolderOutput) SetMetadata(v *FolderMetadata) *GetFolderOutput {
 	s.Metadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.CustomMetadata) > 0 {
+		v := s.CustomMetadata
+
+		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderPathRequest
@@ -8202,6 +9772,37 @@ func (s *GetFolderPathInput) SetMarker(v string) *GetFolderPathInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderPathInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Limit != nil {
+		v := *s.Limit
+
+		e.SetValue(protocol.QueryTarget, "limit", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Marker != nil {
+		v := *s.Marker
+
+		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/GetFolderPathResponse
 type GetFolderPathOutput struct {
 	_ struct{} `type:"structure"`
@@ -8224,6 +9825,17 @@ func (s GetFolderPathOutput) GoString() string {
 func (s *GetFolderPathOutput) SetPath(v *ResourcePath) *GetFolderPathOutput {
 	s.Path = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetFolderPathOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Path != nil {
+		v := s.Path
+
+		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the metadata of a user group.
@@ -8258,6 +9870,30 @@ func (s *GroupMetadata) SetId(v string) *GroupMetadata {
 func (s *GroupMetadata) SetName(v string) *GroupMetadata {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GroupMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeGroupMetadataList(vs []*GroupMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUploadRequest
@@ -8378,6 +10014,52 @@ func (s *InitiateDocumentVersionUploadInput) SetParentFolderId(v string) *Initia
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ContentCreatedTimestamp != nil {
+		v := *s.ContentCreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentCreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentModifiedTimestamp != nil {
+		v := *s.ContentModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ContentModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ContentType != nil {
+		v := *s.ContentType
+
+		e.SetValue(protocol.BodyTarget, "ContentType", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentSizeInBytes != nil {
+		v := *s.DocumentSizeInBytes
+
+		e.SetValue(protocol.BodyTarget, "DocumentSizeInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/InitiateDocumentVersionUploadResponse
 type InitiateDocumentVersionUploadOutput struct {
 	_ struct{} `type:"structure"`
@@ -8409,6 +10091,22 @@ func (s *InitiateDocumentVersionUploadOutput) SetMetadata(v *DocumentMetadata) *
 func (s *InitiateDocumentVersionUploadOutput) SetUploadMetadata(v *UploadMetadata) *InitiateDocumentVersionUploadOutput {
 	s.UploadMetadata = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *InitiateDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Metadata != nil {
+		v := s.Metadata
+
+		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
+	}
+	if s.UploadMetadata != nil {
+		v := s.UploadMetadata
+
+		e.SetFields(protocol.BodyTarget, "UploadMetadata", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Set of options which defines notification preferences of given action.
@@ -8445,6 +10143,22 @@ func (s *NotificationOptions) SetSendEmail(v bool) *NotificationOptions {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *NotificationOptions) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailMessage != nil {
+		v := *s.EmailMessage
+
+		e.SetValue(protocol.BodyTarget, "EmailMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SendEmail != nil {
+		v := *s.SendEmail
+
+		e.SetValue(protocol.BodyTarget, "SendEmail", protocol.BoolValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the users or user groups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/Participants
 type Participants struct {
@@ -8479,6 +10193,22 @@ func (s *Participants) SetUsers(v []*UserMetadata) *Participants {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Participants) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Groups) > 0 {
+		v := s.Groups
+
+		e.SetList(protocol.BodyTarget, "Groups", encodeGroupMetadataList(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeUserMetadataList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the permissions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/PermissionInfo
 type PermissionInfo struct {
@@ -8511,6 +10241,30 @@ func (s *PermissionInfo) SetRole(v string) *PermissionInfo {
 func (s *PermissionInfo) SetType(v string) *PermissionInfo {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PermissionInfo) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePermissionInfoList(vs []*PermissionInfo) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes a resource.
@@ -8554,6 +10308,35 @@ func (s *Principal) SetRoles(v []*PermissionInfo) *Principal {
 func (s *Principal) SetType(v string) *Principal {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Principal) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Roles) > 0 {
+		v := s.Roles
+
+		e.SetList(protocol.BodyTarget, "Roles", encodePermissionInfoList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodePrincipalList(vs []*Principal) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveAllResourcePermissionsRequest
@@ -8611,6 +10394,22 @@ func (s *RemoveAllResourcePermissionsInput) SetResourceId(v string) *RemoveAllRe
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveAllResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveAllResourcePermissionsOutput
 type RemoveAllResourcePermissionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8624,6 +10423,12 @@ func (s RemoveAllResourcePermissionsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveAllResourcePermissionsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveAllResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveResourcePermissionRequest
@@ -8707,6 +10512,32 @@ func (s *RemoveResourcePermissionInput) SetResourceId(v string) *RemoveResourceP
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveResourcePermissionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.PathTarget, "PrincipalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.PrincipalType != nil {
+		v := *s.PrincipalType
+
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/RemoveResourcePermissionOutput
 type RemoveResourcePermissionOutput struct {
 	_ struct{} `type:"structure"`
@@ -8720,6 +10551,12 @@ func (s RemoveResourcePermissionOutput) String() string {
 // GoString returns the string representation
 func (s RemoveResourcePermissionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *RemoveResourcePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Describes the metadata of a resource.
@@ -8802,6 +10639,47 @@ func (s *ResourceMetadata) SetVersionId(v string) *ResourceMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourceMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.OriginalName != nil {
+		v := *s.OriginalName
+
+		e.SetValue(protocol.BodyTarget, "OriginalName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Owner != nil {
+		v := s.Owner
+
+		e.SetFields(protocol.BodyTarget, "Owner", v, protocol.Metadata{})
+	}
+	if s.ParentId != nil {
+		v := *s.ParentId
+
+		e.SetValue(protocol.BodyTarget, "ParentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Describes the path information of a resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ResourcePath
 type ResourcePath struct {
@@ -8825,6 +10703,17 @@ func (s ResourcePath) GoString() string {
 func (s *ResourcePath) SetComponents(v []*ResourcePathComponent) *ResourcePath {
 	s.Components = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourcePath) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Components) > 0 {
+		v := s.Components
+
+		e.SetList(protocol.BodyTarget, "Components", encodeResourcePathComponentList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the resource path.
@@ -8859,6 +10748,30 @@ func (s *ResourcePathComponent) SetId(v string) *ResourcePathComponent {
 func (s *ResourcePathComponent) SetName(v string) *ResourcePathComponent {
 	s.Name = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ResourcePathComponent) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeResourcePathComponentList(vs []*ResourcePathComponent) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Describes the recipient type and ID, if available.
@@ -8932,6 +10845,35 @@ func (s *SharePrincipal) SetType(v string) *SharePrincipal {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *SharePrincipal) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSharePrincipalList(vs []*SharePrincipal) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the share results of a resource.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/ShareResult
 type ShareResult struct {
@@ -8993,6 +10935,45 @@ func (s *ShareResult) SetStatusMessage(v string) *ShareResult {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ShareResult) MarshalFields(e protocol.FieldEncoder) error {
+	if s.PrincipalId != nil {
+		v := *s.PrincipalId
+
+		e.SetValue(protocol.BodyTarget, "PrincipalId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Role != nil {
+		v := *s.Role
+
+		e.SetValue(protocol.BodyTarget, "Role", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ShareId != nil {
+		v := *s.ShareId
+
+		e.SetValue(protocol.BodyTarget, "ShareId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StatusMessage != nil {
+		v := *s.StatusMessage
+
+		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeShareResultList(vs []*ShareResult) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the storage for a user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/StorageRuleType
 type StorageRuleType struct {
@@ -9025,6 +11006,22 @@ func (s *StorageRuleType) SetStorageAllocatedInBytes(v int64) *StorageRuleType {
 func (s *StorageRuleType) SetStorageType(v string) *StorageRuleType {
 	s.StorageType = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *StorageRuleType) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageAllocatedInBytes != nil {
+		v := *s.StorageAllocatedInBytes
+
+		e.SetValue(protocol.BodyTarget, "StorageAllocatedInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.StorageType != nil {
+		v := *s.StorageType
+
+		e.SetValue(protocol.BodyTarget, "StorageType", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a subscription.
@@ -9068,6 +11065,35 @@ func (s *Subscription) SetProtocol(v string) *Subscription {
 func (s *Subscription) SetSubscriptionId(v string) *Subscription {
 	s.SubscriptionId = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndPoint != nil {
+		v := *s.EndPoint
+
+		e.SetValue(protocol.BodyTarget, "EndPoint", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Protocol != nil {
+		v := *s.Protocol
+
+		e.SetValue(protocol.BodyTarget, "Protocol", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SubscriptionId != nil {
+		v := *s.SubscriptionId
+
+		e.SetValue(protocol.BodyTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSubscriptionList(vs []*Subscription) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentRequest
@@ -9158,6 +11184,37 @@ func (s *UpdateDocumentInput) SetResourceState(v string) *UpdateDocumentInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentOutput
 type UpdateDocumentOutput struct {
 	_ struct{} `type:"structure"`
@@ -9171,6 +11228,12 @@ func (s UpdateDocumentOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDocumentOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentVersionRequest
@@ -9254,6 +11317,32 @@ func (s *UpdateDocumentVersionInput) SetVersionStatus(v string) *UpdateDocumentV
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionStatus != nil {
+		v := *s.VersionStatus
+
+		e.SetValue(protocol.BodyTarget, "VersionStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateDocumentVersionOutput
 type UpdateDocumentVersionOutput struct {
 	_ struct{} `type:"structure"`
@@ -9267,6 +11356,12 @@ func (s UpdateDocumentVersionOutput) String() string {
 // GoString returns the string representation
 func (s UpdateDocumentVersionOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateFolderRequest
@@ -9358,6 +11453,37 @@ func (s *UpdateFolderInput) SetResourceState(v string) *UpdateFolderInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ParentFolderId != nil {
+		v := *s.ParentFolderId
+
+		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceState != nil {
+		v := *s.ResourceState
+
+		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateFolderOutput
 type UpdateFolderOutput struct {
 	_ struct{} `type:"structure"`
@@ -9371,6 +11497,12 @@ func (s UpdateFolderOutput) String() string {
 // GoString returns the string representation
 func (s UpdateFolderOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateUserRequest
@@ -9500,6 +11632,57 @@ func (s *UpdateUserInput) SetUserId(v string) *UpdateUserInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUserInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GrantPoweruserPrivileges != nil {
+		v := *s.GrantPoweruserPrivileges
+
+		e.SetValue(protocol.BodyTarget, "GrantPoweruserPrivileges", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserId != nil {
+		v := *s.UserId
+
+		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UpdateUserResponse
 type UpdateUserOutput struct {
 	_ struct{} `type:"structure"`
@@ -9522,6 +11705,17 @@ func (s UpdateUserOutput) GoString() string {
 func (s *UpdateUserOutput) SetUser(v *User) *UpdateUserOutput {
 	s.User = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UpdateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.User != nil {
+		v := s.User
+
+		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes the upload.
@@ -9556,6 +11750,22 @@ func (s *UploadMetadata) SetSignedHeaders(v map[string]*string) *UploadMetadata 
 func (s *UploadMetadata) SetUploadUrl(v string) *UploadMetadata {
 	s.UploadUrl = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UploadMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.SignedHeaders) > 0 {
+		v := s.SignedHeaders
+
+		e.SetMap(protocol.BodyTarget, "SignedHeaders", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.UploadUrl != nil {
+		v := *s.UploadUrl
+
+		e.SetValue(protocol.BodyTarget, "UploadUrl", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Describes a user.
@@ -9709,6 +11919,95 @@ func (s *User) SetUsername(v string) *User {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *User) MarshalFields(e protocol.FieldEncoder) error {
+	if s.CreatedTimestamp != nil {
+		v := *s.CreatedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "CreatedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Locale != nil {
+		v := *s.Locale
+
+		e.SetValue(protocol.BodyTarget, "Locale", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ModifiedTimestamp != nil {
+		v := *s.ModifiedTimestamp
+
+		e.SetValue(protocol.BodyTarget, "ModifiedTimestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.BodyTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RecycleBinFolderId != nil {
+		v := *s.RecycleBinFolderId
+
+		e.SetValue(protocol.BodyTarget, "RecycleBinFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.RootFolderId != nil {
+		v := *s.RootFolderId
+
+		e.SetValue(protocol.BodyTarget, "RootFolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Status != nil {
+		v := *s.Status
+
+		e.SetValue(protocol.BodyTarget, "Status", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Storage != nil {
+		v := s.Storage
+
+		e.SetFields(protocol.BodyTarget, "Storage", v, protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.TimeZoneId != nil {
+		v := *s.TimeZoneId
+
+		e.SetValue(protocol.BodyTarget, "TimeZoneId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUserList(vs []*User) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the metadata of the user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserMetadata
 type UserMetadata struct {
@@ -9770,6 +12069,45 @@ func (s *UserMetadata) SetUsername(v string) *UserMetadata {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UserMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EmailAddress != nil {
+		v := *s.EmailAddress
+
+		e.SetValue(protocol.BodyTarget, "EmailAddress", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.GivenName != nil {
+		v := *s.GivenName
+
+		e.SetValue(protocol.BodyTarget, "GivenName", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Surname != nil {
+		v := *s.Surname
+
+		e.SetValue(protocol.BodyTarget, "Surname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Username != nil {
+		v := *s.Username
+
+		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUserMetadataList(vs []*UserMetadata) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Describes the storage for a user.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/workdocs-2016-05-01/UserStorageMetadata
 type UserStorageMetadata struct {
@@ -9802,6 +12140,22 @@ func (s *UserStorageMetadata) SetStorageRule(v *StorageRuleType) *UserStorageMet
 func (s *UserStorageMetadata) SetStorageUtilizedInBytes(v int64) *UserStorageMetadata {
 	s.StorageUtilizedInBytes = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UserStorageMetadata) MarshalFields(e protocol.FieldEncoder) error {
+	if s.StorageRule != nil {
+		v := s.StorageRule
+
+		e.SetFields(protocol.BodyTarget, "StorageRule", v, protocol.Metadata{})
+	}
+	if s.StorageUtilizedInBytes != nil {
+		v := *s.StorageUtilizedInBytes
+
+		e.SetValue(protocol.BodyTarget, "StorageUtilizedInBytes", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 const (

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -4176,7 +4176,6 @@ func (s *AbortDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder)
 
 		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4197,7 +4196,6 @@ func (s AbortDocumentVersionUploadOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AbortDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -4268,7 +4266,6 @@ func (s *ActivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4303,7 +4300,6 @@ func (s *ActivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4441,7 +4437,6 @@ func (s *Activity) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4543,11 +4538,6 @@ func (s *AddResourcePermissionsInput) SetResourceId(v string) *AddResourcePermis
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *AddResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.NotificationOptions != nil {
 		v := s.NotificationOptions
 
@@ -4558,12 +4548,16 @@ func (s *AddResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetList(protocol.BodyTarget, "Principals", encodeSharePrincipalList(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
 		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4598,7 +4592,6 @@ func (s *AddResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetList(protocol.BodyTarget, "ShareResults", encodeShareResultList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4751,7 +4744,6 @@ func (s *Comment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4851,7 +4843,6 @@ func (s *CommentMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "RecipientId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -4991,16 +4982,6 @@ func (s *CreateCommentInput) SetVisibility(v string) *CreateCommentInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCommentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DocumentId != nil {
-		v := *s.DocumentId
-
-		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.NotifyCollaborators != nil {
 		v := *s.NotifyCollaborators
 
@@ -5021,17 +5002,26 @@ func (s *CreateCommentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ThreadId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VersionId != nil {
-		v := *s.VersionId
-
-		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Visibility != nil {
 		v := *s.Visibility
 
 		e.SetValue(protocol.BodyTarget, "Visibility", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5066,7 +5056,6 @@ func (s *CreateCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Comment", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5157,15 +5146,15 @@ func (s *CreateCustomMetadataInput) SetVersionId(v string) *CreateCustomMetadata
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.CustomMetadata) > 0 {
 		v := s.CustomMetadata
 
 		e.SetMap(protocol.BodyTarget, "CustomMetadata", protocol.EncodeStringMap(v), protocol.Metadata{})
+	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
@@ -5177,7 +5166,6 @@ func (s *CreateCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.QueryTarget, "versionid", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5198,7 +5186,6 @@ func (s CreateCustomMetadataOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5271,11 +5258,6 @@ func (s *CreateFolderInput) SetParentFolderId(v string) *CreateFolderInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
@@ -5286,7 +5268,11 @@ func (s *CreateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5321,7 +5307,6 @@ func (s *CreateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5396,22 +5381,21 @@ func (s *CreateLabelsInput) SetResourceId(v string) *CreateLabelsInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if len(s.Labels) > 0 {
 		v := s.Labels
 
 		e.SetList(protocol.BodyTarget, "Labels", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
 		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5432,7 +5416,6 @@ func (s CreateLabelsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -5532,11 +5515,6 @@ func (s *CreateNotificationSubscriptionInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "Endpoint", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.OrganizationId != nil {
-		v := *s.OrganizationId
-
-		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Protocol != nil {
 		v := *s.Protocol
 
@@ -5547,7 +5525,11 @@ func (s *CreateNotificationSubscriptionInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.BodyTarget, "SubscriptionType", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
 
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5582,7 +5564,6 @@ func (s *CreateNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEnc
 
 		e.SetFields(protocol.BodyTarget, "Subscription", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5739,11 +5720,6 @@ func (s *CreateUserInput) SetUsername(v string) *CreateUserInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *CreateUserInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.EmailAddress != nil {
 		v := *s.EmailAddress
 
@@ -5784,7 +5760,11 @@ func (s *CreateUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -5819,7 +5799,6 @@ func (s *CreateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5890,7 +5869,6 @@ func (s *DeactivateUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -5911,7 +5889,6 @@ func (s DeactivateUserOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeactivateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6026,7 +6003,6 @@ func (s *DeleteCommentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6047,7 +6023,6 @@ func (s DeleteCommentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCommentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6145,6 +6120,11 @@ func (s *DeleteCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.DeleteAll != nil {
 		v := *s.DeleteAll
 
@@ -6155,17 +6135,11 @@ func (s *DeleteCustomMetadataInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetList(protocol.QueryTarget, "keys", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.VersionId != nil {
 		v := *s.VersionId
 
 		e.SetValue(protocol.QueryTarget, "versionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6186,7 +6160,6 @@ func (s DeleteCustomMetadataOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteCustomMetadataOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6257,7 +6230,6 @@ func (s *DeleteDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6278,7 +6250,6 @@ func (s DeleteDocumentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6349,7 +6320,6 @@ func (s *DeleteFolderContentsInput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6370,7 +6340,6 @@ func (s DeleteFolderContentsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6441,7 +6410,6 @@ func (s *DeleteFolderInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6462,7 +6430,6 @@ func (s DeleteFolderOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6546,6 +6513,11 @@ func (s *DeleteLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.DeleteAll != nil {
 		v := *s.DeleteAll
 
@@ -6556,12 +6528,6 @@ func (s *DeleteLabelsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.QueryTarget, "labels", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -6582,7 +6548,6 @@ func (s DeleteLabelsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteLabelsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6657,7 +6622,6 @@ func (s *DeleteNotificationSubscriptionInput) MarshalFields(e protocol.FieldEnco
 
 		e.SetValue(protocol.PathTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6678,7 +6642,6 @@ func (s DeleteNotificationSubscriptionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteNotificationSubscriptionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6749,7 +6712,6 @@ func (s *DeleteUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6770,7 +6732,6 @@ func (s DeleteUserOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DeleteUserOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -6920,7 +6881,6 @@ func (s *DescribeActivitiesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "userId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -6969,7 +6929,6 @@ func (s *DescribeActivitiesOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "UserActivities", encodeActivityList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7082,6 +7041,11 @@ func (s *DescribeCommentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -7092,12 +7056,6 @@ func (s *DescribeCommentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VersionId != nil {
-		v := *s.VersionId
-
-		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7147,7 +7105,6 @@ func (s *DescribeCommentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7289,7 +7246,6 @@ func (s *DescribeDocumentVersionsInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7339,7 +7295,6 @@ func (s *DescribeDocumentVersionsOutput) MarshalFields(e protocol.FieldEncoder) 
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7504,7 +7459,6 @@ func (s *DescribeFolderContentsInput) MarshalFields(e protocol.FieldEncoder) err
 
 		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7568,7 +7522,6 @@ func (s *DescribeFolderContentsOutput) MarshalFields(e protocol.FieldEncoder) er
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7691,7 +7644,6 @@ func (s *DescribeGroupsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "searchQuery", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7741,7 +7693,6 @@ func (s *DescribeGroupsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7814,6 +7765,11 @@ func (s *DescribeNotificationSubscriptionsInput) SetOrganizationId(v string) *De
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *DescribeNotificationSubscriptionsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OrganizationId != nil {
+		v := *s.OrganizationId
+
+		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -7824,12 +7780,6 @@ func (s *DescribeNotificationSubscriptionsInput) MarshalFields(e protocol.FieldE
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.OrganizationId != nil {
-		v := *s.OrganizationId
-
-		e.SetValue(protocol.PathTarget, "OrganizationId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -7879,7 +7829,6 @@ func (s *DescribeNotificationSubscriptionsOutput) MarshalFields(e protocol.Field
 
 		e.SetList(protocol.BodyTarget, "Subscriptions", encodeSubscriptionList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -7982,6 +7931,11 @@ func (s *DescribeResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.ResourceId != nil {
+		v := *s.ResourceId
+
+		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Limit != nil {
 		v := *s.Limit
 
@@ -7997,12 +7951,6 @@ func (s *DescribeResourcePermissionsInput) MarshalFields(e protocol.FieldEncoder
 
 		e.SetValue(protocol.QueryTarget, "principalId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.ResourceId != nil {
-		v := *s.ResourceId
-
-		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -8052,7 +8000,6 @@ func (s *DescribeResourcePermissionsOutput) MarshalFields(e protocol.FieldEncode
 
 		e.SetList(protocol.BodyTarget, "Principals", encodePrincipalList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8141,7 +8088,6 @@ func (s *DescribeRootFoldersInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8190,7 +8136,6 @@ func (s *DescribeRootFoldersOutput) MarshalFields(e protocol.FieldEncoder) error
 
 		e.SetValue(protocol.BodyTarget, "Marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8385,7 +8330,6 @@ func (s *DescribeUsersInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "userIds", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8449,7 +8393,6 @@ func (s *DescribeUsersOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Users", encodeUserList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8583,7 +8526,6 @@ func (s *DocumentMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8795,7 +8737,6 @@ func (s *DocumentVersionMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetMap(protocol.BodyTarget, "Thumbnail", protocol.EncodeStringMap(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -8979,7 +8920,6 @@ func (s *FolderMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Size", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9041,7 +8981,6 @@ func (s *GetCurrentUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9076,7 +9015,6 @@ func (s *GetCurrentUserOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9161,7 +9099,6 @@ func (s *GetDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9210,7 +9147,6 @@ func (s *GetDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9333,7 +9269,6 @@ func (s *GetDocumentPathInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9368,7 +9303,6 @@ func (s *GetDocumentPathOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9478,6 +9412,11 @@ func (s *GetDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.VersionId != nil {
+		v := *s.VersionId
+
+		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.Fields != nil {
 		v := *s.Fields
 
@@ -9488,12 +9427,6 @@ func (s *GetDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
 	}
-	if s.VersionId != nil {
-		v := *s.VersionId
-
-		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -9542,7 +9475,6 @@ func (s *GetDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9627,7 +9559,6 @@ func (s *GetFolderInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "includeCustomMetadata", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9676,7 +9607,6 @@ func (s *GetFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Metadata", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9779,15 +9709,15 @@ func (s *GetFolderPathInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.Fields != nil {
-		v := *s.Fields
-
-		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.FolderId != nil {
 		v := *s.FolderId
 
 		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Fields != nil {
+		v := *s.Fields
+
+		e.SetValue(protocol.QueryTarget, "fields", protocol.StringValue(v), protocol.Metadata{})
 	}
 	if s.Limit != nil {
 		v := *s.Limit
@@ -9799,7 +9729,6 @@ func (s *GetFolderPathInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.QueryTarget, "marker", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9834,7 +9763,6 @@ func (s *GetFolderPathOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "Path", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -9884,7 +9812,6 @@ func (s *GroupMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10016,11 +9943,6 @@ func (s *InitiateDocumentVersionUploadInput) SetParentFolderId(v string) *Initia
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *InitiateDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ContentCreatedTimestamp != nil {
 		v := *s.ContentCreatedTimestamp
 
@@ -10056,7 +9978,11 @@ func (s *InitiateDocumentVersionUploadInput) MarshalFields(e protocol.FieldEncod
 
 		e.SetValue(protocol.BodyTarget, "ParentFolderId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -10105,7 +10031,6 @@ func (s *InitiateDocumentVersionUploadOutput) MarshalFields(e protocol.FieldEnco
 
 		e.SetFields(protocol.BodyTarget, "UploadMetadata", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10155,7 +10080,6 @@ func (s *NotificationOptions) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SendEmail", protocol.BoolValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10205,7 +10129,6 @@ func (s *Participants) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Users", encodeUserMetadataList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10255,7 +10178,6 @@ func (s *PermissionInfo) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10327,7 +10249,6 @@ func (s *Principal) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10406,7 +10327,6 @@ func (s *RemoveAllResourcePermissionsInput) MarshalFields(e protocol.FieldEncode
 
 		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10427,7 +10347,6 @@ func (s RemoveAllResourcePermissionsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveAllResourcePermissionsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10524,17 +10443,16 @@ func (s *RemoveResourcePermissionInput) MarshalFields(e protocol.FieldEncoder) e
 
 		e.SetValue(protocol.PathTarget, "PrincipalId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.PrincipalType != nil {
-		v := *s.PrincipalType
-
-		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.ResourceId != nil {
 		v := *s.ResourceId
 
 		e.SetValue(protocol.PathTarget, "ResourceId", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.PrincipalType != nil {
+		v := *s.PrincipalType
 
+		e.SetValue(protocol.QueryTarget, "type", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -10555,7 +10473,6 @@ func (s RemoveResourcePermissionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *RemoveResourcePermissionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -10676,7 +10593,6 @@ func (s *ResourceMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10712,7 +10628,6 @@ func (s *ResourcePath) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Components", encodeResourcePathComponentList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10762,7 +10677,6 @@ func (s *ResourcePathComponent) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10862,7 +10776,6 @@ func (s *SharePrincipal) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -10962,7 +10875,6 @@ func (s *ShareResult) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StatusMessage", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11020,7 +10932,6 @@ func (s *StorageRuleType) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageType", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11084,7 +10995,6 @@ func (s *Subscription) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "SubscriptionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11186,16 +11096,6 @@ func (s *UpdateDocumentInput) SetResourceState(v string) *UpdateDocumentInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.DocumentId != nil {
-		v := *s.DocumentId
-
-		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
@@ -11211,7 +11111,16 @@ func (s *UpdateDocumentInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.DocumentId != nil {
+		v := *s.DocumentId
+
+		e.SetValue(protocol.PathTarget, "DocumentId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11232,7 +11141,6 @@ func (s UpdateDocumentOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11319,6 +11227,11 @@ func (s *UpdateDocumentVersionInput) SetVersionStatus(v string) *UpdateDocumentV
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.VersionStatus != nil {
+		v := *s.VersionStatus
+
+		e.SetValue(protocol.BodyTarget, "VersionStatus", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.AuthenticationToken != nil {
 		v := *s.AuthenticationToken
 
@@ -11334,12 +11247,6 @@ func (s *UpdateDocumentVersionInput) MarshalFields(e protocol.FieldEncoder) erro
 
 		e.SetValue(protocol.PathTarget, "VersionId", protocol.StringValue(v), protocol.Metadata{})
 	}
-	if s.VersionStatus != nil {
-		v := *s.VersionStatus
-
-		e.SetValue(protocol.BodyTarget, "VersionStatus", protocol.StringValue(v), protocol.Metadata{})
-	}
-
 	return nil
 }
 
@@ -11360,7 +11267,6 @@ func (s UpdateDocumentVersionOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateDocumentVersionOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11455,16 +11361,6 @@ func (s *UpdateFolderInput) SetResourceState(v string) *UpdateFolderInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
-	if s.FolderId != nil {
-		v := *s.FolderId
-
-		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.Name != nil {
 		v := *s.Name
 
@@ -11480,7 +11376,16 @@ func (s *UpdateFolderInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "ResourceState", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
 
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.FolderId != nil {
+		v := *s.FolderId
+
+		e.SetValue(protocol.PathTarget, "FolderId", protocol.StringValue(v), protocol.Metadata{})
+	}
 	return nil
 }
 
@@ -11501,7 +11406,6 @@ func (s UpdateFolderOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateFolderOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -11634,11 +11538,6 @@ func (s *UpdateUserInput) SetUserId(v string) *UpdateUserInput {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *UpdateUserInput) MarshalFields(e protocol.FieldEncoder) error {
-	if s.AuthenticationToken != nil {
-		v := *s.AuthenticationToken
-
-		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
-	}
 	if s.GivenName != nil {
 		v := *s.GivenName
 
@@ -11674,12 +11573,16 @@ func (s *UpdateUserInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
+	if s.AuthenticationToken != nil {
+		v := *s.AuthenticationToken
+
+		e.SetValue(protocol.HeaderTarget, "Authentication", protocol.StringValue(v), protocol.Metadata{})
+	}
 	if s.UserId != nil {
 		v := *s.UserId
 
 		e.SetValue(protocol.PathTarget, "UserId", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11714,7 +11617,6 @@ func (s *UpdateUserOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "User", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11764,7 +11666,6 @@ func (s *UploadMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UploadUrl", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -11996,7 +11897,6 @@ func (s *User) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12096,7 +11996,6 @@ func (s *UserMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Username", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -12154,7 +12053,6 @@ func (s *UserStorageMetadata) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StorageUtilizedInBytes", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -855,7 +855,6 @@ func (s *Alias) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -928,7 +927,6 @@ func (s *AnnotationValue) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1027,7 +1025,6 @@ func (s *BackendConnectionErrors) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UnknownHostCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1091,7 +1088,6 @@ func (s *BatchGetTracesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1154,7 +1150,6 @@ func (s *BatchGetTracesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "UnprocessedTraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1260,7 +1255,6 @@ func (s *Edge) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetFields(protocol.BodyTarget, "SummaryStatistics", v, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1360,7 +1354,6 @@ func (s *EdgeStatistics) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1425,7 +1418,6 @@ func (s *ErrorStatistics) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1476,7 +1468,6 @@ func (s *FaultStatistics) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1559,7 +1550,6 @@ func (s *GetServiceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1637,7 +1627,6 @@ func (s *GetServiceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1701,7 +1690,6 @@ func (s *GetTraceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1750,7 +1738,6 @@ func (s *GetTraceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Services", encodeServiceList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1866,7 +1853,6 @@ func (s *GetTraceSummariesInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1945,7 +1931,6 @@ func (s *GetTraceSummariesOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TracesProcessedCount", protocol.Int64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -1996,7 +1981,6 @@ func (s *HistogramEntry) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Value", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2096,7 +2080,6 @@ func (s *Http) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UserAgent", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2193,7 +2176,6 @@ func (s *PutTelemetryRecordsInput) MarshalFields(e protocol.FieldEncoder) error 
 
 		e.SetList(protocol.BodyTarget, "TelemetryRecords", encodeTelemetryRecordList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2214,7 +2196,6 @@ func (s PutTelemetryRecordsOutput) GoString() string {
 
 // MarshalFields encodes the AWS API shape using the passed in protocol encoder.
 func (s *PutTelemetryRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
-
 	return nil
 }
 
@@ -2264,7 +2245,6 @@ func (s *PutTraceSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "TraceSegmentDocuments", protocol.EncodeStringList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2299,7 +2279,6 @@ func (s *PutTraceSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "UnprocessedTraceSegments", encodeUnprocessedTraceSegmentList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2352,7 +2331,6 @@ func (s *Segment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2578,7 +2556,6 @@ func (s *Service) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2659,7 +2636,6 @@ func (s *ServiceId) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2759,7 +2735,6 @@ func (s *ServiceStatistics) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2872,7 +2847,6 @@ func (s *TelemetryRecord) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -2946,7 +2920,6 @@ func (s *Trace) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Segments", encodeSegmentList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3140,7 +3113,6 @@ func (s *TraceSummary) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "Users", encodeTraceUserList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3198,7 +3170,6 @@ func (s *TraceUser) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "UserName", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3270,7 +3241,6 @@ func (s *UnprocessedTraceSegment) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 
@@ -3328,7 +3298,6 @@ func (s *ValueWithServiceIds) MarshalFields(e protocol.FieldEncoder) error {
 
 		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
 	}
-
 	return nil
 }
 

--- a/service/xray/api.go
+++ b/service/xray/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
 const opBatchGetTraces = "BatchGetTraces"
@@ -837,6 +838,35 @@ func (s *Alias) SetType(v string) *Alias {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Alias) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeAliasList(vs []*Alias) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Value of a segment annotation. Has one of three value types: Number, Boolean
 // or String.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/AnnotationValue
@@ -879,6 +909,27 @@ func (s *AnnotationValue) SetNumberValue(v float64) *AnnotationValue {
 func (s *AnnotationValue) SetStringValue(v string) *AnnotationValue {
 	s.StringValue = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *AnnotationValue) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BooleanValue != nil {
+		v := *s.BooleanValue
+
+		e.SetValue(protocol.BodyTarget, "BooleanValue", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.NumberValue != nil {
+		v := *s.NumberValue
+
+		e.SetValue(protocol.BodyTarget, "NumberValue", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.StringValue != nil {
+		v := *s.StringValue
+
+		e.SetValue(protocol.BodyTarget, "StringValue", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BackendConnectionErrors
@@ -944,6 +995,42 @@ func (s *BackendConnectionErrors) SetUnknownHostCount(v int64) *BackendConnectio
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BackendConnectionErrors) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ConnectionRefusedCount != nil {
+		v := *s.ConnectionRefusedCount
+
+		e.SetValue(protocol.BodyTarget, "ConnectionRefusedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPCode4XXCount != nil {
+		v := *s.HTTPCode4XXCount
+
+		e.SetValue(protocol.BodyTarget, "HTTPCode4XXCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HTTPCode5XXCount != nil {
+		v := *s.HTTPCode5XXCount
+
+		e.SetValue(protocol.BodyTarget, "HTTPCode5XXCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TimeoutCount != nil {
+		v := *s.TimeoutCount
+
+		e.SetValue(protocol.BodyTarget, "TimeoutCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.UnknownHostCount != nil {
+		v := *s.UnknownHostCount
+
+		e.SetValue(protocol.BodyTarget, "UnknownHostCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BatchGetTracesRequest
 type BatchGetTracesInput struct {
 	_ struct{} `type:"structure"`
@@ -992,6 +1079,22 @@ func (s *BatchGetTracesInput) SetTraceIds(v []*string) *BatchGetTracesInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetTracesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceIds) > 0 {
+		v := s.TraceIds
+
+		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/BatchGetTracesResult
 type BatchGetTracesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1032,6 +1135,27 @@ func (s *BatchGetTracesOutput) SetTraces(v []*Trace) *BatchGetTracesOutput {
 func (s *BatchGetTracesOutput) SetUnprocessedTraceIds(v []*string) *BatchGetTracesOutput {
 	s.UnprocessedTraceIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *BatchGetTracesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Traces) > 0 {
+		v := s.Traces
+
+		e.SetList(protocol.BodyTarget, "Traces", encodeTraceList(v), protocol.Metadata{})
+	}
+	if len(s.UnprocessedTraceIds) > 0 {
+		v := s.UnprocessedTraceIds
+
+		e.SetList(protocol.BodyTarget, "UnprocessedTraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Information about a connection between two services.
@@ -1104,6 +1228,50 @@ func (s *Edge) SetSummaryStatistics(v *EdgeStatistics) *Edge {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Edge) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Aliases) > 0 {
+		v := s.Aliases
+
+		e.SetList(protocol.BodyTarget, "Aliases", encodeAliasList(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.ReferenceId != nil {
+		v := *s.ReferenceId
+
+		e.SetValue(protocol.BodyTarget, "ReferenceId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTimeHistogram) > 0 {
+		v := s.ResponseTimeHistogram
+
+		e.SetList(protocol.BodyTarget, "ResponseTimeHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.SummaryStatistics != nil {
+		v := s.SummaryStatistics
+
+		e.SetFields(protocol.BodyTarget, "SummaryStatistics", v, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeEdgeList(vs []*Edge) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Response statistics for an edge.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/EdgeStatistics
 type EdgeStatistics struct {
@@ -1165,6 +1333,37 @@ func (s *EdgeStatistics) SetTotalResponseTime(v float64) *EdgeStatistics {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *EdgeStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorStatistics != nil {
+		v := s.ErrorStatistics
+
+		e.SetFields(protocol.BodyTarget, "ErrorStatistics", v, protocol.Metadata{})
+	}
+	if s.FaultStatistics != nil {
+		v := s.FaultStatistics
+
+		e.SetFields(protocol.BodyTarget, "FaultStatistics", v, protocol.Metadata{})
+	}
+	if s.OkCount != nil {
+		v := *s.OkCount
+
+		e.SetValue(protocol.BodyTarget, "OkCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalResponseTime != nil {
+		v := *s.TotalResponseTime
+
+		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information about requests that failed with a 4xx Client Error status code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ErrorStatistics
 type ErrorStatistics struct {
@@ -1209,6 +1408,27 @@ func (s *ErrorStatistics) SetTotalCount(v int64) *ErrorStatistics {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ErrorStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.ThrottleCount != nil {
+		v := *s.ThrottleCount
+
+		e.SetValue(protocol.BodyTarget, "ThrottleCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Information about requests that failed with a 5xx Server Error status code.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/FaultStatistics
 type FaultStatistics struct {
@@ -1242,6 +1462,22 @@ func (s *FaultStatistics) SetOtherCount(v int64) *FaultStatistics {
 func (s *FaultStatistics) SetTotalCount(v int64) *FaultStatistics {
 	s.TotalCount = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *FaultStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.OtherCount != nil {
+		v := *s.OtherCount
+
+		e.SetValue(protocol.BodyTarget, "OtherCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetServiceGraphRequest
@@ -1306,6 +1542,27 @@ func (s *GetServiceGraphInput) SetStartTime(v time.Time) *GetServiceGraphInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetServiceGraphResult
 type GetServiceGraphOutput struct {
 	_ struct{} `type:"structure"`
@@ -1358,6 +1615,32 @@ func (s *GetServiceGraphOutput) SetStartTime(v time.Time) *GetServiceGraphOutput
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetServiceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Services) > 0 {
+		v := s.Services
+
+		e.SetList(protocol.BodyTarget, "Services", encodeServiceList(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceGraphRequest
 type GetTraceGraphInput struct {
 	_ struct{} `type:"structure"`
@@ -1406,6 +1689,22 @@ func (s *GetTraceGraphInput) SetTraceIds(v []*string) *GetTraceGraphInput {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceGraphInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceIds) > 0 {
+		v := s.TraceIds
+
+		e.SetList(protocol.BodyTarget, "TraceIds", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceGraphResult
 type GetTraceGraphOutput struct {
 	_ struct{} `type:"structure"`
@@ -1437,6 +1736,22 @@ func (s *GetTraceGraphOutput) SetNextToken(v string) *GetTraceGraphOutput {
 func (s *GetTraceGraphOutput) SetServices(v []*Service) *GetTraceGraphOutput {
 	s.Services = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceGraphOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Services) > 0 {
+		v := s.Services
+
+		e.SetList(protocol.BodyTarget, "Services", encodeServiceList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceSummariesRequest
@@ -1524,6 +1839,37 @@ func (s *GetTraceSummariesInput) SetStartTime(v time.Time) *GetTraceSummariesInp
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceSummariesInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.FilterExpression != nil {
+		v := *s.FilterExpression
+
+		e.SetValue(protocol.BodyTarget, "FilterExpression", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Sampling != nil {
+		v := *s.Sampling
+
+		e.SetValue(protocol.BodyTarget, "Sampling", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/GetTraceSummariesResult
 type GetTraceSummariesOutput struct {
 	_ struct{} `type:"structure"`
@@ -1577,6 +1923,32 @@ func (s *GetTraceSummariesOutput) SetTracesProcessedCount(v int64) *GetTraceSumm
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *GetTraceSummariesOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ApproximateTime != nil {
+		v := *s.ApproximateTime
+
+		e.SetValue(protocol.BodyTarget, "ApproximateTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.NextToken != nil {
+		v := *s.NextToken
+
+		e.SetValue(protocol.BodyTarget, "NextToken", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TraceSummaries) > 0 {
+		v := s.TraceSummaries
+
+		e.SetList(protocol.BodyTarget, "TraceSummaries", encodeTraceSummaryList(v), protocol.Metadata{})
+	}
+	if s.TracesProcessedCount != nil {
+		v := *s.TracesProcessedCount
+
+		e.SetValue(protocol.BodyTarget, "TracesProcessedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // An entry in a histogram for a statistic. A histogram maps the range of observed
 // values on the X axis, and the prevalence of each value on the Y axis.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/HistogramEntry
@@ -1610,6 +1982,30 @@ func (s *HistogramEntry) SetCount(v int64) *HistogramEntry {
 func (s *HistogramEntry) SetValue(v float64) *HistogramEntry {
 	s.Value = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *HistogramEntry) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Count != nil {
+		v := *s.Count
+
+		e.SetValue(protocol.BodyTarget, "Count", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Value != nil {
+		v := *s.Value
+
+		e.SetValue(protocol.BodyTarget, "Value", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeHistogramEntryList(vs []*HistogramEntry) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an HTTP request.
@@ -1671,6 +2067,37 @@ func (s *Http) SetHttpURL(v string) *Http {
 func (s *Http) SetUserAgent(v string) *Http {
 	s.UserAgent = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Http) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ClientIp != nil {
+		v := *s.ClientIp
+
+		e.SetValue(protocol.BodyTarget, "ClientIp", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpMethod != nil {
+		v := *s.HttpMethod
+
+		e.SetValue(protocol.BodyTarget, "HttpMethod", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.HttpStatus != nil {
+		v := *s.HttpStatus
+
+		e.SetValue(protocol.BodyTarget, "HttpStatus", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.HttpURL != nil {
+		v := *s.HttpURL
+
+		e.SetValue(protocol.BodyTarget, "HttpURL", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.UserAgent != nil {
+		v := *s.UserAgent
+
+		e.SetValue(protocol.BodyTarget, "UserAgent", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTelemetryRecordsRequest
@@ -1744,6 +2171,32 @@ func (s *PutTelemetryRecordsInput) SetTelemetryRecords(v []*TelemetryRecord) *Pu
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTelemetryRecordsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if s.EC2InstanceId != nil {
+		v := *s.EC2InstanceId
+
+		e.SetValue(protocol.BodyTarget, "EC2InstanceId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Hostname != nil {
+		v := *s.Hostname
+
+		e.SetValue(protocol.BodyTarget, "Hostname", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.ResourceARN != nil {
+		v := *s.ResourceARN
+
+		e.SetValue(protocol.BodyTarget, "ResourceARN", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.TelemetryRecords) > 0 {
+		v := s.TelemetryRecords
+
+		e.SetList(protocol.BodyTarget, "TelemetryRecords", encodeTelemetryRecordList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTelemetryRecordsResult
 type PutTelemetryRecordsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1757,6 +2210,12 @@ func (s PutTelemetryRecordsOutput) String() string {
 // GoString returns the string representation
 func (s PutTelemetryRecordsOutput) GoString() string {
 	return s.String()
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTelemetryRecordsOutput) MarshalFields(e protocol.FieldEncoder) error {
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTraceSegmentsRequest
@@ -1798,6 +2257,17 @@ func (s *PutTraceSegmentsInput) SetTraceSegmentDocuments(v []*string) *PutTraceS
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTraceSegmentsInput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.TraceSegmentDocuments) > 0 {
+		v := s.TraceSegmentDocuments
+
+		e.SetList(protocol.BodyTarget, "TraceSegmentDocuments", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/PutTraceSegmentsResult
 type PutTraceSegmentsOutput struct {
 	_ struct{} `type:"structure"`
@@ -1820,6 +2290,17 @@ func (s PutTraceSegmentsOutput) GoString() string {
 func (s *PutTraceSegmentsOutput) SetUnprocessedTraceSegments(v []*UnprocessedTraceSegment) *PutTraceSegmentsOutput {
 	s.UnprocessedTraceSegments = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *PutTraceSegmentsOutput) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.UnprocessedTraceSegments) > 0 {
+		v := s.UnprocessedTraceSegments
+
+		e.SetList(protocol.BodyTarget, "UnprocessedTraceSegments", encodeUnprocessedTraceSegmentList(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // A segment from a trace that has been ingested by the X-Ray service. The segment
@@ -1857,6 +2338,30 @@ func (s *Segment) SetDocument(v string) *Segment {
 func (s *Segment) SetId(v string) *Segment {
 	s.Id = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Segment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Document != nil {
+		v := *s.Document
+
+		e.SetValue(protocol.BodyTarget, "Document", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeSegmentList(vs []*Segment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about an application that processed requests, users that made
@@ -2006,6 +2511,85 @@ func (s *Service) SetType(v string) *Service {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Service) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.DurationHistogram) > 0 {
+		v := s.DurationHistogram
+
+		e.SetList(protocol.BodyTarget, "DurationHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if len(s.Edges) > 0 {
+		v := s.Edges
+
+		e.SetList(protocol.BodyTarget, "Edges", encodeEdgeList(v), protocol.Metadata{})
+	}
+	if s.EndTime != nil {
+		v := *s.EndTime
+
+		e.SetValue(protocol.BodyTarget, "EndTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.ReferenceId != nil {
+		v := *s.ReferenceId
+
+		e.SetValue(protocol.BodyTarget, "ReferenceId", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if len(s.ResponseTimeHistogram) > 0 {
+		v := s.ResponseTimeHistogram
+
+		e.SetList(protocol.BodyTarget, "ResponseTimeHistogram", encodeHistogramEntryList(v), protocol.Metadata{})
+	}
+	if s.Root != nil {
+		v := *s.Root
+
+		e.SetValue(protocol.BodyTarget, "Root", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.StartTime != nil {
+		v := *s.StartTime
+
+		e.SetValue(protocol.BodyTarget, "StartTime", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+	if s.State != nil {
+		v := *s.State
+
+		e.SetValue(protocol.BodyTarget, "State", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.SummaryStatistics != nil {
+		v := s.SummaryStatistics
+
+		e.SetFields(protocol.BodyTarget, "SummaryStatistics", v, protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeServiceList(vs []*Service) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ServiceId
 type ServiceId struct {
 	_ struct{} `type:"structure"`
@@ -2051,6 +2635,40 @@ func (s *ServiceId) SetNames(v []*string) *ServiceId {
 func (s *ServiceId) SetType(v string) *ServiceId {
 	s.Type = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServiceId) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AccountId != nil {
+		v := *s.AccountId
+
+		e.SetValue(protocol.BodyTarget, "AccountId", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Name != nil {
+		v := *s.Name
+
+		e.SetValue(protocol.BodyTarget, "Name", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Names) > 0 {
+		v := s.Names
+
+		e.SetList(protocol.BodyTarget, "Names", protocol.EncodeStringList(v), protocol.Metadata{})
+	}
+	if s.Type != nil {
+		v := *s.Type
+
+		e.SetValue(protocol.BodyTarget, "Type", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeServiceIdList(vs []*ServiceId) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Response statistics for a service.
@@ -2112,6 +2730,37 @@ func (s *ServiceStatistics) SetTotalCount(v int64) *ServiceStatistics {
 func (s *ServiceStatistics) SetTotalResponseTime(v float64) *ServiceStatistics {
 	s.TotalResponseTime = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ServiceStatistics) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorStatistics != nil {
+		v := s.ErrorStatistics
+
+		e.SetFields(protocol.BodyTarget, "ErrorStatistics", v, protocol.Metadata{})
+	}
+	if s.FaultStatistics != nil {
+		v := s.FaultStatistics
+
+		e.SetFields(protocol.BodyTarget, "FaultStatistics", v, protocol.Metadata{})
+	}
+	if s.OkCount != nil {
+		v := *s.OkCount
+
+		e.SetValue(protocol.BodyTarget, "OkCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalCount != nil {
+		v := *s.TotalCount
+
+		e.SetValue(protocol.BodyTarget, "TotalCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.TotalResponseTime != nil {
+		v := *s.TotalResponseTime
+
+		e.SetValue(protocol.BodyTarget, "TotalResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+
+	return nil
 }
 
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/TelemetryRecord
@@ -2191,6 +2840,50 @@ func (s *TelemetryRecord) SetTimestamp(v time.Time) *TelemetryRecord {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TelemetryRecord) MarshalFields(e protocol.FieldEncoder) error {
+	if s.BackendConnectionErrors != nil {
+		v := s.BackendConnectionErrors
+
+		e.SetFields(protocol.BodyTarget, "BackendConnectionErrors", v, protocol.Metadata{})
+	}
+	if s.SegmentsReceivedCount != nil {
+		v := *s.SegmentsReceivedCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsReceivedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsRejectedCount != nil {
+		v := *s.SegmentsRejectedCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsRejectedCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsSentCount != nil {
+		v := *s.SegmentsSentCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsSentCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.SegmentsSpilloverCount != nil {
+		v := *s.SegmentsSpilloverCount
+
+		e.SetValue(protocol.BodyTarget, "SegmentsSpilloverCount", protocol.Int64Value(v), protocol.Metadata{})
+	}
+	if s.Timestamp != nil {
+		v := *s.Timestamp
+
+		e.SetValue(protocol.BodyTarget, "Timestamp", protocol.TimeValue{V: v, Format: protocol.UnixTimeFormat}, protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTelemetryRecordList(vs []*TelemetryRecord) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // A collection of segment documents with matching trace IDs.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/Trace
 type Trace struct {
@@ -2234,6 +2927,35 @@ func (s *Trace) SetId(v string) *Trace {
 func (s *Trace) SetSegments(v []*Segment) *Trace {
 	s.Segments = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *Trace) MarshalFields(e protocol.FieldEncoder) error {
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if len(s.Segments) > 0 {
+		v := s.Segments
+
+		e.SetList(protocol.BodyTarget, "Segments", encodeSegmentList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceList(vs []*Trace) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Metadata generated from the segment documents in a trace.
@@ -2356,6 +3078,80 @@ func (s *TraceSummary) SetUsers(v []*TraceUser) *TraceSummary {
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TraceSummary) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.Annotations) > 0 {
+		v := s.Annotations
+
+		e.SetMap(protocol.BodyTarget, "Annotations", func(me protocol.MapEncoder) {
+			for k, item := range v {
+				v := item
+				me.MapSetList(k, encodeValueWithServiceIdsList(v))
+			}
+		}, protocol.Metadata{})
+	}
+	if s.Duration != nil {
+		v := *s.Duration
+
+		e.SetValue(protocol.BodyTarget, "Duration", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if s.HasError != nil {
+		v := *s.HasError
+
+		e.SetValue(protocol.BodyTarget, "HasError", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasFault != nil {
+		v := *s.HasFault
+
+		e.SetValue(protocol.BodyTarget, "HasFault", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.HasThrottle != nil {
+		v := *s.HasThrottle
+
+		e.SetValue(protocol.BodyTarget, "HasThrottle", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.Http != nil {
+		v := s.Http
+
+		e.SetFields(protocol.BodyTarget, "Http", v, protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.IsPartial != nil {
+		v := *s.IsPartial
+
+		e.SetValue(protocol.BodyTarget, "IsPartial", protocol.BoolValue(v), protocol.Metadata{})
+	}
+	if s.ResponseTime != nil {
+		v := *s.ResponseTime
+
+		e.SetValue(protocol.BodyTarget, "ResponseTime", protocol.Float64Value(v), protocol.Metadata{})
+	}
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+	if len(s.Users) > 0 {
+		v := s.Users
+
+		e.SetList(protocol.BodyTarget, "Users", encodeTraceUserList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceSummaryList(vs []*TraceSummary) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about a user recorded in segment documents.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/TraceUser
 type TraceUser struct {
@@ -2388,6 +3184,30 @@ func (s *TraceUser) SetServiceIds(v []*ServiceId) *TraceUser {
 func (s *TraceUser) SetUserName(v string) *TraceUser {
 	s.UserName = &v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *TraceUser) MarshalFields(e protocol.FieldEncoder) error {
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+	if s.UserName != nil {
+		v := *s.UserName
+
+		e.SetValue(protocol.BodyTarget, "UserName", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeTraceUserList(vs []*TraceUser) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }
 
 // Information about a segment that failed processing.
@@ -2433,6 +3253,35 @@ func (s *UnprocessedTraceSegment) SetMessage(v string) *UnprocessedTraceSegment 
 	return s
 }
 
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *UnprocessedTraceSegment) MarshalFields(e protocol.FieldEncoder) error {
+	if s.ErrorCode != nil {
+		v := *s.ErrorCode
+
+		e.SetValue(protocol.BodyTarget, "ErrorCode", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Id != nil {
+		v := *s.Id
+
+		e.SetValue(protocol.BodyTarget, "Id", protocol.StringValue(v), protocol.Metadata{})
+	}
+	if s.Message != nil {
+		v := *s.Message
+
+		e.SetValue(protocol.BodyTarget, "Message", protocol.StringValue(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeUnprocessedTraceSegmentList(vs []*UnprocessedTraceSegment) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
+}
+
 // Information about a segment annotation.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/xray-2016-04-12/ValueWithServiceIds
 type ValueWithServiceIds struct {
@@ -2465,4 +3314,28 @@ func (s *ValueWithServiceIds) SetAnnotationValue(v *AnnotationValue) *ValueWithS
 func (s *ValueWithServiceIds) SetServiceIds(v []*ServiceId) *ValueWithServiceIds {
 	s.ServiceIds = v
 	return s
+}
+
+// MarshalFields encodes the AWS API shape using the passed in protocol encoder.
+func (s *ValueWithServiceIds) MarshalFields(e protocol.FieldEncoder) error {
+	if s.AnnotationValue != nil {
+		v := s.AnnotationValue
+
+		e.SetFields(protocol.BodyTarget, "AnnotationValue", v, protocol.Metadata{})
+	}
+	if len(s.ServiceIds) > 0 {
+		v := s.ServiceIds
+
+		e.SetList(protocol.BodyTarget, "ServiceIds", encodeServiceIdList(v), protocol.Metadata{})
+	}
+
+	return nil
+}
+
+func encodeValueWithServiceIdsList(vs []*ValueWithServiceIds) func(protocol.ListEncoder) {
+	return func(le protocol.ListEncoder) {
+		for _, v := range vs {
+			le.ListAddFields(v)
+		}
+	}
 }


### PR DESCRIPTION
Fixes the RESTXML protocol marshaler's code generation logic to handle the case where a service API's input parameter is decorated with the `locationName` attribute. This attribute requires the input type's fields to be wrapped with a named element.

In the case of Route 53 API ChangeResourceRecordSets:

```xml
<ChangeBatch>...</ChangeBatch>
```

Should of been:

```xml
<ChangeResourceRecordSetsRequest><ChangeBatch>...</ChangeBatch></ChangeResourceRecordSetsRequest>
```


Fix #1550