### PR TITLE
Fix protocol tests merge error in 62ba2fa9

### DIFF
--- a/private/protocol/query/build_test.go
+++ b/private/protocol/query/build_test.go
@@ -3373,10 +3373,14 @@ func TestInputService12ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 	// build request
 	query.Build(req)
-	assert.NoError(t, req.Error)
+	if req.Error != nil {
+		t.Errorf("expect no error, got %v", req.Error)
+	}
 
 	// assert body
-	assert.NotNil(t, r.Body)
+	if r.Body == nil {
+		t.Errorf("expect body not to be nil")
+	}
 	body, _ := ioutil.ReadAll(r.Body)
 	awstesting.AssertQuery(t, `Action=OperationName&TimeArg=2015-01-25T08%3A00%3A00Z&Version=2014-01-01`, util.Trim(string(body)))
 


### PR DESCRIPTION
Merge of 62ba2fa9 broke the build because while git though the code was merge-able, but was not. The code generation needed to be re-run, because new test cases were added.