### PR TITLE
service/s3/s3crypto: Correct PutObjectRequest documentation

### DIFF
--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -64,7 +64,7 @@ func NewEncryptionClient(prov client.ConfigProvider, builder ContentCipherBuilde
 //	req, out := svc.PutObjectRequest(&s3.PutObjectInput {
 //	  Key: aws.String("testKey"),
 //	  Bucket: aws.String("testBucket"),
-//	  Body: bytes.NewBuffer("test data"),
+//	  Body: strings.NewReader("test data"),
 //	})
 //	err := req.Send()
 func (c *EncryptionClient) PutObjectRequest(input *s3.PutObjectInput) (*request.Request, *s3.PutObjectOutput) {


### PR DESCRIPTION
Fixes the documentation example on PutObjectRequest to use a type that implements io.ReadSeeker.