### PR TITLE
aws/request: Treat ConcurrentUpdateException as retryable

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -40,6 +40,7 @@ var throttleCodes = map[string]struct{}{
 	"RequestThrottled":                       {},
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
+	"ConcurrentUpdateException":              {}, // Application Autoscaling
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials


### PR DESCRIPTION
I have received the following error when trying to create two autoscaling targets at the same time:

```
ConcurrentUpdateException: You already have a pending update to an Auto Scaling resource.
			status code: 400, request id: 12bcfbd4-a8ed-11e7-ab84-f5312ac9a28e
```
