### PR TITLE
v1.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Release v1.12.5 (2017-10-04)
+===
+
+### Service Client Updates
+* `service/kinesisanalytics`: Updates service API and documentation
+  * Kinesis Analytics now supports schema discovery on objects in S3. Additionally, Kinesis Analytics now supports input data preprocessing through Lambda.
+* `service/route53domains`: Updates service API and documentation
+  * Added a new API that checks whether a domain name can be transferred to Amazon Route 53.
+
+### SDK Bugs
+* `service/s3/s3crypto`: Correct PutObjectRequest documentation ([#1568](https://github.com/aws/aws-sdk-go/pull/1568))
+  * s3Crypto's PutObjectRequest docstring example was using an incorrect value. Corrected the type used in the example.
 Release v1.12.4 (2017-10-03)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,3 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `service/s3/s3crypto`: Correct PutObjectRequest documentation ([#1568](https://github.com/aws/aws-sdk-go/pull/1568))
-  * s3Crypto's PutObjectRequest docstring example was using an incorrect value. Corrected the type used in the example.

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.4"
+const SDKVersion = "1.12.5"

--- a/models/apis/kinesisanalytics/2015-08-14/api-2.json
+++ b/models/apis/kinesisanalytics/2015-08-14/api-2.json
@@ -44,6 +44,21 @@
         {"shape":"CodeValidationException"}
       ]
     },
+    "AddApplicationInputProcessingConfiguration":{
+      "name":"AddApplicationInputProcessingConfiguration",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"AddApplicationInputProcessingConfigurationRequest"},
+      "output":{"shape":"AddApplicationInputProcessingConfigurationResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"ConcurrentModificationException"}
+      ]
+    },
     "AddApplicationOutput":{
       "name":"AddApplicationOutput",
       "http":{
@@ -111,6 +126,21 @@
       },
       "input":{"shape":"DeleteApplicationCloudWatchLoggingOptionRequest"},
       "output":{"shape":"DeleteApplicationCloudWatchLoggingOptionResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"ConcurrentModificationException"}
+      ]
+    },
+    "DeleteApplicationInputProcessingConfiguration":{
+      "name":"DeleteApplicationInputProcessingConfiguration",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteApplicationInputProcessingConfigurationRequest"},
+      "output":{"shape":"DeleteApplicationInputProcessingConfigurationResponse"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"ResourceInUseException"},
@@ -244,6 +274,26 @@
       }
     },
     "AddApplicationCloudWatchLoggingOptionResponse":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "AddApplicationInputProcessingConfigurationRequest":{
+      "type":"structure",
+      "required":[
+        "ApplicationName",
+        "CurrentApplicationVersionId",
+        "InputId",
+        "InputProcessingConfiguration"
+      ],
+      "members":{
+        "ApplicationName":{"shape":"ApplicationName"},
+        "CurrentApplicationVersionId":{"shape":"ApplicationVersionId"},
+        "InputId":{"shape":"Id"},
+        "InputProcessingConfiguration":{"shape":"InputProcessingConfiguration"}
+      }
+    },
+    "AddApplicationInputProcessingConfigurationResponse":{
       "type":"structure",
       "members":{
       }
@@ -497,6 +547,24 @@
       "members":{
       }
     },
+    "DeleteApplicationInputProcessingConfigurationRequest":{
+      "type":"structure",
+      "required":[
+        "ApplicationName",
+        "CurrentApplicationVersionId",
+        "InputId"
+      ],
+      "members":{
+        "ApplicationName":{"shape":"ApplicationName"},
+        "CurrentApplicationVersionId":{"shape":"ApplicationVersionId"},
+        "InputId":{"shape":"Id"}
+      }
+    },
+    "DeleteApplicationInputProcessingConfigurationResponse":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "DeleteApplicationOutputRequest":{
       "type":"structure",
       "required":[
@@ -571,15 +639,12 @@
     },
     "DiscoverInputSchemaRequest":{
       "type":"structure",
-      "required":[
-        "ResourceARN",
-        "RoleARN",
-        "InputStartingPositionConfiguration"
-      ],
       "members":{
         "ResourceARN":{"shape":"ResourceARN"},
         "RoleARN":{"shape":"RoleARN"},
-        "InputStartingPositionConfiguration":{"shape":"InputStartingPositionConfiguration"}
+        "InputStartingPositionConfiguration":{"shape":"InputStartingPositionConfiguration"},
+        "S3Configuration":{"shape":"S3Configuration"},
+        "InputProcessingConfiguration":{"shape":"InputProcessingConfiguration"}
       }
     },
     "DiscoverInputSchemaResponse":{
@@ -587,11 +652,16 @@
       "members":{
         "InputSchema":{"shape":"SourceSchema"},
         "ParsedInputRecords":{"shape":"ParsedInputRecords"},
+        "ProcessedInputRecords":{"shape":"ProcessedInputRecords"},
         "RawInputRecords":{"shape":"RawInputRecords"}
       }
     },
     "ErrorMessage":{"type":"string"},
-    "FileKey":{"type":"string"},
+    "FileKey":{
+      "type":"string",
+      "max":1024,
+      "min":1
+    },
     "Id":{
       "type":"string",
       "max":50,
@@ -622,6 +692,7 @@
       ],
       "members":{
         "NamePrefix":{"shape":"InAppStreamName"},
+        "InputProcessingConfiguration":{"shape":"InputProcessingConfiguration"},
         "KinesisStreamsInput":{"shape":"KinesisStreamsInput"},
         "KinesisFirehoseInput":{"shape":"KinesisFirehoseInput"},
         "InputParallelism":{"shape":"InputParallelism"},
@@ -649,6 +720,7 @@
         "InputId":{"shape":"Id"},
         "NamePrefix":{"shape":"InAppStreamName"},
         "InAppStreamNames":{"shape":"InAppStreamNames"},
+        "InputProcessingConfigurationDescription":{"shape":"InputProcessingConfigurationDescription"},
         "KinesisStreamsInputDescription":{"shape":"KinesisStreamsInputDescription"},
         "KinesisFirehoseInputDescription":{"shape":"KinesisFirehoseInputDescription"},
         "InputSchema":{"shape":"SourceSchema"},
@@ -659,6 +731,31 @@
     "InputDescriptions":{
       "type":"list",
       "member":{"shape":"InputDescription"}
+    },
+    "InputLambdaProcessor":{
+      "type":"structure",
+      "required":[
+        "ResourceARN",
+        "RoleARN"
+      ],
+      "members":{
+        "ResourceARN":{"shape":"ResourceARN"},
+        "RoleARN":{"shape":"RoleARN"}
+      }
+    },
+    "InputLambdaProcessorDescription":{
+      "type":"structure",
+      "members":{
+        "ResourceARN":{"shape":"ResourceARN"},
+        "RoleARN":{"shape":"RoleARN"}
+      }
+    },
+    "InputLambdaProcessorUpdate":{
+      "type":"structure",
+      "members":{
+        "ResourceARNUpdate":{"shape":"ResourceARN"},
+        "RoleARNUpdate":{"shape":"RoleARN"}
+      }
     },
     "InputParallelism":{
       "type":"structure",
@@ -675,6 +772,26 @@
       "type":"structure",
       "members":{
         "CountUpdate":{"shape":"InputParallelismCount"}
+      }
+    },
+    "InputProcessingConfiguration":{
+      "type":"structure",
+      "required":["InputLambdaProcessor"],
+      "members":{
+        "InputLambdaProcessor":{"shape":"InputLambdaProcessor"}
+      }
+    },
+    "InputProcessingConfigurationDescription":{
+      "type":"structure",
+      "members":{
+        "InputLambdaProcessorDescription":{"shape":"InputLambdaProcessorDescription"}
+      }
+    },
+    "InputProcessingConfigurationUpdate":{
+      "type":"structure",
+      "required":["InputLambdaProcessorUpdate"],
+      "members":{
+        "InputLambdaProcessorUpdate":{"shape":"InputLambdaProcessorUpdate"}
       }
     },
     "InputSchemaUpdate":{
@@ -705,6 +822,7 @@
       "members":{
         "InputId":{"shape":"Id"},
         "NamePrefixUpdate":{"shape":"InAppStreamName"},
+        "InputProcessingConfigurationUpdate":{"shape":"InputProcessingConfigurationUpdate"},
         "KinesisStreamsInputUpdate":{"shape":"KinesisStreamsInputUpdate"},
         "KinesisFirehoseInputUpdate":{"shape":"KinesisFirehoseInputUpdate"},
         "InputSchemaUpdate":{"shape":"InputSchemaUpdate"},
@@ -938,6 +1056,11 @@
       "type":"list",
       "member":{"shape":"ParsedInputRecord"}
     },
+    "ProcessedInputRecord":{"type":"string"},
+    "ProcessedInputRecords":{
+      "type":"list",
+      "member":{"shape":"ProcessedInputRecord"}
+    },
     "RawInputRecord":{"type":"string"},
     "RawInputRecords":{
       "type":"list",
@@ -964,7 +1087,10 @@
       "type":"string",
       "pattern":"[a-zA-Z_][a-zA-Z0-9_]*"
     },
-    "RecordColumnSqlType":{"type":"string"},
+    "RecordColumnSqlType":{
+      "type":"string",
+      "min":1
+    },
     "RecordColumns":{
       "type":"list",
       "member":{"shape":"RecordColumn"},
@@ -994,7 +1120,10 @@
       "type":"string",
       "min":1
     },
-    "RecordRowPath":{"type":"string"},
+    "RecordRowPath":{
+      "type":"string",
+      "min":1
+    },
     "ReferenceDataSource":{
       "type":"structure",
       "required":[
@@ -1043,7 +1172,7 @@
       "type":"string",
       "max":2048,
       "min":1,
-      "pattern":"arn:[a-zA-Z0-9\\-]+:[a-zA-Z0-9\\-]+:[a-zA-Z0-9\\-]*:\\d{12}:[a-zA-Z_0-9+=,.@\\-_/:]+"
+      "pattern":"arn:.*"
     },
     "ResourceInUseException":{
       "type":"structure",
@@ -1071,6 +1200,19 @@
       "max":2048,
       "min":1,
       "pattern":"arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
+    "S3Configuration":{
+      "type":"structure",
+      "required":[
+        "RoleARN",
+        "BucketARN",
+        "FileKey"
+      ],
+      "members":{
+        "RoleARN":{"shape":"RoleARN"},
+        "BucketARN":{"shape":"BucketARN"},
+        "FileKey":{"shape":"FileKey"}
+      }
     },
     "S3ReferenceDataSource":{
       "type":"structure",
@@ -1111,7 +1253,8 @@
       "members":{
         "message":{"shape":"ErrorMessage"}
       },
-      "exception":true
+      "exception":true,
+      "fault":true
     },
     "SourceSchema":{
       "type":"structure",
@@ -1158,7 +1301,8 @@
       "type":"structure",
       "members":{
         "message":{"shape":"ErrorMessage"},
-        "RawInputRecords":{"shape":"RawInputRecords"}
+        "RawInputRecords":{"shape":"RawInputRecords"},
+        "ProcessedInputRecords":{"shape":"ProcessedInputRecords"}
       },
       "exception":true
     },

--- a/models/apis/kinesisanalytics/2015-08-14/docs-2.json
+++ b/models/apis/kinesisanalytics/2015-08-14/docs-2.json
@@ -4,11 +4,13 @@
   "operations": {
     "AddApplicationCloudWatchLoggingOption": "<p>Adds a CloudWatch log stream to monitor application configuration errors. For more information about using CloudWatch log streams with Amazon Kinesis Analytics applications, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/cloudwatch-logs.html\">Working with Amazon CloudWatch Logs</a>.</p>",
     "AddApplicationInput": "<p> Adds a streaming source to your Amazon Kinesis application. For conceptual information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p> <p>You can add a streaming source either when you create an application or you can use this operation to add a streaming source after you create an application. For more information, see <a>CreateApplication</a>.</p> <p>Any configuration update, including adding a streaming source using this operation, results in a new version of the application. You can use the <a>DescribeApplication</a> operation to find the current application version. </p> <p>This operation requires permissions to perform the <code>kinesisanalytics:AddApplicationInput</code> action.</p>",
+    "AddApplicationInputProcessingConfiguration": "<p>Adds an <a>InputProcessingConfiguration</a> to an application. An input processor preprocesses records on the input stream before the application's SQL code executes. Currently, the only input processor available is <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a>.</p>",
     "AddApplicationOutput": "<p>Adds an external destination to your Amazon Kinesis Analytics application.</p> <p>If you want Amazon Kinesis Analytics to deliver data from an in-application stream within your application to an external destination (such as an Amazon Kinesis stream or a Firehose delivery stream), you add the relevant configuration to your application using this operation. You can configure one or more outputs for your application. Each output configuration maps an in-application stream and an external destination.</p> <p> You can use one of the output configurations to deliver data from your in-application error stream to an external destination so that you can analyze the errors. For conceptual information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-output.html\">Understanding Application Output (Destination)</a>. </p> <p> Note that any configuration update, including adding a streaming source using this operation, results in a new version of the application. You can use the <a>DescribeApplication</a> operation to find the current application version.</p> <p>For the limits on the number of application inputs and outputs you can configure, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/limits.html\">Limits</a>.</p> <p>This operation requires permissions to perform the <code>kinesisanalytics:AddApplicationOutput</code> action.</p>",
     "AddApplicationReferenceDataSource": "<p>Adds a reference data source to an existing application.</p> <p>Amazon Kinesis Analytics reads reference data (that is, an Amazon S3 object) and creates an in-application table within your application. In the request, you provide the source (S3 bucket name and object key name), name of the in-application table to create, and the necessary mapping information that describes how data in Amazon S3 object maps to columns in the resulting in-application table.</p> <p> For conceptual information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. For the limits on data sources you can add to your application, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/limits.html\">Limits</a>. </p> <p> This operation requires permissions to perform the <code>kinesisanalytics:AddApplicationOutput</code> action. </p>",
     "CreateApplication": "<p> Creates an Amazon Kinesis Analytics application. You can configure each application with one streaming source as input, application code to process the input, and up to five streaming destinations where you want Amazon Kinesis Analytics to write the output data from your application. For an overview, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works.html\">How it Works</a>. </p> <p>In the input configuration, you map the streaming source to an in-application stream, which you can think of as a constantly updating table. In the mapping, you must provide a schema for the in-application stream and map each data column in the in-application stream to a data element in the streaming source.</p> <p>Your application code is one or more SQL statements that read input data, transform it, and generate output. Your application code can create one or more SQL artifacts like SQL streams or pumps.</p> <p>In the output configuration, you can configure the application to write data from in-application streams created in your applications to up to five streaming destinations.</p> <p> To read data from your source stream or write data to destination streams, Amazon Kinesis Analytics needs your permissions. You grant these permissions by creating IAM roles. This operation requires permissions to perform the <code>kinesisanalytics:CreateApplication</code> action. </p> <p> For introductory exercises to create an Amazon Kinesis Analytics application, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/getting-started.html\">Getting Started</a>. </p>",
     "DeleteApplication": "<p>Deletes the specified application. Amazon Kinesis Analytics halts application execution and deletes the application, including any application artifacts (such as in-application streams, reference table, and application code).</p> <p>This operation requires permissions to perform the <code>kinesisanalytics:DeleteApplication</code> action.</p>",
     "DeleteApplicationCloudWatchLoggingOption": "<p>Deletes a CloudWatch log stream from an application. For more information about using CloudWatch log streams with Amazon Kinesis Analytics applications, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/cloudwatch-logs.html\">Working with Amazon CloudWatch Logs</a>.</p>",
+    "DeleteApplicationInputProcessingConfiguration": "<p>Deletes an <a>InputProcessingConfiguration</a> from an input.</p>",
     "DeleteApplicationOutput": "<p>Deletes output destination configuration from your application configuration. Amazon Kinesis Analytics will no longer write data from the corresponding in-application stream to the external output destination.</p> <p>This operation requires permissions to perform the <code>kinesisanalytics:DeleteApplicationOutput</code> action.</p>",
     "DeleteApplicationReferenceDataSource": "<p>Deletes a reference data source configuration from the specified application configuration.</p> <p>If the application is running, Amazon Kinesis Analytics immediately removes the in-application table that you created using the <a>AddApplicationReferenceDataSource</a> operation. </p> <p>This operation requires permissions to perform the <code>kinesisanalytics.DeleteApplicationReferenceDataSource</code> action.</p>",
     "DescribeApplication": "<p>Returns information about a specific Amazon Kinesis Analytics application.</p> <p>If you want to retrieve a list of all applications in your account, use the <a>ListApplications</a> operation.</p> <p>This operation requires permissions to perform the <code>kinesisanalytics:DescribeApplication</code> action. You can use <code>DescribeApplication</code> to get the current application versionId, which you need to call other operations such as <code>Update</code>. </p>",
@@ -25,6 +27,16 @@
       }
     },
     "AddApplicationCloudWatchLoggingOptionResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "AddApplicationInputProcessingConfigurationRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "AddApplicationInputProcessingConfigurationResponse": {
       "base": null,
       "refs": {
       }
@@ -84,6 +96,7 @@
       "base": null,
       "refs": {
         "AddApplicationCloudWatchLoggingOptionRequest$ApplicationName": "<p>The Kinesis Analytics application name.</p>",
+        "AddApplicationInputProcessingConfigurationRequest$ApplicationName": "<p>Name of the application to which you want to add the input processing configuration.</p>",
         "AddApplicationInputRequest$ApplicationName": "<p>Name of your existing Amazon Kinesis Analytics application to which you want to add the streaming source.</p>",
         "AddApplicationOutputRequest$ApplicationName": "<p>Name of the application to which you want to add the output configuration.</p>",
         "AddApplicationReferenceDataSourceRequest$ApplicationName": "<p>Name of an existing application.</p>",
@@ -91,6 +104,7 @@
         "ApplicationSummary$ApplicationName": "<p>Name of the application.</p>",
         "CreateApplicationRequest$ApplicationName": "<p>Name of your Amazon Kinesis Analytics application (for example, <code>sample-app</code>).</p>",
         "DeleteApplicationCloudWatchLoggingOptionRequest$ApplicationName": "<p>The Kinesis Analytics application name.</p>",
+        "DeleteApplicationInputProcessingConfigurationRequest$ApplicationName": "<p>The Kinesis Analytics application name.</p>",
         "DeleteApplicationOutputRequest$ApplicationName": "<p>Amazon Kinesis Analytics application name.</p>",
         "DeleteApplicationReferenceDataSourceRequest$ApplicationName": "<p>Name of an existing application.</p>",
         "DeleteApplicationRequest$ApplicationName": "<p>Name of the Amazon Kinesis Analytics application to delete.</p>",
@@ -131,11 +145,13 @@
       "base": null,
       "refs": {
         "AddApplicationCloudWatchLoggingOptionRequest$CurrentApplicationVersionId": "<p>The version ID of the Kinesis Analytics application.</p>",
+        "AddApplicationInputProcessingConfigurationRequest$CurrentApplicationVersionId": "<p>Version of the application to which you want to add the input processing configuration. You can use the <a>DescribeApplication</a> operation to get the current application version. If the version specified is not the current version, the <code>ConcurrentModificationException</code> is returned.</p>",
         "AddApplicationInputRequest$CurrentApplicationVersionId": "<p>Current version of your Amazon Kinesis Analytics application. You can use the <a>DescribeApplication</a> operation to find the current application version.</p>",
         "AddApplicationOutputRequest$CurrentApplicationVersionId": "<p>Version of the application to which you want add the output configuration. You can use the <a>DescribeApplication</a> operation to get the current application version. If the version specified is not the current version, the <code>ConcurrentModificationException</code> is returned. </p>",
         "AddApplicationReferenceDataSourceRequest$CurrentApplicationVersionId": "<p>Version of the application for which you are adding the reference data source. You can use the <a>DescribeApplication</a> operation to get the current application version. If the version specified is not the current version, the <code>ConcurrentModificationException</code> is returned.</p>",
         "ApplicationDetail$ApplicationVersionId": "<p>Provides the current application version.</p>",
         "DeleteApplicationCloudWatchLoggingOptionRequest$CurrentApplicationVersionId": "<p>The version ID of the Kinesis Analytics application.</p>",
+        "DeleteApplicationInputProcessingConfigurationRequest$CurrentApplicationVersionId": "<p>The version ID of the Kinesis Analytics application.</p>",
         "DeleteApplicationOutputRequest$CurrentApplicationVersionId": "<p>Amazon Kinesis Analytics application version. You can use the <a>DescribeApplication</a> operation to get the current application version. If the version specified is not the current version, the <code>ConcurrentModificationException</code> is returned. </p>",
         "DeleteApplicationReferenceDataSourceRequest$CurrentApplicationVersionId": "<p>Version of the application. You can use the <a>DescribeApplication</a> operation to get the current application version. If the version specified is not the current version, the <code>ConcurrentModificationException</code> is returned.</p>",
         "UpdateApplicationRequest$CurrentApplicationVersionId": "<p>The current application version ID. You can use the <a>DescribeApplication</a> operation to get this value.</p>"
@@ -150,6 +166,7 @@
     "BucketARN": {
       "base": null,
       "refs": {
+        "S3Configuration$BucketARN": null,
         "S3ReferenceDataSource$BucketARN": "<p>Amazon Resource Name (ARN) of the S3 bucket.</p>",
         "S3ReferenceDataSourceDescription$BucketARN": "<p>Amazon Resource Name (ARN) of the S3 bucket.</p>",
         "S3ReferenceDataSourceUpdate$BucketARNUpdate": "<p>Amazon Resource Name (ARN) of the S3 bucket.</p>"
@@ -228,6 +245,16 @@
       "refs": {
       }
     },
+    "DeleteApplicationInputProcessingConfigurationRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteApplicationInputProcessingConfigurationResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DeleteApplicationOutputRequest": {
       "base": "<p/>",
       "refs": {
@@ -277,7 +304,7 @@
       }
     },
     "DiscoverInputSchemaRequest": {
-      "base": "<p/>",
+      "base": null,
       "refs": {
       }
     },
@@ -304,6 +331,7 @@
     "FileKey": {
       "base": null,
       "refs": {
+        "S3Configuration$FileKey": null,
         "S3ReferenceDataSource$FileKey": "<p>Object key name containing reference data.</p>",
         "S3ReferenceDataSourceDescription$FileKey": "<p>Amazon S3 object key name.</p>",
         "S3ReferenceDataSourceUpdate$FileKeyUpdate": "<p>Object key name.</p>"
@@ -312,9 +340,11 @@
     "Id": {
       "base": null,
       "refs": {
+        "AddApplicationInputProcessingConfigurationRequest$InputId": "<p>The ID of the input configuration to which to add the input configuration. You can get a list of the input IDs for an application using the <a>DescribeApplication</a> operation.</p>",
         "CloudWatchLoggingOptionDescription$CloudWatchLoggingOptionId": "<p>ID of the CloudWatch logging option description.</p>",
         "CloudWatchLoggingOptionUpdate$CloudWatchLoggingOptionId": "<p>ID of the CloudWatch logging option to update</p>",
         "DeleteApplicationCloudWatchLoggingOptionRequest$CloudWatchLoggingOptionId": "<p>The <code>CloudWatchLoggingOptionId</code> of the CloudWatch logging option to delete. You can use the <a>DescribeApplication</a> operation to get the <code>CloudWatchLoggingOptionId</code>. </p>",
+        "DeleteApplicationInputProcessingConfigurationRequest$InputId": "<p>The ID of the input configuration from which to delete the input configuration. You can get a list of the input IDs for an application using the <a>DescribeApplication</a> operation.</p>",
         "DeleteApplicationOutputRequest$OutputId": "<p>The ID of the configuration to delete. Each output configuration that is added to the application, either when the application is created or later using the <a>AddApplicationOutput</a> operation, has a unique ID. You need to provide the ID to uniquely identify the output configuration that you want to delete from the application configuration. You can use the <a>DescribeApplication</a> operation to get the specific <code>OutputId</code>. </p>",
         "DeleteApplicationReferenceDataSourceRequest$ReferenceId": "<p>ID of the reference data source. When you add a reference data source to your application using the <a>AddApplicationReferenceDataSource</a>, Amazon Kinesis Analytics assigns an ID. You can use the <a>DescribeApplication</a> operation to get the reference ID. </p>",
         "InputConfiguration$Id": "<p>Input source ID. You can get this ID by calling the <a>DescribeApplication</a> operation.</p>",
@@ -355,7 +385,7 @@
     "Input": {
       "base": "<p>When you configure the application input, you specify the streaming source, the in-application stream name that is created, and the mapping between the two. For more information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p>",
       "refs": {
-        "AddApplicationInputRequest$Input": "<p/>",
+        "AddApplicationInputRequest$Input": "<p>The <a>Input</a> to add.</p>",
         "Inputs$member": null
       }
     },
@@ -383,6 +413,24 @@
         "ApplicationDetail$InputDescriptions": "<p>Describes the application input configuration. For more information, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p>"
       }
     },
+    "InputLambdaProcessor": {
+      "base": "<p>An object that contains the ARN of the <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a> function that is used to preprocess records in the stream, and the ARN of the IAM role used to access the AWS Lambda function. </p>",
+      "refs": {
+        "InputProcessingConfiguration$InputLambdaProcessor": "<p>The <a>InputLambdaProcessor</a> that is used to preprocess the records in the stream prior to being processed by your application code.</p>"
+      }
+    },
+    "InputLambdaProcessorDescription": {
+      "base": "<p>An object that contains the ARN of the <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a> function that is used to preprocess records in the stream, and the ARN of the IAM role used to access the AWS Lambda expression.</p>",
+      "refs": {
+        "InputProcessingConfigurationDescription$InputLambdaProcessorDescription": "<p>Provides configuration information about the associated <a>InputLambdaProcessorDescription</a>.</p>"
+      }
+    },
+    "InputLambdaProcessorUpdate": {
+      "base": "<p>Represents an update to the <a>InputLambdaProcessor</a> that is used to preprocess the records in the stream.</p>",
+      "refs": {
+        "InputProcessingConfigurationUpdate$InputLambdaProcessorUpdate": "<p>Provides update information for an <a>InputLambdaProcessor</a>.</p>"
+      }
+    },
     "InputParallelism": {
       "base": "<p>Describes the number of in-application streams to create for a given streaming source. For information about parallelism, see <a href=\"http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html\">Configuring Application Input</a>. </p>",
       "refs": {
@@ -403,8 +451,28 @@
         "InputUpdate$InputParallelismUpdate": "<p>Describes the parallelism updates (the number in-application streams Amazon Kinesis Analytics creates for the specific streaming source).</p>"
       }
     },
+    "InputProcessingConfiguration": {
+      "base": "<p>Provides a description of a processor that is used to preprocess the records in the stream prior to being processed by your application code. Currently, the only input processor available is <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a>.</p>",
+      "refs": {
+        "AddApplicationInputProcessingConfigurationRequest$InputProcessingConfiguration": "<p>The <a>InputProcessingConfiguration</a> to add to the application.</p>",
+        "DiscoverInputSchemaRequest$InputProcessingConfiguration": "<p>The <a>InputProcessingConfiguration</a> to use to preprocess the records before discovering the schema of the records.</p>",
+        "Input$InputProcessingConfiguration": "<p>The <a>InputProcessingConfiguration</a> for the Input. An input processor transforms records as they are received from the stream, before the application's SQL code executes. Currently, the only input processing configuration available is <a>InputLambdaProcessor</a>.</p>"
+      }
+    },
+    "InputProcessingConfigurationDescription": {
+      "base": "<p>Provides configuration information about an input processor. Currently, the only input processor available is <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a>.</p>",
+      "refs": {
+        "InputDescription$InputProcessingConfigurationDescription": "<p>The description of the preprocessor that executes on records in this input before the application's code is run.</p>"
+      }
+    },
+    "InputProcessingConfigurationUpdate": {
+      "base": "<p>Describes updates to an <a>InputProcessingConfiguration</a>. </p>",
+      "refs": {
+        "InputUpdate$InputProcessingConfigurationUpdate": "<p>Describes updates for an input processing configuration.</p>"
+      }
+    },
     "InputSchemaUpdate": {
-      "base": "<p> Describes updates for the application's input schema. </p>",
+      "base": "<p>Describes updates for the application's input schema.</p>",
       "refs": {
         "InputUpdate$InputSchemaUpdate": "<p>Describes the data format on the streaming source, and how record elements on the streaming source map to columns of the in-application stream that is created.</p>"
       }
@@ -619,6 +687,19 @@
         "DiscoverInputSchemaResponse$ParsedInputRecords": "<p>An array of elements, where each element corresponds to a row in a stream record (a stream record can have more than one row).</p>"
       }
     },
+    "ProcessedInputRecord": {
+      "base": null,
+      "refs": {
+        "ProcessedInputRecords$member": null
+      }
+    },
+    "ProcessedInputRecords": {
+      "base": null,
+      "refs": {
+        "DiscoverInputSchemaResponse$ProcessedInputRecords": "<p>Stream data that was modified by the processor specified in the <code>InputProcessingConfiguration</code> parameter.</p>",
+        "UnableToDetectSchemaException$ProcessedInputRecords": null
+      }
+    },
     "RawInputRecord": {
       "base": null,
       "refs": {
@@ -738,6 +819,9 @@
         "ApplicationDetail$ApplicationARN": "<p>ARN of the application.</p>",
         "ApplicationSummary$ApplicationARN": "<p>ARN of the application.</p>",
         "DiscoverInputSchemaRequest$ResourceARN": "<p>Amazon Resource Name (ARN) of the streaming source.</p>",
+        "InputLambdaProcessor$ResourceARN": "<p>The ARN of the <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a> function that operates on records in the stream.</p>",
+        "InputLambdaProcessorDescription$ResourceARN": "<p>The ARN of the <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a> function that is used to preprocess the records in the stream.</p>",
+        "InputLambdaProcessorUpdate$ResourceARNUpdate": "<p>The ARN of the new <a href=\"https://aws.amazon.com/documentation/lambda/\">AWS Lambda</a> function that is used to preprocess the records in the stream.</p>",
         "KinesisFirehoseInput$ResourceARN": "<p>ARN of the input Firehose delivery stream.</p>",
         "KinesisFirehoseInputDescription$ResourceARN": "<p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>",
         "KinesisFirehoseInputUpdate$ResourceARNUpdate": "<p>ARN of the input Amazon Kinesis Firehose delivery stream to read.</p>",
@@ -774,6 +858,9 @@
         "CloudWatchLoggingOptionDescription$RoleARN": "<p>IAM ARN of the role to use to send application messages. Note: To write application messages to CloudWatch, the IAM role used must have the <code>PutLogEvents</code> policy action enabled.</p>",
         "CloudWatchLoggingOptionUpdate$RoleARNUpdate": "<p>IAM ARN of the role to use to send application messages. Note: To write application messages to CloudWatch, the IAM role used must have the <code>PutLogEvents</code> policy action enabled.</p>",
         "DiscoverInputSchemaRequest$RoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to access the stream on your behalf.</p>",
+        "InputLambdaProcessor$RoleARN": "<p>The ARN of the IAM role used to access the AWS Lambda function.</p>",
+        "InputLambdaProcessorDescription$RoleARN": "<p>The ARN of the IAM role used to access the AWS Lambda function.</p>",
+        "InputLambdaProcessorUpdate$RoleARNUpdate": "<p>The ARN of the new IAM role used to access the AWS Lambda function.</p>",
         "KinesisFirehoseInput$RoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to access the stream on your behalf. You need to make sure the role has necessary permissions to access the stream.</p>",
         "KinesisFirehoseInputDescription$RoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics assumes to access the stream.</p>",
         "KinesisFirehoseInputUpdate$RoleARNUpdate": "<p>Amazon Resource Name (ARN) of the IAM role that Amazon Kinesis Analytics can assume to access the stream on your behalf. You need to grant necessary permissions to this role.</p>",
@@ -786,9 +873,16 @@
         "KinesisStreamsOutput$RoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to write to the destination stream on your behalf. You need to grant the necessary permissions to this role.</p>",
         "KinesisStreamsOutputDescription$RoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to access the stream.</p>",
         "KinesisStreamsOutputUpdate$RoleARNUpdate": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to access the stream on your behalf. You need to grant the necessary permissions to this role.</p>",
+        "S3Configuration$RoleARN": null,
         "S3ReferenceDataSource$ReferenceRoleARN": "<p>ARN of the IAM role that the service can assume to read data on your behalf. This role must have permission for the <code>s3:GetObject</code> action on the object and trust policy that allows Amazon Kinesis Analytics service principal to assume this role.</p>",
         "S3ReferenceDataSourceDescription$ReferenceRoleARN": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to read the Amazon S3 object on your behalf to populate the in-application reference table.</p>",
         "S3ReferenceDataSourceUpdate$ReferenceRoleARNUpdate": "<p>ARN of the IAM role that Amazon Kinesis Analytics can assume to read the Amazon S3 object and populate the in-application.</p>"
+      }
+    },
+    "S3Configuration": {
+      "base": null,
+      "refs": {
+        "DiscoverInputSchemaRequest$S3Configuration": null
       }
     },
     "S3ReferenceDataSource": {
@@ -819,7 +913,7 @@
       "refs": {
         "DiscoverInputSchemaResponse$InputSchema": "<p>Schema inferred from the streaming source. It identifies the format of the data in the streaming source and how each data element maps to corresponding columns in the in-application stream that you can create.</p>",
         "Input$InputSchema": "<p>Describes the format of the data in the streaming source, and how each data element maps to corresponding columns in the in-application stream that is being created.</p> <p>Also used to describe the format of the reference data source.</p>",
-        "InputDescription$InputSchema": null,
+        "InputDescription$InputSchema": "<p>Describes the format of the data in the streaming source, and how each data element maps to corresponding columns in the in-application stream that is being created. </p>",
         "ReferenceDataSource$ReferenceSchema": null,
         "ReferenceDataSourceDescription$ReferenceSchema": null,
         "ReferenceDataSourceUpdate$ReferenceSchemaUpdate": null

--- a/models/apis/route53domains/2014-05-15/api-2.json
+++ b/models/apis/route53domains/2014-05-15/api-2.json
@@ -24,6 +24,19 @@
         {"shape":"UnsupportedTLD"}
       ]
     },
+    "CheckDomainTransferability":{
+      "name":"CheckDomainTransferability",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CheckDomainTransferabilityRequest"},
+      "output":{"shape":"CheckDomainTransferabilityResponse"},
+      "errors":[
+        {"shape":"InvalidInput"},
+        {"shape":"UnsupportedTLD"}
+      ]
+    },
     "DeleteTagsForDomain":{
       "name":"DeleteTagsForDomain",
       "http":{
@@ -374,6 +387,21 @@
         "Availability":{"shape":"DomainAvailability"}
       }
     },
+    "CheckDomainTransferabilityRequest":{
+      "type":"structure",
+      "required":["DomainName"],
+      "members":{
+        "DomainName":{"shape":"DomainName"},
+        "AuthCode":{"shape":"DomainAuthCode"}
+      }
+    },
+    "CheckDomainTransferabilityResponse":{
+      "type":"structure",
+      "required":["Transferability"],
+      "members":{
+        "Transferability":{"shape":"DomainTransferability"}
+      }
+    },
     "City":{
       "type":"string",
       "max":255
@@ -721,8 +749,7 @@
     },
     "DomainName":{
       "type":"string",
-      "max":255,
-      "pattern":"[a-zA-Z0-9_\\-.]*"
+      "max":255
     },
     "DomainStatus":{"type":"string"},
     "DomainStatusList":{
@@ -753,6 +780,12 @@
     "DomainSummaryList":{
       "type":"list",
       "member":{"shape":"DomainSummary"}
+    },
+    "DomainTransferability":{
+      "type":"structure",
+      "members":{
+        "Transferable":{"shape":"Transferable"}
+      }
     },
     "DuplicateRequest":{
       "type":"structure",
@@ -831,11 +864,16 @@
         "ES_LEGAL_FORM",
         "FI_BUSINESS_NUMBER",
         "FI_ID_NUMBER",
+        "FI_NATIONALITY",
+        "FI_ORGANIZATION_TYPE",
         "IT_PIN",
+        "IT_REGISTRANT_ENTITY_TYPE",
         "RU_PASSPORT_DATA",
         "SE_ID_NUMBER",
         "SG_ID_NUMBER",
-        "VAT_NUMBER"
+        "VAT_NUMBER",
+        "UK_CONTACT_TYPE",
+        "UK_COMPANY_NUMBER"
       ]
     },
     "ExtraParamValue":{
@@ -1064,7 +1102,16 @@
         "UPDATE_DOMAIN_CONTACT",
         "UPDATE_NAMESERVER",
         "CHANGE_PRIVACY_PROTECTION",
-        "DOMAIN_LOCK"
+        "DOMAIN_LOCK",
+        "ENABLE_AUTORENEW",
+        "DISABLE_AUTORENEW",
+        "ADD_DNSSEC",
+        "REMOVE_DNSSEC",
+        "EXPIRE_DOMAIN",
+        "TRANSFER_OUT_DOMAIN",
+        "CHANGE_DOMAIN_OWNER",
+        "RENEW_DOMAIN",
+        "PUSH_DOMAIN"
       ]
     },
     "PageMarker":{
@@ -1226,6 +1273,14 @@
         "OperationId":{"shape":"OperationId"}
       }
     },
+    "Transferable":{
+      "type":"string",
+      "enum":[
+        "TRANSFERABLE",
+        "UNTRANSFERABLE",
+        "DONT_KNOW"
+      ]
+    },
     "UnsupportedTLD":{
       "type":"structure",
       "members":{
@@ -1275,7 +1330,10 @@
       ],
       "members":{
         "DomainName":{"shape":"DomainName"},
-        "FIAuthKey":{"shape":"FIAuthKey"},
+        "FIAuthKey":{
+          "shape":"FIAuthKey",
+          "deprecated":true
+        },
         "Nameservers":{"shape":"NameserverList"}
       }
     },

--- a/models/apis/route53domains/2014-05-15/docs-2.json
+++ b/models/apis/route53domains/2014-05-15/docs-2.json
@@ -3,7 +3,8 @@
   "service": "<p>Amazon Route 53 API actions let you register domain names and perform related operations.</p>",
   "operations": {
     "CheckDomainAvailability": "<p>This operation checks the availability of one domain name. Note that if the availability status of a domain is pending, you must submit another request to determine the availability of the domain name.</p>",
-    "DeleteTagsForDomain": "<p>This operation deletes the specified tags for a domain.</p> <p>All tag operations are eventually consistent; subsequent operations may not immediately represent all issued operations.</p>",
+    "CheckDomainTransferability": "<p>Checks whether a domain name can be transferred to Amazon Route 53. </p>",
+    "DeleteTagsForDomain": "<p>This operation deletes the specified tags for a domain.</p> <p>All tag operations are eventually consistent; subsequent operations might not immediately represent all issued operations.</p>",
     "DisableDomainAutoRenew": "<p>This operation disables automatic renewal of domain registration for the specified domain.</p>",
     "DisableDomainTransferLock": "<p>This operation removes the transfer lock on the domain (specifically the <code>clientTransferProhibited</code> status) to allow domain transfers. We recommend you refrain from performing this action unless you intend to transfer the domain to a different registrar. Successful submission returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email.</p>",
     "EnableDomainAutoRenew": "<p>This operation configures Amazon Route 53 to automatically renew the specified domain before the domain registration expires. The cost of renewing your domain registration is billed to your AWS account.</p> <p>The period during which you can renew a domain name varies by TLD. For a list of TLDs and their renewal policies, see <a href=\"http://wiki.gandi.net/en/domains/renew#renewal_restoration_and_deletion_times\">\"Renewal, restoration, and deletion times\"</a> on the website for our registrar partner, Gandi. Route 53 requires that you renew before the end of the renewal period that is listed on the Gandi website so we can complete processing before the deadline.</p>",
@@ -14,7 +15,7 @@
     "GetOperationDetail": "<p>This operation returns the current status of an operation that is not completed.</p>",
     "ListDomains": "<p>This operation returns all the domain names registered with Amazon Route 53 for the current AWS account.</p>",
     "ListOperations": "<p>This operation returns the operation IDs of operations that are not yet complete.</p>",
-    "ListTagsForDomain": "<p>This operation returns all of the tags that are associated with the specified domain.</p> <p>All tag operations are eventually consistent; subsequent operations may not immediately represent all issued operations.</p>",
+    "ListTagsForDomain": "<p>This operation returns all of the tags that are associated with the specified domain.</p> <p>All tag operations are eventually consistent; subsequent operations might not immediately represent all issued operations.</p>",
     "RegisterDomain": "<p>This operation registers a domain. Domains are registered by the AWS registrar partner, Gandi. For some top-level domains (TLDs), this operation requires extra parameters.</p> <p>When you register a domain, Amazon Route 53 does the following:</p> <ul> <li> <p>Creates a Amazon Route 53 hosted zone that has the same name as the domain. Amazon Route 53 assigns four name servers to your hosted zone and automatically updates your domain registration with the names of these name servers.</p> </li> <li> <p>Enables autorenew, so your domain registration will renew automatically each year. We'll notify you in advance of the renewal date so you can choose whether to renew the registration.</p> </li> <li> <p>Optionally enables privacy protection, so WHOIS queries return contact information for our registrar partner, Gandi, instead of the information you entered for registrant, admin, and tech contacts.</p> </li> <li> <p>If registration is successful, returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant is notified by email.</p> </li> <li> <p>Charges your AWS account an amount based on the top-level domain. For more information, see <a href=\"http://aws.amazon.com/route53/pricing/\">Amazon Route 53 Pricing</a>.</p> </li> </ul>",
     "RenewDomain": "<p>This operation renews a domain for the specified number of years. The cost of renewing your domain is billed to your AWS account.</p> <p>We recommend that you renew your domain several weeks before the expiration date. Some TLD registries delete domains before the expiration date if you haven't renewed far enough in advance. For more information about renewing domain registration, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-renew.html\">Renewing Registration for a Domain</a> in the Amazon Route 53 Developer Guide.</p>",
     "ResendContactReachabilityEmail": "<p>For operations that require confirmation that the email address for the registrant contact is valid, such as registering a new domain, this operation resends the confirmation email to the current email address for the registrant contact.</p>",
@@ -23,7 +24,7 @@
     "UpdateDomainContact": "<p>This operation updates the contact information for a particular domain. Information for at least one contact (registrant, administrator, or technical) must be supplied for update.</p> <p>If the update is successful, this method returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email.</p>",
     "UpdateDomainContactPrivacy": "<p>This operation updates the specified domain contact's privacy setting. When the privacy option is enabled, personal information such as postal or email address is hidden from the results of a public WHOIS query. The privacy services are provided by the AWS registrar, Gandi. For more information, see the <a href=\"http://www.gandi.net/domain/whois/?currency=USD&amp;amp;lang=en\">Gandi privacy features</a>.</p> <p>This operation only affects the privacy of the specified contact type (registrant, administrator, or tech). Successful acceptance returns an operation ID that you can use with <a>GetOperationDetail</a> to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email.</p>",
     "UpdateDomainNameservers": "<p>This operation replaces the current set of name servers for the domain with the specified set of name servers. If you use Amazon Route 53 as your DNS service, specify the four name servers in the delegation set for the hosted zone for the domain.</p> <p>If successful, this operation returns an operation ID that you can use to track the progress and completion of the action. If the request is not completed successfully, the domain registrant will be notified by email.</p>",
-    "UpdateTagsForDomain": "<p>This operation adds or updates tags for a specified domain.</p> <p>All tag operations are eventually consistent; subsequent operations may not immediately represent all issued operations.</p>",
+    "UpdateTagsForDomain": "<p>This operation adds or updates tags for a specified domain.</p> <p>All tag operations are eventually consistent; subsequent operations might not immediately represent all issued operations.</p>",
     "ViewBilling": "<p>Returns all the domain-related billing records for the current AWS account for a specified period</p>"
   },
   "shapes": {
@@ -77,6 +78,16 @@
     },
     "CheckDomainAvailabilityResponse": {
       "base": "<p>The CheckDomainAvailability response includes the following elements.</p>",
+      "refs": {
+      }
+    },
+    "CheckDomainTransferabilityRequest": {
+      "base": "<p>The CheckDomainTransferability request contains the following elements.</p>",
+      "refs": {
+      }
+    },
+    "CheckDomainTransferabilityResponse": {
+      "base": "<p>The CheckDomainTransferability response includes the following elements.</p>",
       "refs": {
       }
     },
@@ -176,6 +187,7 @@
     "DomainAuthCode": {
       "base": null,
       "refs": {
+        "CheckDomainTransferabilityRequest$AuthCode": "<p>If the registrar for the top-level domain (TLD) requires an authorization code to transfer the domain, the code that you got from the current registrar for the domain.</p>",
         "RetrieveDomainAuthCodeResponse$AuthCode": "<p>The authorization code for the domain.</p>",
         "TransferDomainRequest$AuthCode": "<p>The authorization code for the domain. You get this value from the current registrar.</p>"
       }
@@ -183,7 +195,7 @@
     "DomainAvailability": {
       "base": null,
       "refs": {
-        "CheckDomainAvailabilityResponse$Availability": "<p>Whether the domain name is available for registering.</p> <note> <p>You can only register domains designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE_RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE_PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT_KNOW</dt> <dd> <p>The TLD registry didn't reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn't return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl>"
+        "CheckDomainAvailabilityResponse$Availability": "<p>Whether the domain name is available for registering.</p> <note> <p>You can register only domains designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE_RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE_PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT_KNOW</dt> <dd> <p>The TLD registry didn't reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn't return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl>"
       }
     },
     "DomainLimitExceeded": {
@@ -196,6 +208,7 @@
       "refs": {
         "BillingRecord$DomainName": "<p>The name of the domain that the billing record applies to. If the domain name contains characters other than a-z, 0-9, and - (hyphen), such as an internationalized domain name, then this value is in Punycode. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html\">DNS Domain Name Format</a> in the <i>Amazon Route 53 Developer Guidezzz</i>.</p>",
         "CheckDomainAvailabilityRequest$DomainName": "<p>The name of the domain that you want to get availability for.</p> <p>Constraints: The domain name can contain only the letters a through z, the numbers 0 through 9, and hyphen (-). Internationalized Domain Names are not supported.</p>",
+        "CheckDomainTransferabilityRequest$DomainName": "<p>The name of the domain that you want to transfer to Amazon Route 53.</p> <p>Constraints: The domain name can contain only the letters a through z, the numbers 0 through 9, and hyphen (-). Internationalized Domain Names are not supported.</p>",
         "DeleteTagsForDomainRequest$DomainName": "<p>The domain for which you want to delete one or more tags.</p>",
         "DisableDomainAutoRenewRequest$DomainName": "<p>The name of the domain that you want to disable automatic renewal for.</p>",
         "DisableDomainTransferLockRequest$DomainName": "<p>The name of the domain that you want to remove the transfer lock for.</p>",
@@ -258,6 +271,12 @@
         "ListDomainsResponse$Domains": "<p>A summary of domains.</p>"
       }
     },
+    "DomainTransferability": {
+      "base": null,
+      "refs": {
+        "CheckDomainTransferabilityResponse$Transferability": "<p>A complex type that contains information about whether the specified domain can be transferred to Amazon Route 53.</p>"
+      }
+    },
     "DuplicateRequest": {
       "base": "<p>The request is already in progress for the domain.</p>",
       "refs": {
@@ -305,10 +324,10 @@
         "DomainLimitExceeded$message": "<p>The number of domains has exceeded the allowed threshold for the account.</p>",
         "DuplicateRequest$message": "<p>The request is already in progress for the domain.</p>",
         "GetOperationDetailResponse$Message": "<p>Detailed information on the status including possible errors.</p>",
-        "InvalidInput$message": "<p>The requested item is not acceptable. For example, for an OperationId it may refer to the ID of an operation that is already completed. For a domain name, it may not be a valid domain name or belong to the requester account.</p>",
+        "InvalidInput$message": "<p>The requested item is not acceptable. For example, for an OperationId it might refer to the ID of an operation that is already completed. For a domain name, it might not be a valid domain name or belong to the requester account.</p>",
         "OperationLimitExceeded$message": "<p>The number of operations or jobs running exceeded the allowed threshold for the account.</p>",
         "TLDRulesViolation$message": "<p>The top-level domain does not support this operation.</p>",
-        "UnsupportedTLD$message": "<p>Amazon Route 53 does not support this top-level domain.</p>"
+        "UnsupportedTLD$message": "<p>Amazon Route 53 does not support this top-level domain (TLD).</p>"
       }
     },
     "ExtraParam": {
@@ -406,7 +425,7 @@
       }
     },
     "InvalidInput": {
-      "base": "<p>The requested item is not acceptable. For example, for an OperationId it may refer to the ID of an operation that is already completed. For a domain name, it may not be a valid domain name or belong to the requester account.</p>",
+      "base": "<p>The requested item is not acceptable. For example, for an OperationId it might refer to the ID of an operation that is already completed. For a domain name, it might not be a valid domain name or belong to the requester account.</p>",
       "refs": {
       }
     },
@@ -690,8 +709,14 @@
       "refs": {
       }
     },
+    "Transferable": {
+      "base": "<p>Whether the domain name can be transferred to Amazon Route 53.</p> <note> <p>You can transfer only domains that have a value of <code>TRANSFERABLE</code> for <code>Transferable</code>.</p> </note> <p>Valid values:</p> <dl> <dt>TRANSFERABLE</dt> <dd> <p>The domain name can be transferred to Amazon Route 53.</p> </dd> <dt>UNTRANSFERRABLE</dt> <dd> <p>The domain name can't be transferred to Amazon Route 53.</p> </dd> <dt>DONT_KNOW</dt> <dd> <p>Reserved for future use.</p> </dd> </dl>",
+      "refs": {
+        "DomainTransferability$Transferable": null
+      }
+    },
     "UnsupportedTLD": {
-      "base": "<p>Amazon Route 53 does not support this top-level domain.</p>",
+      "base": "<p>Amazon Route 53 does not support this top-level domain (TLD).</p>",
       "refs": {
       }
     },

--- a/service/kinesisanalytics/api.go
+++ b/service/kinesisanalytics/api.go
@@ -209,6 +209,98 @@ func (c *KinesisAnalytics) AddApplicationInputWithContext(ctx aws.Context, input
 	return out, req.Send()
 }
 
+const opAddApplicationInputProcessingConfiguration = "AddApplicationInputProcessingConfiguration"
+
+// AddApplicationInputProcessingConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the AddApplicationInputProcessingConfiguration operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AddApplicationInputProcessingConfiguration for more information on using the AddApplicationInputProcessingConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AddApplicationInputProcessingConfigurationRequest method.
+//    req, resp := client.AddApplicationInputProcessingConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/AddApplicationInputProcessingConfiguration
+func (c *KinesisAnalytics) AddApplicationInputProcessingConfigurationRequest(input *AddApplicationInputProcessingConfigurationInput) (req *request.Request, output *AddApplicationInputProcessingConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opAddApplicationInputProcessingConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &AddApplicationInputProcessingConfigurationInput{}
+	}
+
+	output = &AddApplicationInputProcessingConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// AddApplicationInputProcessingConfiguration API operation for Amazon Kinesis Analytics.
+//
+// Adds an InputProcessingConfiguration to an application. An input processor
+// preprocesses records on the input stream before the application's SQL code
+// executes. Currently, the only input processor available is AWS Lambda (https://aws.amazon.com/documentation/lambda/).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Analytics's
+// API operation AddApplicationInputProcessingConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   Specified application can't be found.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   Application is not available for this operation.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   Specified input parameter value is invalid.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Exception thrown as a result of concurrent modification to an application.
+//   For example, two individuals attempting to edit the same application at the
+//   same time.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/AddApplicationInputProcessingConfiguration
+func (c *KinesisAnalytics) AddApplicationInputProcessingConfiguration(input *AddApplicationInputProcessingConfigurationInput) (*AddApplicationInputProcessingConfigurationOutput, error) {
+	req, out := c.AddApplicationInputProcessingConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// AddApplicationInputProcessingConfigurationWithContext is the same as AddApplicationInputProcessingConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AddApplicationInputProcessingConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KinesisAnalytics) AddApplicationInputProcessingConfigurationWithContext(ctx aws.Context, input *AddApplicationInputProcessingConfigurationInput, opts ...request.Option) (*AddApplicationInputProcessingConfigurationOutput, error) {
+	req, out := c.AddApplicationInputProcessingConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opAddApplicationOutput = "AddApplicationOutput"
 
 // AddApplicationOutputRequest generates a "aws/request.Request" representing the
@@ -718,6 +810,96 @@ func (c *KinesisAnalytics) DeleteApplicationCloudWatchLoggingOption(input *Delet
 // for more information on using Contexts.
 func (c *KinesisAnalytics) DeleteApplicationCloudWatchLoggingOptionWithContext(ctx aws.Context, input *DeleteApplicationCloudWatchLoggingOptionInput, opts ...request.Option) (*DeleteApplicationCloudWatchLoggingOptionOutput, error) {
 	req, out := c.DeleteApplicationCloudWatchLoggingOptionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteApplicationInputProcessingConfiguration = "DeleteApplicationInputProcessingConfiguration"
+
+// DeleteApplicationInputProcessingConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteApplicationInputProcessingConfiguration operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteApplicationInputProcessingConfiguration for more information on using the DeleteApplicationInputProcessingConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteApplicationInputProcessingConfigurationRequest method.
+//    req, resp := client.DeleteApplicationInputProcessingConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DeleteApplicationInputProcessingConfiguration
+func (c *KinesisAnalytics) DeleteApplicationInputProcessingConfigurationRequest(input *DeleteApplicationInputProcessingConfigurationInput) (req *request.Request, output *DeleteApplicationInputProcessingConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteApplicationInputProcessingConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteApplicationInputProcessingConfigurationInput{}
+	}
+
+	output = &DeleteApplicationInputProcessingConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteApplicationInputProcessingConfiguration API operation for Amazon Kinesis Analytics.
+//
+// Deletes an InputProcessingConfiguration from an input.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Analytics's
+// API operation DeleteApplicationInputProcessingConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   Specified application can't be found.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   Application is not available for this operation.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   Specified input parameter value is invalid.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Exception thrown as a result of concurrent modification to an application.
+//   For example, two individuals attempting to edit the same application at the
+//   same time.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DeleteApplicationInputProcessingConfiguration
+func (c *KinesisAnalytics) DeleteApplicationInputProcessingConfiguration(input *DeleteApplicationInputProcessingConfigurationInput) (*DeleteApplicationInputProcessingConfigurationOutput, error) {
+	req, out := c.DeleteApplicationInputProcessingConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// DeleteApplicationInputProcessingConfigurationWithContext is the same as DeleteApplicationInputProcessingConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteApplicationInputProcessingConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KinesisAnalytics) DeleteApplicationInputProcessingConfigurationWithContext(ctx aws.Context, input *DeleteApplicationInputProcessingConfigurationInput, opts ...request.Option) (*DeleteApplicationInputProcessingConfigurationOutput, error) {
+	req, out := c.DeleteApplicationInputProcessingConfigurationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1594,9 +1776,7 @@ type AddApplicationInputInput struct {
 	// CurrentApplicationVersionId is a required field
 	CurrentApplicationVersionId *int64 `min:"1" type:"long" required:"true"`
 
-	// When you configure the application input, you specify the streaming source,
-	// the in-application stream name that is created, and the mapping between the
-	// two. For more information, see Configuring Application Input (http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html).
+	// The Input to add.
 	//
 	// Input is a required field
 	Input *Input `type:"structure" required:"true"`
@@ -1672,6 +1852,121 @@ func (s AddApplicationInputOutput) String() string {
 
 // GoString returns the string representation
 func (s AddApplicationInputOutput) GoString() string {
+	return s.String()
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/AddApplicationInputProcessingConfigurationRequest
+type AddApplicationInputProcessingConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Name of the application to which you want to add the input processing configuration.
+	//
+	// ApplicationName is a required field
+	ApplicationName *string `min:"1" type:"string" required:"true"`
+
+	// Version of the application to which you want to add the input processing
+	// configuration. You can use the DescribeApplication operation to get the current
+	// application version. If the version specified is not the current version,
+	// the ConcurrentModificationException is returned.
+	//
+	// CurrentApplicationVersionId is a required field
+	CurrentApplicationVersionId *int64 `min:"1" type:"long" required:"true"`
+
+	// The ID of the input configuration to which to add the input configuration.
+	// You can get a list of the input IDs for an application using the DescribeApplication
+	// operation.
+	//
+	// InputId is a required field
+	InputId *string `min:"1" type:"string" required:"true"`
+
+	// The InputProcessingConfiguration to add to the application.
+	//
+	// InputProcessingConfiguration is a required field
+	InputProcessingConfiguration *InputProcessingConfiguration `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AddApplicationInputProcessingConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddApplicationInputProcessingConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AddApplicationInputProcessingConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AddApplicationInputProcessingConfigurationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.CurrentApplicationVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CurrentApplicationVersionId"))
+	}
+	if s.CurrentApplicationVersionId != nil && *s.CurrentApplicationVersionId < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("CurrentApplicationVersionId", 1))
+	}
+	if s.InputId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputId"))
+	}
+	if s.InputId != nil && len(*s.InputId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputId", 1))
+	}
+	if s.InputProcessingConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputProcessingConfiguration"))
+	}
+	if s.InputProcessingConfiguration != nil {
+		if err := s.InputProcessingConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("InputProcessingConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *AddApplicationInputProcessingConfigurationInput) SetApplicationName(v string) *AddApplicationInputProcessingConfigurationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *AddApplicationInputProcessingConfigurationInput) SetCurrentApplicationVersionId(v int64) *AddApplicationInputProcessingConfigurationInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetInputId sets the InputId field's value.
+func (s *AddApplicationInputProcessingConfigurationInput) SetInputId(v string) *AddApplicationInputProcessingConfigurationInput {
+	s.InputId = &v
+	return s
+}
+
+// SetInputProcessingConfiguration sets the InputProcessingConfiguration field's value.
+func (s *AddApplicationInputProcessingConfigurationInput) SetInputProcessingConfiguration(v *InputProcessingConfiguration) *AddApplicationInputProcessingConfigurationInput {
+	s.InputProcessingConfiguration = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/AddApplicationInputProcessingConfigurationResponse
+type AddApplicationInputProcessingConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddApplicationInputProcessingConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AddApplicationInputProcessingConfigurationOutput) GoString() string {
 	return s.String()
 }
 
@@ -2764,6 +3059,99 @@ func (s *DeleteApplicationInput) SetCreateTimestamp(v time.Time) *DeleteApplicat
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DeleteApplicationInputProcessingConfigurationRequest
+type DeleteApplicationInputProcessingConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Kinesis Analytics application name.
+	//
+	// ApplicationName is a required field
+	ApplicationName *string `min:"1" type:"string" required:"true"`
+
+	// The version ID of the Kinesis Analytics application.
+	//
+	// CurrentApplicationVersionId is a required field
+	CurrentApplicationVersionId *int64 `min:"1" type:"long" required:"true"`
+
+	// The ID of the input configuration from which to delete the input configuration.
+	// You can get a list of the input IDs for an application using the DescribeApplication
+	// operation.
+	//
+	// InputId is a required field
+	InputId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteApplicationInputProcessingConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationInputProcessingConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteApplicationInputProcessingConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteApplicationInputProcessingConfigurationInput"}
+	if s.ApplicationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationName"))
+	}
+	if s.ApplicationName != nil && len(*s.ApplicationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationName", 1))
+	}
+	if s.CurrentApplicationVersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("CurrentApplicationVersionId"))
+	}
+	if s.CurrentApplicationVersionId != nil && *s.CurrentApplicationVersionId < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("CurrentApplicationVersionId", 1))
+	}
+	if s.InputId == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputId"))
+	}
+	if s.InputId != nil && len(*s.InputId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationName sets the ApplicationName field's value.
+func (s *DeleteApplicationInputProcessingConfigurationInput) SetApplicationName(v string) *DeleteApplicationInputProcessingConfigurationInput {
+	s.ApplicationName = &v
+	return s
+}
+
+// SetCurrentApplicationVersionId sets the CurrentApplicationVersionId field's value.
+func (s *DeleteApplicationInputProcessingConfigurationInput) SetCurrentApplicationVersionId(v int64) *DeleteApplicationInputProcessingConfigurationInput {
+	s.CurrentApplicationVersionId = &v
+	return s
+}
+
+// SetInputId sets the InputId field's value.
+func (s *DeleteApplicationInputProcessingConfigurationInput) SetInputId(v string) *DeleteApplicationInputProcessingConfigurationInput {
+	s.InputId = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DeleteApplicationInputProcessingConfigurationResponse
+type DeleteApplicationInputProcessingConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteApplicationInputProcessingConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationInputProcessingConfigurationOutput) GoString() string {
+	return s.String()
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DeleteApplicationResponse
 type DeleteApplicationOutput struct {
 	_ struct{} `type:"structure"`
@@ -3073,22 +3461,22 @@ func (s *DestinationSchema) SetRecordFormatType(v string) *DestinationSchema {
 type DiscoverInputSchemaInput struct {
 	_ struct{} `type:"structure"`
 
+	// The InputProcessingConfiguration to use to preprocess the records before
+	// discovering the schema of the records.
+	InputProcessingConfiguration *InputProcessingConfiguration `type:"structure"`
+
 	// Point at which you want Amazon Kinesis Analytics to start reading records
 	// from the specified streaming source discovery purposes.
-	//
-	// InputStartingPositionConfiguration is a required field
-	InputStartingPositionConfiguration *InputStartingPositionConfiguration `type:"structure" required:"true"`
+	InputStartingPositionConfiguration *InputStartingPositionConfiguration `type:"structure"`
 
 	// Amazon Resource Name (ARN) of the streaming source.
-	//
-	// ResourceARN is a required field
-	ResourceARN *string `min:"1" type:"string" required:"true"`
+	ResourceARN *string `min:"1" type:"string"`
 
 	// ARN of the IAM role that Amazon Kinesis Analytics can assume to access the
 	// stream on your behalf.
-	//
-	// RoleARN is a required field
-	RoleARN *string `min:"1" type:"string" required:"true"`
+	RoleARN *string `min:"1" type:"string"`
+
+	S3Configuration *S3Configuration `type:"structure"`
 }
 
 // String returns the string representation
@@ -3104,26 +3492,33 @@ func (s DiscoverInputSchemaInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DiscoverInputSchemaInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DiscoverInputSchemaInput"}
-	if s.InputStartingPositionConfiguration == nil {
-		invalidParams.Add(request.NewErrParamRequired("InputStartingPositionConfiguration"))
-	}
-	if s.ResourceARN == nil {
-		invalidParams.Add(request.NewErrParamRequired("ResourceARN"))
-	}
 	if s.ResourceARN != nil && len(*s.ResourceARN) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ResourceARN", 1))
 	}
-	if s.RoleARN == nil {
-		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
-	}
 	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+	if s.InputProcessingConfiguration != nil {
+		if err := s.InputProcessingConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("InputProcessingConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.S3Configuration != nil {
+		if err := s.S3Configuration.Validate(); err != nil {
+			invalidParams.AddNested("S3Configuration", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetInputProcessingConfiguration sets the InputProcessingConfiguration field's value.
+func (s *DiscoverInputSchemaInput) SetInputProcessingConfiguration(v *InputProcessingConfiguration) *DiscoverInputSchemaInput {
+	s.InputProcessingConfiguration = v
+	return s
 }
 
 // SetInputStartingPositionConfiguration sets the InputStartingPositionConfiguration field's value.
@@ -3144,6 +3539,12 @@ func (s *DiscoverInputSchemaInput) SetRoleARN(v string) *DiscoverInputSchemaInpu
 	return s
 }
 
+// SetS3Configuration sets the S3Configuration field's value.
+func (s *DiscoverInputSchemaInput) SetS3Configuration(v *S3Configuration) *DiscoverInputSchemaInput {
+	s.S3Configuration = v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/DiscoverInputSchemaResponse
 type DiscoverInputSchemaOutput struct {
 	_ struct{} `type:"structure"`
@@ -3156,6 +3557,10 @@ type DiscoverInputSchemaOutput struct {
 	// An array of elements, where each element corresponds to a row in a stream
 	// record (a stream record can have more than one row).
 	ParsedInputRecords [][]*string `type:"list"`
+
+	// Stream data that was modified by the processor specified in the InputProcessingConfiguration
+	// parameter.
+	ProcessedInputRecords []*string `type:"list"`
 
 	// Raw stream data that was sampled to infer the schema.
 	RawInputRecords []*string `type:"list"`
@@ -3183,6 +3588,12 @@ func (s *DiscoverInputSchemaOutput) SetParsedInputRecords(v [][]*string) *Discov
 	return s
 }
 
+// SetProcessedInputRecords sets the ProcessedInputRecords field's value.
+func (s *DiscoverInputSchemaOutput) SetProcessedInputRecords(v []*string) *DiscoverInputSchemaOutput {
+	s.ProcessedInputRecords = v
+	return s
+}
+
 // SetRawInputRecords sets the RawInputRecords field's value.
 func (s *DiscoverInputSchemaOutput) SetRawInputRecords(v []*string) *DiscoverInputSchemaOutput {
 	s.RawInputRecords = v
@@ -3202,6 +3613,12 @@ type Input struct {
 	//
 	// (see Configuring Application Input (http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html).
 	InputParallelism *InputParallelism `type:"structure"`
+
+	// The InputProcessingConfiguration for the Input. An input processor transforms
+	// records as they are received from the stream, before the application's SQL
+	// code executes. Currently, the only input processing configuration available
+	// is InputLambdaProcessor.
+	InputProcessingConfiguration *InputProcessingConfiguration `type:"structure"`
 
 	// Describes the format of the data in the streaming source, and how each data
 	// element maps to corresponding columns in the in-application stream that is
@@ -3263,6 +3680,11 @@ func (s *Input) Validate() error {
 			invalidParams.AddNested("InputParallelism", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.InputProcessingConfiguration != nil {
+		if err := s.InputProcessingConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("InputProcessingConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.InputSchema != nil {
 		if err := s.InputSchema.Validate(); err != nil {
 			invalidParams.AddNested("InputSchema", err.(request.ErrInvalidParams))
@@ -3288,6 +3710,12 @@ func (s *Input) Validate() error {
 // SetInputParallelism sets the InputParallelism field's value.
 func (s *Input) SetInputParallelism(v *InputParallelism) *Input {
 	s.InputParallelism = v
+	return s
+}
+
+// SetInputProcessingConfiguration sets the InputProcessingConfiguration field's value.
+func (s *Input) SetInputProcessingConfiguration(v *InputProcessingConfiguration) *Input {
+	s.InputProcessingConfiguration = v
 	return s
 }
 
@@ -3392,8 +3820,13 @@ type InputDescription struct {
 	// to the streaming source).
 	InputParallelism *InputParallelism `type:"structure"`
 
+	// The description of the preprocessor that executes on records in this input
+	// before the application's code is run.
+	InputProcessingConfigurationDescription *InputProcessingConfigurationDescription `type:"structure"`
+
 	// Describes the format of the data in the streaming source, and how each data
-	// element maps to corresponding columns created in the in-application stream.
+	// element maps to corresponding columns in the in-application stream that is
+	// being created.
 	InputSchema *SourceSchema `type:"structure"`
 
 	// Point at which the application is configured to read from the input stream.
@@ -3442,6 +3875,12 @@ func (s *InputDescription) SetInputParallelism(v *InputParallelism) *InputDescri
 	return s
 }
 
+// SetInputProcessingConfigurationDescription sets the InputProcessingConfigurationDescription field's value.
+func (s *InputDescription) SetInputProcessingConfigurationDescription(v *InputProcessingConfigurationDescription) *InputDescription {
+	s.InputProcessingConfigurationDescription = v
+	return s
+}
+
 // SetInputSchema sets the InputSchema field's value.
 func (s *InputDescription) SetInputSchema(v *SourceSchema) *InputDescription {
 	s.InputSchema = v
@@ -3469,6 +3908,158 @@ func (s *InputDescription) SetKinesisStreamsInputDescription(v *KinesisStreamsIn
 // SetNamePrefix sets the NamePrefix field's value.
 func (s *InputDescription) SetNamePrefix(v string) *InputDescription {
 	s.NamePrefix = &v
+	return s
+}
+
+// An object that contains the ARN of the AWS Lambda (https://aws.amazon.com/documentation/lambda/)
+// function that is used to preprocess records in the stream, and the ARN of
+// the IAM role used to access the AWS Lambda function.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputLambdaProcessor
+type InputLambdaProcessor struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the AWS Lambda (https://aws.amazon.com/documentation/lambda/)
+	// function that operates on records in the stream.
+	//
+	// ResourceARN is a required field
+	ResourceARN *string `min:"1" type:"string" required:"true"`
+
+	// The ARN of the IAM role used to access the AWS Lambda function.
+	//
+	// RoleARN is a required field
+	RoleARN *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s InputLambdaProcessor) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputLambdaProcessor) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputLambdaProcessor) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputLambdaProcessor"}
+	if s.ResourceARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceARN"))
+	}
+	if s.ResourceARN != nil && len(*s.ResourceARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceARN", 1))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *InputLambdaProcessor) SetResourceARN(v string) *InputLambdaProcessor {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *InputLambdaProcessor) SetRoleARN(v string) *InputLambdaProcessor {
+	s.RoleARN = &v
+	return s
+}
+
+// An object that contains the ARN of the AWS Lambda (https://aws.amazon.com/documentation/lambda/)
+// function that is used to preprocess records in the stream, and the ARN of
+// the IAM role used to access the AWS Lambda expression.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputLambdaProcessorDescription
+type InputLambdaProcessorDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the AWS Lambda (https://aws.amazon.com/documentation/lambda/)
+	// function that is used to preprocess the records in the stream.
+	ResourceARN *string `min:"1" type:"string"`
+
+	// The ARN of the IAM role used to access the AWS Lambda function.
+	RoleARN *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s InputLambdaProcessorDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputLambdaProcessorDescription) GoString() string {
+	return s.String()
+}
+
+// SetResourceARN sets the ResourceARN field's value.
+func (s *InputLambdaProcessorDescription) SetResourceARN(v string) *InputLambdaProcessorDescription {
+	s.ResourceARN = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *InputLambdaProcessorDescription) SetRoleARN(v string) *InputLambdaProcessorDescription {
+	s.RoleARN = &v
+	return s
+}
+
+// Represents an update to the InputLambdaProcessor that is used to preprocess
+// the records in the stream.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputLambdaProcessorUpdate
+type InputLambdaProcessorUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the new AWS Lambda (https://aws.amazon.com/documentation/lambda/)
+	// function that is used to preprocess the records in the stream.
+	ResourceARNUpdate *string `min:"1" type:"string"`
+
+	// The ARN of the new IAM role used to access the AWS Lambda function.
+	RoleARNUpdate *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s InputLambdaProcessorUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputLambdaProcessorUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputLambdaProcessorUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputLambdaProcessorUpdate"}
+	if s.ResourceARNUpdate != nil && len(*s.ResourceARNUpdate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceARNUpdate", 1))
+	}
+	if s.RoleARNUpdate != nil && len(*s.RoleARNUpdate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARNUpdate", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceARNUpdate sets the ResourceARNUpdate field's value.
+func (s *InputLambdaProcessorUpdate) SetResourceARNUpdate(v string) *InputLambdaProcessorUpdate {
+	s.ResourceARNUpdate = &v
+	return s
+}
+
+// SetRoleARNUpdate sets the RoleARNUpdate field's value.
+func (s *InputLambdaProcessorUpdate) SetRoleARNUpdate(v string) *InputLambdaProcessorUpdate {
+	s.RoleARNUpdate = &v
 	return s
 }
 
@@ -3548,6 +4139,125 @@ func (s *InputParallelismUpdate) Validate() error {
 // SetCountUpdate sets the CountUpdate field's value.
 func (s *InputParallelismUpdate) SetCountUpdate(v int64) *InputParallelismUpdate {
 	s.CountUpdate = &v
+	return s
+}
+
+// Provides a description of a processor that is used to preprocess the records
+// in the stream prior to being processed by your application code. Currently,
+// the only input processor available is AWS Lambda (https://aws.amazon.com/documentation/lambda/).
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputProcessingConfiguration
+type InputProcessingConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The InputLambdaProcessor that is used to preprocess the records in the stream
+	// prior to being processed by your application code.
+	//
+	// InputLambdaProcessor is a required field
+	InputLambdaProcessor *InputLambdaProcessor `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s InputProcessingConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputProcessingConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputProcessingConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputProcessingConfiguration"}
+	if s.InputLambdaProcessor == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputLambdaProcessor"))
+	}
+	if s.InputLambdaProcessor != nil {
+		if err := s.InputLambdaProcessor.Validate(); err != nil {
+			invalidParams.AddNested("InputLambdaProcessor", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInputLambdaProcessor sets the InputLambdaProcessor field's value.
+func (s *InputProcessingConfiguration) SetInputLambdaProcessor(v *InputLambdaProcessor) *InputProcessingConfiguration {
+	s.InputLambdaProcessor = v
+	return s
+}
+
+// Provides configuration information about an input processor. Currently, the
+// only input processor available is AWS Lambda (https://aws.amazon.com/documentation/lambda/).
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputProcessingConfigurationDescription
+type InputProcessingConfigurationDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Provides configuration information about the associated InputLambdaProcessorDescription.
+	InputLambdaProcessorDescription *InputLambdaProcessorDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s InputProcessingConfigurationDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputProcessingConfigurationDescription) GoString() string {
+	return s.String()
+}
+
+// SetInputLambdaProcessorDescription sets the InputLambdaProcessorDescription field's value.
+func (s *InputProcessingConfigurationDescription) SetInputLambdaProcessorDescription(v *InputLambdaProcessorDescription) *InputProcessingConfigurationDescription {
+	s.InputLambdaProcessorDescription = v
+	return s
+}
+
+// Describes updates to an InputProcessingConfiguration.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/InputProcessingConfigurationUpdate
+type InputProcessingConfigurationUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Provides update information for an InputLambdaProcessor.
+	//
+	// InputLambdaProcessorUpdate is a required field
+	InputLambdaProcessorUpdate *InputLambdaProcessorUpdate `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s InputProcessingConfigurationUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InputProcessingConfigurationUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputProcessingConfigurationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputProcessingConfigurationUpdate"}
+	if s.InputLambdaProcessorUpdate == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputLambdaProcessorUpdate"))
+	}
+	if s.InputLambdaProcessorUpdate != nil {
+		if err := s.InputLambdaProcessorUpdate.Validate(); err != nil {
+			invalidParams.AddNested("InputLambdaProcessorUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInputLambdaProcessorUpdate sets the InputLambdaProcessorUpdate field's value.
+func (s *InputProcessingConfigurationUpdate) SetInputLambdaProcessorUpdate(v *InputLambdaProcessorUpdate) *InputProcessingConfigurationUpdate {
+	s.InputLambdaProcessorUpdate = v
 	return s
 }
 
@@ -3675,6 +4385,9 @@ type InputUpdate struct {
 	// Kinesis Analytics creates for the specific streaming source).
 	InputParallelismUpdate *InputParallelismUpdate `type:"structure"`
 
+	// Describes updates for an input processing configuration.
+	InputProcessingConfigurationUpdate *InputProcessingConfigurationUpdate `type:"structure"`
+
 	// Describes the data format on the streaming source, and how record elements
 	// on the streaming source map to columns of the in-application stream that
 	// is created.
@@ -3721,6 +4434,11 @@ func (s *InputUpdate) Validate() error {
 			invalidParams.AddNested("InputParallelismUpdate", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.InputProcessingConfigurationUpdate != nil {
+		if err := s.InputProcessingConfigurationUpdate.Validate(); err != nil {
+			invalidParams.AddNested("InputProcessingConfigurationUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.InputSchemaUpdate != nil {
 		if err := s.InputSchemaUpdate.Validate(); err != nil {
 			invalidParams.AddNested("InputSchemaUpdate", err.(request.ErrInvalidParams))
@@ -3752,6 +4470,12 @@ func (s *InputUpdate) SetInputId(v string) *InputUpdate {
 // SetInputParallelismUpdate sets the InputParallelismUpdate field's value.
 func (s *InputUpdate) SetInputParallelismUpdate(v *InputParallelismUpdate) *InputUpdate {
 	s.InputParallelismUpdate = v
+	return s
+}
+
+// SetInputProcessingConfigurationUpdate sets the InputProcessingConfigurationUpdate field's value.
+func (s *InputUpdate) SetInputProcessingConfigurationUpdate(v *InputProcessingConfigurationUpdate) *InputUpdate {
+	s.InputProcessingConfigurationUpdate = v
 	return s
 }
 
@@ -3788,7 +4512,7 @@ type JSONMappingParameters struct {
 	// Path to the top-level parent that contains the records.
 	//
 	// RecordRowPath is a required field
-	RecordRowPath *string `type:"string" required:"true"`
+	RecordRowPath *string `min:"1" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -3806,6 +4530,9 @@ func (s *JSONMappingParameters) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "JSONMappingParameters"}
 	if s.RecordRowPath == nil {
 		invalidParams.Add(request.NewErrParamRequired("RecordRowPath"))
+	}
+	if s.RecordRowPath != nil && len(*s.RecordRowPath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RecordRowPath", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4857,7 +5584,7 @@ type RecordColumn struct {
 	// Type of column created in the in-application input stream or reference table.
 	//
 	// SqlType is a required field
-	SqlType *string `type:"string" required:"true"`
+	SqlType *string `min:"1" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -4878,6 +5605,9 @@ func (s *RecordColumn) Validate() error {
 	}
 	if s.SqlType == nil {
 		invalidParams.Add(request.NewErrParamRequired("SqlType"))
+	}
+	if s.SqlType != nil && len(*s.SqlType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SqlType", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5204,6 +5934,76 @@ func (s *ReferenceDataSourceUpdate) SetTableNameUpdate(v string) *ReferenceDataS
 	return s
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/kinesisanalytics-2015-08-14/S3Configuration
+type S3Configuration struct {
+	_ struct{} `type:"structure"`
+
+	// BucketARN is a required field
+	BucketARN *string `min:"1" type:"string" required:"true"`
+
+	// FileKey is a required field
+	FileKey *string `min:"1" type:"string" required:"true"`
+
+	// RoleARN is a required field
+	RoleARN *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s S3Configuration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s S3Configuration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *S3Configuration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "S3Configuration"}
+	if s.BucketARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("BucketARN"))
+	}
+	if s.BucketARN != nil && len(*s.BucketARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BucketARN", 1))
+	}
+	if s.FileKey == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileKey"))
+	}
+	if s.FileKey != nil && len(*s.FileKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileKey", 1))
+	}
+	if s.RoleARN == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoleARN"))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucketARN sets the BucketARN field's value.
+func (s *S3Configuration) SetBucketARN(v string) *S3Configuration {
+	s.BucketARN = &v
+	return s
+}
+
+// SetFileKey sets the FileKey field's value.
+func (s *S3Configuration) SetFileKey(v string) *S3Configuration {
+	s.FileKey = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *S3Configuration) SetRoleARN(v string) *S3Configuration {
+	s.RoleARN = &v
+	return s
+}
+
 // Identifies the S3 bucket and object that contains the reference data. Also
 // identifies the IAM role Amazon Kinesis Analytics can assume to read this
 // object on your behalf.
@@ -5223,7 +6023,7 @@ type S3ReferenceDataSource struct {
 	// Object key name containing reference data.
 	//
 	// FileKey is a required field
-	FileKey *string `type:"string" required:"true"`
+	FileKey *string `min:"1" type:"string" required:"true"`
 
 	// ARN of the IAM role that the service can assume to read data on your behalf.
 	// This role must have permission for the s3:GetObject action on the object
@@ -5255,6 +6055,9 @@ func (s *S3ReferenceDataSource) Validate() error {
 	}
 	if s.FileKey == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileKey"))
+	}
+	if s.FileKey != nil && len(*s.FileKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileKey", 1))
 	}
 	if s.ReferenceRoleARN == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReferenceRoleARN"))
@@ -5300,7 +6103,7 @@ type S3ReferenceDataSourceDescription struct {
 	// Amazon S3 object key name.
 	//
 	// FileKey is a required field
-	FileKey *string `type:"string" required:"true"`
+	FileKey *string `min:"1" type:"string" required:"true"`
 
 	// ARN of the IAM role that Amazon Kinesis Analytics can assume to read the
 	// Amazon S3 object on your behalf to populate the in-application reference
@@ -5349,7 +6152,7 @@ type S3ReferenceDataSourceUpdate struct {
 	BucketARNUpdate *string `min:"1" type:"string"`
 
 	// Object key name.
-	FileKeyUpdate *string `type:"string"`
+	FileKeyUpdate *string `min:"1" type:"string"`
 
 	// ARN of the IAM role that Amazon Kinesis Analytics can assume to read the
 	// Amazon S3 object and populate the in-application.
@@ -5371,6 +6174,9 @@ func (s *S3ReferenceDataSourceUpdate) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "S3ReferenceDataSourceUpdate"}
 	if s.BucketARNUpdate != nil && len(*s.BucketARNUpdate) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("BucketARNUpdate", 1))
+	}
+	if s.FileKeyUpdate != nil && len(*s.FileKeyUpdate) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileKeyUpdate", 1))
 	}
 	if s.ReferenceRoleARNUpdate != nil && len(*s.ReferenceRoleARNUpdate) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ReferenceRoleARNUpdate", 1))

--- a/service/kinesisanalytics/kinesisanalyticsiface/interface.go
+++ b/service/kinesisanalytics/kinesisanalyticsiface/interface.go
@@ -68,6 +68,10 @@ type KinesisAnalyticsAPI interface {
 	AddApplicationInputWithContext(aws.Context, *kinesisanalytics.AddApplicationInputInput, ...request.Option) (*kinesisanalytics.AddApplicationInputOutput, error)
 	AddApplicationInputRequest(*kinesisanalytics.AddApplicationInputInput) (*request.Request, *kinesisanalytics.AddApplicationInputOutput)
 
+	AddApplicationInputProcessingConfiguration(*kinesisanalytics.AddApplicationInputProcessingConfigurationInput) (*kinesisanalytics.AddApplicationInputProcessingConfigurationOutput, error)
+	AddApplicationInputProcessingConfigurationWithContext(aws.Context, *kinesisanalytics.AddApplicationInputProcessingConfigurationInput, ...request.Option) (*kinesisanalytics.AddApplicationInputProcessingConfigurationOutput, error)
+	AddApplicationInputProcessingConfigurationRequest(*kinesisanalytics.AddApplicationInputProcessingConfigurationInput) (*request.Request, *kinesisanalytics.AddApplicationInputProcessingConfigurationOutput)
+
 	AddApplicationOutput(*kinesisanalytics.AddApplicationOutputInput) (*kinesisanalytics.AddApplicationOutputOutput, error)
 	AddApplicationOutputWithContext(aws.Context, *kinesisanalytics.AddApplicationOutputInput, ...request.Option) (*kinesisanalytics.AddApplicationOutputOutput, error)
 	AddApplicationOutputRequest(*kinesisanalytics.AddApplicationOutputInput) (*request.Request, *kinesisanalytics.AddApplicationOutputOutput)
@@ -87,6 +91,10 @@ type KinesisAnalyticsAPI interface {
 	DeleteApplicationCloudWatchLoggingOption(*kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionInput) (*kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionOutput, error)
 	DeleteApplicationCloudWatchLoggingOptionWithContext(aws.Context, *kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionInput, ...request.Option) (*kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionOutput, error)
 	DeleteApplicationCloudWatchLoggingOptionRequest(*kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionInput) (*request.Request, *kinesisanalytics.DeleteApplicationCloudWatchLoggingOptionOutput)
+
+	DeleteApplicationInputProcessingConfiguration(*kinesisanalytics.DeleteApplicationInputProcessingConfigurationInput) (*kinesisanalytics.DeleteApplicationInputProcessingConfigurationOutput, error)
+	DeleteApplicationInputProcessingConfigurationWithContext(aws.Context, *kinesisanalytics.DeleteApplicationInputProcessingConfigurationInput, ...request.Option) (*kinesisanalytics.DeleteApplicationInputProcessingConfigurationOutput, error)
+	DeleteApplicationInputProcessingConfigurationRequest(*kinesisanalytics.DeleteApplicationInputProcessingConfigurationInput) (*request.Request, *kinesisanalytics.DeleteApplicationInputProcessingConfigurationOutput)
 
 	DeleteApplicationOutput(*kinesisanalytics.DeleteApplicationOutputInput) (*kinesisanalytics.DeleteApplicationOutputOutput, error)
 	DeleteApplicationOutputWithContext(aws.Context, *kinesisanalytics.DeleteApplicationOutputInput, ...request.Option) (*kinesisanalytics.DeleteApplicationOutputOutput, error)

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -69,11 +69,11 @@ func (c *Route53Domains) CheckDomainAvailabilityRequest(input *CheckDomainAvaila
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/CheckDomainAvailability
 func (c *Route53Domains) CheckDomainAvailability(input *CheckDomainAvailabilityInput) (*CheckDomainAvailabilityOutput, error) {
@@ -92,6 +92,90 @@ func (c *Route53Domains) CheckDomainAvailability(input *CheckDomainAvailabilityI
 // for more information on using Contexts.
 func (c *Route53Domains) CheckDomainAvailabilityWithContext(ctx aws.Context, input *CheckDomainAvailabilityInput, opts ...request.Option) (*CheckDomainAvailabilityOutput, error) {
 	req, out := c.CheckDomainAvailabilityRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCheckDomainTransferability = "CheckDomainTransferability"
+
+// CheckDomainTransferabilityRequest generates a "aws/request.Request" representing the
+// client's request for the CheckDomainTransferability operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CheckDomainTransferability for more information on using the CheckDomainTransferability
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CheckDomainTransferabilityRequest method.
+//    req, resp := client.CheckDomainTransferabilityRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/CheckDomainTransferability
+func (c *Route53Domains) CheckDomainTransferabilityRequest(input *CheckDomainTransferabilityInput) (req *request.Request, output *CheckDomainTransferabilityOutput) {
+	op := &request.Operation{
+		Name:       opCheckDomainTransferability,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CheckDomainTransferabilityInput{}
+	}
+
+	output = &CheckDomainTransferabilityOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CheckDomainTransferability API operation for Amazon Route 53 Domains.
+//
+// Checks whether a domain name can be transferred to Amazon Route 53.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Route 53 Domains's
+// API operation CheckDomainTransferability for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidInput "InvalidInput"
+//   The requested item is not acceptable. For example, for an OperationId it
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
+//
+//   * ErrCodeUnsupportedTLD "UnsupportedTLD"
+//   Amazon Route 53 does not support this top-level domain (TLD).
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/CheckDomainTransferability
+func (c *Route53Domains) CheckDomainTransferability(input *CheckDomainTransferabilityInput) (*CheckDomainTransferabilityOutput, error) {
+	req, out := c.CheckDomainTransferabilityRequest(input)
+	return out, req.Send()
+}
+
+// CheckDomainTransferabilityWithContext is the same as CheckDomainTransferability with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CheckDomainTransferability for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Route53Domains) CheckDomainTransferabilityWithContext(ctx aws.Context, input *CheckDomainTransferabilityInput, opts ...request.Option) (*CheckDomainTransferabilityOutput, error) {
+	req, out := c.CheckDomainTransferabilityRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -143,8 +227,8 @@ func (c *Route53Domains) DeleteTagsForDomainRequest(input *DeleteTagsForDomainIn
 //
 // This operation deletes the specified tags for a domain.
 //
-// All tag operations are eventually consistent; subsequent operations may not
-// immediately represent all issued operations.
+// All tag operations are eventually consistent; subsequent operations might
+// not immediately represent all issued operations.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -156,15 +240,15 @@ func (c *Route53Domains) DeleteTagsForDomainRequest(input *DeleteTagsForDomainIn
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeOperationLimitExceeded "OperationLimitExceeded"
 //   The number of operations or jobs running exceeded the allowed threshold for
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/DeleteTagsForDomain
 func (c *Route53Domains) DeleteTagsForDomain(input *DeleteTagsForDomainInput) (*DeleteTagsForDomainOutput, error) {
@@ -245,11 +329,11 @@ func (c *Route53Domains) DisableDomainAutoRenewRequest(input *DisableDomainAutoR
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/DisableDomainAutoRenew
 func (c *Route53Domains) DisableDomainAutoRenew(input *DisableDomainAutoRenewInput) (*DisableDomainAutoRenewOutput, error) {
@@ -335,8 +419,8 @@ func (c *Route53Domains) DisableDomainTransferLockRequest(input *DisableDomainTr
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -349,7 +433,7 @@ func (c *Route53Domains) DisableDomainTransferLockRequest(input *DisableDomainTr
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/DisableDomainTransferLock
 func (c *Route53Domains) DisableDomainTransferLock(input *DisableDomainTransferLockInput) (*DisableDomainTransferLockOutput, error) {
@@ -438,11 +522,11 @@ func (c *Route53Domains) EnableDomainAutoRenewRequest(input *EnableDomainAutoRen
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 //   * ErrCodeTLDRulesViolation "TLDRulesViolation"
 //   The top-level domain does not support this operation.
@@ -529,8 +613,8 @@ func (c *Route53Domains) EnableDomainTransferLockRequest(input *EnableDomainTran
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -543,7 +627,7 @@ func (c *Route53Domains) EnableDomainTransferLockRequest(input *EnableDomainTran
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/EnableDomainTransferLock
 func (c *Route53Domains) EnableDomainTransferLock(input *EnableDomainTransferLockInput) (*EnableDomainTransferLockOutput, error) {
@@ -628,15 +712,15 @@ func (c *Route53Domains) GetContactReachabilityStatusRequest(input *GetContactRe
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeOperationLimitExceeded "OperationLimitExceeded"
 //   The number of operations or jobs running exceeded the allowed threshold for
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/GetContactReachabilityStatus
 func (c *Route53Domains) GetContactReachabilityStatus(input *GetContactReachabilityStatusInput) (*GetContactReachabilityStatusOutput, error) {
@@ -718,11 +802,11 @@ func (c *Route53Domains) GetDomainDetailRequest(input *GetDomainDetailInput) (re
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/GetDomainDetail
 func (c *Route53Domains) GetDomainDetail(input *GetDomainDetailInput) (*GetDomainDetailOutput, error) {
@@ -804,11 +888,11 @@ func (c *Route53Domains) GetDomainSuggestionsRequest(input *GetDomainSuggestions
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/GetDomainSuggestions
 func (c *Route53Domains) GetDomainSuggestions(input *GetDomainSuggestionsInput) (*GetDomainSuggestionsOutput, error) {
@@ -888,8 +972,8 @@ func (c *Route53Domains) GetOperationDetailRequest(input *GetOperationDetailInpu
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/GetOperationDetail
 func (c *Route53Domains) GetOperationDetail(input *GetOperationDetailInput) (*GetOperationDetailOutput, error) {
@@ -976,8 +1060,8 @@ func (c *Route53Domains) ListDomainsRequest(input *ListDomainsInput) (req *reque
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/ListDomains
 func (c *Route53Domains) ListDomains(input *ListDomainsInput) (*ListDomainsOutput, error) {
@@ -1113,8 +1197,8 @@ func (c *Route53Domains) ListOperationsRequest(input *ListOperationsInput) (req 
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/ListOperations
 func (c *Route53Domains) ListOperations(input *ListOperationsInput) (*ListOperationsOutput, error) {
@@ -1235,8 +1319,8 @@ func (c *Route53Domains) ListTagsForDomainRequest(input *ListTagsForDomainInput)
 // This operation returns all of the tags that are associated with the specified
 // domain.
 //
-// All tag operations are eventually consistent; subsequent operations may not
-// immediately represent all issued operations.
+// All tag operations are eventually consistent; subsequent operations might
+// not immediately represent all issued operations.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1248,15 +1332,15 @@ func (c *Route53Domains) ListTagsForDomainRequest(input *ListTagsForDomainInput)
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeOperationLimitExceeded "OperationLimitExceeded"
 //   The number of operations or jobs running exceeded the allowed threshold for
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/ListTagsForDomain
 func (c *Route53Domains) ListTagsForDomain(input *ListTagsForDomainInput) (*ListTagsForDomainOutput, error) {
@@ -1360,11 +1444,11 @@ func (c *Route53Domains) RegisterDomainRequest(input *RegisterDomainInput) (req 
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -1464,11 +1548,11 @@ func (c *Route53Domains) RenewDomainRequest(input *RenewDomainInput) (req *reque
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -1560,15 +1644,15 @@ func (c *Route53Domains) ResendContactReachabilityEmailRequest(input *ResendCont
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeOperationLimitExceeded "OperationLimitExceeded"
 //   The number of operations or jobs running exceeded the allowed threshold for
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/ResendContactReachabilityEmail
 func (c *Route53Domains) ResendContactReachabilityEmail(input *ResendContactReachabilityEmailInput) (*ResendContactReachabilityEmailOutput, error) {
@@ -1649,11 +1733,11 @@ func (c *Route53Domains) RetrieveDomainAuthCodeRequest(input *RetrieveDomainAuth
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/RetrieveDomainAuthCode
 func (c *Route53Domains) RetrieveDomainAuthCode(input *RetrieveDomainAuthCodeInput) (*RetrieveDomainAuthCodeOutput, error) {
@@ -1757,11 +1841,11 @@ func (c *Route53Domains) TransferDomainRequest(input *TransferDomainInput) (req 
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -1861,8 +1945,8 @@ func (c *Route53Domains) UpdateDomainContactRequest(input *UpdateDomainContactIn
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -1875,7 +1959,7 @@ func (c *Route53Domains) UpdateDomainContactRequest(input *UpdateDomainContactIn
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/UpdateDomainContact
 func (c *Route53Domains) UpdateDomainContact(input *UpdateDomainContactInput) (*UpdateDomainContactOutput, error) {
@@ -1965,8 +2049,8 @@ func (c *Route53Domains) UpdateDomainContactPrivacyRequest(input *UpdateDomainCo
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -1979,7 +2063,7 @@ func (c *Route53Domains) UpdateDomainContactPrivacyRequest(input *UpdateDomainCo
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/UpdateDomainContactPrivacy
 func (c *Route53Domains) UpdateDomainContactPrivacy(input *UpdateDomainContactPrivacyInput) (*UpdateDomainContactPrivacyOutput, error) {
@@ -2066,8 +2150,8 @@ func (c *Route53Domains) UpdateDomainNameserversRequest(input *UpdateDomainNames
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeDuplicateRequest "DuplicateRequest"
 //   The request is already in progress for the domain.
@@ -2080,7 +2164,7 @@ func (c *Route53Domains) UpdateDomainNameserversRequest(input *UpdateDomainNames
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/UpdateDomainNameservers
 func (c *Route53Domains) UpdateDomainNameservers(input *UpdateDomainNameserversInput) (*UpdateDomainNameserversOutput, error) {
@@ -2150,8 +2234,8 @@ func (c *Route53Domains) UpdateTagsForDomainRequest(input *UpdateTagsForDomainIn
 //
 // This operation adds or updates tags for a specified domain.
 //
-// All tag operations are eventually consistent; subsequent operations may not
-// immediately represent all issued operations.
+// All tag operations are eventually consistent; subsequent operations might
+// not immediately represent all issued operations.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2163,15 +2247,15 @@ func (c *Route53Domains) UpdateTagsForDomainRequest(input *UpdateTagsForDomainIn
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 //   * ErrCodeOperationLimitExceeded "OperationLimitExceeded"
 //   The number of operations or jobs running exceeded the allowed threshold for
 //   the account.
 //
 //   * ErrCodeUnsupportedTLD "UnsupportedTLD"
-//   Amazon Route 53 does not support this top-level domain.
+//   Amazon Route 53 does not support this top-level domain (TLD).
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/UpdateTagsForDomain
 func (c *Route53Domains) UpdateTagsForDomain(input *UpdateTagsForDomainInput) (*UpdateTagsForDomainOutput, error) {
@@ -2252,8 +2336,8 @@ func (c *Route53Domains) ViewBillingRequest(input *ViewBillingInput) (req *reque
 // Returned Error Codes:
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The requested item is not acceptable. For example, for an OperationId it
-//   may refer to the ID of an operation that is already completed. For a domain
-//   name, it may not be a valid domain name or belong to the requester account.
+//   might refer to the ID of an operation that is already completed. For a domain
+//   name, it might not be a valid domain name or belong to the requester account.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/ViewBilling
 func (c *Route53Domains) ViewBilling(input *ViewBillingInput) (*ViewBillingOutput, error) {
@@ -2404,7 +2488,7 @@ type CheckDomainAvailabilityOutput struct {
 
 	// Whether the domain name is available for registering.
 	//
-	// You can only register domains designated as AVAILABLE.
+	// You can register only domains designated as AVAILABLE.
 	//
 	// Valid values:
 	//
@@ -2448,6 +2532,89 @@ func (s CheckDomainAvailabilityOutput) GoString() string {
 // SetAvailability sets the Availability field's value.
 func (s *CheckDomainAvailabilityOutput) SetAvailability(v string) *CheckDomainAvailabilityOutput {
 	s.Availability = &v
+	return s
+}
+
+// The CheckDomainTransferability request contains the following elements.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/CheckDomainTransferabilityRequest
+type CheckDomainTransferabilityInput struct {
+	_ struct{} `type:"structure"`
+
+	// If the registrar for the top-level domain (TLD) requires an authorization
+	// code to transfer the domain, the code that you got from the current registrar
+	// for the domain.
+	AuthCode *string `type:"string"`
+
+	// The name of the domain that you want to transfer to Amazon Route 53.
+	//
+	// Constraints: The domain name can contain only the letters a through z, the
+	// numbers 0 through 9, and hyphen (-). Internationalized Domain Names are not
+	// supported.
+	//
+	// DomainName is a required field
+	DomainName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CheckDomainTransferabilityInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CheckDomainTransferabilityInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CheckDomainTransferabilityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CheckDomainTransferabilityInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthCode sets the AuthCode field's value.
+func (s *CheckDomainTransferabilityInput) SetAuthCode(v string) *CheckDomainTransferabilityInput {
+	s.AuthCode = &v
+	return s
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *CheckDomainTransferabilityInput) SetDomainName(v string) *CheckDomainTransferabilityInput {
+	s.DomainName = &v
+	return s
+}
+
+// The CheckDomainTransferability response includes the following elements.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/CheckDomainTransferabilityResponse
+type CheckDomainTransferabilityOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A complex type that contains information about whether the specified domain
+	// can be transferred to Amazon Route 53.
+	//
+	// Transferability is a required field
+	Transferability *DomainTransferability `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s CheckDomainTransferabilityOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CheckDomainTransferabilityOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransferability sets the Transferability field's value.
+func (s *CheckDomainTransferabilityOutput) SetTransferability(v *DomainTransferability) *CheckDomainTransferabilityOutput {
+	s.Transferability = v
 	return s
 }
 
@@ -2927,6 +3094,40 @@ func (s *DomainSummary) SetExpiry(v time.Time) *DomainSummary {
 // SetTransferLock sets the TransferLock field's value.
 func (s *DomainSummary) SetTransferLock(v bool) *DomainSummary {
 	s.TransferLock = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/route53domains-2014-05-15/DomainTransferability
+type DomainTransferability struct {
+	_ struct{} `type:"structure"`
+
+	// Whether the domain name can be transferred to Amazon Route 53.
+	//
+	// You can transfer only domains that have a value of TRANSFERABLE for Transferable.
+	//
+	// Valid values:
+	//
+	// TRANSFERABLEThe domain name can be transferred to Amazon Route 53.
+	//
+	// UNTRANSFERRABLEThe domain name can't be transferred to Amazon Route 53.
+	//
+	// DONT_KNOWReserved for future use.
+	Transferable *string `type:"string" enum:"Transferable"`
+}
+
+// String returns the string representation
+func (s DomainTransferability) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DomainTransferability) GoString() string {
+	return s.String()
+}
+
+// SetTransferable sets the Transferable field's value.
+func (s *DomainTransferability) SetTransferable(v string) *DomainTransferability {
+	s.Transferable = &v
 	return s
 }
 
@@ -4978,7 +5179,7 @@ type UpdateDomainNameserversInput struct {
 	DomainName *string `type:"string" required:"true"`
 
 	// The authorization key for .fi domains
-	FIAuthKey *string `type:"string"`
+	FIAuthKey *string `deprecated:"true" type:"string"`
 
 	// A list of new name servers for the domain.
 	//
@@ -6014,8 +6215,17 @@ const (
 	// ExtraParamNameFiIdNumber is a ExtraParamName enum value
 	ExtraParamNameFiIdNumber = "FI_ID_NUMBER"
 
+	// ExtraParamNameFiNationality is a ExtraParamName enum value
+	ExtraParamNameFiNationality = "FI_NATIONALITY"
+
+	// ExtraParamNameFiOrganizationType is a ExtraParamName enum value
+	ExtraParamNameFiOrganizationType = "FI_ORGANIZATION_TYPE"
+
 	// ExtraParamNameItPin is a ExtraParamName enum value
 	ExtraParamNameItPin = "IT_PIN"
+
+	// ExtraParamNameItRegistrantEntityType is a ExtraParamName enum value
+	ExtraParamNameItRegistrantEntityType = "IT_REGISTRANT_ENTITY_TYPE"
 
 	// ExtraParamNameRuPassportData is a ExtraParamName enum value
 	ExtraParamNameRuPassportData = "RU_PASSPORT_DATA"
@@ -6028,6 +6238,12 @@ const (
 
 	// ExtraParamNameVatNumber is a ExtraParamName enum value
 	ExtraParamNameVatNumber = "VAT_NUMBER"
+
+	// ExtraParamNameUkContactType is a ExtraParamName enum value
+	ExtraParamNameUkContactType = "UK_CONTACT_TYPE"
+
+	// ExtraParamNameUkCompanyNumber is a ExtraParamName enum value
+	ExtraParamNameUkCompanyNumber = "UK_COMPANY_NUMBER"
 )
 
 const (
@@ -6068,6 +6284,33 @@ const (
 
 	// OperationTypeDomainLock is a OperationType enum value
 	OperationTypeDomainLock = "DOMAIN_LOCK"
+
+	// OperationTypeEnableAutorenew is a OperationType enum value
+	OperationTypeEnableAutorenew = "ENABLE_AUTORENEW"
+
+	// OperationTypeDisableAutorenew is a OperationType enum value
+	OperationTypeDisableAutorenew = "DISABLE_AUTORENEW"
+
+	// OperationTypeAddDnssec is a OperationType enum value
+	OperationTypeAddDnssec = "ADD_DNSSEC"
+
+	// OperationTypeRemoveDnssec is a OperationType enum value
+	OperationTypeRemoveDnssec = "REMOVE_DNSSEC"
+
+	// OperationTypeExpireDomain is a OperationType enum value
+	OperationTypeExpireDomain = "EXPIRE_DOMAIN"
+
+	// OperationTypeTransferOutDomain is a OperationType enum value
+	OperationTypeTransferOutDomain = "TRANSFER_OUT_DOMAIN"
+
+	// OperationTypeChangeDomainOwner is a OperationType enum value
+	OperationTypeChangeDomainOwner = "CHANGE_DOMAIN_OWNER"
+
+	// OperationTypeRenewDomain is a OperationType enum value
+	OperationTypeRenewDomain = "RENEW_DOMAIN"
+
+	// OperationTypePushDomain is a OperationType enum value
+	OperationTypePushDomain = "PUSH_DOMAIN"
 )
 
 const (
@@ -6079,4 +6322,26 @@ const (
 
 	// ReachabilityStatusExpired is a ReachabilityStatus enum value
 	ReachabilityStatusExpired = "EXPIRED"
+)
+
+// Whether the domain name can be transferred to Amazon Route 53.
+//
+// You can transfer only domains that have a value of TRANSFERABLE for Transferable.
+//
+// Valid values:
+//
+// TRANSFERABLEThe domain name can be transferred to Amazon Route 53.
+//
+// UNTRANSFERRABLEThe domain name can't be transferred to Amazon Route 53.
+//
+// DONT_KNOWReserved for future use.
+const (
+	// TransferableTransferable is a Transferable enum value
+	TransferableTransferable = "TRANSFERABLE"
+
+	// TransferableUntransferable is a Transferable enum value
+	TransferableUntransferable = "UNTRANSFERABLE"
+
+	// TransferableDontKnow is a Transferable enum value
+	TransferableDontKnow = "DONT_KNOW"
 )

--- a/service/route53domains/errors.go
+++ b/service/route53domains/errors.go
@@ -20,8 +20,8 @@ const (
 	// "InvalidInput".
 	//
 	// The requested item is not acceptable. For example, for an OperationId it
-	// may refer to the ID of an operation that is already completed. For a domain
-	// name, it may not be a valid domain name or belong to the requester account.
+	// might refer to the ID of an operation that is already completed. For a domain
+	// name, it might not be a valid domain name or belong to the requester account.
 	ErrCodeInvalidInput = "InvalidInput"
 
 	// ErrCodeOperationLimitExceeded for service response error code
@@ -40,6 +40,6 @@ const (
 	// ErrCodeUnsupportedTLD for service response error code
 	// "UnsupportedTLD".
 	//
-	// Amazon Route 53 does not support this top-level domain.
+	// Amazon Route 53 does not support this top-level domain (TLD).
 	ErrCodeUnsupportedTLD = "UnsupportedTLD"
 )

--- a/service/route53domains/route53domainsiface/interface.go
+++ b/service/route53domains/route53domainsiface/interface.go
@@ -64,6 +64,10 @@ type Route53DomainsAPI interface {
 	CheckDomainAvailabilityWithContext(aws.Context, *route53domains.CheckDomainAvailabilityInput, ...request.Option) (*route53domains.CheckDomainAvailabilityOutput, error)
 	CheckDomainAvailabilityRequest(*route53domains.CheckDomainAvailabilityInput) (*request.Request, *route53domains.CheckDomainAvailabilityOutput)
 
+	CheckDomainTransferability(*route53domains.CheckDomainTransferabilityInput) (*route53domains.CheckDomainTransferabilityOutput, error)
+	CheckDomainTransferabilityWithContext(aws.Context, *route53domains.CheckDomainTransferabilityInput, ...request.Option) (*route53domains.CheckDomainTransferabilityOutput, error)
+	CheckDomainTransferabilityRequest(*route53domains.CheckDomainTransferabilityInput) (*request.Request, *route53domains.CheckDomainTransferabilityOutput)
+
 	DeleteTagsForDomain(*route53domains.DeleteTagsForDomainInput) (*route53domains.DeleteTagsForDomainOutput, error)
 	DeleteTagsForDomainWithContext(aws.Context, *route53domains.DeleteTagsForDomainInput, ...request.Option) (*route53domains.DeleteTagsForDomainOutput, error)
 	DeleteTagsForDomainRequest(*route53domains.DeleteTagsForDomainInput) (*request.Request, *route53domains.DeleteTagsForDomainOutput)


### PR DESCRIPTION
Release v1.12.5 (2017-10-04)
===

### Service Client Updates
* `service/kinesisanalytics`: Updates service API and documentation
  * Kinesis Analytics now supports schema discovery on objects in S3. Additionally, Kinesis Analytics now supports input data preprocessing through Lambda.
* `service/route53domains`: Updates service API and documentation
  * Added a new API that checks whether a domain name can be transferred to Amazon Route 53.

### SDK Bugs
* `service/s3/s3crypto`: Correct PutObjectRequest documentation ([#1568](https://github.com/aws/aws-sdk-go/pull/1568))
  * s3Crypto's PutObjectRequest docstring example was using an incorrect value. Corrected the type used in the example.
