### PR TITLE
service/dynamodb/dynamodbattribute: Add support for using json.Number with dynamodbattribute Encoder & Decoder

### DIFF
--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -202,6 +202,12 @@ type Encoder struct {
 	//
 	// Enabled by default.
 	NullEmptyString bool
+
+	// Recognise encoding/json.Number and marshal to the DynamoDB Number type
+	// (otherwise, marshal to String)
+	//
+	// Enabled by default.
+	SupportJSONNumber bool
 }
 
 // NewEncoder creates a new Encoder with default configuration. Use
@@ -211,7 +217,8 @@ func NewEncoder(opts ...func(*Encoder)) *Encoder {
 		MarshalOptions: MarshalOptions{
 			SupportJSONTags: true,
 		},
-		NullEmptyString: true,
+		NullEmptyString:   true,
+		SupportJSONNumber: true,
 	}
 	for _, o := range opts {
 		o(e)
@@ -438,7 +445,7 @@ func (e *Encoder) encodeList(v reflect.Value, fieldTag tag, elemFn func(dynamodb
 }
 
 func (e *Encoder) encodeScalar(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
-	if v.Type() == numberType {
+	if v.Type() == numberType || (e.SupportJSONNumber && (v.Type() == jsonNumberType)) {
 		s := v.String()
 		if fieldTag.AsString {
 			av.S = &s


### PR DESCRIPTION
This allows json.Number to be used with the dynamodbattribute Encoder and Decoder types, in a similar manner to how dynamodbattribute.Number can be used. The benefit of using json.Number over dynamodbattribute.Number is that it will work out-of-the-box with code that's designed to be compatible with Go's JSON serialisation.

E.g. I'm currently trying to write some code to allow arbitrary JSON data to be stored in DynamoDB, using map[string]interface{} as the intermediate form. But the library which is handling the JSON deserialisation for me is deserialising the numbers as json.Number, which the current AWS SDK will convert to the DynamoDB String type. When attempting to read the data back and convert back to the original JSON this obviously results in all numbers being returned as strings.

I did consider handling this in my own code by writing a bunch of reflection code that would convert the structure between json.Number and dynamodbattribute.Number, but adding a few lines of code directly to the AWS SDK seemed like the better choice.

On the other hand, this might be the start of a slippery slope of people requesting support for their favourite data types, so maybe this would be better if it was handled some other way?