### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Option's SharedConfigState parameter.
   }))
 ```
 
-[credentials_pkg]: ttps://docs.aws.amazon.com/sdk-for-go/api/aws/credentials
+[credentials_pkg]: https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials
 
 ### Configuring AWS Region
 


### PR DESCRIPTION
Missing 'h' in URL to credentials package.

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
