### PR TITLE
aws/session: Fix testing bug in non-dev environment

### DIFF
--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -91,7 +91,8 @@ func TestSessionCopy(t *testing.T) {
 
 func TestSessionClientConfig(t *testing.T) {
 	s, err := NewSession(&aws.Config{
-		Region: aws.String("orig_region"),
+		Credentials: credentials.AnonymousCredentials,
+		Region:      aws.String("orig_region"),
 		EndpointResolver: endpoints.ResolverFunc(
 			func(service, region string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 				if e, a := "mock-service", service; e != a {


### PR DESCRIPTION
Fixes a session testing bug that caused the test to fail if not run in an environment with shared credentials file.