### PR TITLE
Update Travis build on branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ script:
 matrix:
   allow_failures:
     - go: tip
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Updates the travis auto builds to only build on `master` branch commits.
PRs are still all built.

This prevents travis from building branch+PR twice. Creating unneeded build jobs.