### PR TITLE
Fixup SDK service client generated docstring

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -371,7 +371,7 @@ var tplServiceDoc = template.Must(template.New("service docs").Funcs(template.Fu
 //
 // Using the Client
 //
-// To {{ .Metadata.ServiceFullName }} with the SDK use the New function to create
+// To contact {{ .Metadata.ServiceFullName }} with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/acm/doc.go
+++ b/service/acm/doc.go
@@ -16,7 +16,7 @@
 //
 // Using the Client
 //
-// To AWS Certificate Manager with the SDK use the New function to create
+// To contact AWS Certificate Manager with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/apigateway/doc.go
+++ b/service/apigateway/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To Amazon API Gateway with the SDK use the New function to create
+// To contact Amazon API Gateway with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/applicationautoscaling/doc.go
+++ b/service/applicationautoscaling/doc.go
@@ -47,7 +47,7 @@
 //
 // Using the Client
 //
-// To Application Auto Scaling with the SDK use the New function to create
+// To contact Application Auto Scaling with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/applicationdiscoveryservice/doc.go
+++ b/service/applicationdiscoveryservice/doc.go
@@ -71,7 +71,7 @@
 //
 // Using the Client
 //
-// To AWS Application Discovery Service with the SDK use the New function to create
+// To contact AWS Application Discovery Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/appstream/doc.go
+++ b/service/appstream/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To Amazon AppStream with the SDK use the New function to create
+// To contact Amazon AppStream with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/athena/doc.go
+++ b/service/athena/doc.go
@@ -23,7 +23,7 @@
 //
 // Using the Client
 //
-// To Amazon Athena with the SDK use the New function to create
+// To contact Amazon Athena with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/autoscaling/doc.go
+++ b/service/autoscaling/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To Auto Scaling with the SDK use the New function to create
+// To contact Auto Scaling with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/batch/doc.go
+++ b/service/batch/doc.go
@@ -28,7 +28,7 @@
 //
 // Using the Client
 //
-// To AWS Batch with the SDK use the New function to create
+// To contact AWS Batch with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/budgets/doc.go
+++ b/service/budgets/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To AWS Budgets with the SDK use the New function to create
+// To contact AWS Budgets with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/clouddirectory/doc.go
+++ b/service/clouddirectory/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudDirectory with the SDK use the New function to create
+// To contact Amazon CloudDirectory with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudformation/doc.go
+++ b/service/cloudformation/doc.go
@@ -30,7 +30,7 @@
 //
 // Using the Client
 //
-// To AWS CloudFormation with the SDK use the New function to create
+// To contact AWS CloudFormation with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudfront/doc.go
+++ b/service/cloudfront/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudFront with the SDK use the New function to create
+// To contact Amazon CloudFront with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudhsm/doc.go
+++ b/service/cloudhsm/doc.go
@@ -19,7 +19,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudHSM with the SDK use the New function to create
+// To contact Amazon CloudHSM with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudhsmv2/doc.go
+++ b/service/cloudhsmv2/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To AWS CloudHSM V2 with the SDK use the New function to create
+// To contact AWS CloudHSM V2 with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudsearch/doc.go
+++ b/service/cloudsearch/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudSearch with the SDK use the New function to create
+// To contact Amazon CloudSearch with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudsearchdomain/doc.go
+++ b/service/cloudsearchdomain/doc.go
@@ -19,7 +19,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudSearch Domain with the SDK use the New function to create
+// To contact Amazon CloudSearch Domain with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudtrail/doc.go
+++ b/service/cloudtrail/doc.go
@@ -32,7 +32,7 @@
 //
 // Using the Client
 //
-// To AWS CloudTrail with the SDK use the New function to create
+// To contact AWS CloudTrail with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudwatch/doc.go
+++ b/service/cloudwatch/doc.go
@@ -26,7 +26,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudWatch with the SDK use the New function to create
+// To contact Amazon CloudWatch with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudwatchevents/doc.go
+++ b/service/cloudwatchevents/doc.go
@@ -29,7 +29,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudWatch Events with the SDK use the New function to create
+// To contact Amazon CloudWatch Events with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cloudwatchlogs/doc.go
+++ b/service/cloudwatchlogs/doc.go
@@ -41,7 +41,7 @@
 //
 // Using the Client
 //
-// To Amazon CloudWatch Logs with the SDK use the New function to create
+// To contact Amazon CloudWatch Logs with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/codebuild/doc.go
+++ b/service/codebuild/doc.go
@@ -67,7 +67,7 @@
 //
 // Using the Client
 //
-// To AWS CodeBuild with the SDK use the New function to create
+// To contact AWS CodeBuild with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/codecommit/doc.go
+++ b/service/codecommit/doc.go
@@ -76,7 +76,7 @@
 //
 // Using the Client
 //
-// To AWS CodeCommit with the SDK use the New function to create
+// To contact AWS CodeCommit with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/codedeploy/doc.go
+++ b/service/codedeploy/doc.go
@@ -65,7 +65,7 @@
 //
 // Using the Client
 //
-// To AWS CodeDeploy with the SDK use the New function to create
+// To contact AWS CodeDeploy with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/codepipeline/doc.go
+++ b/service/codepipeline/doc.go
@@ -124,7 +124,7 @@
 //
 // Using the Client
 //
-// To AWS CodePipeline with the SDK use the New function to create
+// To contact AWS CodePipeline with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/codestar/doc.go
+++ b/service/codestar/doc.go
@@ -60,7 +60,7 @@
 //
 // Using the Client
 //
-// To AWS CodeStar with the SDK use the New function to create
+// To contact AWS CodeStar with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cognitoidentity/doc.go
+++ b/service/cognitoidentity/doc.go
@@ -43,7 +43,7 @@
 //
 // Using the Client
 //
-// To Amazon Cognito Identity with the SDK use the New function to create
+// To contact Amazon Cognito Identity with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cognitoidentityprovider/doc.go
+++ b/service/cognitoidentityprovider/doc.go
@@ -19,7 +19,7 @@
 //
 // Using the Client
 //
-// To Amazon Cognito Identity Provider with the SDK use the New function to create
+// To contact Amazon Cognito Identity Provider with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/cognitosync/doc.go
+++ b/service/cognitosync/doc.go
@@ -29,7 +29,7 @@
 //
 // Using the Client
 //
-// To Amazon Cognito Sync with the SDK use the New function to create
+// To contact Amazon Cognito Sync with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/configservice/doc.go
+++ b/service/configservice/doc.go
@@ -35,7 +35,7 @@
 //
 // Using the Client
 //
-// To AWS Config with the SDK use the New function to create
+// To contact AWS Config with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/costandusagereportservice/doc.go
+++ b/service/costandusagereportservice/doc.go
@@ -12,7 +12,7 @@
 //
 // Using the Client
 //
-// To AWS Cost and Usage Report Service with the SDK use the New function to create
+// To contact AWS Cost and Usage Report Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/databasemigrationservice/doc.go
+++ b/service/databasemigrationservice/doc.go
@@ -21,7 +21,7 @@
 //
 // Using the Client
 //
-// To AWS Database Migration Service with the SDK use the New function to create
+// To contact AWS Database Migration Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/datapipeline/doc.go
+++ b/service/datapipeline/doc.go
@@ -33,7 +33,7 @@
 //
 // Using the Client
 //
-// To AWS Data Pipeline with the SDK use the New function to create
+// To contact AWS Data Pipeline with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/dax/doc.go
+++ b/service/dax/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To Amazon DynamoDB Accelerator (DAX) with the SDK use the New function to create
+// To contact Amazon DynamoDB Accelerator (DAX) with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/devicefarm/doc.go
+++ b/service/devicefarm/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To AWS Device Farm with the SDK use the New function to create
+// To contact AWS Device Farm with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/directconnect/doc.go
+++ b/service/directconnect/doc.go
@@ -23,7 +23,7 @@
 //
 // Using the Client
 //
-// To AWS Direct Connect with the SDK use the New function to create
+// To contact AWS Direct Connect with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/directoryservice/doc.go
+++ b/service/directoryservice/doc.go
@@ -24,7 +24,7 @@
 //
 // Using the Client
 //
-// To AWS Directory Service with the SDK use the New function to create
+// To contact AWS Directory Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/dynamodb/doc.go
+++ b/service/dynamodb/doc.go
@@ -29,7 +29,7 @@
 //
 // Using the Client
 //
-// To Amazon DynamoDB with the SDK use the New function to create
+// To contact Amazon DynamoDB with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/dynamodbstreams/doc.go
+++ b/service/dynamodbstreams/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To Amazon DynamoDB Streams with the SDK use the New function to create
+// To contact Amazon DynamoDB Streams with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/ec2/doc.go
+++ b/service/ec2/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To Amazon Elastic Compute Cloud with the SDK use the New function to create
+// To contact Amazon Elastic Compute Cloud with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/ecr/doc.go
+++ b/service/ecr/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To Amazon EC2 Container Registry with the SDK use the New function to create
+// To contact Amazon EC2 Container Registry with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/ecs/doc.go
+++ b/service/ecs/doc.go
@@ -23,7 +23,7 @@
 //
 // Using the Client
 //
-// To Amazon EC2 Container Service with the SDK use the New function to create
+// To contact Amazon EC2 Container Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/efs/doc.go
+++ b/service/efs/doc.go
@@ -16,7 +16,7 @@
 //
 // Using the Client
 //
-// To Amazon Elastic File System with the SDK use the New function to create
+// To contact Amazon Elastic File System with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elasticache/doc.go
+++ b/service/elasticache/doc.go
@@ -22,7 +22,7 @@
 //
 // Using the Client
 //
-// To Amazon ElastiCache with the SDK use the New function to create
+// To contact Amazon ElastiCache with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elasticbeanstalk/doc.go
+++ b/service/elasticbeanstalk/doc.go
@@ -28,7 +28,7 @@
 //
 // Using the Client
 //
-// To AWS Elastic Beanstalk with the SDK use the New function to create
+// To contact AWS Elastic Beanstalk with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elasticsearchservice/doc.go
+++ b/service/elasticsearchservice/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To Amazon Elasticsearch Service with the SDK use the New function to create
+// To contact Amazon Elasticsearch Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elastictranscoder/doc.go
+++ b/service/elastictranscoder/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Elastic Transcoder with the SDK use the New function to create
+// To contact Amazon Elastic Transcoder with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elb/doc.go
+++ b/service/elb/doc.go
@@ -39,7 +39,7 @@
 //
 // Using the Client
 //
-// To Elastic Load Balancing with the SDK use the New function to create
+// To contact Elastic Load Balancing with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/elbv2/doc.go
+++ b/service/elbv2/doc.go
@@ -60,7 +60,7 @@
 //
 // Using the Client
 //
-// To Elastic Load Balancing with the SDK use the New function to create
+// To contact Elastic Load Balancing with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/emr/doc.go
+++ b/service/emr/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To Amazon Elastic MapReduce with the SDK use the New function to create
+// To contact Amazon Elastic MapReduce with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/firehose/doc.go
+++ b/service/firehose/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To Amazon Kinesis Firehose with the SDK use the New function to create
+// To contact Amazon Kinesis Firehose with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/gamelift/doc.go
+++ b/service/gamelift/doc.go
@@ -288,7 +288,7 @@
 //
 // Using the Client
 //
-// To Amazon GameLift with the SDK use the New function to create
+// To contact Amazon GameLift with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/glacier/doc.go
+++ b/service/glacier/doc.go
@@ -40,7 +40,7 @@
 //
 // Using the Client
 //
-// To Amazon Glacier with the SDK use the New function to create
+// To contact Amazon Glacier with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/glue/doc.go
+++ b/service/glue/doc.go
@@ -12,7 +12,7 @@
 //
 // Using the Client
 //
-// To AWS Glue with the SDK use the New function to create
+// To contact AWS Glue with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/greengrass/doc.go
+++ b/service/greengrass/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To AWS Greengrass with the SDK use the New function to create
+// To contact AWS Greengrass with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/health/doc.go
+++ b/service/health/doc.go
@@ -49,7 +49,7 @@
 //
 // Using the Client
 //
-// To AWS Health APIs and Notifications with the SDK use the New function to create
+// To contact AWS Health APIs and Notifications with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/iam/doc.go
+++ b/service/iam/doc.go
@@ -64,7 +64,7 @@
 //
 // Using the Client
 //
-// To AWS Identity and Access Management with the SDK use the New function to create
+// To contact AWS Identity and Access Management with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/inspector/doc.go
+++ b/service/inspector/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To Amazon Inspector with the SDK use the New function to create
+// To contact Amazon Inspector with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/iot/doc.go
+++ b/service/iot/doc.go
@@ -17,7 +17,7 @@
 //
 // Using the Client
 //
-// To AWS IoT with the SDK use the New function to create
+// To contact AWS IoT with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/iotdataplane/doc.go
+++ b/service/iotdataplane/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To AWS IoT Data Plane with the SDK use the New function to create
+// To contact AWS IoT Data Plane with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/kinesis/doc.go
+++ b/service/kinesis/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To Amazon Kinesis with the SDK use the New function to create
+// To contact Amazon Kinesis with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/kinesisanalytics/doc.go
+++ b/service/kinesisanalytics/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Kinesis Analytics with the SDK use the New function to create
+// To contact Amazon Kinesis Analytics with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/kms/doc.go
+++ b/service/kms/doc.go
@@ -82,7 +82,7 @@
 //
 // Using the Client
 //
-// To AWS Key Management Service with the SDK use the New function to create
+// To contact AWS Key Management Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/lambda/doc.go
+++ b/service/lambda/doc.go
@@ -18,7 +18,7 @@
 //
 // Using the Client
 //
-// To AWS Lambda with the SDK use the New function to create
+// To contact AWS Lambda with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/lexmodelbuildingservice/doc.go
+++ b/service/lexmodelbuildingservice/doc.go
@@ -14,7 +14,7 @@
 //
 // Using the Client
 //
-// To Amazon Lex Model Building Service with the SDK use the New function to create
+// To contact Amazon Lex Model Building Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/lexruntimeservice/doc.go
+++ b/service/lexruntimeservice/doc.go
@@ -22,7 +22,7 @@
 //
 // Using the Client
 //
-// To Amazon Lex Runtime Service with the SDK use the New function to create
+// To contact Amazon Lex Runtime Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/lightsail/doc.go
+++ b/service/lightsail/doc.go
@@ -24,7 +24,7 @@
 //
 // Using the Client
 //
-// To Amazon Lightsail with the SDK use the New function to create
+// To contact Amazon Lightsail with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/machinelearning/doc.go
+++ b/service/machinelearning/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Machine Learning with the SDK use the New function to create
+// To contact Amazon Machine Learning with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/marketplacecommerceanalytics/doc.go
+++ b/service/marketplacecommerceanalytics/doc.go
@@ -12,7 +12,7 @@
 //
 // Using the Client
 //
-// To AWS Marketplace Commerce Analytics with the SDK use the New function to create
+// To contact AWS Marketplace Commerce Analytics with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/marketplaceentitlementservice/doc.go
+++ b/service/marketplaceentitlementservice/doc.go
@@ -23,7 +23,7 @@
 //
 // Using the Client
 //
-// To AWS Marketplace Entitlement Service with the SDK use the New function to create
+// To contact AWS Marketplace Entitlement Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/marketplacemetering/doc.go
+++ b/service/marketplacemetering/doc.go
@@ -32,7 +32,7 @@
 //
 // Using the Client
 //
-// To AWSMarketplace Metering with the SDK use the New function to create
+// To contact AWSMarketplace Metering with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/migrationhub/doc.go
+++ b/service/migrationhub/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To AWS Migration Hub with the SDK use the New function to create
+// To contact AWS Migration Hub with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/mobile/doc.go
+++ b/service/mobile/doc.go
@@ -15,7 +15,7 @@
 //
 // Using the Client
 //
-// To AWS Mobile with the SDK use the New function to create
+// To contact AWS Mobile with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/mobileanalytics/doc.go
+++ b/service/mobileanalytics/doc.go
@@ -11,7 +11,7 @@
 //
 // Using the Client
 //
-// To Amazon Mobile Analytics with the SDK use the New function to create
+// To contact Amazon Mobile Analytics with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/mturk/doc.go
+++ b/service/mturk/doc.go
@@ -12,7 +12,7 @@
 //
 // Using the Client
 //
-// To Amazon Mechanical Turk with the SDK use the New function to create
+// To contact Amazon Mechanical Turk with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/opsworks/doc.go
+++ b/service/opsworks/doc.go
@@ -81,7 +81,7 @@
 //
 // Using the Client
 //
-// To AWS OpsWorks with the SDK use the New function to create
+// To contact AWS OpsWorks with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/opsworkscm/doc.go
+++ b/service/opsworkscm/doc.go
@@ -59,7 +59,7 @@
 //
 // Using the Client
 //
-// To AWS OpsWorks for Chef Automate with the SDK use the New function to create
+// To contact AWS OpsWorks for Chef Automate with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/organizations/doc.go
+++ b/service/organizations/doc.go
@@ -123,7 +123,7 @@
 //
 // Using the Client
 //
-// To AWS Organizations with the SDK use the New function to create
+// To contact AWS Organizations with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/pinpoint/doc.go
+++ b/service/pinpoint/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Pinpoint with the SDK use the New function to create
+// To contact Amazon Pinpoint with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/polly/doc.go
+++ b/service/polly/doc.go
@@ -18,7 +18,7 @@
 //
 // Using the Client
 //
-// To Amazon Polly with the SDK use the New function to create
+// To contact Amazon Polly with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/rds/doc.go
+++ b/service/rds/doc.go
@@ -53,7 +53,7 @@
 //
 // Using the Client
 //
-// To Amazon Relational Database Service with the SDK use the New function to create
+// To contact Amazon Relational Database Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/redshift/doc.go
+++ b/service/redshift/doc.go
@@ -35,7 +35,7 @@
 //
 // Using the Client
 //
-// To Amazon Redshift with the SDK use the New function to create
+// To contact Amazon Redshift with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/rekognition/doc.go
+++ b/service/rekognition/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Rekognition with the SDK use the New function to create
+// To contact Amazon Rekognition with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/resourcegroupstaggingapi/doc.go
+++ b/service/resourcegroupstaggingapi/doc.go
@@ -48,7 +48,7 @@
 //
 // Using the Client
 //
-// To AWS Resource Groups Tagging API with the SDK use the New function to create
+// To contact AWS Resource Groups Tagging API with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/route53/doc.go
+++ b/service/route53/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Route 53 with the SDK use the New function to create
+// To contact Amazon Route 53 with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/route53domains/doc.go
+++ b/service/route53domains/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To Amazon Route 53 Domains with the SDK use the New function to create
+// To contact Amazon Route 53 Domains with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/s3/doc.go
+++ b/service/s3/doc.go
@@ -10,7 +10,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Storage Service with the SDK use the New function to create
+// To contact Amazon Simple Storage Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/servicecatalog/doc.go
+++ b/service/servicecatalog/doc.go
@@ -24,7 +24,7 @@
 //
 // Using the Client
 //
-// To AWS Service Catalog with the SDK use the New function to create
+// To contact AWS Service Catalog with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/ses/doc.go
+++ b/service/ses/doc.go
@@ -18,7 +18,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Email Service with the SDK use the New function to create
+// To contact Amazon Simple Email Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/sfn/doc.go
+++ b/service/sfn/doc.go
@@ -27,7 +27,7 @@
 //
 // Using the Client
 //
-// To AWS Step Functions with the SDK use the New function to create
+// To contact AWS Step Functions with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/shield/doc.go
+++ b/service/shield/doc.go
@@ -16,7 +16,7 @@
 //
 // Using the Client
 //
-// To AWS Shield with the SDK use the New function to create
+// To contact AWS Shield with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/simpledb/doc.go
+++ b/service/simpledb/doc.go
@@ -24,7 +24,7 @@
 //
 // Using the Client
 //
-// To Amazon SimpleDB with the SDK use the New function to create
+// To contact Amazon SimpleDB with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/sms/doc.go
+++ b/service/sms/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To AWS Server Migration Service with the SDK use the New function to create
+// To contact AWS Server Migration Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/snowball/doc.go
+++ b/service/snowball/doc.go
@@ -19,7 +19,7 @@
 //
 // Using the Client
 //
-// To Amazon Import/Export Snowball with the SDK use the New function to create
+// To contact Amazon Import/Export Snowball with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/sns/doc.go
+++ b/service/sns/doc.go
@@ -24,7 +24,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Notification Service with the SDK use the New function to create
+// To contact Amazon Simple Notification Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/sqs/doc.go
+++ b/service/sqs/doc.go
@@ -48,7 +48,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Queue Service with the SDK use the New function to create
+// To contact Amazon Simple Queue Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/ssm/doc.go
+++ b/service/ssm/doc.go
@@ -28,7 +28,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Systems Manager (SSM) with the SDK use the New function to create
+// To contact Amazon Simple Systems Manager (SSM) with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/storagegateway/doc.go
+++ b/service/storagegateway/doc.go
@@ -63,7 +63,7 @@
 //
 // Using the Client
 //
-// To AWS Storage Gateway with the SDK use the New function to create
+// To contact AWS Storage Gateway with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/sts/doc.go
+++ b/service/sts/doc.go
@@ -56,7 +56,7 @@
 //
 // Using the Client
 //
-// To AWS Security Token Service with the SDK use the New function to create
+// To contact AWS Security Token Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/support/doc.go
+++ b/service/support/doc.go
@@ -61,7 +61,7 @@
 //
 // Using the Client
 //
-// To AWS Support with the SDK use the New function to create
+// To contact AWS Support with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/swf/doc.go
+++ b/service/swf/doc.go
@@ -22,7 +22,7 @@
 //
 // Using the Client
 //
-// To Amazon Simple Workflow Service with the SDK use the New function to create
+// To contact Amazon Simple Workflow Service with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/waf/doc.go
+++ b/service/waf/doc.go
@@ -18,7 +18,7 @@
 //
 // Using the Client
 //
-// To AWS WAF with the SDK use the New function to create
+// To contact AWS WAF with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/wafregional/doc.go
+++ b/service/wafregional/doc.go
@@ -20,7 +20,7 @@
 //
 // Using the Client
 //
-// To AWS WAF Regional with the SDK use the New function to create
+// To contact AWS WAF Regional with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/workdocs/doc.go
+++ b/service/workdocs/doc.go
@@ -42,7 +42,7 @@
 //
 // Using the Client
 //
-// To Amazon WorkDocs with the SDK use the New function to create
+// To contact Amazon WorkDocs with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/workspaces/doc.go
+++ b/service/workspaces/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To Amazon WorkSpaces with the SDK use the New function to create
+// To contact Amazon WorkSpaces with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //

--- a/service/xray/doc.go
+++ b/service/xray/doc.go
@@ -13,7 +13,7 @@
 //
 // Using the Client
 //
-// To AWS X-Ray with the SDK use the New function to create
+// To contact AWS X-Ray with the SDK use the New function to create
 // a new service client. With that client you can make API requests to the service.
 // These clients are safe to use concurrently.
 //


### PR DESCRIPTION
Follow up on #1575 that corrects the service client generated docstrings with better wording. This PR replaces 1575 and includes the generated code updates.