### PR TITLE
codegen: Fix SDK codegen to not create empty string API names

### DIFF
--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -164,7 +164,7 @@ func (a *API) fixStutterNames() {
 
 	for name, op := range a.Operations {
 		newName := re.ReplaceAllString(name, "")
-		if newName != name {
+		if newName != name && len(newName) > 0 {
 			delete(a.Operations, name)
 			a.Operations[newName] = op
 		}
@@ -173,7 +173,7 @@ func (a *API) fixStutterNames() {
 
 	for k, s := range a.Shapes {
 		newName := re.ReplaceAllString(k, "")
-		if newName != s.ShapeName {
+		if newName != s.ShapeName && len(newName) > 0 {
 			s.Rename(newName)
 		}
 	}


### PR DESCRIPTION
Updates the SDK's code generation stutter filter to not  perform the stutter correction if the correction would result in an empty string.

e.g. ServiceName `ABC` with API operation `ABC` will no longer be converted to an empty string, but stay as `ABC`