### PR TITLE
aws/client: fixing bug where throttled retry's math was off

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+*	`aws/client`: Retry delays for throttled exception were not limited to 5 mintues [#1654](https://github.com/aws/aws-sdk-go/pull/1654)
+	* Fixes [#1653](https://github.com/aws/aws-sdk-go/issues/1653)

--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -47,10 +47,10 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	}
 
 	retryCount := r.RetryCount
-	if retryCount > 13 {
-		retryCount = 13
-	} else if throttle && retryCount > 8 {
+	if throttle && retryCount > 8 {
 		retryCount = 8
+	} else if retryCount > 13 {
+		retryCount = 13
 	}
 
 	delay := (1 << uint(retryCount)) * (seededRand.Intn(minTime) + minTime)

--- a/aws/client/default_retryer_test.go
+++ b/aws/client/default_retryer_test.go
@@ -164,3 +164,26 @@ func TestGetRetryDelay(t *testing.T) {
 		}
 	}
 }
+
+func TestRetryDelay(t *testing.T) {
+	r := request.Request{}
+	for i := 0; i < 100; i++ {
+		rTemp := r
+		rTemp.HTTPResponse = &http.Response{StatusCode: 500, Header: http.Header{"Retry-After": []string{""}}}
+		rTemp.RetryCount = i
+		a, _ := getRetryDelay(&rTemp)
+		if a > 5*time.Minute {
+			t.Errorf("retry delay should never be greater than five minutes, received %d", a)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		rTemp := r
+		rTemp.RetryCount = i
+		rTemp.HTTPResponse = &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{""}}}
+		a, _ := getRetryDelay(&rTemp)
+		if a > 5*time.Minute {
+			t.Errorf("retry delay should never be greater than five minutes, received %d", a)
+		}
+	}
+}


### PR DESCRIPTION
fixes #1653 