### PR TITLE
Fix code examples in s3manager/batch comments

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -206,7 +206,7 @@ type BatchDelete struct {
 //		},
 //	}
 //
-//	if err := batcher.Delete(&s3manager.DeleteObjectsIterator{
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
 //		Objects: objects,
 //	}); err != nil {
 //		return err
@@ -239,7 +239,7 @@ func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete
 //		},
 //	}
 //
-//	if err := batcher.Delete(&s3manager.DeleteObjectsIterator{
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
 //		Objects: objects,
 //	}); err != nil {
 //		return err


### PR DESCRIPTION
## Why is this change necessary?

- The code examples are missing first argument `aws.Context`
- Originally from
  - https://github.com/aws/aws-sdk-go/commit/06f6a4aab0aa9a66df003d882b4224677ff38a64#diff-ce4c43e777b437102576d41814658cd1R111
  - https://github.com/aws/aws-sdk-go/commit/06f6a4aab0aa9a66df003d882b4224677ff38a64#diff-ce4c43e777b437102576d41814658cd1R197
  - https://github.com/aws/aws-sdk-go/commit/06f6a4aab0aa9a66df003d882b4224677ff38a64#diff-ce4c43e777b437102576d41814658cd1R111 (correct example)
- This change will save time for SDK users who try to figure out the usage from code example.

## How does it address the issue?

- Update code examples in comments

## What side effects does this change have?

- [ ] Will this add confusion to the code design? Should we consider `func (d *BatchDelete) DeleteWithContext(ctx aws.Context, iter BatchDeleteIterator) error` signature?