### PR TITLE
private/model/api: Fix SDK service client name gen for lowercase names

### DIFF
--- a/models/customizations/service-aliases.json
+++ b/models/customizations/service-aliases.json
@@ -1,4 +1,5 @@
 {
+	"costandusagereportservice": "CostandUsageReportService",
 	"elasticloadbalancing": "ELB",
 	"elasticloadbalancingv2": "ELBV2",
 	"config": "ConfigService"

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -10,10 +10,10 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"text/template"
+	"unicode"
 )
 
 // An API defines a service API's definition. and logic to serialize the definition.
@@ -94,23 +94,52 @@ func (a *API) InterfacePackageName() string {
 	return a.PackageName() + "iface"
 }
 
-var nameRegex = regexp.MustCompile(`^Amazon|AWS\s*|\(.*|\s+|\W+`)
+var stripServiceNamePrefixes = []string{
+	"Amazon",
+	"AWS",
+}
 
 // StructName returns the struct name for a given API.
 func (a *API) StructName() string {
-	if a.name == "" {
-		name := a.Metadata.ServiceAbbreviation
-		if name == "" {
-			name = a.Metadata.ServiceFullName
-		}
+	if len(a.name) != 0 {
+		return a.name
+	}
 
-		name = nameRegex.ReplaceAllString(name, "")
+	name := a.Metadata.ServiceAbbreviation
+	if len(name) == 0 {
+		name = a.Metadata.ServiceFullName
+	}
 
-		a.name = name
-		if name, ok := serviceAliases[strings.ToLower(name)]; ok {
-			a.name = name
+	name = strings.TrimSpace(name)
+
+	// Strip out prefix names not reflected in service client symbol names.
+	for _, prefix := range stripServiceNamePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			name = name[len(prefix):]
 		}
 	}
+
+	// Replace all Non-letter/number values with space
+	runes := []rune(name)
+	for i := 0; i < len(runes); i++ {
+		if r := runes[i]; !(unicode.IsNumber(r) || unicode.IsLetter(r)) {
+			runes[i] = ' '
+		}
+	}
+	name = string(runes)
+
+	// Title case name so its readable as a symbol.
+	name = strings.Title(name)
+
+	// Strip out spaces.
+	name = strings.Replace(name, " ", "", -1)
+
+	// Swap out for alias name if one is defined.
+	if alias, ok := serviceAliases[strings.ToLower(name)]; ok {
+		name = alias
+	}
+
+	a.name = name
 	return a.name
 }
 

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -116,6 +116,7 @@ func (a *API) StructName() string {
 	for _, prefix := range stripServiceNamePrefixes {
 		if strings.HasPrefix(name, prefix) {
 			name = name[len(prefix):]
+			break
 		}
 	}
 

--- a/private/model/api/api_test.go
+++ b/private/model/api/api_test.go
@@ -1,4 +1,4 @@
-// +build 1.6,codegen
+// +build go1.8,codegen
 
 package api
 
@@ -6,49 +6,66 @@ import (
 	"testing"
 )
 
-func TestStructNameWithFullName(t *testing.T) {
-	a := API{
-		Metadata: Metadata{
-			ServiceFullName: "Amazon Service Name-100",
+func TestAPI_StructName(t *testing.T) {
+	origAliases := serviceAliases
+	defer func() { serviceAliases = origAliases }()
+
+	cases := map[string]struct {
+		Aliases    map[string]string
+		Metadata   Metadata
+		StructName string
+	}{
+		"FullName": {
+			Metadata: Metadata{
+				ServiceFullName: "Amazon Service Name-100",
+			},
+			StructName: "ServiceName100",
+		},
+		"Abbreviation": {
+			Metadata: Metadata{
+				ServiceFullName:     "Amazon Service Name-100",
+				ServiceAbbreviation: "AWS SN100",
+			},
+			StructName: "SN100",
+		},
+		"Lowercase Name": {
+			Metadata: Metadata{
+				EndpointPrefix:      "other",
+				ServiceFullName:     "AWS Lowercase service",
+				ServiceAbbreviation: "lowercase",
+			},
+			StructName: "Lowercase",
+		},
+		"Lowercase Name Mixed": {
+			Metadata: Metadata{
+				EndpointPrefix:      "other",
+				ServiceFullName:     "AWS Lowercase service",
+				ServiceAbbreviation: "lowercase name Goes heRe",
+			},
+			StructName: "LowercaseNameGoesHeRe",
+		},
+		"Alias": {
+			Aliases: map[string]string{
+				"elasticloadbalancing": "ELB",
+			},
+			Metadata: Metadata{
+				ServiceFullName: "Elastic Load Balancing",
+			},
+			StructName: "ELB",
 		},
 	}
-	if a.StructName() != "ServiceName100" {
-		t.Errorf("API struct name should have been %s, but received %s", "ServiceName100", a.StructName())
-	}
-}
 
-func TestStructNameWithAbbreviation(t *testing.T) {
-	a := API{
-		Metadata: Metadata{
-			ServiceFullName:     "AWS Service Name-100",
-			ServiceAbbreviation: "AWS SN100",
-		},
-	}
-	if a.StructName() != "SN100" {
-		t.Errorf("API struct name should have been %s, but received %s", "SN100", a.StructName())
-	}
-}
+	for k, c := range cases {
+		t.Run(k, func(t *testing.T) {
+			serviceAliases = c.Aliases
 
-func TestStructNameForExceptions(t *testing.T) {
-	serviceAliases = map[string]string{}
-	serviceAliases["elasticloadbalancing"] = "ELB"
-	serviceAliases["config"] = "ConfigService"
+			a := API{
+				Metadata: c.Metadata,
+			}
 
-	a := API{
-		Metadata: Metadata{
-			ServiceFullName: "Elastic Load Balancing",
-		},
-	}
-	if a.StructName() != "ELB" {
-		t.Errorf("API struct name should have been %s, but received %s", "ELB", a.StructName())
-	}
-
-	a = API{
-		Metadata: Metadata{
-			ServiceFullName: "AWS Config",
-		},
-	}
-	if a.StructName() != "ConfigService" {
-		t.Errorf("API struct name should have been %s, but received %s", "ConfigService", a.StructName())
+			if e, o := c.StructName, a.StructName(); e != o {
+				t.Errorf("expect %v structName, got %v", e, o)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes the SDK's code generation for services with lowercase names in the
abbreviation field of the model. This also fixes Title casing
bugs in the StructName method.

Added alias special case for Cost and Usage Report service since the `and` was not being title cased.  For service client names, all words should of been title cased.
