### PR TITLE
Refine AWS_CONTAINER_CREDENTIALS_FULL_URI host validation

### DIFF
--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -151,8 +151,8 @@ func localHTTPCredProvider(cfg aws.Config, handlers request.Handlers, u string) 
 		host := aws.URLHostname(parsed)
 		if len(host) == 0 {
 			errMsg = "unable to parse host from local HTTP cred provider URL"
-		} else if isLoopback, err := isLoopbackHost(host); err != nil {
-			errMsg = fmt.Sprintf("failed to resolve host %q, %v", host, err)
+		} else if isLoopback, loopbackErr := isLoopbackHost(host); loopbackErr != nil {
+			errMsg = fmt.Sprintf("failed to resolve host %q, %v", host, loopbackErr)
 		} else if !isLoopback {
 			errMsg = fmt.Sprintf("invalid endpoint host, %q, only loopback hosts are allowed.", host)
 		}

--- a/aws/defaults/defaults_test.go
+++ b/aws/defaults/defaults_test.go
@@ -53,7 +53,6 @@ func TestHTTPCredProvider(t *testing.T) {
 
 	for i, c := range cases {
 		u := fmt.Sprintf("http://%s/abc/123", c.Host)
-		fmt.Println(u)
 		os.Setenv(httpProviderEnvVar, u)
 
 		provider := RemoteCredProvider(aws.Config{}, request.Handlers{})

--- a/aws/defaults/defaults_test.go
+++ b/aws/defaults/defaults_test.go
@@ -13,18 +13,47 @@ import (
 )
 
 func TestHTTPCredProvider(t *testing.T) {
+	origFn := lookupHostFn
+	defer func() { lookupHostFn = origFn }()
+
+	lookupHostFn = func(host string) ([]string, error) {
+		m := map[string]struct {
+			Addrs []string
+			Err   error
+		}{
+			"localhost":       {Addrs: []string{"::1", "127.0.0.1"}},
+			"actuallylocal":   {Addrs: []string{"127.0.0.2"}},
+			"notlocal":        {Addrs: []string{"::1", "127.0.0.1", "192.168.1.10"}},
+			"www.example.com": {Addrs: []string{"10.10.10.10"}},
+		}
+
+		h, ok := m[host]
+		if !ok {
+			t.Fatalf("unknown host in test, %v", host)
+			return nil, fmt.Errorf("unknown host")
+		}
+
+		return h.Addrs, h.Err
+	}
+
 	cases := []struct {
 		Host string
 		Fail bool
 	}{
-		{"localhost", false}, {"127.0.0.1", false},
-		{"www.example.com", true}, {"169.254.170.2", true},
+		{"localhost", false},
+		{"actuallylocal", false},
+		{"127.0.0.1", false},
+		{"127.1.1.1", false},
+		{"[::1]", false},
+		{"www.example.com", true},
+		{"169.254.170.2", true},
 	}
 
 	defer os.Clearenv()
 
 	for i, c := range cases {
 		u := fmt.Sprintf("http://%s/abc/123", c.Host)
+		fmt.Println(u)
 		os.Setenv(httpProviderEnvVar, u)
 
 		provider := RemoteCredProvider(aws.Config{}, request.Handlers{})


### PR DESCRIPTION
Refines how the AWS_CONTAINER_CREDENTIALS_FULL_URI endpoint's host value
is validated to include resolving the host only resolves to loopback IPs.

This also makes the loopback validation be more generic including ipv6
::1/128 and 127.0.0.1/8.