### PR TITLE
Added a variable in envConfig to limit the minimum version of SSL/TLS.

### DIFF
--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"strconv"
+	"crypto/tls"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
@@ -95,6 +96,8 @@ type envConfig struct {
 	//
 	//  AWS_CA_BUNDLE=$HOME/my_custom_ca_bundle
 	CustomCABundle string
+
+	TLSMinVersion uint16
 }
 
 var (
@@ -177,6 +180,14 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 	setFromEnvVal(&cfg.SharedConfigFile, sharedConfigFileEnvKey)
 
 	cfg.CustomCABundle = os.Getenv("AWS_CA_BUNDLE")
+
+	ver, err := strconv.ParseUint(os.Getenv("AWS_SSL_TLS_MIN_VERSION"),0,16)
+	if err == nil {
+		switch uver := uint16(ver); uver {
+		case tls.VersionSSL30, tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12:
+			cfg.TLSMinVersion = uver
+		}
+	}
 
 	return cfg
 }

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -355,7 +355,6 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 
 	// Setup HTTP client with min version for SSL/TLS if enabled
 	if envCfg.TLSMinVersion != 0 {
-		fmt.Println("!")
 		if err := setSslTlsMinVersion(s, envCfg.TLSMinVersion); err != nil {
 			return nil, err
 		}

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -353,7 +353,40 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 		}
 	}
 
+	// Setup HTTP client with min version for SSL/TLS if enabled
+	if envCfg.TLSMinVersion != 0 {
+		fmt.Println("!")
+		if err := setSslTlsMinVersion(s, envCfg.TLSMinVersion); err != nil {
+			return nil, err
+		}
+	}
+
 	return s, nil
+}
+
+func setSslTlsMinVersion(s *Session, version uint16) error {
+	var t *http.Transport
+	switch v := s.Config.HTTPClient.Transport.(type) {
+	case *http.Transport:
+		t = v
+	default:
+		if s.Config.HTTPClient.Transport != nil {
+			return awserr.New("LoadCustomCABundleError",
+				"unable to load custom CA bundle, HTTPClient's transport unsupported type", nil)
+		}
+	}
+	if t == nil {
+		t = &http.Transport{}
+	}
+
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	t.TLSClientConfig.MinVersion = version
+
+	s.Config.HTTPClient.Transport = t
+
+	return nil
 }
 
 func loadCustomCABundle(s *Session, bundle io.Reader) error {


### PR DESCRIPTION
Some might want to limit the version of TLS to more than a certain version for security reason.
I know one of our client wants to have this feature because they are very sensitive to the security matter in terms of their business.
Actually, they would only allow using TLS version 1.2 or higher.

Therefore, this pull request should be reasonably considered to be able to do it by any user himself. 
Currently, it is necessary to build sources with modifying the code to set MinVersion in TLSClientConfig.

