### PR TITLE
v1.12.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.12.58 (2018-01-09)
+===
+
+### Service Client Updates
+* `service/ds`: Updates service API and documentation
+  * On October 24 we introduced AWS Directory Service for Microsoft Active Directory (Standard Edition), also known as AWS Microsoft AD (Standard Edition), which is a managed Microsoft Active Directory (AD) that is optimized for small and midsize businesses (SMBs). With this SDK release, you can now create an AWS Microsoft AD directory using API. This enables you to run typical SMB workloads using a cost-effective, highly available, and managed Microsoft AD in the AWS Cloud.
+
 Release v1.12.57 (2018-01-08)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.57"
+const SDKVersion = "1.12.58"

--- a/models/apis/ds/2015-04-16/api-2.json
+++ b/models/apis/ds/2015-04-16/api-2.json
@@ -910,7 +910,8 @@
         "ShortName":{"shape":"DirectoryShortName"},
         "Password":{"shape":"Password"},
         "Description":{"shape":"Description"},
-        "VpcSettings":{"shape":"DirectoryVpcSettings"}
+        "VpcSettings":{"shape":"DirectoryVpcSettings"},
+        "Edition":{"shape":"DirectoryEdition"}
       }
     },
     "CreateMicrosoftADResult":{
@@ -1165,6 +1166,7 @@
         "Name":{"shape":"DirectoryName"},
         "ShortName":{"shape":"DirectoryShortName"},
         "Size":{"shape":"DirectorySize"},
+        "Edition":{"shape":"DirectoryEdition"},
         "Alias":{"shape":"AliasName"},
         "AccessUrl":{"shape":"AccessUrl"},
         "Description":{"shape":"Description"},
@@ -1185,6 +1187,13 @@
     "DirectoryDescriptions":{
       "type":"list",
       "member":{"shape":"DirectoryDescription"}
+    },
+    "DirectoryEdition":{
+      "type":"string",
+      "enum":[
+        "Enterprise",
+        "Standard"
+      ]
     },
     "DirectoryId":{
       "type":"string",

--- a/models/apis/ds/2015-04-16/docs-2.json
+++ b/models/apis/ds/2015-04-16/docs-2.json
@@ -462,6 +462,13 @@
         "DescribeDirectoriesResult$DirectoryDescriptions": "<p>The list of <a>DirectoryDescription</a> objects that were retrieved.</p> <p>It is possible that this list contains less than the number of items specified in the <i>Limit</i> member of the request. This occurs if there are less than the requested number of items left to retrieve, or if the limitations of the operation have been exceeded.</p>"
       }
     },
+    "DirectoryEdition": {
+      "base": null,
+      "refs": {
+        "CreateMicrosoftADRequest$Edition": "<p>AWS Microsoft AD is available in two editions: Standard and Enterprise. Enterprise is the default.</p>",
+        "DirectoryDescription$Edition": "<p>The edition associated with this directory.</p>"
+      }
+    },
     "DirectoryId": {
       "base": null,
       "refs": {
@@ -1105,7 +1112,7 @@
       "base": null,
       "refs": {
         "DirectoryConnectSettingsDescription$SecurityGroupId": "<p>The security group identifier for the AD Connector directory.</p>",
-        "DirectoryVpcSettingsDescription$SecurityGroupId": "<p>The security group identifier for the directory. If the directory was created before 8/1/2014, this is the identifier of the directory members security group that was created when the directory was created. If the directory was created after this date, this value is null.</p>"
+        "DirectoryVpcSettingsDescription$SecurityGroupId": "<p>The domain controller security group identifier for the directory.</p>"
       }
     },
     "Server": {

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -4805,6 +4805,10 @@ type CreateMicrosoftADInput struct {
 	// console Directory Details page after the directory is created.
 	Description *string `type:"string"`
 
+	// AWS Microsoft AD is available in two editions: Standard and Enterprise. Enterprise
+	// is the default.
+	Edition *string `type:"string" enum:"DirectoryEdition"`
+
 	// The fully qualified domain name for the directory, such as corp.example.com.
 	// This name will resolve inside your VPC only. It does not need to be publicly
 	// resolvable.
@@ -4865,6 +4869,12 @@ func (s *CreateMicrosoftADInput) Validate() error {
 // SetDescription sets the Description field's value.
 func (s *CreateMicrosoftADInput) SetDescription(v string) *CreateMicrosoftADInput {
 	s.Description = &v
+	return s
+}
+
+// SetEdition sets the Edition field's value.
+func (s *CreateMicrosoftADInput) SetEdition(v string) *CreateMicrosoftADInput {
+	s.Edition = &v
 	return s
 }
 
@@ -6208,6 +6218,9 @@ type DirectoryDescription struct {
 	// which the AD Connector is connected.
 	DnsIpAddrs []*string `type:"list"`
 
+	// The edition associated with this directory.
+	Edition *string `type:"string" enum:"DirectoryEdition"`
+
 	// Specifies when the directory was created.
 	LaunchTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -6298,6 +6311,12 @@ func (s *DirectoryDescription) SetDirectoryId(v string) *DirectoryDescription {
 // SetDnsIpAddrs sets the DnsIpAddrs field's value.
 func (s *DirectoryDescription) SetDnsIpAddrs(v []*string) *DirectoryDescription {
 	s.DnsIpAddrs = v
+	return s
+}
+
+// SetEdition sets the Edition field's value.
+func (s *DirectoryDescription) SetEdition(v string) *DirectoryDescription {
+	s.Edition = &v
 	return s
 }
 
@@ -6534,10 +6553,7 @@ type DirectoryVpcSettingsDescription struct {
 	// The list of Availability Zones that the directory is in.
 	AvailabilityZones []*string `type:"list"`
 
-	// The security group identifier for the directory. If the directory was created
-	// before 8/1/2014, this is the identifier of the directory members security
-	// group that was created when the directory was created. If the directory was
-	// created after this date, this value is null.
+	// The domain controller security group identifier for the directory.
 	SecurityGroupId *string `type:"string"`
 
 	// The identifiers of the subnets for the directory servers.
@@ -8707,6 +8723,14 @@ func (s *VerifyTrustOutput) SetTrustId(v string) *VerifyTrustOutput {
 	s.TrustId = &v
 	return s
 }
+
+const (
+	// DirectoryEditionEnterprise is a DirectoryEdition enum value
+	DirectoryEditionEnterprise = "Enterprise"
+
+	// DirectoryEditionStandard is a DirectoryEdition enum value
+	DirectoryEditionStandard = "Standard"
+)
 
 const (
 	// DirectorySizeSmall is a DirectorySize enum value


### PR DESCRIPTION
Release v1.12.58 (2018-01-09)
===

### Service Client Updates
* `service/ds`: Updates service API and documentation
  * On October 24 we introduced AWS Directory Service for Microsoft Active Directory (Standard Edition), also known as AWS Microsoft AD (Standard Edition), which is a managed Microsoft Active Directory (AD) that is optimized for small and midsize businesses (SMBs). With this SDK release, you can now create an AWS Microsoft AD directory using API. This enables you to run typical SMB workloads using a cost-effective, highly available, and managed Microsoft AD in the AWS Cloud.

