### PR TITLE
v1.12.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.12.61 (2018-01-12)
+===
+
+### Service Client Updates
+* `service/glue`: Updates service API and documentation
+  * Support is added to generate ETL scripts in Scala which can now be run by  AWS Glue ETL jobs. In addition, the trigger API now supports firing when any conditions are met (in addition to all conditions). Also, jobs can be triggered based on a "failed" or "stopped" job run (in addition to a "succeeded" job run).
+
 Release v1.12.60 (2018-01-11)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.60"
+const SDKVersion = "1.12.61"

--- a/models/apis/glue/2017-03-31/api-2.json
+++ b/models/apis/glue/2017-03-31/api-2.json
@@ -192,7 +192,8 @@
         {"shape":"AlreadyExistsException"},
         {"shape":"InternalServiceException"},
         {"shape":"OperationTimeoutException"},
-        {"shape":"ResourceNumberLimitExceededException"}
+        {"shape":"ResourceNumberLimitExceededException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "CreatePartition":{
@@ -254,9 +255,11 @@
       "errors":[
         {"shape":"AlreadyExistsException"},
         {"shape":"InvalidInputException"},
+        {"shape":"IdempotentParameterMismatchException"},
         {"shape":"InternalServiceException"},
         {"shape":"OperationTimeoutException"},
-        {"shape":"ResourceNumberLimitExceededException"}
+        {"shape":"ResourceNumberLimitExceededException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "CreateUserDefinedFunction":{
@@ -401,7 +404,8 @@
       "errors":[
         {"shape":"InvalidInputException"},
         {"shape":"InternalServiceException"},
-        {"shape":"OperationTimeoutException"}
+        {"shape":"OperationTimeoutException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "DeleteUserDefinedFunction":{
@@ -951,7 +955,8 @@
         {"shape":"InvalidInputException"},
         {"shape":"InternalServiceException"},
         {"shape":"EntityNotFoundException"},
-        {"shape":"OperationTimeoutException"}
+        {"shape":"OperationTimeoutException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "UpdateClassifier":{
@@ -1058,7 +1063,8 @@
         {"shape":"InvalidInputException"},
         {"shape":"EntityNotFoundException"},
         {"shape":"InternalServiceException"},
-        {"shape":"OperationTimeoutException"}
+        {"shape":"OperationTimeoutException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "UpdatePartition":{
@@ -1104,7 +1110,8 @@
         {"shape":"InvalidInputException"},
         {"shape":"InternalServiceException"},
         {"shape":"EntityNotFoundException"},
-        {"shape":"OperationTimeoutException"}
+        {"shape":"OperationTimeoutException"},
+        {"shape":"ConcurrentModificationException"}
       ]
     },
     "UpdateUserDefinedFunction":{
@@ -1786,13 +1793,15 @@
       "type":"structure",
       "members":{
         "DagNodes":{"shape":"DagNodes"},
-        "DagEdges":{"shape":"DagEdges"}
+        "DagEdges":{"shape":"DagEdges"},
+        "Language":{"shape":"Language"}
       }
     },
     "CreateScriptResponse":{
       "type":"structure",
       "members":{
-        "PythonScript":{"shape":"PythonScript"}
+        "PythonScript":{"shape":"PythonScript"},
+        "ScalaCode":{"shape":"ScalaCode"}
       }
     },
     "CreateTableRequest":{
@@ -2467,13 +2476,15 @@
         "Mapping":{"shape":"MappingList"},
         "Source":{"shape":"CatalogEntry"},
         "Sinks":{"shape":"CatalogEntries"},
-        "Location":{"shape":"Location"}
+        "Location":{"shape":"Location"},
+        "Language":{"shape":"Language"}
       }
     },
     "GetPlanResponse":{
       "type":"structure",
       "members":{
-        "PythonScript":{"shape":"PythonScript"}
+        "PythonScript":{"shape":"PythonScript"},
+        "ScalaCode":{"shape":"ScalaCode"}
       }
     },
     "GetTableRequest":{
@@ -2778,6 +2789,13 @@
       "min":1,
       "pattern":"[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
     },
+    "Language":{
+      "type":"string",
+      "enum":[
+        "PYTHON",
+        "SCALA"
+      ]
+    },
     "LastCrawlInfo":{
       "type":"structure",
       "members":{
@@ -2828,7 +2846,10 @@
     },
     "Logical":{
       "type":"string",
-      "enum":["AND"]
+      "enum":[
+        "AND",
+        "ANY"
+      ]
     },
     "LogicalOperator":{
       "type":"string",
@@ -3083,6 +3104,7 @@
       "type":"list",
       "member":{"shape":"S3Target"}
     },
+    "ScalaCode":{"type":"string"},
     "Schedule":{
       "type":"structure",
       "members":{

--- a/models/apis/glue/2017-03-31/docs-2.json
+++ b/models/apis/glue/2017-03-31/docs-2.json
@@ -7,7 +7,7 @@
     "BatchDeletePartition": "<p>Deletes one or more partitions in a batch operation.</p>",
     "BatchDeleteTable": "<p>Deletes multiple tables at once.</p>",
     "BatchGetPartition": "<p>Retrieves partitions in a batch request.</p>",
-    "BatchStopJobRun": "<p>Stops a batch of job runs for a given job.</p>",
+    "BatchStopJobRun": "<p>Stops one or more job runs for a specified Job.</p>",
     "CreateClassifier": "<p>Creates a classifier in the user's account. This may be either a <code>GrokClassifier</code> or an <code>XMLClassifier</code>. </p>",
     "CreateConnection": "<p>Creates a connection definition in the Data Catalog.</p>",
     "CreateCrawler": "<p>Creates a new crawler with specified targets, role, configuration, and optional schedule. At least one crawl target must be specified, in either the <i>s3Targets</i> or the <i>jdbcTargets</i> field.</p>",
@@ -15,7 +15,7 @@
     "CreateDevEndpoint": "<p>Creates a new DevEndpoint.</p>",
     "CreateJob": "<p>Creates a new job.</p>",
     "CreatePartition": "<p>Creates a new partition.</p>",
-    "CreateScript": "<p>Transforms a directed acyclic graph (DAG) into a Python script.</p>",
+    "CreateScript": "<p>Transforms a directed acyclic graph (DAG) into code.</p>",
     "CreateTable": "<p>Creates a new table definition in the Data Catalog.</p>",
     "CreateTrigger": "<p>Creates a new trigger.</p>",
     "CreateUserDefinedFunction": "<p>Creates a new function definition in the Data Catalog.</p>",
@@ -24,10 +24,10 @@
     "DeleteCrawler": "<p>Removes a specified crawler from the Data Catalog, unless the crawler state is <code>RUNNING</code>.</p>",
     "DeleteDatabase": "<p>Removes a specified Database from a Data Catalog.</p>",
     "DeleteDevEndpoint": "<p>Deletes a specified DevEndpoint.</p>",
-    "DeleteJob": "<p>Deletes a specified job.</p>",
+    "DeleteJob": "<p>Deletes a specified job. If the job is not found, no exception is thrown.</p>",
     "DeletePartition": "<p>Deletes a specified partition.</p>",
     "DeleteTable": "<p>Removes a table definition from the Data Catalog.</p>",
-    "DeleteTrigger": "<p>Deletes a specified trigger.</p>",
+    "DeleteTrigger": "<p>Deletes a specified trigger. If the trigger is not found, no exception is thrown.</p>",
     "DeleteUserDefinedFunction": "<p>Deletes an existing function definition from the Data Catalog.</p>",
     "GetCatalogImportStatus": "<p>Retrieves the status of a migration operation.</p>",
     "GetClassifier": "<p>Retrieve a classifier by name.</p>",
@@ -49,7 +49,7 @@
     "GetMapping": "<p>Creates mappings.</p>",
     "GetPartition": "<p>Retrieves information about a specified partition.</p>",
     "GetPartitions": "<p>Retrieves information about the partitions in a table.</p>",
-    "GetPlan": "<p>Gets a Python script to perform a specified mapping.</p>",
+    "GetPlan": "<p>Gets code to perform a specified mapping.</p>",
     "GetTable": "<p>Retrieves the <code>Table</code> definition in a Data Catalog for a specified table.</p>",
     "GetTableVersions": "<p>Retrieves a list of strings that identify available versions of a specified table.</p>",
     "GetTables": "<p>Retrieves the definitions of some or all of the tables in a given <code>Database</code>.</p>",
@@ -62,7 +62,7 @@
     "StartCrawler": "<p>Starts a crawl using the specified crawler, regardless of what is scheduled. If the crawler is already running, does nothing.</p>",
     "StartCrawlerSchedule": "<p>Changes the schedule state of the specified crawler to <code>SCHEDULED</code>, unless the crawler is already running or the schedule state is already <code>SCHEDULED</code>.</p>",
     "StartJobRun": "<p>Runs a job.</p>",
-    "StartTrigger": "<p>Starts an existing trigger.</p>",
+    "StartTrigger": "<p>Starts an existing trigger. See <a href=\"http://docs.aws.amazon.com/glue/latest/dg/trigger-job.html\">Triggering Jobs</a> for information about how different types of trigger are started.</p>",
     "StopCrawler": "<p>If the specified crawler is running, stops the crawl.</p>",
     "StopCrawlerSchedule": "<p>Sets the schedule state of the specified crawler to <code>NOT_SCHEDULED</code>, but does not stop the crawler if it is already running.</p>",
     "StopTrigger": "<p>Stops a specified trigger.</p>",
@@ -106,7 +106,7 @@
     "AttemptCount": {
       "base": null,
       "refs": {
-        "JobRun$Attempt": "<p>The number or the attempt to run this job.</p>"
+        "JobRun$Attempt": "<p>The number of the attempt to run this job.</p>"
       }
     },
     "BatchCreatePartitionRequest": {
@@ -179,7 +179,7 @@
       }
     },
     "BatchStopJobRunError": {
-      "base": "<p>Details about the job run and the error that occurred while trying to submit it for stopping.</p>",
+      "base": "<p>Records an error that occurred when attempting to stop a specified JobRun.</p>",
       "refs": {
         "BatchStopJobRunErrorList$member": null
       }
@@ -187,13 +187,13 @@
     "BatchStopJobRunErrorList": {
       "base": null,
       "refs": {
-        "BatchStopJobRunResponse$Errors": "<p>A list containing the job run Ids and details of the error that occurred for each job run while submitting to stop.</p>"
+        "BatchStopJobRunResponse$Errors": "<p>A list of the errors that were encountered in tryng to stop JobRuns, including the JobRunId for which each error was encountered and details about the error.</p>"
       }
     },
     "BatchStopJobRunJobRunIdList": {
       "base": null,
       "refs": {
-        "BatchStopJobRunRequest$JobRunIds": "<p>A list of job run Ids of the given job to be stopped.</p>"
+        "BatchStopJobRunRequest$JobRunIds": "<p>A list of the JobRunIds that should be stopped for that Job.</p>"
       }
     },
     "BatchStopJobRunRequest": {
@@ -207,7 +207,7 @@
       }
     },
     "BatchStopJobRunSuccessfulSubmission": {
-      "base": "<p>Details about the job run which is submitted successfully for stopping.</p>",
+      "base": "<p>Records a successful request to stop a specified JobRun.</p>",
       "refs": {
         "BatchStopJobRunSuccessfulSubmissionList$member": null
       }
@@ -215,7 +215,7 @@
     "BatchStopJobRunSuccessfulSubmissionList": {
       "base": null,
       "refs": {
-        "BatchStopJobRunResponse$SuccessfulSubmissions": "<p>A list of job runs which are successfully submitted for stopping.</p>"
+        "BatchStopJobRunResponse$SuccessfulSubmissions": "<p>A list of the JobRuns that were successfully submitted for stopping.</p>"
       }
     },
     "Boolean": {
@@ -231,7 +231,7 @@
     "BooleanValue": {
       "base": null,
       "refs": {
-        "GetJobRunRequest$PredecessorsIncluded": "<p>A list of the predecessor runs to return as well.</p>",
+        "GetJobRunRequest$PredecessorsIncluded": "<p>True if a list of predecessor runs should be returned.</p>",
         "UpdateDevEndpointRequest$UpdateEtlLibraries": "<p>True if the list of custom libraries to be loaded in the development endpoint needs to be updated, or False otherwise.</p>"
       }
     },
@@ -512,9 +512,9 @@
     "CrawlerConfiguration": {
       "base": null,
       "refs": {
-        "Crawler$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition. Use the following JSON string to specify that behavior:</p>",
-        "CreateCrawlerRequest$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition.</p>",
-        "UpdateCrawlerRequest$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition. Use the following JSON string to specify that behavior:</p>"
+        "Crawler$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition. Use the following JSON string to specify that behavior:</p> <p>Example: <code>'{ \"Version\": 1.0, \"CrawlerOutput\": { \"Partitions\": { \"AddOrUpdateBehavior\": \"InheritFromTable\" } } }'</code> </p>",
+        "CreateCrawlerRequest$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition. Use the following JSON string to specify that behavior:</p> <p>Example: <code>'{ \"Version\": 1.0, \"CrawlerOutput\": { \"Partitions\": { \"AddOrUpdateBehavior\": \"InheritFromTable\" } } }'</code> </p>",
+        "UpdateCrawlerRequest$Configuration": "<p>Crawler configuration information. This versioned JSON string allows users to specify aspects of a Crawler's behavior.</p> <p>You can use this field to force partitions to inherit metadata such as classification, input format, output format, serde information, and schema from their parent table, rather than detect this information separately for each partition. Use the following JSON string to specify that behavior:</p> <p>Example:  <code>'{ \"Version\": 1.0, \"CrawlerOutput\": { \"Partitions\": { \"AddOrUpdateBehavior\": \"InheritFromTable\" } } }'</code> </p>"
       }
     },
     "CrawlerList": {
@@ -923,7 +923,7 @@
     "ErrorDetail": {
       "base": "<p>Contains details about an error.</p>",
       "refs": {
-        "BatchStopJobRunError$ErrorDetail": "<p>The details of the error that occurred.</p>",
+        "BatchStopJobRunError$ErrorDetail": "<p>Specifies details about the error that was encountered.</p>",
         "ErrorByName$value": null,
         "PartitionError$ErrorDetail": "<p>Details about the partition error.</p>",
         "TableError$ErrorDetail": "<p>Detail about the error.</p>"
@@ -966,12 +966,12 @@
     "GenericMap": {
       "base": null,
       "refs": {
-        "Action$Arguments": "<p>Arguments to be passed to the job.</p>",
-        "CreateJobRequest$DefaultArguments": "<p>The default parameters for this job.</p>",
-        "Job$DefaultArguments": "<p>The default parameters for this job.</p>",
-        "JobRun$Arguments": "<p>The job arguments associated with this run.</p>",
-        "JobUpdate$DefaultArguments": "<p>The default parameters for this job.</p>",
-        "StartJobRunRequest$Arguments": "<p>Specific arguments for this job run.</p>"
+        "Action$Arguments": "<p>Arguments to be passed to the job.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>",
+        "CreateJobRequest$DefaultArguments": "<p>The default arguments for this job.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>",
+        "Job$DefaultArguments": "<p>The default arguments for this job, specified as name-value pairs.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>",
+        "JobRun$Arguments": "<p>The job arguments associated with this run. These override equivalent default arguments set for the job.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>",
+        "JobUpdate$DefaultArguments": "<p>The default arguments for this job.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>",
+        "StartJobRunRequest$Arguments": "<p>The job arguments specifically for this run. They override the equivalent default arguments set for the job itself.</p> <p>You can specify arguments here that your own job-execution script consumes, as well as arguments that AWS Glue itself consumes.</p> <p>For information about how to specify and consume your own Job arguments, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html\">Calling AWS Glue APIs in Python</a> topic in the developer guide.</p> <p>For information about the key-value pairs that AWS Glue consumes to set up your job, see the <a href=\"http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html\">Special Parameters Used by AWS Glue</a> topic in the developer guide.</p>"
       }
     },
     "GenericString": {
@@ -991,7 +991,7 @@
         "CreateDevEndpointResponse$ExtraPythonLibsS3Path": "<p>Path(s) to one or more Python libraries in an S3 bucket that will be loaded in your DevEndpoint.</p>",
         "CreateDevEndpointResponse$ExtraJarsS3Path": "<p>Path to one or more Java Jars in an S3 bucket that will be loaded in your DevEndpoint.</p>",
         "CreateDevEndpointResponse$FailureReason": "<p>The reason for a current failure in this DevEndpoint.</p>",
-        "CreateTriggerRequest$Schedule": "<p>A <code>cron</code> expression used to specify the schedule (see <a href=\"http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html\">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>",
+        "CreateTriggerRequest$Schedule": "<p>A <code>cron</code> expression used to specify the schedule (see <a href=\"http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html\">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p> <p>This field is required when the trigger type is SCHEDULED.</p>",
         "DeleteDevEndpointRequest$EndpointName": "<p>The name of the DevEndpoint.</p>",
         "DevEndpoint$EndpointName": "<p>The name of the DevEndpoint.</p>",
         "DevEndpoint$SubnetId": "<p>The subnet ID for this DevEndpoint.</p>",
@@ -1018,10 +1018,10 @@
         "GetJobsResponse$NextToken": "<p>A continuation token, if not all jobs have yet been returned.</p>",
         "GetTriggersRequest$NextToken": "<p>A continuation token, if this is a continuation call.</p>",
         "GetTriggersResponse$NextToken": "<p>A continuation token, if not all the requested triggers have yet been returned.</p>",
-        "JobCommand$Name": "<p>The name of this job command.</p>",
+        "JobCommand$Name": "<p>The name of the job command: this must be <code>glueetl</code>.</p>",
         "StringList$member": null,
         "Trigger$Schedule": "<p>A <code>cron</code> expression used to specify the schedule (see <a href=\"http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html\">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>",
-        "TriggerUpdate$Schedule": "<p>An updated <code>cron</code> expression used to specify the schedule (see <a href=\"http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html\">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>",
+        "TriggerUpdate$Schedule": "<p>A <code>cron</code> expression used to specify the schedule (see <a href=\"http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html\">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>",
         "UpdateDevEndpointRequest$EndpointName": "<p>The name of the DevEndpoint to be updated.</p>",
         "UpdateDevEndpointRequest$PublicKey": "<p>The public key for the DevEndpoint to use.</p>"
       }
@@ -1335,16 +1335,16 @@
     "IdString": {
       "base": null,
       "refs": {
-        "BatchStopJobRunError$JobRunId": "<p>The job run Id.</p>",
+        "BatchStopJobRunError$JobRunId": "<p>The JobRunId of the JobRun in question.</p>",
         "BatchStopJobRunJobRunIdList$member": null,
-        "BatchStopJobRunSuccessfulSubmission$JobRunId": "<p>The job run Id.</p>",
+        "BatchStopJobRunSuccessfulSubmission$JobRunId": "<p>The JobRunId of the JobRun in question.</p>",
         "GetJobRunRequest$RunId": "<p>The ID of the job run.</p>",
         "JobRun$Id": "<p>The ID of this job run.</p>",
-        "JobRun$PreviousRunId": "<p>The ID of the previous run of this job.</p>",
-        "Predecessor$RunId": "<p>The job-run ID of the precessor job run.</p>",
-        "StartJobRunRequest$JobRunId": "<p>The ID of the job run to start.</p>",
+        "JobRun$PreviousRunId": "<p>The ID of the previous run of this job. For example, the JobRunId specified in the StartJobRun action.</p>",
+        "Predecessor$RunId": "<p>The job-run ID of the predecessor job run.</p>",
+        "StartJobRunRequest$JobRunId": "<p>The ID of a previous JobRun to retry.</p>",
         "StartJobRunResponse$JobRunId": "<p>The ID assigned to this job run.</p>",
-        "Trigger$Id": "<p>The trigger ID.</p>"
+        "Trigger$Id": "<p>Reserved for future use.</p>"
       }
     },
     "IdempotentParameterMismatchException": {
@@ -1381,16 +1381,16 @@
         "CreateDevEndpointRequest$NumberOfNodes": "<p>The number of AWS Glue Data Processing Units (DPUs) to allocate to this DevEndpoint.</p>",
         "CreateDevEndpointResponse$ZeppelinRemoteSparkInterpreterPort": "<p>The Apache Zeppelin port for the remote Apache Spark interpreter.</p>",
         "CreateDevEndpointResponse$NumberOfNodes": "<p>The number of AWS Glue Data Processing Units (DPUs) allocated to this DevEndpoint.</p>",
-        "CreateJobRequest$AllocatedCapacity": "<p>The number of capacity units allocated to this job.</p>",
+        "CreateJobRequest$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
         "DevEndpoint$ZeppelinRemoteSparkInterpreterPort": "<p>The Apache Zeppelin port for the remote Apache Spark interpreter.</p>",
         "DevEndpoint$NumberOfNodes": "<p>The number of AWS Glue Data Processing Units (DPUs) allocated to this DevEndpoint.</p>",
-        "Job$AllocatedCapacity": "<p>The number of capacity units allocated to this job.</p>",
+        "Job$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) allocated to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
         "JobBookmarkEntry$Version": "<p>Version of the job.</p>",
         "JobBookmarkEntry$Run": "<p>The run ID number.</p>",
         "JobBookmarkEntry$Attempt": "<p>The attempt ID number.</p>",
-        "JobRun$AllocatedCapacity": "<p>The amount of infrastructure capacity allocated to this job run.</p>",
-        "JobUpdate$AllocatedCapacity": "<p>The number of capacity units allocated to this job.</p>",
-        "StartJobRunRequest$AllocatedCapacity": "<p>The infrastructure capacity to allocate to this job.</p>"
+        "JobRun$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
+        "JobUpdate$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
+        "StartJobRunRequest$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>"
       }
     },
     "InternalServiceException": {
@@ -1416,7 +1416,7 @@
       }
     },
     "Job": {
-      "base": "<p>Specifies a job in the Data Catalog.</p>",
+      "base": "<p>Specifies a job.</p>",
       "refs": {
         "GetJobResponse$Job": "<p>The requested job definition.</p>",
         "JobList$member": null
@@ -1433,7 +1433,7 @@
       "refs": {
         "CreateJobRequest$Command": "<p>The JobCommand that executes this job.</p>",
         "Job$Command": "<p>The JobCommand that executes this job.</p>",
-        "JobUpdate$Command": "<p>The JobCommand that executes this job.</p>"
+        "JobUpdate$Command": "<p>The JobCommand that executes this job (required).</p>"
       }
     },
     "JobList": {
@@ -1465,12 +1465,12 @@
     "JobRunState": {
       "base": null,
       "refs": {
-        "Condition$State": "<p>The condition state.</p>",
+        "Condition$State": "<p>The condition state. Currently, the values supported are SUCCEEDED, STOPPED and FAILED.</p>",
         "JobRun$JobRunState": "<p>The current state of the job run.</p>"
       }
     },
     "JobUpdate": {
-      "base": "<p>Specifies information used to update an existing job.</p>",
+      "base": "<p>Specifies information used to update an existing job. Note that the previous job definition will be completely overwritten by this information.</p>",
       "refs": {
         "UpdateJobRequest$JobUpdate": "<p>Specifies the values with which to update the job.</p>"
       }
@@ -1485,6 +1485,13 @@
       "base": null,
       "refs": {
         "ParametersMap$key": null
+      }
+    },
+    "Language": {
+      "base": null,
+      "refs": {
+        "CreateScriptRequest$Language": "<p>The programming language of the resulting code from the DAG.</p>",
+        "GetPlanRequest$Language": "<p>The programming language of the code to perform the mapping.</p>"
       }
     },
     "LastCrawlInfo": {
@@ -1566,7 +1573,7 @@
     "MaxConcurrentRuns": {
       "base": null,
       "refs": {
-        "ExecutionProperty$MaxConcurrentRuns": "<p>The maximum number of concurrent runs allowed for a job.</p>"
+        "ExecutionProperty$MaxConcurrentRuns": "<p>The maximum number of concurrent runs allowed for a job. The default is 1. An error is returned when this threshold is reached. The maximum value you can specify is controlled by a service limit.</p>"
       }
     },
     "MaxRetries": {
@@ -1625,15 +1632,15 @@
         "BatchDeleteTableRequest$DatabaseName": "<p>The name of the catalog database where the tables to delete reside.</p>",
         "BatchGetPartitionRequest$DatabaseName": "<p>The name of the catalog database where the partitions reside.</p>",
         "BatchGetPartitionRequest$TableName": "<p>The name of the partitions' table.</p>",
-        "BatchStopJobRunError$JobName": "<p>The name of the job.</p>",
-        "BatchStopJobRunRequest$JobName": "<p>The name of the job whose job runs are to be stopped.</p>",
-        "BatchStopJobRunSuccessfulSubmission$JobName": "<p>The name of the job.</p>",
+        "BatchStopJobRunError$JobName": "<p>The name of the Job in question.</p>",
+        "BatchStopJobRunRequest$JobName": "<p>The name of the Job in question.</p>",
+        "BatchStopJobRunSuccessfulSubmission$JobName": "<p>The Name of the Job in question.</p>",
         "CatalogEntry$DatabaseName": "<p>The database in which the table metadata resides.</p>",
         "CatalogEntry$TableName": "<p>The name of the table in question.</p>",
         "CatalogImportStatus$ImportedBy": "<p>The name of the person who initiated the migration.</p>",
         "ClassifierNameList$member": null,
         "Column$Name": "<p>The name of the <code>Column</code>.</p>",
-        "Condition$JobName": "<p>The name of the job in question.</p>",
+        "Condition$JobName": "<p>The name of the Job to whose JobRuns this condition applies and on which this trigger waits.</p>",
         "Connection$Name": "<p>The name of the connection definition.</p>",
         "Connection$LastUpdatedBy": "<p>The user, group or role that last updated this connection definition.</p>",
         "ConnectionInput$Name": "<p>The name of the connection.</p>",
@@ -1642,13 +1649,13 @@
         "CrawlerNameList$member": null,
         "CreateCrawlerRequest$Name": "<p>Name of the new crawler.</p>",
         "CreateGrokClassifierRequest$Name": "<p>The name of the new classifier.</p>",
-        "CreateJobRequest$Name": "<p>The name you assign to this job.</p>",
-        "CreateJobResponse$Name": "<p>The unique name of the new job that has been created.</p>",
+        "CreateJobRequest$Name": "<p>The name you assign to this job. It must be unique in your account.</p>",
+        "CreateJobResponse$Name": "<p>The unique name that was provided.</p>",
         "CreatePartitionRequest$DatabaseName": "<p>The name of the metadata database in which the partition is to be created.</p>",
         "CreatePartitionRequest$TableName": "<p>The name of the metadata table in which the partition is to be created.</p>",
         "CreateTableRequest$DatabaseName": "<p>The catalog database in which to create the new table.</p>",
-        "CreateTriggerRequest$Name": "<p>The name to assign to the new trigger.</p>",
-        "CreateTriggerResponse$Name": "<p>The name assigned to the new trigger.</p>",
+        "CreateTriggerRequest$Name": "<p>The name of the trigger.</p>",
+        "CreateTriggerResponse$Name": "<p>The name of the trigger.</p>",
         "CreateUserDefinedFunctionRequest$DatabaseName": "<p>The name of the catalog database in which to create the function.</p>",
         "CreateXMLClassifierRequest$Name": "<p>The name of the classifier.</p>",
         "Database$Name": "<p>Name of the database.</p>",
@@ -1687,14 +1694,14 @@
         "GetTableVersionsRequest$TableName": "<p>The name of the table.</p>",
         "GetTablesRequest$DatabaseName": "<p>The database in the catalog whose tables to list.</p>",
         "GetTriggerRequest$Name": "<p>The name of the trigger to retrieve.</p>",
-        "GetTriggersRequest$DependentJobName": "<p>The name of the job for which to retrieve triggers.</p>",
+        "GetTriggersRequest$DependentJobName": "<p>The name of the job for which to retrieve triggers. The trigger that can start this job will be returned, and if there is no such trigger, all triggers will be returned.</p>",
         "GetUserDefinedFunctionRequest$DatabaseName": "<p>The name of the catalog database where the function is located.</p>",
         "GetUserDefinedFunctionRequest$FunctionName": "<p>The name of the function.</p>",
         "GetUserDefinedFunctionsRequest$DatabaseName": "<p>The name of the catalog database where the functions are located.</p>",
         "GetUserDefinedFunctionsRequest$Pattern": "<p>An optional function-name pattern string that filters the function definitions returned.</p>",
         "GrokClassifier$Name": "<p>The name of the classifier.</p>",
         "Job$Name": "<p>The name you assign to this job.</p>",
-        "JobRun$TriggerName": "<p>The name of the trigger for this job run.</p>",
+        "JobRun$TriggerName": "<p>The name of the trigger that started this job run.</p>",
         "JobRun$JobName": "<p>The name of the job being run.</p>",
         "MatchCriteria$member": null,
         "NameStringList$member": null,
@@ -1724,7 +1731,7 @@
         "TableInput$Name": "<p>Name of the table.</p>",
         "TableInput$Owner": "<p>Owner of the table.</p>",
         "Trigger$Name": "<p>Name of the trigger.</p>",
-        "TriggerUpdate$Name": "<p>The name of the trigger.</p>",
+        "TriggerUpdate$Name": "<p>Reserved for future use.</p>",
         "UpdateConnectionRequest$Name": "<p>The name of the connection definition to update.</p>",
         "UpdateCrawlerRequest$Name": "<p>Name of the new crawler.</p>",
         "UpdateCrawlerScheduleRequest$CrawlerName": "<p>Name of the crawler whose schedule to update.</p>",
@@ -1905,7 +1912,7 @@
       }
     },
     "Predecessor": {
-      "base": "<p>A job run that preceded this one.</p>",
+      "base": "<p>A job run that was used in the predicate of a conditional trigger that triggered this job run.</p>",
       "refs": {
         "PredecessorList$member": null
       }
@@ -1919,8 +1926,8 @@
     "Predicate": {
       "base": "<p>Defines the predicate of the trigger, which determines when it fires.</p>",
       "refs": {
-        "CreateTriggerRequest$Predicate": "<p>A predicate to specify when the new trigger should fire.</p>",
-        "Trigger$Predicate": "<p>The predicate of this trigger.</p>",
+        "CreateTriggerRequest$Predicate": "<p>A predicate to specify when the new trigger should fire.</p> <p>This field is required when the trigger type is CONDITIONAL.</p>",
+        "Trigger$Predicate": "<p>The predicate of this trigger, which defines when it will fire.</p>",
         "TriggerUpdate$Predicate": "<p>The predicate of this trigger, which defines when it will fire.</p>"
       }
     },
@@ -1998,17 +2005,17 @@
     "RoleString": {
       "base": null,
       "refs": {
-        "CreateJobRequest$Role": "<p>The role associated with this job.</p>",
-        "Job$Role": "<p>The role associated with this job.</p>",
-        "JobUpdate$Role": "<p>The role associated with this job.</p>"
+        "CreateJobRequest$Role": "<p>The name of the IAM role associated with this job.</p>",
+        "Job$Role": "<p>The name of the IAM role associated with this job.</p>",
+        "JobUpdate$Role": "<p>The name of the IAM role associated with this job (required).</p>"
       }
     },
     "RowTag": {
       "base": null,
       "refs": {
-        "CreateXMLClassifierRequest$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot be an empty element. It must contain child elements representing fields in the record.</p>",
-        "UpdateXMLClassifierRequest$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot be an empty element. It must contain child elements representing fields in the record.</p>",
-        "XMLClassifier$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot be an empty element. It must contain child elements representing fields in the record.</p>"
+        "CreateXMLClassifierRequest$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot identify a self-closing element (closed by <code>/&gt;</code>). An empty row element that contains only attributes can be parsed as long as it ends with a closing tag (for example, <code>&lt;row item_a=\"A\" item_b=\"B\"&gt;&lt;/row&gt;</code> is okay, but <code>&lt;row item_a=\"A\" item_b=\"B\" /&gt;</code> is not).</p>",
+        "UpdateXMLClassifierRequest$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot identify a self-closing element (closed by <code>/&gt;</code>). An empty row element that contains only attributes can be parsed as long as it ends with a closing tag (for example, <code>&lt;row item_a=\"A\" item_b=\"B\"&gt;&lt;/row&gt;</code> is okay, but <code>&lt;row item_a=\"A\" item_b=\"B\" /&gt;</code> is not).</p>",
+        "XMLClassifier$RowTag": "<p>The XML tag designating the element that contains each record in an XML document being parsed. Note that this cannot identify a self-closing element (closed by <code>/&gt;</code>). An empty row element that contains only attributes can be parsed as long as it ends with a closing tag (for example, <code>&lt;row item_a=\"A\" item_b=\"B\"&gt;&lt;/row&gt;</code> is okay, but <code>&lt;row item_a=\"A\" item_b=\"B\" /&gt;</code> is not).</p>"
       }
     },
     "S3Target": {
@@ -2021,6 +2028,13 @@
       "base": null,
       "refs": {
         "CrawlerTargets$S3Targets": "<p>Specifies Amazon S3 targets.</p>"
+      }
+    },
+    "ScalaCode": {
+      "base": null,
+      "refs": {
+        "CreateScriptResponse$ScalaCode": "<p>The Scala code generated from the DAG.</p>",
+        "GetPlanResponse$ScalaCode": "<p>Scala code to perform the mapping.</p>"
       }
     },
     "Schedule": {
@@ -2068,7 +2082,7 @@
     "ScriptLocationString": {
       "base": null,
       "refs": {
-        "JobCommand$ScriptLocation": "<p>Specifies the location of a script that executes a job.</p>"
+        "JobCommand$ScriptLocation": "<p>Specifies the S3 path to a script that executes a job (required).</p>"
       }
     },
     "SecurityGroupIdList": {
@@ -2342,7 +2356,7 @@
       }
     },
     "TriggerUpdate": {
-      "base": "<p>A structure used to provide information used to updata a trigger.</p>",
+      "base": "<p>A structure used to provide information used to update a trigger. This object will update the the previous trigger definition by overwriting it completely.</p>",
       "refs": {
         "UpdateTriggerRequest$TriggerUpdate": "<p>The new values with which to update the trigger.</p>"
       }

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -495,7 +495,7 @@ func (c *Glue) BatchStopJobRunRequest(input *BatchStopJobRunInput) (req *request
 
 // BatchStopJobRun API operation for AWS Glue.
 //
-// Stops a batch of job runs for a given job.
+// Stops one or more job runs for a specified Job.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1060,6 +1060,9 @@ func (c *Glue) CreateJobRequest(input *CreateJobInput) (req *request.Request, ou
 //   * ErrCodeResourceNumberLimitExceededException "ResourceNumberLimitExceededException"
 //   A resource numerical limit was exceeded.
 //
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/CreateJob
 func (c *Glue) CreateJob(input *CreateJobInput) (*CreateJobOutput, error) {
 	req, out := c.CreateJobRequest(input)
@@ -1220,7 +1223,7 @@ func (c *Glue) CreateScriptRequest(input *CreateScriptInput) (req *request.Reque
 
 // CreateScript API operation for AWS Glue.
 //
-// Transforms a directed acyclic graph (DAG) into a Python script.
+// Transforms a directed acyclic graph (DAG) into code.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1415,6 +1418,9 @@ func (c *Glue) CreateTriggerRequest(input *CreateTriggerInput) (req *request.Req
 //   * ErrCodeInvalidInputException "InvalidInputException"
 //   The input provided was not valid.
 //
+//   * ErrCodeIdempotentParameterMismatchException "IdempotentParameterMismatchException"
+//   The same unique identifier was associated with two different records.
+//
 //   * ErrCodeInternalServiceException "InternalServiceException"
 //   An internal service error occurred.
 //
@@ -1423,6 +1429,9 @@ func (c *Glue) CreateTriggerRequest(input *CreateTriggerInput) (req *request.Req
 //
 //   * ErrCodeResourceNumberLimitExceededException "ResourceNumberLimitExceededException"
 //   A resource numerical limit was exceeded.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/CreateTrigger
 func (c *Glue) CreateTrigger(input *CreateTriggerInput) (*CreateTriggerOutput, error) {
@@ -2010,7 +2019,7 @@ func (c *Glue) DeleteJobRequest(input *DeleteJobInput) (req *request.Request, ou
 
 // DeleteJob API operation for AWS Glue.
 //
-// Deletes a specified job.
+// Deletes a specified job. If the job is not found, no exception is thrown.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2271,7 +2280,8 @@ func (c *Glue) DeleteTriggerRequest(input *DeleteTriggerInput) (req *request.Req
 
 // DeleteTrigger API operation for AWS Glue.
 //
-// Deletes a specified trigger.
+// Deletes a specified trigger. If the trigger is not found, no exception is
+// thrown.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2289,6 +2299,9 @@ func (c *Glue) DeleteTriggerRequest(input *DeleteTriggerInput) (req *request.Req
 //
 //   * ErrCodeOperationTimeoutException "OperationTimeoutException"
 //   The operation timed out.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/DeleteTrigger
 func (c *Glue) DeleteTrigger(input *DeleteTriggerInput) (*DeleteTriggerOutput, error) {
@@ -4645,7 +4658,7 @@ func (c *Glue) GetPlanRequest(input *GetPlanInput) (req *request.Request, output
 
 // GetPlan API operation for AWS Glue.
 //
-// Gets a Python script to perform a specified mapping.
+// Gets code to perform a specified mapping.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6013,7 +6026,8 @@ func (c *Glue) StartTriggerRequest(input *StartTriggerInput) (req *request.Reque
 
 // StartTrigger API operation for AWS Glue.
 //
-// Starts an existing trigger.
+// Starts an existing trigger. See Triggering Jobs (http://docs.aws.amazon.com/glue/latest/dg/trigger-job.html)
+// for information about how different types of trigger are started.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -6305,6 +6319,9 @@ func (c *Glue) StopTriggerRequest(input *StopTriggerInput) (req *request.Request
 //
 //   * ErrCodeOperationTimeoutException "OperationTimeoutException"
 //   The operation timed out.
+//
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/StopTrigger
 func (c *Glue) StopTrigger(input *StopTriggerInput) (*StopTriggerOutput, error) {
@@ -6929,6 +6946,9 @@ func (c *Glue) UpdateJobRequest(input *UpdateJobInput) (req *request.Request, ou
 //   * ErrCodeOperationTimeoutException "OperationTimeoutException"
 //   The operation timed out.
 //
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/UpdateJob
 func (c *Glue) UpdateJob(input *UpdateJobInput) (*UpdateJobOutput, error) {
 	req, out := c.UpdateJobRequest(input)
@@ -7196,6 +7216,9 @@ func (c *Glue) UpdateTriggerRequest(input *UpdateTriggerInput) (req *request.Req
 //   * ErrCodeOperationTimeoutException "OperationTimeoutException"
 //   The operation timed out.
 //
+//   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
+//   Two processes are trying to modify a resource simultaneously.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/UpdateTrigger
 func (c *Glue) UpdateTrigger(input *UpdateTriggerInput) (*UpdateTriggerOutput, error) {
 	req, out := c.UpdateTriggerRequest(input)
@@ -7312,6 +7335,17 @@ type Action struct {
 	_ struct{} `type:"structure"`
 
 	// Arguments to be passed to the job.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own Job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	Arguments map[string]*string `type:"map"`
 
 	// The name of a job to be executed.
@@ -7902,19 +7936,18 @@ func (s *BatchGetPartitionOutput) SetUnprocessedKeys(v []*PartitionValueList) *B
 	return s
 }
 
-// Details about the job run and the error that occurred while trying to submit
-// it for stopping.
+// Records an error that occurred when attempting to stop a specified JobRun.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/BatchStopJobRunError
 type BatchStopJobRunError struct {
 	_ struct{} `type:"structure"`
 
-	// The details of the error that occurred.
+	// Specifies details about the error that was encountered.
 	ErrorDetail *ErrorDetail `type:"structure"`
 
-	// The name of the job.
+	// The name of the Job in question.
 	JobName *string `min:"1" type:"string"`
 
-	// The job run Id.
+	// The JobRunId of the JobRun in question.
 	JobRunId *string `min:"1" type:"string"`
 }
 
@@ -7950,12 +7983,12 @@ func (s *BatchStopJobRunError) SetJobRunId(v string) *BatchStopJobRunError {
 type BatchStopJobRunInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the job whose job runs are to be stopped.
+	// The name of the Job in question.
 	//
 	// JobName is a required field
 	JobName *string `min:"1" type:"string" required:"true"`
 
-	// A list of job run Ids of the given job to be stopped.
+	// A list of the JobRunIds that should be stopped for that Job.
 	//
 	// JobRunIds is a required field
 	JobRunIds []*string `min:"1" type:"list" required:"true"`
@@ -8009,11 +8042,11 @@ func (s *BatchStopJobRunInput) SetJobRunIds(v []*string) *BatchStopJobRunInput {
 type BatchStopJobRunOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list containing the job run Ids and details of the error that occurred
-	// for each job run while submitting to stop.
+	// A list of the errors that were encountered in tryng to stop JobRuns, including
+	// the JobRunId for which each error was encountered and details about the error.
 	Errors []*BatchStopJobRunError `type:"list"`
 
-	// A list of job runs which are successfully submitted for stopping.
+	// A list of the JobRuns that were successfully submitted for stopping.
 	SuccessfulSubmissions []*BatchStopJobRunSuccessfulSubmission `type:"list"`
 }
 
@@ -8039,15 +8072,15 @@ func (s *BatchStopJobRunOutput) SetSuccessfulSubmissions(v []*BatchStopJobRunSuc
 	return s
 }
 
-// Details about the job run which is submitted successfully for stopping.
+// Records a successful request to stop a specified JobRun.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/BatchStopJobRunSuccessfulSubmission
 type BatchStopJobRunSuccessfulSubmission struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the job.
+	// The Name of the Job in question.
 	JobName *string `min:"1" type:"string"`
 
-	// The job run Id.
+	// The JobRunId of the JobRun in question.
 	JobRunId *string `min:"1" type:"string"`
 }
 
@@ -8505,13 +8538,15 @@ func (s *Column) SetType(v string) *Column {
 type Condition struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the job in question.
+	// The name of the Job to whose JobRuns this condition applies and on which
+	// this trigger waits.
 	JobName *string `min:"1" type:"string"`
 
 	// A logical operator.
 	LogicalOperator *string `type:"string" enum:"LogicalOperator"`
 
-	// The condition state.
+	// The condition state. Currently, the values supported are SUCCEEDED, STOPPED
+	// and FAILED.
 	State *string `type:"string" enum:"JobRunState"`
 }
 
@@ -8787,6 +8822,9 @@ type Crawler struct {
 	// input format, output format, serde information, and schema from their parent
 	// table, rather than detect this information separately for each partition.
 	// Use the following JSON string to specify that behavior:
+	//
+	// Example: '{ "Version": 1.0, "CrawlerOutput": { "Partitions": { "AddOrUpdateBehavior":
+	// "InheritFromTable" } } }'
 	Configuration *string `type:"string"`
 
 	// If the crawler is running, contains the total time elapsed since the last
@@ -9219,6 +9257,10 @@ type CreateCrawlerInput struct {
 	// You can use this field to force partitions to inherit metadata such as classification,
 	// input format, output format, serde information, and schema from their parent
 	// table, rather than detect this information separately for each partition.
+	// Use the following JSON string to specify that behavior:
+	//
+	// Example: '{ "Version": 1.0, "CrawlerOutput": { "Partitions": { "AddOrUpdateBehavior":
+	// "InheritFromTable" } } }'
 	Configuration *string `type:"string"`
 
 	// The AWS Glue database where results are written, such as: arn:aws:daylight:us-east-1::database/sometable/*.
@@ -9790,7 +9832,11 @@ func (s *CreateGrokClassifierRequest) SetName(v string) *CreateGrokClassifierReq
 type CreateJobInput struct {
 	_ struct{} `type:"structure"`
 
-	// The number of capacity units allocated to this job.
+	// The number of AWS Glue data processing units (DPUs) to allocate to this Job.
+	// From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative
+	// measure of processing power that consists of 4 vCPUs of compute capacity
+	// and 16 GB of memory. For more information, see the AWS Glue pricing page
+	// (https://aws.amazon.com/glue/pricing/).
 	AllocatedCapacity *int64 `type:"integer"`
 
 	// The JobCommand that executes this job.
@@ -9801,7 +9847,18 @@ type CreateJobInput struct {
 	// The connections used for this job.
 	Connections *ConnectionsList `type:"structure"`
 
-	// The default parameters for this job.
+	// The default arguments for this job.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own Job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	DefaultArguments map[string]*string `type:"map"`
 
 	// Description of the job.
@@ -9817,12 +9874,12 @@ type CreateJobInput struct {
 	// The maximum number of times to retry this job if it fails.
 	MaxRetries *int64 `type:"integer"`
 
-	// The name you assign to this job.
+	// The name you assign to this job. It must be unique in your account.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The role associated with this job.
+	// The name of the IAM role associated with this job.
 	//
 	// Role is a required field
 	Role *string `type:"string" required:"true"`
@@ -9924,7 +9981,7 @@ func (s *CreateJobInput) SetRole(v string) *CreateJobInput {
 type CreateJobOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The unique name of the new job that has been created.
+	// The unique name that was provided.
 	Name *string `min:"1" type:"string"`
 }
 
@@ -10059,6 +10116,9 @@ type CreateScriptInput struct {
 
 	// A list of the nodes in the DAG.
 	DagNodes []*CodeGenNode `type:"list"`
+
+	// The programming language of the resulting code from the DAG.
+	Language *string `type:"string" enum:"Language"`
 }
 
 // String returns the string representation
@@ -10113,12 +10173,21 @@ func (s *CreateScriptInput) SetDagNodes(v []*CodeGenNode) *CreateScriptInput {
 	return s
 }
 
+// SetLanguage sets the Language field's value.
+func (s *CreateScriptInput) SetLanguage(v string) *CreateScriptInput {
+	s.Language = &v
+	return s
+}
+
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/CreateScriptResponse
 type CreateScriptOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Python script generated from the DAG.
 	PythonScript *string `type:"string"`
+
+	// The Scala code generated from the DAG.
+	ScalaCode *string `type:"string"`
 }
 
 // String returns the string representation
@@ -10134,6 +10203,12 @@ func (s CreateScriptOutput) GoString() string {
 // SetPythonScript sets the PythonScript field's value.
 func (s *CreateScriptOutput) SetPythonScript(v string) *CreateScriptOutput {
 	s.PythonScript = &v
+	return s
+}
+
+// SetScalaCode sets the ScalaCode field's value.
+func (s *CreateScriptOutput) SetScalaCode(v string) *CreateScriptOutput {
+	s.ScalaCode = &v
 	return s
 }
 
@@ -10238,18 +10313,22 @@ type CreateTriggerInput struct {
 	// A description of the new trigger.
 	Description *string `type:"string"`
 
-	// The name to assign to the new trigger.
+	// The name of the trigger.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// A predicate to specify when the new trigger should fire.
+	//
+	// This field is required when the trigger type is CONDITIONAL.
 	Predicate *Predicate `type:"structure"`
 
 	// A cron expression used to specify the schedule (see Time-Based Schedules
 	// for Jobs and Crawlers (http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html).
 	// For example, to run something every day at 12:15 UTC, you would specify:
 	// cron(15 12 * * ? *).
+	//
+	// This field is required when the trigger type is SCHEDULED.
 	Schedule *string `type:"string"`
 
 	// The type of the new trigger.
@@ -10345,7 +10424,7 @@ func (s *CreateTriggerInput) SetType(v string) *CreateTriggerInput {
 type CreateTriggerOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The name assigned to the new trigger.
+	// The name of the trigger.
 	Name *string `min:"1" type:"string"`
 }
 
@@ -10470,8 +10549,10 @@ type CreateXMLClassifierRequest struct {
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The XML tag designating the element that contains each record in an XML document
-	// being parsed. Note that this cannot be an empty element. It must contain
-	// child elements representing fields in the record.
+	// being parsed. Note that this cannot identify a self-closing element (closed
+	// by />). An empty row element that contains only attributes can be parsed
+	// as long as it ends with a closing tag (for example, <row item_a="A" item_b="B"></row>
+	// is okay, but <row item_a="A" item_b="B" /> is not).
 	RowTag *string `type:"string"`
 }
 
@@ -11645,7 +11726,9 @@ func (s *ErrorDetail) SetErrorMessage(v string) *ErrorDetail {
 type ExecutionProperty struct {
 	_ struct{} `type:"structure"`
 
-	// The maximum number of concurrent runs allowed for a job.
+	// The maximum number of concurrent runs allowed for a job. The default is 1.
+	// An error is returned when this threshold is reached. The maximum value you
+	// can specify is controlled by a service limit.
 	MaxConcurrentRuns *int64 `type:"integer"`
 }
 
@@ -12772,7 +12855,7 @@ type GetJobRunInput struct {
 	// JobName is a required field
 	JobName *string `min:"1" type:"string" required:"true"`
 
-	// A list of the predecessor runs to return as well.
+	// True if a list of predecessor runs should be returned.
 	PredecessorsIncluded *bool `type:"boolean"`
 
 	// The ID of the job run.
@@ -13397,6 +13480,9 @@ func (s *GetPartitionsOutput) SetPartitions(v []*Partition) *GetPartitionsOutput
 type GetPlanInput struct {
 	_ struct{} `type:"structure"`
 
+	// The programming language of the code to perform the mapping.
+	Language *string `type:"string" enum:"Language"`
+
 	// Parameters for the mapping.
 	Location *Location `type:"structure"`
 
@@ -13460,6 +13546,12 @@ func (s *GetPlanInput) Validate() error {
 	return nil
 }
 
+// SetLanguage sets the Language field's value.
+func (s *GetPlanInput) SetLanguage(v string) *GetPlanInput {
+	s.Language = &v
+	return s
+}
+
 // SetLocation sets the Location field's value.
 func (s *GetPlanInput) SetLocation(v *Location) *GetPlanInput {
 	s.Location = v
@@ -13490,6 +13582,9 @@ type GetPlanOutput struct {
 
 	// A Python script to perform the mapping.
 	PythonScript *string `type:"string"`
+
+	// Scala code to perform the mapping.
+	ScalaCode *string `type:"string"`
 }
 
 // String returns the string representation
@@ -13505,6 +13600,12 @@ func (s GetPlanOutput) GoString() string {
 // SetPythonScript sets the PythonScript field's value.
 func (s *GetPlanOutput) SetPythonScript(v string) *GetPlanOutput {
 	s.PythonScript = &v
+	return s
+}
+
+// SetScalaCode sets the ScalaCode field's value.
+func (s *GetPlanOutput) SetScalaCode(v string) *GetPlanOutput {
+	s.ScalaCode = &v
 	return s
 }
 
@@ -13920,7 +14021,9 @@ func (s *GetTriggerOutput) SetTrigger(v *Trigger) *GetTriggerOutput {
 type GetTriggersInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the job for which to retrieve triggers.
+	// The name of the job for which to retrieve triggers. The trigger that can
+	// start this job will be returned, and if there is no such trigger, all triggers
+	// will be returned.
 	DependentJobName *string `min:"1" type:"string"`
 
 	// The maximum size of the response.
@@ -14416,12 +14519,16 @@ func (s *JdbcTarget) SetPath(v string) *JdbcTarget {
 	return s
 }
 
-// Specifies a job in the Data Catalog.
+// Specifies a job.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/Job
 type Job struct {
 	_ struct{} `type:"structure"`
 
-	// The number of capacity units allocated to this job.
+	// The number of AWS Glue data processing units (DPUs) allocated to this Job.
+	// From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative
+	// measure of processing power that consists of 4 vCPUs of compute capacity
+	// and 16 GB of memory. For more information, see the AWS Glue pricing page
+	// (https://aws.amazon.com/glue/pricing/).
 	AllocatedCapacity *int64 `type:"integer"`
 
 	// The JobCommand that executes this job.
@@ -14433,7 +14540,18 @@ type Job struct {
 	// The time and date that this job specification was created.
 	CreatedOn *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The default parameters for this job.
+	// The default arguments for this job, specified as name-value pairs.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own Job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	DefaultArguments map[string]*string `type:"map"`
 
 	// Description of this job.
@@ -14455,7 +14573,7 @@ type Job struct {
 	// The name you assign to this job.
 	Name *string `min:"1" type:"string"`
 
-	// The role associated with this job.
+	// The name of the IAM role associated with this job.
 	Role *string `type:"string"`
 }
 
@@ -14607,10 +14725,10 @@ func (s *JobBookmarkEntry) SetVersion(v int64) *JobBookmarkEntry {
 type JobCommand struct {
 	_ struct{} `type:"structure"`
 
-	// The name of this job command.
+	// The name of the job command: this must be glueetl.
 	Name *string `type:"string"`
 
-	// Specifies the location of a script that executes a job.
+	// Specifies the S3 path to a script that executes a job (required).
 	ScriptLocation *string `type:"string"`
 }
 
@@ -14641,13 +14759,29 @@ func (s *JobCommand) SetScriptLocation(v string) *JobCommand {
 type JobRun struct {
 	_ struct{} `type:"structure"`
 
-	// The amount of infrastructure capacity allocated to this job run.
+	// The number of AWS Glue data processing units (DPUs) allocated to this JobRun.
+	// From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative
+	// measure of processing power that consists of 4 vCPUs of compute capacity
+	// and 16 GB of memory. For more information, see the AWS Glue pricing page
+	// (https://aws.amazon.com/glue/pricing/).
 	AllocatedCapacity *int64 `type:"integer"`
 
-	// The job arguments associated with this run.
+	// The job arguments associated with this run. These override equivalent default
+	// arguments set for the job.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	Arguments map[string]*string `type:"map"`
 
-	// The number or the attempt to run this job.
+	// The number of the attempt to run this job.
 	Attempt *int64 `type:"integer"`
 
 	// The date and time this job run completed.
@@ -14671,13 +14805,14 @@ type JobRun struct {
 	// A list of predecessors to this job run.
 	PredecessorRuns []*Predecessor `type:"list"`
 
-	// The ID of the previous run of this job.
+	// The ID of the previous run of this job. For example, the JobRunId specified
+	// in the StartJobRun action.
 	PreviousRunId *string `min:"1" type:"string"`
 
 	// The date and time at which this job run was started.
 	StartedOn *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The name of the trigger for this job run.
+	// The name of the trigger that started this job run.
 	TriggerName *string `min:"1" type:"string"`
 }
 
@@ -14769,21 +14904,37 @@ func (s *JobRun) SetTriggerName(v string) *JobRun {
 	return s
 }
 
-// Specifies information used to update an existing job.
+// Specifies information used to update an existing job. Note that the previous
+// job definition will be completely overwritten by this information.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/JobUpdate
 type JobUpdate struct {
 	_ struct{} `type:"structure"`
 
-	// The number of capacity units allocated to this job.
+	// The number of AWS Glue data processing units (DPUs) to allocate to this Job.
+	// From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative
+	// measure of processing power that consists of 4 vCPUs of compute capacity
+	// and 16 GB of memory. For more information, see the AWS Glue pricing page
+	// (https://aws.amazon.com/glue/pricing/).
 	AllocatedCapacity *int64 `type:"integer"`
 
-	// The JobCommand that executes this job.
+	// The JobCommand that executes this job (required).
 	Command *JobCommand `type:"structure"`
 
 	// The connections used for this job.
 	Connections *ConnectionsList `type:"structure"`
 
-	// The default parameters for this job.
+	// The default arguments for this job.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own Job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	DefaultArguments map[string]*string `type:"map"`
 
 	// Description of the job.
@@ -14799,7 +14950,7 @@ type JobUpdate struct {
 	// The maximum number of times to retry this job if it fails.
 	MaxRetries *int64 `type:"integer"`
 
-	// The role associated with this job.
+	// The name of the IAM role associated with this job (required).
 	Role *string `type:"string"`
 }
 
@@ -15426,7 +15577,8 @@ func (s *PhysicalConnectionRequirements) SetSubnetId(v string) *PhysicalConnecti
 	return s
 }
 
-// A job run that preceded this one.
+// A job run that was used in the predicate of a conditional trigger that triggered
+// this job run.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/Predecessor
 type Predecessor struct {
 	_ struct{} `type:"structure"`
@@ -15434,7 +15586,7 @@ type Predecessor struct {
 	// The name of the predecessor job.
 	JobName *string `min:"1" type:"string"`
 
-	// The job-run ID of the precessor job run.
+	// The job-run ID of the predecessor job run.
 	RunId *string `min:"1" type:"string"`
 }
 
@@ -16012,10 +16164,26 @@ func (s StartCrawlerScheduleOutput) GoString() string {
 type StartJobRunInput struct {
 	_ struct{} `type:"structure"`
 
-	// The infrastructure capacity to allocate to this job.
+	// The number of AWS Glue data processing units (DPUs) to allocate to this JobRun.
+	// From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative
+	// measure of processing power that consists of 4 vCPUs of compute capacity
+	// and 16 GB of memory. For more information, see the AWS Glue pricing page
+	// (https://aws.amazon.com/glue/pricing/).
 	AllocatedCapacity *int64 `type:"integer"`
 
-	// Specific arguments for this job run.
+	// The job arguments specifically for this run. They override the equivalent
+	// default arguments set for the job itself.
+	//
+	// You can specify arguments here that your own job-execution script consumes,
+	// as well as arguments that AWS Glue itself consumes.
+	//
+	// For information about how to specify and consume your own Job arguments,
+	// see the Calling AWS Glue APIs in Python (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-calling.html)
+	// topic in the developer guide.
+	//
+	// For information about the key-value pairs that AWS Glue consumes to set up
+	// your job, see the Special Parameters Used by AWS Glue (http://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-glue-arguments.html)
+	// topic in the developer guide.
 	Arguments map[string]*string `type:"map"`
 
 	// The name of the job to start.
@@ -16023,7 +16191,7 @@ type StartJobRunInput struct {
 	// JobName is a required field
 	JobName *string `min:"1" type:"string" required:"true"`
 
-	// The ID of the job run to start.
+	// The ID of a previous JobRun to retry.
 	JobRunId *string `min:"1" type:"string"`
 }
 
@@ -16921,13 +17089,13 @@ type Trigger struct {
 	// A description of this trigger.
 	Description *string `type:"string"`
 
-	// The trigger ID.
+	// Reserved for future use.
 	Id *string `min:"1" type:"string"`
 
 	// Name of the trigger.
 	Name *string `min:"1" type:"string"`
 
-	// The predicate of this trigger.
+	// The predicate of this trigger, which defines when it will fire.
 	Predicate *Predicate `type:"structure"`
 
 	// A cron expression used to specify the schedule (see Time-Based Schedules
@@ -17001,7 +17169,8 @@ func (s *Trigger) SetType(v string) *Trigger {
 	return s
 }
 
-// A structure used to provide information used to updata a trigger.
+// A structure used to provide information used to update a trigger. This object
+// will update the the previous trigger definition by overwriting it completely.
 // See also, https://docs.aws.amazon.com/goto/WebAPI/glue-2017-03-31/TriggerUpdate
 type TriggerUpdate struct {
 	_ struct{} `type:"structure"`
@@ -17012,13 +17181,13 @@ type TriggerUpdate struct {
 	// A description of this trigger.
 	Description *string `type:"string"`
 
-	// The name of the trigger.
+	// Reserved for future use.
 	Name *string `min:"1" type:"string"`
 
 	// The predicate of this trigger, which defines when it will fire.
 	Predicate *Predicate `type:"structure"`
 
-	// An updated cron expression used to specify the schedule (see Time-Based Schedules
+	// A cron expression used to specify the schedule (see Time-Based Schedules
 	// for Jobs and Crawlers (http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html).
 	// For example, to run something every day at 12:15 UTC, you would specify:
 	// cron(15 12 * * ? *).
@@ -17266,6 +17435,9 @@ type UpdateCrawlerInput struct {
 	// input format, output format, serde information, and schema from their parent
 	// table, rather than detect this information separately for each partition.
 	// Use the following JSON string to specify that behavior:
+	//
+	// Example:  '{ "Version": 1.0, "CrawlerOutput": { "Partitions": { "AddOrUpdateBehavior":
+	// "InheritFromTable" } } }'
 	Configuration *string `type:"string"`
 
 	// The AWS Glue database where results are stored, such as: arn:aws:daylight:us-east-1::database/sometable/*.
@@ -18209,8 +18381,10 @@ type UpdateXMLClassifierRequest struct {
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The XML tag designating the element that contains each record in an XML document
-	// being parsed. Note that this cannot be an empty element. It must contain
-	// child elements representing fields in the record.
+	// being parsed. Note that this cannot identify a self-closing element (closed
+	// by />). An empty row element that contains only attributes can be parsed
+	// as long as it ends with a closing tag (for example, <row item_a="A" item_b="B"></row>
+	// is okay, but <row item_a="A" item_b="B" /> is not).
 	RowTag *string `type:"string"`
 }
 
@@ -18440,8 +18614,10 @@ type XMLClassifier struct {
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The XML tag designating the element that contains each record in an XML document
-	// being parsed. Note that this cannot be an empty element. It must contain
-	// child elements representing fields in the record.
+	// being parsed. Note that this cannot identify a self-closing element (closed
+	// by />). An empty row element that contains only attributes can be parsed
+	// as long as it ends with a closing tag (for example, <row item_a="A" item_b="B"></row>
+	// is okay, but <row item_a="A" item_b="B" /> is not).
 	RowTag *string `type:"string"`
 
 	// The version of this classifier.
@@ -18580,6 +18756,14 @@ const (
 )
 
 const (
+	// LanguagePython is a Language enum value
+	LanguagePython = "PYTHON"
+
+	// LanguageScala is a Language enum value
+	LanguageScala = "SCALA"
+)
+
+const (
 	// LastCrawlStatusSucceeded is a LastCrawlStatus enum value
 	LastCrawlStatusSucceeded = "SUCCEEDED"
 
@@ -18593,6 +18777,9 @@ const (
 const (
 	// LogicalAnd is a Logical enum value
 	LogicalAnd = "AND"
+
+	// LogicalAny is a Logical enum value
+	LogicalAny = "ANY"
 )
 
 const (


### PR DESCRIPTION
Release v1.12.61 (2018-01-12)
===

### Service Client Updates
* `service/glue`: Updates service API and documentation
  * Support is added to generate ETL scripts in Scala which can now be run by  AWS Glue ETL jobs. In addition, the trigger API now supports firing when any conditions are met (in addition to all conditions). Also, jobs can be triggered based on a "failed" or "stopped" job run (in addition to a "succeeded" job run).

