### PR TITLE
aws/request: Fix Pagination handling of empty string NextToken

### DIFF
--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -142,13 +142,28 @@ func (r *Request) nextPageTokens() []interface{} {
 	tokens := []interface{}{}
 	tokenAdded := false
 	for _, outToken := range r.Operation.OutputTokens {
-		v, _ := awsutil.ValuesAtPath(r.Data, outToken)
-		if len(v) > 0 {
-			tokens = append(tokens, v[0])
-			tokenAdded = true
-		} else {
+		vs, _ := awsutil.ValuesAtPath(r.Data, outToken)
+		if len(vs) == 0 {
 			tokens = append(tokens, nil)
+			continue
 		}
+		v := vs[0]
+
+		switch tv := v.(type) {
+		case *string:
+			if len(aws.StringValue(tv)) == 0 {
+				tokens = append(tokens, nil)
+				continue
+			}
+		case string:
+			if len(tv) == 0 {
+				tokens = append(tokens, nil)
+				continue
+			}
+		}
+
+		tokenAdded = true
+		tokens = append(tokens, v)
 	}
 	if !tokenAdded {
 		return nil

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -454,78 +454,93 @@ func TestPaginationWithContextNilInput(t *testing.T) {
 	}
 }
 
-type testPageInput struct {
-	NextToken string
-}
-type testPageOutput struct {
-	Value     string
-	NextToken *string
-}
-
 func TestPagination_Standalone(t *testing.T) {
-	expect := []struct {
-		Value, PrevToken, NextToken string
-	}{
-		{"FirstValue", "InitalToken", "FirstToken"},
-		{"SecondValue", "FirstToken", "SecondToken"},
-		{"ThirdValue", "SecondToken", ""},
+	type testPageInput struct {
+		NextToken *string
 	}
-	input := testPageInput{
-		NextToken: expect[0].PrevToken,
+	type testPageOutput struct {
+		Value     *string
+		NextToken *string
+	}
+	type testCase struct {
+		Value, PrevToken, NextToken *string
 	}
 
-	c := awstesting.NewClient()
-	i := 0
-	p := request.Pagination{
-		NewRequest: func() (*request.Request, error) {
-			r := c.NewRequest(
-				&request.Operation{
-					Name: "Operation",
-					Paginator: &request.Paginator{
-						InputTokens:  []string{"NextToken"},
-						OutputTokens: []string{"NextToken"},
-					},
-				},
-				&input, &testPageOutput{},
-			)
-			// Setup handlers for testing
-			r.Handlers.Clear()
-			r.Handlers.Build.PushBack(func(req *request.Request) {
-				in := req.Params.(*testPageInput)
-				if e, a := expect[i].PrevToken, in.NextToken; e != a {
-					t.Errorf("%d, expect NextToken input %q, got %q", i, e, a)
-				}
-			})
-			r.Handlers.Unmarshal.PushBack(func(req *request.Request) {
-				out := &testPageOutput{
-					Value: expect[i].Value,
-				}
-				if len(expect[i].NextToken) > 0 {
-					out.NextToken = aws.String(expect[i].NextToken)
-				}
-				req.Data = out
-			})
-			return r, nil
+	cases := [][]testCase{
+		{
+			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), nil},
+		},
+		{
+			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), aws.String("")},
 		},
 	}
 
-	for p.Next() {
-		data := p.Page().(*testPageOutput)
-
-		if e, a := expect[i].Value, data.Value; e != a {
-			t.Errorf("%d, expect Value to be %q, got %q", i, e, a)
-		}
-		if e, a := expect[i].NextToken, aws.StringValue(data.NextToken); e != a {
-			t.Errorf("%d, expect NextToken to be %q, got %q", i, e, a)
+	for _, c := range cases {
+		input := testPageInput{
+			NextToken: c[0].PrevToken,
 		}
 
-		i++
-	}
-	if e, a := len(expect), i; e != a {
-		t.Errorf("expected to process %d pages, did %d", e, a)
-	}
-	if err := p.Err(); err != nil {
-		t.Fatalf("%d, expected no error, got %v", i, err)
+		svc := awstesting.NewClient()
+		i := 0
+		p := request.Pagination{
+			NewRequest: func() (*request.Request, error) {
+				r := svc.NewRequest(
+					&request.Operation{
+						Name: "Operation",
+						Paginator: &request.Paginator{
+							InputTokens:  []string{"NextToken"},
+							OutputTokens: []string{"NextToken"},
+						},
+					},
+					&input, &testPageOutput{},
+				)
+				// Setup handlers for testing
+				r.Handlers.Clear()
+				r.Handlers.Build.PushBack(func(req *request.Request) {
+					if e, a := len(c), i+1; a > e {
+						t.Fatalf("expect no more than %d requests, got %d", e, a)
+					}
+					in := req.Params.(*testPageInput)
+					if e, a := aws.StringValue(c[i].PrevToken), aws.StringValue(in.NextToken); e != a {
+						t.Errorf("%d, expect NextToken input %q, got %q", i, e, a)
+					}
+				})
+				r.Handlers.Unmarshal.PushBack(func(req *request.Request) {
+					out := &testPageOutput{
+						Value: c[i].Value,
+					}
+					if c[i].NextToken != nil {
+						next := *c[i].NextToken
+						out.NextToken = aws.String(next)
+					}
+					req.Data = out
+				})
+				return r, nil
+			},
+		}
+
+		for p.Next() {
+			data := p.Page().(*testPageOutput)
+
+			if e, a := aws.StringValue(c[i].Value), aws.StringValue(data.Value); e != a {
+				t.Errorf("%d, expect Value to be %q, got %q", i, e, a)
+			}
+			if e, a := aws.StringValue(c[i].NextToken), aws.StringValue(data.NextToken); e != a {
+				t.Errorf("%d, expect NextToken to be %q, got %q", i, e, a)
+			}
+
+			i++
+		}
+		if e, a := len(c), i; e != a {
+			t.Errorf("expected to process %d pages, did %d", e, a)
+		}
+		if err := p.Err(); err != nil {
+			t.Fatalf("%d, expected no error, got %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the SDK's handling of a Pagination NextToken's value being an
empty string compared to a nil value. The SDK was expecting NextToken's
to always be unset (nil) and treating any non-nil value as a valid
value. This was not the case in MediaLive's List APIs. As those APIs
return a empty string value instead of null or not setting the field at
all.

V1 SDK port of aws/aws-sdk-go-v2#94
