### PR TITLE
aws/endpoints: Workaround CloudHSMv2 signing name not modeled

### DIFF
--- a/aws/endpoints/decode.go
+++ b/aws/endpoints/decode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -101,11 +102,13 @@ func custFixCloudHSMv2SigningName(p *partition) {
 	}
 
 	if len(s.Defaults.CredentialScope.Service) != 0 {
+		fmt.Fprintf(os.Stderr, "cloudhsmv2 signing name already set, ignoring override.\n")
 		// If the value is already set don't override
 		return
 	}
 
 	s.Defaults.CredentialScope.Service = "cloudhsm"
+	fmt.Fprintf(os.Stderr, "cloudhsmv2 signing name not set, overriding.\n")
 
 	p.Services["cloudhsmv2"] = s
 }

--- a/aws/endpoints/decode.go
+++ b/aws/endpoints/decode.go
@@ -84,9 +84,30 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		custAddEC2Metadata(p)
 		custAddS3DualStack(p)
 		custRmIotDataService(p)
+
+		custFixCloudHSMv2SigningName(p)
 	}
 
 	return ps, nil
+}
+
+func custFixCloudHSMv2SigningName(p *partition) {
+	// Workaround for aws/aws-sdk-go#1745 until the endpoint model can be
+	// fixed upstream. TODO remove this once the endpoints model is updated.
+
+	s, ok := p.Services["cloudhsmv2"]
+	if !ok {
+		return
+	}
+
+	if len(s.Defaults.CredentialScope.Service) != 0 {
+		// If the value is already set don't override
+		return
+	}
+
+	s.Defaults.CredentialScope.Service = "cloudhsm"
+
+	p.Services["cloudhsmv2"] = s
 }
 
 func custAddS3DualStack(p *partition) {

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -476,7 +476,11 @@ var awsPartition = partition{
 			},
 		},
 		"cloudhsmv2": service{
-
+			Defaults: endpoint{
+				CredentialScope: credentialScope{
+					Service: "cloudhsm",
+				},
+			},
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-south-1":     endpoint{},

--- a/awstesting/integration/smoke/cloudhsmv2/client.go
+++ b/awstesting/integration/smoke/cloudhsmv2/client.go
@@ -1,0 +1,16 @@
+// +build integration
+
+//Package cloudhsmv2 provides gucumber integration tests support.
+package cloudhsmv2
+
+import (
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/cloudhsmv2"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	gucumber.Before("@cloudhsmv2", func() {
+		gucumber.World["client"] = cloudhsmv2.New(smoke.Session)
+	})
+}

--- a/awstesting/integration/smoke/cloudhsmv2/cloudhsmv2.feature
+++ b/awstesting/integration/smoke/cloudhsmv2/cloudhsmv2.feature
@@ -1,0 +1,7 @@
+# language: en
+@cloudhsmv2 @client
+Feature: Amazon CloudHSMv2
+
+  Scenario: Making a request
+    When I call the "DescribeBackups" API
+    Then the request should be successful


### PR DESCRIPTION
Provides a endpoint customization as a workaround CloudHSMv2 not
modeling the service's signing name correctly. When the model is
eventually updated this change should be removed.

Fix #1745