### PR TITLE
models/apis: adds validation to ensure no collision are happening in models/apis

### DIFF
--- a/models/apis/check_collisions_test.go
+++ b/models/apis/check_collisions_test.go
@@ -1,0 +1,35 @@
+// +build awsinclude
+
+package apis
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCollidingFolders(t *testing.T) {
+	m := map[string]struct{}{}
+	folders, err := getFolderNames()
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, folder := range folders {
+		lcName := strings.ToLower(folder)
+		if _, ok := m[lcName]; ok {
+			t.Errorf("folder %q collision detected", folder)
+		}
+		m[lcName] = struct{}{}
+	}
+}
+
+func getFolderNames() ([]string, error) {
+	cmd := exec.Command("git", "ls-tree", "-d", "--name-only", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(output), "\n"), nil
+}

--- a/models/apis/stub.go
+++ b/models/apis/stub.go
@@ -1,0 +1,3 @@
+// +build awsinclude
+
+package apis

--- a/private/model/cli/gen-api/main.go
+++ b/private/model/cli/gen-api/main.go
@@ -132,7 +132,7 @@ func main() {
 
 	for svcName := range excludeServices {
 		if strings.Contains(os.Getenv("SERVICES"), svcName) {
-			fmt.Printf("Service %s is not supported\n", svcName)
+			fmt.Fprintf(os.Stderr, "Service %s is not supported\n", svcName)
 			os.Exit(1)
 		}
 	}
@@ -141,6 +141,10 @@ func main() {
 
 	// Remove old API versions from list
 	m := map[string]bool{}
+	// caches paths to ensure we are not overriding previously generated
+	// code.
+	servicePaths := map[string]struct{}{}
+
 	for i := range files {
 		idx := len(files) - 1 - i
 		parts := strings.Split(files[idx], string(filepath.Separator))
@@ -167,6 +171,13 @@ func main() {
 			// Skip services not yet supported.
 			continue
 		}
+
+		if _, ok := servicePaths[genInfo.PackageDir]; ok {
+			fmt.Fprintf(os.Stderr, "Path %q has already been generated", genInfo.PackageDir)
+			os.Exit(1)
+		}
+
+		servicePaths[genInfo.PackageDir] = struct{}{}
 
 		wg.Add(1)
 		go func(g *generateInfo, filename string) {


### PR DESCRIPTION
This change prevents service teams from releasing multiple apis under different names. This has caused dep and builds to fail for some due to insensitive casing and folder naming collisions on specific OS builds.
#1753 
#1755 
