### PR TITLE
Fix typos in ec2 instancesbyRegion example

### DIFF
--- a/example/service/ec2/instancesbyRegion/README.md
+++ b/example/service/ec2/instancesbyRegion/README.md
@@ -8,10 +8,10 @@ This is an example using the AWS SDK for Go to list ec2 instances instance state
 
 
 ```sh
-# To fetch the stopped instance of all region use below:
+# To fetch the stopped and running instances of all region use below:
 ./filter_ec2_by_region --state running --state stopped
 
-# To fetch the stopped and running instance  for  region us-west-1 and eu-west-1 use below:
+# To fetch the stopped and running instances for region us-west-1 and eu-west-1 use below:
 ./filter_ec2_by_region --state running --state stopped --region us-west-1 --region=eu-west-1
 ```
 

--- a/example/service/ec2/instancesbyRegion/instancesByRegion.go
+++ b/example/service/ec2/instancesbyRegion/instancesByRegion.go
@@ -60,9 +60,9 @@ func main() {
 		if err != nil {
 			fmt.Println("Error", err)
 		} else {
-			fmt.Printf("\n\n\nFetching instace details  for region: %s with criteria: %s**\n ", region, instanceCriteria)
+			fmt.Printf("\n\n\nFetching instance details for region: %s with criteria: %s**\n ", region, instanceCriteria)
 			if len(result.Reservations) == 0 {
-				fmt.Printf("There is no instance for the for region %s with the matching Criteria:%s  \n", region, instanceCriteria)
+				fmt.Printf("There is no instance for the region: %s with the matching criteria:%s  \n", region, instanceCriteria)
 			}
 			for _, reservation := range result.Reservations {
 


### PR DESCRIPTION
Fixed a few typos that I came across while looking at examples.