### PR TITLE
 aws/session: Fix bug in session.New not supporting AWS_SDK_LOAD_CONFIG

### DIFF
--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 )
 
 // EnvProviderName provides a name of the provider when config is loaded from environment.
@@ -175,6 +176,13 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 
 	setFromEnvVal(&cfg.SharedCredentialsFile, sharedCredsFileEnvKey)
 	setFromEnvVal(&cfg.SharedConfigFile, sharedConfigFileEnvKey)
+
+	if len(cfg.SharedCredentialsFile) == 0 {
+		cfg.SharedCredentialsFile = defaults.SharedCredentialsFilename()
+	}
+	if len(cfg.SharedConfigFile) == 0 {
+		cfg.SharedConfigFile = defaults.SharedConfigFilename()
+	}
 
 	cfg.CustomCABundle = os.Getenv("AWS_CA_BUNDLE")
 

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/internal/shareddefaults"
 )
 
 func TestLoadEnvConfig_Creds(t *testing.T) {
@@ -105,6 +106,8 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
@@ -116,6 +119,8 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
@@ -128,13 +133,19 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
 			Env: map[string]string{
 				"AWS_DEFAULT_REGION":  "default_region",
 				"AWS_DEFAULT_PROFILE": "default_profile",
+			},
+			Config: envConfig{
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
@@ -145,7 +156,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "default_region", Profile: "default_profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
@@ -155,7 +168,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},
@@ -168,7 +183,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},
@@ -182,7 +199,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "region", Profile: "profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},
@@ -193,7 +212,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "default_region", Profile: "default_profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},
@@ -205,7 +226,9 @@ func TestLoadEnvConfig(t *testing.T) {
 			},
 			Config: envConfig{
 				Region: "default_region", Profile: "default_profile",
-				EnableSharedConfig: true,
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},
@@ -214,7 +237,9 @@ func TestLoadEnvConfig(t *testing.T) {
 				"AWS_CA_BUNDLE": "custom_ca_bundle",
 			},
 			Config: envConfig{
-				CustomCABundle: "custom_ca_bundle",
+				CustomCABundle:        "custom_ca_bundle",
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 		},
 		{
@@ -222,8 +247,10 @@ func TestLoadEnvConfig(t *testing.T) {
 				"AWS_CA_BUNDLE": "custom_ca_bundle",
 			},
 			Config: envConfig{
-				CustomCABundle:     "custom_ca_bundle",
-				EnableSharedConfig: true,
+				CustomCABundle:        "custom_ca_bundle",
+				EnableSharedConfig:    true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
 			},
 			UseSharedConfigCall: true,
 		},

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -58,7 +58,12 @@ func New(cfgs ...*aws.Config) *Session {
 	envCfg := loadEnvConfig()
 
 	if envCfg.EnableSharedConfig {
-		s, err := newSession(Options{}, envCfg, cfgs...)
+		var cfg aws.Config
+		cfg.MergeIn(cfgs...)
+		s, err := NewSessionWithOptions(Options{
+			Config:            cfg,
+			SharedConfigState: SharedConfigEnable,
+		})
 		if err != nil {
 			// Old session.New expected all errors to be discovered when
 			// a request is made, and would report the errors then. This

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -243,13 +243,6 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 		envCfg.EnableSharedConfig = true
 	}
 
-	if len(envCfg.SharedCredentialsFile) == 0 {
-		envCfg.SharedCredentialsFile = defaults.SharedCredentialsFilename()
-	}
-	if len(envCfg.SharedConfigFile) == 0 {
-		envCfg.SharedConfigFile = defaults.SharedConfigFilename()
-	}
-
 	// Only use AWS_CA_BUNDLE if session option is not provided.
 	if len(envCfg.CustomCABundle) != 0 && opts.CustomCABundle == nil {
 		f, err := os.Open(envCfg.CustomCABundle)


### PR DESCRIPTION
Fixes a bug in the session.New function that was not correctly sourcing
the shared configuration files' path.

5f43689 broke the session.New's handling of the shared configfuration
files when AWS_SDK_LOAD_CONFIG was enabled, because the default file
paths were moved from the envConfig to NewSessionWithOptions. This
prevented session.New from having access to these values.

Fix #1771
Related to awslabs/amazon-ecr-credential-helper#84