### PR TITLE
aws/request: Fix support for streamed payloads for unsigned body request

### DIFF
--- a/aws/client/logger_test.go
+++ b/aws/client/logger_test.go
@@ -2,8 +2,17 @@ package client
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"reflect"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 type mockCloser struct {
@@ -54,4 +63,82 @@ func TestLogWriter(t *testing.T) {
 	if expected != lw.buf.String() {
 		t.Errorf("Expected %q, but received %q", expected, lw.buf.String())
 	}
+}
+
+func TestLogRequest(t *testing.T) {
+	cases := []struct {
+		Body       io.ReadSeeker
+		ExpectBody []byte
+		LogLevel   aws.LogLevelType
+	}{
+		{
+			Body:       aws.ReadSeekCloser(bytes.NewBuffer([]byte("body content"))),
+			ExpectBody: []byte("body content"),
+		},
+		{
+			Body:       aws.ReadSeekCloser(bytes.NewBuffer([]byte("body content"))),
+			LogLevel:   aws.LogDebugWithHTTPBody,
+			ExpectBody: []byte("body content"),
+		},
+		{
+			Body:       bytes.NewReader([]byte("body content")),
+			ExpectBody: []byte("body content"),
+		},
+		{
+			Body:       bytes.NewReader([]byte("body content")),
+			LogLevel:   aws.LogDebugWithHTTPBody,
+			ExpectBody: []byte("body content"),
+		},
+	}
+
+	for i, c := range cases {
+		logW := bytes.NewBuffer(nil)
+		req := request.New(
+			aws.Config{
+				Credentials: credentials.AnonymousCredentials,
+				Logger:      &bufLogger{w: logW},
+				LogLevel:    aws.LogLevel(c.LogLevel),
+			},
+			metadata.ClientInfo{
+				Endpoint: "https://mock-service.mock-region.amazonaws.com",
+			},
+			testHandlers(),
+			nil,
+			&request.Operation{
+				Name:       "APIName",
+				HTTPMethod: "POST",
+				HTTPPath:   "/",
+			},
+			struct{}{}, nil,
+		)
+		req.SetReaderBody(c.Body)
+		req.Build()
+
+		logRequest(req)
+
+		b, err := ioutil.ReadAll(req.HTTPRequest.Body)
+		if err != nil {
+			t.Fatalf("%d, expect to read SDK request Body", i)
+		}
+
+		if e, a := c.ExpectBody, b; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %v body, got %v", i, e, a)
+		}
+	}
+}
+
+type bufLogger struct {
+	w *bytes.Buffer
+}
+
+func (l *bufLogger) Log(args ...interface{}) {
+	fmt.Fprintln(l.w, args...)
+}
+
+func testHandlers() request.Handlers {
+	var handlers request.Handlers
+
+	handlers.Build.PushBackNamed(corehandlers.SDKVersionUserAgentHandler)
+
+	return handlers
 }

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -199,6 +199,10 @@ var ValidateResponseHandler = request.NamedHandler{Name: "core.ValidateResponseH
 // AfterRetryHandler performs final checks to determine if the request should
 // be retried and how long to delay.
 var AfterRetryHandler = request.NamedHandler{Name: "core.AfterRetryHandler", Fn: func(r *request.Request) {
+	if !aws.IsReaderSeekable(r.Body) {
+		r.Retryable = aws.Bool(false)
+	}
+
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
 	if r.Retryable == nil || aws.BoolValue(r.Config.EnforceShouldRetryCheck) {

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -199,10 +199,6 @@ var ValidateResponseHandler = request.NamedHandler{Name: "core.ValidateResponseH
 // AfterRetryHandler performs final checks to determine if the request should
 // be retried and how long to delay.
 var AfterRetryHandler = request.NamedHandler{Name: "core.AfterRetryHandler", Fn: func(r *request.Request) {
-	if !aws.IsReaderSeekable(r.Body) {
-		r.Retryable = aws.Bool(false)
-	}
-
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
 	if r.Retryable == nil || aws.BoolValue(r.Config.EnforceShouldRetryCheck) {

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -167,34 +167,6 @@ func TestAfterRetryWithContext(t *testing.T) {
 	}
 }
 
-func TestAfterRetryWithUnseekableBody(t *testing.T) {
-	c := awstesting.NewClient()
-
-	req := c.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
-	req.SetReaderBody(aws.ReadSeekCloser(bytes.NewBuffer([]byte("hello"))))
-
-	req.Error = fmt.Errorf("some error")
-	req.Retryable = aws.Bool(true)
-	req.HTTPResponse = &http.Response{
-		StatusCode: 500,
-	}
-
-	corehandlers.AfterRetryHandler.Fn(req)
-
-	if req.Error == nil {
-		t.Fatalf("expect error, got none")
-	}
-	if e, a := "some error", req.Error.Error(); !strings.Contains(a, e) {
-		t.Errorf("expect %q error in %q", e, a)
-	}
-	if *req.Retryable {
-		t.Errorf("expect request not to be retryable")
-	}
-	if e, a := 0, req.RetryCount; e != a {
-		t.Errorf("expect retry count to be %d, got %d", e, a)
-	}
-}
-
 func TestSendWithContextCanceled(t *testing.T) {
 	c := awstesting.NewClient(&aws.Config{
 		SleepDelay: func(dur time.Duration) {

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -181,8 +181,11 @@ func TestAfterRetryWithUnseekableBody(t *testing.T) {
 
 	corehandlers.AfterRetryHandler.Fn(req)
 
-	if req.Error != nil {
-		t.Fatalf("expect no error, got %v", req.Error)
+	if req.Error == nil {
+		t.Fatalf("expect error, got none")
+	}
+	if e, a := "some error", req.Error.Error(); !strings.Contains(a, e) {
+		t.Errorf("expect %q error in %q", e, a)
 	}
 	if *req.Retryable {
 		t.Errorf("expect request not to be retryable")

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
-	"github.com/aws/aws-sdk-go/aws/defaults"
 )
 
 type testData struct {
@@ -893,7 +893,6 @@ func TestRequest_Presign(t *testing.T) {
 			},
 			SignerFn: func(r *request.Request) {
 				r.HTTPRequest.URL = mustParseURL("https://endpoint/presignedURL")
-				fmt.Println("url", r.HTTPRequest.URL.String())
 				if r.NotHoist {
 					r.Error = fmt.Errorf("expect NotHoist to be cleared")
 				}
@@ -961,7 +960,7 @@ func TestRequest_Presign(t *testing.T) {
 		}
 	}
 }
-  
+
 func TestNew_EndpointWithDefaultPort(t *testing.T) {
 	endpoint := "https://estest.us-east-1.es.amazonaws.com:443"
 	expectedRequestHost := "estest.us-east-1.es.amazonaws.com"
@@ -983,7 +982,7 @@ func TestNew_EndpointWithDefaultPort(t *testing.T) {
 
 func TestSanitizeHostForHeader(t *testing.T) {
 	cases := []struct {
-		url            string
+		url                 string
 		expectedRequestHost string
 	}{
 		{"https://estest.us-east-1.es.amazonaws.com:443", "estest.us-east-1.es.amazonaws.com"},
@@ -999,6 +998,91 @@ func TestSanitizeHostForHeader(t *testing.T) {
 
 		if h := r.Host; h != c.expectedRequestHost {
 			t.Errorf("expect %v host, got %q", c.expectedRequestHost, h)
-    }
-  }
+		}
+	}
+}
+
+func TestRequestWillRetry_ByBody(t *testing.T) {
+	svc := awstesting.NewClient()
+
+	cases := []struct {
+		WillRetry   bool
+		HTTPMethod  string
+		Body        io.ReadSeeker
+		IsReqNoBody bool
+	}{
+		{
+			WillRetry:   true,
+			HTTPMethod:  "GET",
+			Body:        bytes.NewReader([]byte{}),
+			IsReqNoBody: true,
+		},
+		{
+			WillRetry:   true,
+			HTTPMethod:  "GET",
+			Body:        bytes.NewReader(nil),
+			IsReqNoBody: true,
+		},
+		{
+			WillRetry:  true,
+			HTTPMethod: "POST",
+			Body:       bytes.NewReader([]byte("abc123")),
+		},
+		{
+			WillRetry:  true,
+			HTTPMethod: "POST",
+			Body:       aws.ReadSeekCloser(bytes.NewReader([]byte("abc123"))),
+		},
+		{
+			WillRetry:   true,
+			HTTPMethod:  "GET",
+			Body:        aws.ReadSeekCloser(bytes.NewBuffer(nil)),
+			IsReqNoBody: true,
+		},
+		{
+			WillRetry:   true,
+			HTTPMethod:  "POST",
+			Body:        aws.ReadSeekCloser(bytes.NewBuffer(nil)),
+			IsReqNoBody: true,
+		},
+		{
+			WillRetry:  false,
+			HTTPMethod: "POST",
+			Body:       aws.ReadSeekCloser(bytes.NewBuffer([]byte("abc123"))),
+		},
+	}
+
+	for i, c := range cases {
+		req := svc.NewRequest(&request.Operation{
+			Name:       "Operation",
+			HTTPMethod: c.HTTPMethod,
+			HTTPPath:   "/",
+		}, nil, nil)
+		req.SetReaderBody(c.Body)
+		req.Build()
+
+		req.Error = fmt.Errorf("some error")
+		req.Retryable = aws.Bool(true)
+		req.HTTPResponse = &http.Response{
+			StatusCode: 500,
+		}
+
+		if e, a := c.IsReqNoBody, request.NoBody == req.HTTPRequest.Body; e != a {
+			t.Errorf("%d, expect request to be no body, %t, got %t, %T", i, e, a, req.HTTPRequest.Body)
+		}
+
+		if e, a := c.WillRetry, req.WillRetry(); e != a {
+			t.Errorf("%d, expect %t willRetry, got %t", i, e, a)
+		}
+
+		if req.Error == nil {
+			t.Fatalf("%d, expect error, got none", i)
+		}
+		if e, a := "some error", req.Error.Error(); !strings.Contains(a, e) {
+			t.Errorf("%d, expect %q error in %q", i, e, a)
+		}
+		if e, a := 0, req.RetryCount; e != a {
+			t.Errorf("%d, expect retry count to be %d, got %d", i, e, a)
+		}
+	}
 }

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -341,7 +341,9 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 
 	ctx.sanitizeHostForHeader()
 	ctx.assignAmzQueryValues()
-	ctx.build(v4.DisableHeaderHoisting)
+	if err := ctx.build(v4.DisableHeaderHoisting); err != nil {
+		return nil, err
+	}
 
 	// If the request is not presigned the body should be attached to it. This
 	// prevents the confusion of wanting to send a signed request without
@@ -503,11 +505,13 @@ func (v4 *Signer) logSigningInfo(ctx *signingCtx) {
 	v4.Logger.Log(msg)
 }
 
-func (ctx *signingCtx) build(disableHeaderHoisting bool) {
+func (ctx *signingCtx) build(disableHeaderHoisting bool) error {
 	ctx.buildTime()             // no depends
 	ctx.buildCredentialString() // no depends
 
-	ctx.buildBodyDigest()
+	if err := ctx.buildBodyDigest(); err != nil {
+		return err
+	}
 
 	unsignedHeaders := ctx.Request.Header
 	if ctx.isPresign {
@@ -535,6 +539,8 @@ func (ctx *signingCtx) build(disableHeaderHoisting bool) {
 		}
 		ctx.Request.Header.Set("Authorization", strings.Join(parts, ", "))
 	}
+
+	return nil
 }
 
 func (ctx *signingCtx) buildTime() {
@@ -661,7 +667,7 @@ func (ctx *signingCtx) buildSignature() {
 	ctx.signature = hex.EncodeToString(signature)
 }
 
-func (ctx *signingCtx) buildBodyDigest() {
+func (ctx *signingCtx) buildBodyDigest() error {
 	hash := ctx.Request.Header.Get("X-Amz-Content-Sha256")
 	if hash == "" {
 		if ctx.unsignedPayload || (ctx.isPresign && ctx.ServiceName == "s3") {
@@ -669,6 +675,9 @@ func (ctx *signingCtx) buildBodyDigest() {
 		} else if ctx.Body == nil {
 			hash = emptyStringSHA256
 		} else {
+			if !aws.IsReaderSeekable(ctx.Body) {
+				return fmt.Errorf("cannot use unseekable request body %T, for signed request with body", ctx.Body)
+			}
 			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
 		}
 		if ctx.unsignedPayload || ctx.ServiceName == "s3" || ctx.ServiceName == "glacier" {
@@ -676,6 +685,8 @@ func (ctx *signingCtx) buildBodyDigest() {
 		}
 	}
 	ctx.bodyDigest = hash
+
+	return nil
 }
 
 // isRequestSigned returns if the request is currently signed or presigned

--- a/aws/types.go
+++ b/aws/types.go
@@ -22,6 +22,22 @@ type ReaderSeekerCloser struct {
 	r io.Reader
 }
 
+// IsReaderSeekable returns if the underlying reader type can be seeked. A
+// io.Reader might not actually be seekable if it is the ReaderSeekerCloser
+// type.
+func IsReaderSeekable(r io.Reader) bool {
+	switch v := r.(type) {
+	case ReaderSeekerCloser:
+		return v.IsSeeker()
+	case *ReaderSeekerCloser:
+		return v.IsSeeker()
+	case io.ReadSeeker:
+		return true
+	default:
+		return false
+	}
+}
+
 // Read reads from the reader up to size of p. The number of bytes read, and
 // error if it occurred will be returned.
 //

--- a/aws/types.go
+++ b/aws/types.go
@@ -72,6 +72,20 @@ func (r ReaderSeekerCloser) IsSeeker() bool {
 	return ok
 }
 
+// HasLen returns the length of the underlying reader if the value implements
+// the Len() int method.
+func (r ReaderSeekerCloser) HasLen() (int, bool) {
+	type lenner interface {
+		Len() int
+	}
+
+	if lr, ok := r.r.(lenner); ok {
+		return lr.Len(), true
+	}
+
+	return 0, false
+}
+
 // Close closes the ReaderSeekerCloser.
 //
 // If the ReaderSeekerCloser is not an io.Closer nothing will be done.

--- a/aws/types.go
+++ b/aws/types.go
@@ -86,6 +86,57 @@ func (r ReaderSeekerCloser) HasLen() (int, bool) {
 	return 0, false
 }
 
+// GetLen returns the length of the bytes remaining in the underlying reader.
+// Checks first for Len(), then io.Seeker to determine the size of the
+// underlying reader.
+//
+// Will return -1 if the length cannot be determined.
+func (r ReaderSeekerCloser) GetLen() (int64, error) {
+	if l, ok := r.HasLen(); ok {
+		return int64(l), nil
+	}
+
+	if s, ok := r.r.(io.Seeker); ok {
+		return seekerLen(s)
+	}
+
+	return -1, nil
+}
+
+// SeekerLen attempts to get the number of bytes remaining at the seeker's
+// current position.  Returns the number of bytes remaining or error.
+func SeekerLen(s io.Seeker) (int64, error) {
+	// Determine if the seeker is actually seekable. ReaderSeekerCloser
+	// hides the fact that a io.Readers might not actually be seekable.
+	switch v := s.(type) {
+	case ReaderSeekerCloser:
+		return v.GetLen()
+	case *ReaderSeekerCloser:
+		return v.GetLen()
+	}
+
+	return seekerLen(s)
+}
+
+func seekerLen(s io.Seeker) (int64, error) {
+	curOffset, err := s.Seek(0, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	endOffset, err := s.Seek(0, 2)
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = s.Seek(curOffset, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return endOffset - curOffset, nil
+}
+
 // Close closes the ReaderSeekerCloser.
 //
 // If the ReaderSeekerCloser is not an io.Closer nothing will be done.

--- a/service/glacier/treehash.go
+++ b/service/glacier/treehash.go
@@ -18,8 +18,8 @@ type Hash struct {
 //
 // See http://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html for more information.
 func ComputeHashes(r io.ReadSeeker) Hash {
-	r.Seek(0, 0)       // Read the whole stream
-	defer r.Seek(0, 0) // Rewind stream at end
+	start, _ := r.Seek(0, 1)  // Read the whole stream
+	defer r.Seek(start, 0) // Rewind stream at end
 
 	buf := make([]byte, bufsize)
 	hashes := [][]byte{}

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -71,12 +71,11 @@ func (c *EncryptionClient) PutObjectRequest(input *s3.PutObjectInput) (*request.
 	req, out := c.S3Client.PutObjectRequest(input)
 
 	// Get Size of file
-	n, err := input.Body.Seek(0, 2)
+	n, err := aws.SeekerLen(input.Body)
 	if err != nil {
 		req.Error = err
 		return req, out
 	}
-	input.Body.Seek(0, 0)
 
 	dst, err := getWriterStore(req, c.TempFolderPath, n >= c.MinFileSize)
 	if err != nil {

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -487,10 +487,7 @@ func (u *uploader) initSize() {
 
 	switch r := u.in.Body.(type) {
 	case io.Seeker:
-		pos, _ := r.Seek(0, 1)
-		defer r.Seek(pos, 0)
-
-		n, err := r.Seek(0, 2)
+		n, err := aws.SeekerLen(r)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Fixes the SDK's handling of the SDK's `ReaderSeekerCloser` helper type to
not allow erroneous request retries, and request signature generation.

This fix allows you to use the `aws.ReaderSeekerCloser` to wrap an
arbitrary `io.Reader` for request `io.ReadSeeker` input parameters.

APIs such as lex-runtime's PostContent can now make use of the
ReaderSeekerCloser type without causing unexpected failures.

```go
resp, err := svc.PostContent(&lexruntimeservice.PostContentInput{
    BotAlias:    aws.String("botAlias"),
    BotName:     aws.String("botName"),
    ContentType: aws.String("audio/l16; rate=16000; channels=1"),
    UserId:      aws.String("userID"),
    InputStream: aws.ReadSeekCloser(myReader),
})
```

Fix #1776
