### PR TITLE
v1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v1.13.4 (2018-02-23)
+===
+
+### Service Client Updates
+* `service/appstream`: Updates service API and documentation
+  * This API update is to enable customers to copy their Amazon AppStream 2.0 images within and between AWS Regions
+* `aws/endpoints`: Updated Regions and Endpoints metadata.
+
 Release v1.13.3 (2018-02-22)
 ===
 

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1623,68 +1623,24 @@ var awsPartition = partition{
 					Hostname:          "s3.ap-northeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"ap-northeast-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-northeast-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"ap-northeast-2": endpoint{},
-				"ap-northeast-2-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-northeast-2.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
-				"ap-northeast-3-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-northeast-3.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
-				"ap-south-1": endpoint{},
-				"ap-south-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-south-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{
 					Hostname:          "s3.ap-southeast-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
-				"ap-southeast-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-southeast-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
 				"ap-southeast-2": endpoint{
 					Hostname:          "s3.ap-southeast-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"ap-southeast-2-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ap-southeast-2.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"ca-central-1": endpoint{},
-				"ca-central-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.ca-central-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"eu-central-1": endpoint{},
-				"eu-central-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.eu-central-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"eu-west-1": endpoint{
 					Hostname:          "s3.eu-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"eu-west-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.eu-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"eu-west-2": endpoint{},
-				"eu-west-2-dualstack": endpoint{
-					Hostname:          "s3.dualstack.eu-west-2.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"eu-west-3": endpoint{},
-				"eu-west-3-dualstack": endpoint{
-					Hostname:          "s3.dualstack.eu-west-3.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"s3-external-1": endpoint{
 					Hostname:          "s3-external-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
@@ -1696,37 +1652,17 @@ var awsPartition = partition{
 					Hostname:          "s3.sa-east-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"sa-east-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.sa-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"us-east-1": endpoint{
 					Hostname:          "s3.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"us-east-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.us-east-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"us-east-2": endpoint{},
-				"us-east-2-dualstack": endpoint{
-					Hostname:          "s3.dualstack.us-east-2.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"us-west-1": endpoint{
 					Hostname:          "s3.us-west-1.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-				"us-west-1-dualstack": endpoint{
-					Hostname:          "s3.dualstack.us-west-1.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
 				"us-west-2": endpoint{
 					Hostname:          "s3.us-west-2.amazonaws.com",
-					SignatureVersions: []string{"s3", "s3v4"},
-				},
-				"us-west-2-dualstack": endpoint{
-					Hostname:          "s3.dualstack.us-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
 			},

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.3"
+const SDKVersion = "1.13.4"

--- a/models/apis/appstream/2016-12-01/api-2.json
+++ b/models/apis/appstream/2016-12-01/api-2.json
@@ -29,6 +29,22 @@
         {"shape":"OperationNotPermittedException"}
       ]
     },
+    "CopyImage":{
+      "name":"CopyImage",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"CopyImageRequest"},
+      "output":{"shape":"CopyImageResponse"},
+      "errors":[
+        {"shape":"ResourceAlreadyExistsException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceNotAvailableException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"IncompatibleImageException"}
+      ]
+    },
     "CreateDirectoryConfig":{
       "name":"CreateDirectoryConfig",
       "http":{
@@ -540,6 +556,26 @@
         "Message":{"shape":"ErrorMessage"}
       },
       "exception":true
+    },
+    "CopyImageRequest":{
+      "type":"structure",
+      "required":[
+        "SourceImageName",
+        "DestinationImageName",
+        "DestinationRegion"
+      ],
+      "members":{
+        "SourceImageName":{"shape":"Name"},
+        "DestinationImageName":{"shape":"Name"},
+        "DestinationRegion":{"shape":"RegionName"},
+        "DestinationImageDescription":{"shape":"Description"}
+      }
+    },
+    "CopyImageResponse":{
+      "type":"structure",
+      "members":{
+        "DestinationImageName":{"shape":"Name"}
+      }
     },
     "CreateDirectoryConfigRequest":{
       "type":"structure",
@@ -1072,6 +1108,7 @@
         "PENDING",
         "AVAILABLE",
         "FAILED",
+        "COPYING",
         "DELETING"
       ]
     },
@@ -1086,7 +1123,8 @@
       "type":"string",
       "enum":[
         "INTERNAL_ERROR",
-        "IMAGE_BUILDER_NOT_AVAILABLE"
+        "IMAGE_BUILDER_NOT_AVAILABLE",
+        "IMAGE_COPY_FAILURE"
       ]
     },
     "IncompatibleImageException":{
@@ -1193,6 +1231,11 @@
     "RedirectURL":{
       "type":"string",
       "max":1000
+    },
+    "RegionName":{
+      "type":"string",
+      "max":32,
+      "min":1
     },
     "ResourceAlreadyExistsException":{
       "type":"structure",

--- a/models/apis/appstream/2016-12-01/docs-2.json
+++ b/models/apis/appstream/2016-12-01/docs-2.json
@@ -3,6 +3,7 @@
   "service": "<fullname>Amazon AppStream 2.0</fullname> <p>You can use Amazon AppStream 2.0 to stream desktop applications to any device running a web browser, without rewriting them.</p>",
   "operations": {
     "AssociateFleet": "<p>Associates the specified fleet with the specified stack.</p>",
+    "CopyImage": "<p>Copies the image within the same region or to a new region within the same AWS account. Note that any tags you added to the image will not be copied.</p>",
     "CreateDirectoryConfig": "<p>Creates a directory configuration.</p>",
     "CreateFleet": "<p>Creates a fleet.</p>",
     "CreateImageBuilder": "<p>Creates an image builder.</p> <p>The initial state of the builder is <code>PENDING</code>. When it is ready, the state is <code>RUNNING</code>.</p>",
@@ -134,6 +135,16 @@
     },
     "ConcurrentModificationException": {
       "base": "<p>An API error occurred. Wait a few minutes and try again.</p>",
+      "refs": {
+      }
+    },
+    "CopyImageRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "CopyImageResponse": {
+      "base": null,
       "refs": {
       }
     },
@@ -310,6 +321,7 @@
     "Description": {
       "base": null,
       "refs": {
+        "CopyImageRequest$DestinationImageDescription": "<p>The description that the image will have when it is copied to the destination.</p>",
         "CreateFleetRequest$Description": "<p>The description for display.</p>",
         "CreateImageBuilderRequest$Description": "<p>The description for display.</p>",
         "CreateStackRequest$Description": "<p>The description for display.</p>",
@@ -611,6 +623,9 @@
     "Name": {
       "base": null,
       "refs": {
+        "CopyImageRequest$SourceImageName": "<p>The name of the image to copy.</p>",
+        "CopyImageRequest$DestinationImageName": "<p>The name that the image will have when it is copied to the destination.</p>",
+        "CopyImageResponse$DestinationImageName": "<p>The name of the destination image.</p>",
         "CreateFleetRequest$Name": "<p>A unique name for the fleet.</p>",
         "CreateImageBuilderRequest$Name": "<p>A unique name for the image builder.</p>",
         "DeleteImageBuilderRequest$Name": "<p>The name of the image builder.</p>",
@@ -650,6 +665,12 @@
         "CreateStackRequest$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>",
         "Stack$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>",
         "UpdateStackRequest$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>"
+      }
+    },
+    "RegionName": {
+      "base": null,
+      "refs": {
+        "CopyImageRequest$DestinationRegion": "<p>The destination region to which the image will be copied. This parameter is required, even if you are copying an image within the same region.</p>"
       }
     },
     "ResourceAlreadyExistsException": {
@@ -862,8 +883,8 @@
         "DescribeFleetsResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "DescribeImageBuildersRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",
         "DescribeImageBuildersResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
-        "DescribeSessionsRequest$StackName": "<p>The name of the stack.</p>",
-        "DescribeSessionsRequest$FleetName": "<p>The name of the fleet.</p>",
+        "DescribeSessionsRequest$StackName": "<p>The name of the stack. This value is case-sensitive.</p>",
+        "DescribeSessionsRequest$FleetName": "<p>The name of the fleet. This value is case-sensitive.</p>",
         "DescribeSessionsRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",
         "DescribeSessionsResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "DescribeStacksRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",

--- a/models/endpoints/endpoints.json
+++ b/models/endpoints/endpoints.json
@@ -1364,68 +1364,24 @@
             "hostname" : "s3.ap-northeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "ap-northeast-1-dualstack" : {
-            "hostname" : "s3.dualstack.ap-northeast-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "ap-northeast-2" : { },
-          "ap-northeast-2-dualstack" : {
-            "hostname" : "s3.dualstack.ap-northeast-2.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
-          "ap-northeast-3-dualstack" : {
-            "hostname" : "s3.dualstack.ap-northeast-3.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "ap-south-1" : { },
-          "ap-south-1-dualstack" : {
-            "hostname" : "s3.dualstack.ap-south-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "ap-southeast-1" : {
             "hostname" : "s3.ap-southeast-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
-          "ap-southeast-1-dualstack" : {
-            "hostname" : "s3.dualstack.ap-southeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
           "ap-southeast-2" : {
             "hostname" : "s3.ap-southeast-2.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "ap-southeast-2-dualstack" : {
-            "hostname" : "s3.dualstack.ap-southeast-2.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "ca-central-1" : { },
-          "ca-central-1-dualstack" : {
-            "hostname" : "s3.dualstack.ca-central-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "eu-central-1" : { },
-          "eu-central-1-dualstack" : {
-            "hostname" : "s3.dualstack.eu-central-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "eu-west-1" : {
             "hostname" : "s3.eu-west-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "eu-west-1-dualstack" : {
-            "hostname" : "s3.dualstack.eu-west-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "eu-west-2" : { },
-          "eu-west-2-dualstack" : {
-            "hostname" : "s3.dualstack.eu-west-2.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "eu-west-3" : { },
-          "eu-west-3-dualstack" : {
-            "hostname" : "s3.dualstack.eu-west-3.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "s3-external-1" : {
             "credentialScope" : {
               "region" : "us-east-1"
@@ -1437,37 +1393,17 @@
             "hostname" : "s3.sa-east-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "sa-east-1-dualstack" : {
-            "hostname" : "s3.dualstack.sa-east-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "us-east-1" : {
             "hostname" : "s3.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "us-east-1-dualstack" : {
-            "hostname" : "s3.dualstack.us-east-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "us-east-2" : { },
-          "us-east-2-dualstack" : {
-            "hostname" : "s3.dualstack.us-east-2.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "us-west-1" : {
             "hostname" : "s3.us-west-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           },
-          "us-west-1-dualstack" : {
-            "hostname" : "s3.dualstack.us-west-1.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
           "us-west-2" : {
             "hostname" : "s3.us-west-2.amazonaws.com",
-            "signatureVersions" : [ "s3", "s3v4" ]
-          },
-          "us-west-2-dualstack" : {
-            "hostname" : "s3.dualstack.us-west-2.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ]
           }
         },

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -102,6 +102,98 @@ func (c *AppStream) AssociateFleetWithContext(ctx aws.Context, input *AssociateF
 	return out, req.Send()
 }
 
+const opCopyImage = "CopyImage"
+
+// CopyImageRequest generates a "aws/request.Request" representing the
+// client's request for the CopyImage operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CopyImage for more information on using the CopyImage
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CopyImageRequest method.
+//    req, resp := client.CopyImageRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CopyImage
+func (c *AppStream) CopyImageRequest(input *CopyImageInput) (req *request.Request, output *CopyImageOutput) {
+	op := &request.Operation{
+		Name:       opCopyImage,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CopyImageInput{}
+	}
+
+	output = &CopyImageOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CopyImage API operation for Amazon AppStream.
+//
+// Copies the image within the same region or to a new region within the same
+// AWS account. Note that any tags you added to the image will not be copied.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation CopyImage for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   The specified resource already exists.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeResourceNotAvailableException "ResourceNotAvailableException"
+//   The specified resource exists and is not in use, but isn't available.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeIncompatibleImageException "IncompatibleImageException"
+//   The image does not support storage connectors.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CopyImage
+func (c *AppStream) CopyImage(input *CopyImageInput) (*CopyImageOutput, error) {
+	req, out := c.CopyImageRequest(input)
+	return out, req.Send()
+}
+
+// CopyImageWithContext is the same as CopyImage with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CopyImage for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) CopyImageWithContext(ctx aws.Context, input *CopyImageInput, opts ...request.Option) (*CopyImageOutput, error) {
+	req, out := c.CopyImageRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateDirectoryConfig = "CreateDirectoryConfig"
 
 // CreateDirectoryConfigRequest generates a "aws/request.Request" representing the
@@ -2996,6 +3088,108 @@ func (s *ComputeCapacityStatus) SetRunning(v int64) *ComputeCapacityStatus {
 	return s
 }
 
+type CopyImageInput struct {
+	_ struct{} `type:"structure"`
+
+	// The description that the image will have when it is copied to the destination.
+	DestinationImageDescription *string `type:"string"`
+
+	// The name that the image will have when it is copied to the destination.
+	//
+	// DestinationImageName is a required field
+	DestinationImageName *string `type:"string" required:"true"`
+
+	// The destination region to which the image will be copied. This parameter
+	// is required, even if you are copying an image within the same region.
+	//
+	// DestinationRegion is a required field
+	DestinationRegion *string `min:"1" type:"string" required:"true"`
+
+	// The name of the image to copy.
+	//
+	// SourceImageName is a required field
+	SourceImageName *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CopyImageInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CopyImageInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CopyImageInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CopyImageInput"}
+	if s.DestinationImageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationImageName"))
+	}
+	if s.DestinationRegion == nil {
+		invalidParams.Add(request.NewErrParamRequired("DestinationRegion"))
+	}
+	if s.DestinationRegion != nil && len(*s.DestinationRegion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DestinationRegion", 1))
+	}
+	if s.SourceImageName == nil {
+		invalidParams.Add(request.NewErrParamRequired("SourceImageName"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestinationImageDescription sets the DestinationImageDescription field's value.
+func (s *CopyImageInput) SetDestinationImageDescription(v string) *CopyImageInput {
+	s.DestinationImageDescription = &v
+	return s
+}
+
+// SetDestinationImageName sets the DestinationImageName field's value.
+func (s *CopyImageInput) SetDestinationImageName(v string) *CopyImageInput {
+	s.DestinationImageName = &v
+	return s
+}
+
+// SetDestinationRegion sets the DestinationRegion field's value.
+func (s *CopyImageInput) SetDestinationRegion(v string) *CopyImageInput {
+	s.DestinationRegion = &v
+	return s
+}
+
+// SetSourceImageName sets the SourceImageName field's value.
+func (s *CopyImageInput) SetSourceImageName(v string) *CopyImageInput {
+	s.SourceImageName = &v
+	return s
+}
+
+type CopyImageOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the destination image.
+	DestinationImageName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s CopyImageOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CopyImageOutput) GoString() string {
+	return s.String()
+}
+
+// SetDestinationImageName sets the DestinationImageName field's value.
+func (s *CopyImageOutput) SetDestinationImageName(v string) *CopyImageOutput {
+	s.DestinationImageName = &v
+	return s
+}
+
 type CreateDirectoryConfigInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4414,7 +4608,7 @@ type DescribeSessionsInput struct {
 	// using a streaming URL.
 	AuthenticationType *string `type:"string" enum:"AuthenticationType"`
 
-	// The name of the fleet.
+	// The name of the fleet. This value is case-sensitive.
 	//
 	// FleetName is a required field
 	FleetName *string `min:"1" type:"string" required:"true"`
@@ -4427,7 +4621,7 @@ type DescribeSessionsInput struct {
 	// operation. If this value is null, it retrieves the first page.
 	NextToken *string `min:"1" type:"string"`
 
-	// The name of the stack.
+	// The name of the stack. This value is case-sensitive.
 	//
 	// StackName is a required field
 	StackName *string `min:"1" type:"string" required:"true"`
@@ -7048,6 +7242,9 @@ const (
 	// ImageStateFailed is a ImageState enum value
 	ImageStateFailed = "FAILED"
 
+	// ImageStateCopying is a ImageState enum value
+	ImageStateCopying = "COPYING"
+
 	// ImageStateDeleting is a ImageState enum value
 	ImageStateDeleting = "DELETING"
 )
@@ -7058,6 +7255,9 @@ const (
 
 	// ImageStateChangeReasonCodeImageBuilderNotAvailable is a ImageStateChangeReasonCode enum value
 	ImageStateChangeReasonCodeImageBuilderNotAvailable = "IMAGE_BUILDER_NOT_AVAILABLE"
+
+	// ImageStateChangeReasonCodeImageCopyFailure is a ImageStateChangeReasonCode enum value
+	ImageStateChangeReasonCodeImageCopyFailure = "IMAGE_COPY_FAILURE"
 )
 
 const (

--- a/service/appstream/appstreamiface/interface.go
+++ b/service/appstream/appstreamiface/interface.go
@@ -64,6 +64,10 @@ type AppStreamAPI interface {
 	AssociateFleetWithContext(aws.Context, *appstream.AssociateFleetInput, ...request.Option) (*appstream.AssociateFleetOutput, error)
 	AssociateFleetRequest(*appstream.AssociateFleetInput) (*request.Request, *appstream.AssociateFleetOutput)
 
+	CopyImage(*appstream.CopyImageInput) (*appstream.CopyImageOutput, error)
+	CopyImageWithContext(aws.Context, *appstream.CopyImageInput, ...request.Option) (*appstream.CopyImageOutput, error)
+	CopyImageRequest(*appstream.CopyImageInput) (*request.Request, *appstream.CopyImageOutput)
+
 	CreateDirectoryConfig(*appstream.CreateDirectoryConfigInput) (*appstream.CreateDirectoryConfigOutput, error)
 	CreateDirectoryConfigWithContext(aws.Context, *appstream.CreateDirectoryConfigInput, ...request.Option) (*appstream.CreateDirectoryConfigOutput, error)
 	CreateDirectoryConfigRequest(*appstream.CreateDirectoryConfigInput) (*request.Request, *appstream.CreateDirectoryConfigOutput)


### PR DESCRIPTION
Release v1.13.4 (2018-02-23)
===

### Service Client Updates
* `service/appstream`: Updates service API and documentation
  * This API update is to enable customers to copy their Amazon AppStream 2.0 images within and between AWS Regions
* `aws/endpoints`: Updated Regions and Endpoints metadata.

