### PR TITLE
Update documentation to point at the correct interface

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -26,7 +26,7 @@ import (
 // Sessions are safe to create service clients concurrently, but it is not safe
 // to mutate the Session concurrently.
 //
-// The Session satisfies the service client's client.ClientConfigProvider.
+// The Session satisfies the service client's client.ConfigProvider.
 type Session struct {
 	Config   *aws.Config
 	Handlers request.Handlers


### PR DESCRIPTION
`client.ClientConfigProvider` does not exist anywhere in the source.
