### PR TITLE
aws/corehandlers: Add support for AWS_EXECUTION_ENV env var

### DIFF
--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -53,13 +52,6 @@ var BuildContentLengthHandler = request.NamedHandler{Name: "core.BuildContentLen
 		r.HTTPRequest.Header.Del("Content-Length")
 	}
 }}
-
-// SDKVersionUserAgentHandler is a request handler for adding the SDK Version to the user agent.
-var SDKVersionUserAgentHandler = request.NamedHandler{
-	Name: "core.SDKVersionUserAgentHandler",
-	Fn: request.MakeAddToUserAgentHandler(aws.SDKName, aws.SDKVersion,
-		runtime.Version(), runtime.GOOS, runtime.GOARCH),
-}
 
 var reStatusCode = regexp.MustCompile(`^(\d{3})`)
 

--- a/aws/corehandlers/user_agent.go
+++ b/aws/corehandlers/user_agent.go
@@ -1,0 +1,37 @@
+package corehandlers
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// SDKVersionUserAgentHandler is a request handler for adding the SDK Version
+// to the user agent.
+var SDKVersionUserAgentHandler = request.NamedHandler{
+	Name: "core.SDKVersionUserAgentHandler",
+	Fn: request.MakeAddToUserAgentHandler(aws.SDKName, aws.SDKVersion,
+		runtime.Version(), runtime.GOOS, runtime.GOARCH),
+}
+
+const execEnvVar = `AWS_EXECUTION_ENV`
+const execEnvUAKey = `exec_env`
+
+// AddHostExecEnvUserAgentHander is a request handler appending the SDK's
+// execution environment to the user agent.
+//
+// If the environment variable AWS_EXECUTION_ENV is set, its value will be
+// appended to the user agent string.
+var AddHostExecEnvUserAgentHander = request.NamedHandler{
+	Name: "core.AddHostExecEnvUserAgentHander",
+	Fn: func(r *request.Request) {
+		v := os.Getenv(execEnvVar)
+		if len(v) == 0 {
+			return
+		}
+
+		request.AddToUserAgent(r, execEnvUAKey+"/"+v)
+	},
+}

--- a/aws/corehandlers/user_agent_test.go
+++ b/aws/corehandlers/user_agent_test.go
@@ -1,0 +1,40 @@
+package corehandlers
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestAddHostExecEnvUserAgentHander(t *testing.T) {
+	cases := []struct {
+		ExecEnv string
+		Expect  string
+	}{
+		{ExecEnv: "Lambda", Expect: "exec_env/Lambda"},
+		{ExecEnv: "", Expect: ""},
+		{ExecEnv: "someThingCool", Expect: "exec_env/someThingCool"},
+	}
+
+	for i, c := range cases {
+		os.Clearenv()
+		os.Setenv(execEnvVar, c.ExecEnv)
+
+		req := &request.Request{
+			HTTPRequest: &http.Request{
+				Header: http.Header{},
+			},
+		}
+		AddHostExecEnvUserAgentHander.Fn(req)
+
+		if err := req.Error; err != nil {
+			t.Fatalf("%d, expect no error, got %v", i, err)
+		}
+
+		if e, a := c.Expect, req.HTTPRequest.Header.Get("User-Agent"); e != a {
+			t.Errorf("%d, expect %v user agent, got %v", i, e, a)
+		}
+	}
+}

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -73,6 +73,7 @@ func Handlers() request.Handlers {
 	handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
 	handlers.Validate.AfterEachFn = request.HandlerListStopOnError
 	handlers.Build.PushBackNamed(corehandlers.SDKVersionUserAgentHandler)
+	handlers.Build.PushBackNamed(corehandlers.AddHostExecEnvUserAgentHander)
 	handlers.Build.AfterEachFn = request.HandlerListStopOnError
 	handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
 	handlers.Send.PushBackNamed(corehandlers.ValidateReqSigHandler)


### PR DESCRIPTION
Adds support for the `AWS_EXECUTION_ENV` environment variable to the SDK's user agent string.