### PR TITLE
aws/client: 501, 'NotImplemented', will no longer be retried

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -62,7 +62,7 @@ func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
 		return *r.Retryable
 	}
 
-	if r.HTTPResponse.StatusCode >= 500 {
+	if r.HTTPResponse.StatusCode >= 500 && r.HTTPResponse.StatusCode != 501 {
 		return true
 	}
 	return r.IsErrorRetryable() || d.shouldThrottle(r)


### PR DESCRIPTION
Prevents the SDK from retrying HTTP status code 501 by default. This brings the AWS SDK for Go in parity with other SDKs which were not retrying this status code.

Fix #1819 