### PR TITLE
aws/endpoints: adding custom signing name for runtime.sagemaker

### DIFF
--- a/aws/endpoints/decode.go
+++ b/aws/endpoints/decode.go
@@ -87,6 +87,7 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		custRmIotDataService(p)
 
 		custFixCloudHSMv2SigningName(p)
+		custFixRuntimeSagemakerSigningName(p)
 	}
 
 	return ps, nil
@@ -144,6 +145,26 @@ func custAddEC2Metadata(p *partition) {
 
 func custRmIotDataService(p *partition) {
 	delete(p.Services, "data.iot")
+}
+
+func custFixRuntimeSagemakerSigningName(p *partition) {
+	// Workaround for aws/aws-sdk-go#1836
+
+	s, ok := p.Services["runtime.sagemaker"]
+	if !ok {
+		return
+	}
+
+	if len(s.Defaults.CredentialScope.Service) != 0 {
+		fmt.Fprintf(os.Stderr, "runtime.sagemaker signing name already set, ignoring override.\n")
+		// If the value is already set don't override
+		return
+	}
+
+	s.Defaults.CredentialScope.Service = "sagemaker"
+	fmt.Fprintf(os.Stderr, "sagemaker signing name not set, overriding.\n")
+
+	p.Services["runtime.sagemaker"] = s
 }
 
 type decodeModelError struct {

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1715,7 +1715,11 @@ var awsPartition = partition{
 			},
 		},
 		"runtime.sagemaker": service{
-
+			Defaults: endpoint{
+				CredentialScope: credentialScope{
+					Service: "sagemaker",
+				},
+			},
 			Endpoints: endpoints{
 				"eu-west-1": endpoint{},
 				"us-east-1": endpoint{},

--- a/awstesting/integration/smoke/sagemakerruntime/client.go
+++ b/awstesting/integration/smoke/sagemakerruntime/client.go
@@ -1,0 +1,16 @@
+// +build integration
+
+//Package sagemakerruntime provides gucumber integration tests support.
+package sagemakerruntime
+
+import (
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/sagemakerruntime"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	gucumber.Before("@sagemakerruntime", func() {
+		gucumber.World["client"] = sagemakerruntime.New(smoke.Session)
+	})
+}

--- a/awstesting/integration/smoke/sagemakerruntime/sagemakerruntime.feature
+++ b/awstesting/integration/smoke/sagemakerruntime/sagemakerruntime.feature
@@ -1,0 +1,10 @@
+# language: en
+@sagemakerruntime @client
+Feature: Amazon SageMaker Runtime
+
+  Scenario: Making a request
+    When I attempt to call the "InvokeEndpoint" API with JSON:
+    """
+    {"EndpointName": "fake-endpoint", "Body": [123, 125]}
+    """
+    Then I expect the response error code to be "ValidationError"


### PR DESCRIPTION
Missing endpoint information. This customization will use the correct signing name when generating endpoint data.

Fix #1836