### PR TITLE
service/s3: Disable S3 object ContentMD5 automatic validation

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -151,6 +151,9 @@ type Config struct {
 	// with accelerate.
 	S3UseAccelerate *bool
 
+	// S3DisableContentMD5Validation config option is temporarily disabled,
+	// For S3 GetObject API calls, #1837.
+	//
 	// Set this to `true` to disable the S3 service client from automatically
 	// adding the ContentMD5 to S3 Object Put and Upload API calls. This option
 	// will also disable the SDK from performing object ContentMD5 validation

--- a/awstesting/integration/customizations/s3/object_checksum_test.go
+++ b/awstesting/integration/customizations/s3/object_checksum_test.go
@@ -19,7 +19,7 @@ func base64Sum(content []byte) string {
 	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
-func TestContentMD5Validate(t *testing.T) {
+func SkipTestContentMD5Validate(t *testing.T) {
 	body := []byte("really cool body content")
 
 	cases := []struct {

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -44,9 +44,10 @@ func defaultInitRequestFn(r *request.Request) {
 		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
 	case opPutObject, opUploadPart:
 		r.Handlers.Build.PushBack(computeBodyHashes)
-	case opGetObject:
-		r.Handlers.Build.PushBack(askForTxEncodingAppendMD5)
-		r.Handlers.Unmarshal.PushBack(useMD5ValidationReader)
+		// Disabled until #1837 root issue is resolved.
+		//	case opGetObject:
+		//		r.Handlers.Build.PushBack(askForTxEncodingAppendMD5)
+		//		r.Handlers.Unmarshal.PushBack(useMD5ValidationReader)
 	}
 }
 


### PR DESCRIPTION
Updates the S3 client to disable automatic ContentMD5 validation of S3
Put and Get objects. This disables the validation added in #1827.

Unexpected case where`Content-Length` response header not set in an a GetObject API call prevents this the content MD5 validation feature from being successfully used until the SDK can handle the case.

The SDK will still set the `Content-MD5` header for PutObject and UploadPart API calls.

Related to: #1837