### PR TITLE
v1.13.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.13.16 (2018-03-16)
+===
+
+### Service Client Updates
+* `service/elasticbeanstalk`: Updates service API and documentation
+  * AWS Elastic Beanstalk is launching a new public API named DescribeAccountAttributes which allows customers to access account level attributes. In this release, the API will support quotas for resources such as applications, application versions, and environments.
+
 Release v1.13.15 (2018-03-15)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.15"
+const SDKVersion = "1.13.16"

--- a/models/apis/elasticbeanstalk/2010-12-01/api-2.json
+++ b/models/apis/elasticbeanstalk/2010-12-01/api-2.json
@@ -6,6 +6,7 @@
     "protocol":"query",
     "serviceAbbreviation":"Elastic Beanstalk",
     "serviceFullName":"AWS Elastic Beanstalk",
+    "serviceId":"Elastic Beanstalk",
     "signatureVersion":"v4",
     "uid":"elasticbeanstalk-2010-12-01",
     "xmlNamespace":"http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/"
@@ -226,6 +227,20 @@
         {"shape":"InsufficientPrivilegesException"},
         {"shape":"ElasticBeanstalkServiceException"},
         {"shape":"PlatformVersionStillReferencedException"}
+      ]
+    },
+    "DescribeAccountAttributes":{
+      "name":"DescribeAccountAttributes",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "output":{
+        "shape":"DescribeAccountAttributesResult",
+        "resultWrapper":"DescribeAccountAttributesResult"
+      },
+      "errors":[
+        {"shape":"InsufficientPrivilegesException"}
       ]
     },
     "DescribeApplicationVersions":{
@@ -1156,6 +1171,12 @@
       }
     },
     "DeploymentTimestamp":{"type":"timestamp"},
+    "DescribeAccountAttributesResult":{
+      "type":"structure",
+      "members":{
+        "ResourceQuotas":{"shape":"ResourceQuotas"}
+      }
+    },
     "DescribeApplicationVersionsMessage":{
       "type":"structure",
       "members":{
@@ -1990,6 +2011,22 @@
         "senderFault":true
       },
       "exception":true
+    },
+    "ResourceQuota":{
+      "type":"structure",
+      "members":{
+        "Maximum":{"shape":"BoxedInt"}
+      }
+    },
+    "ResourceQuotas":{
+      "type":"structure",
+      "members":{
+        "ApplicationQuota":{"shape":"ResourceQuota"},
+        "ApplicationVersionQuota":{"shape":"ResourceQuota"},
+        "EnvironmentQuota":{"shape":"ResourceQuota"},
+        "ConfigurationTemplateQuota":{"shape":"ResourceQuota"},
+        "CustomPlatformQuota":{"shape":"ResourceQuota"}
+      }
     },
     "ResourceTagsDescriptionMessage":{
       "type":"structure",

--- a/models/apis/elasticbeanstalk/2010-12-01/docs-2.json
+++ b/models/apis/elasticbeanstalk/2010-12-01/docs-2.json
@@ -17,6 +17,7 @@
     "DeleteConfigurationTemplate": "<p>Deletes the specified configuration template.</p> <note> <p>When you launch an environment using a configuration template, the environment gets a copy of the template. You can delete or modify the environment's copy of the template without affecting the running environment.</p> </note>",
     "DeleteEnvironmentConfiguration": "<p>Deletes the draft configuration associated with the running environment.</p> <p>Updating a running environment with any configuration changes creates a draft configuration set. You can get the draft configuration using <a>DescribeConfigurationSettings</a> while the update is in progress or if the update fails. The <code>DeploymentStatus</code> for the draft configuration indicates whether the deployment is in process or has failed. The draft configuration remains in existence until it is deleted with this action.</p>",
     "DeletePlatformVersion": "<p>Deletes the specified version of a custom platform.</p>",
+    "DescribeAccountAttributes": null,
     "DescribeApplicationVersions": "<p>Retrieve a list of application versions.</p>",
     "DescribeApplications": "<p>Returns the descriptions of existing applications.</p>",
     "DescribeConfigurationOptions": "<p>Describes the configuration options that are used in a particular configuration template or environment, or that a specified solution stack defines. The description includes the values the options, their default values, and an indication of the required action on a running environment if an option value is changed.</p>",
@@ -263,7 +264,8 @@
       "refs": {
         "BuildConfiguration$TimeoutInMinutes": "<p>How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.</p>",
         "MaxAgeRule$MaxAgeInDays": "<p>Specify the number of days to retain an application versions.</p>",
-        "MaxCountRule$MaxCount": "<p>Specify the maximum number of application versions to retain.</p>"
+        "MaxCountRule$MaxCount": "<p>Specify the maximum number of application versions to retain.</p>",
+        "ResourceQuota$Maximum": null
       }
     },
     "BuildConfiguration": {
@@ -579,6 +581,11 @@
       "base": null,
       "refs": {
         "Deployment$DeploymentTime": "<p>For in-progress deployments, the time that the deployment started.</p> <p>For completed deployments, the time that the deployment ended.</p>"
+      }
+    },
+    "DescribeAccountAttributesResult": {
+      "base": null,
+      "refs": {
       }
     },
     "DescribeApplicationVersionsMessage": {
@@ -1520,6 +1527,22 @@
     "ResourceNotFoundException": {
       "base": "<p>A resource doesn't exist for the specified Amazon Resource Name (ARN).</p>",
       "refs": {
+      }
+    },
+    "ResourceQuota": {
+      "base": null,
+      "refs": {
+        "ResourceQuotas$ApplicationQuota": null,
+        "ResourceQuotas$ApplicationVersionQuota": null,
+        "ResourceQuotas$EnvironmentQuota": null,
+        "ResourceQuotas$ConfigurationTemplateQuota": null,
+        "ResourceQuotas$CustomPlatformQuota": null
+      }
+    },
+    "ResourceQuotas": {
+      "base": null,
+      "refs": {
+        "DescribeAccountAttributesResult$ResourceQuotas": null
       }
     },
     "ResourceTagsDescriptionMessage": {

--- a/models/apis/elasticbeanstalk/2010-12-01/smoke.json
+++ b/models/apis/elasticbeanstalk/2010-12-01/smoke.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "defaultRegion": "us-west-2",
+    "testCases": [
+        {
+            "operationName": "ListAvailableSolutionStacks",
+            "input": {},
+            "errorExpectedFromService": false
+        },
+        {
+            "operationName": "DescribeEnvironmentResources",
+            "input": {
+                "EnvironmentId": "fake_environment"
+            },
+            "errorExpectedFromService": true
+        }
+    ]
+}

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -1344,6 +1344,84 @@ func (c *ElasticBeanstalk) DeletePlatformVersionWithContext(ctx aws.Context, inp
 	return out, req.Send()
 }
 
+const opDescribeAccountAttributes = "DescribeAccountAttributes"
+
+// DescribeAccountAttributesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAccountAttributes operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeAccountAttributes for more information on using the DescribeAccountAttributes
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeAccountAttributesRequest method.
+//    req, resp := client.DescribeAccountAttributesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/DescribeAccountAttributes
+func (c *ElasticBeanstalk) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *request.Request, output *DescribeAccountAttributesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAccountAttributes,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeAccountAttributesInput{}
+	}
+
+	output = &DescribeAccountAttributesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAccountAttributes API operation for AWS Elastic Beanstalk.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elastic Beanstalk's
+// API operation DescribeAccountAttributes for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInsufficientPrivilegesException "InsufficientPrivilegesException"
+//   The specified account does not have sufficient privileges for one of more
+//   AWS services.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticbeanstalk-2010-12-01/DescribeAccountAttributes
+func (c *ElasticBeanstalk) DescribeAccountAttributes(input *DescribeAccountAttributesInput) (*DescribeAccountAttributesOutput, error) {
+	req, out := c.DescribeAccountAttributesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAccountAttributesWithContext is the same as DescribeAccountAttributes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAccountAttributes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticBeanstalk) DescribeAccountAttributesWithContext(ctx aws.Context, input *DescribeAccountAttributesInput, opts ...request.Option) (*DescribeAccountAttributesOutput, error) {
+	req, out := c.DescribeAccountAttributesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeApplicationVersions = "DescribeApplicationVersions"
 
 // DescribeApplicationVersionsRequest generates a "aws/request.Request" representing the
@@ -6192,6 +6270,42 @@ func (s *Deployment) SetVersionLabel(v string) *Deployment {
 	return s
 }
 
+type DescribeAccountAttributesInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesInput) GoString() string {
+	return s.String()
+}
+
+type DescribeAccountAttributesOutput struct {
+	_ struct{} `type:"structure"`
+
+	ResourceQuotas *ResourceQuotas `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesOutput) GoString() string {
+	return s.String()
+}
+
+// SetResourceQuotas sets the ResourceQuotas field's value.
+func (s *DescribeAccountAttributesOutput) SetResourceQuotas(v *ResourceQuotas) *DescribeAccountAttributesOutput {
+	s.ResourceQuotas = v
+	return s
+}
+
 // Request to describe application versions.
 type DescribeApplicationVersionsInput struct {
 	_ struct{} `type:"structure"`
@@ -9525,6 +9639,82 @@ func (s RequestEnvironmentInfoOutput) String() string {
 // GoString returns the string representation
 func (s RequestEnvironmentInfoOutput) GoString() string {
 	return s.String()
+}
+
+type ResourceQuota struct {
+	_ struct{} `type:"structure"`
+
+	Maximum *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s ResourceQuota) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceQuota) GoString() string {
+	return s.String()
+}
+
+// SetMaximum sets the Maximum field's value.
+func (s *ResourceQuota) SetMaximum(v int64) *ResourceQuota {
+	s.Maximum = &v
+	return s
+}
+
+type ResourceQuotas struct {
+	_ struct{} `type:"structure"`
+
+	ApplicationQuota *ResourceQuota `type:"structure"`
+
+	ApplicationVersionQuota *ResourceQuota `type:"structure"`
+
+	ConfigurationTemplateQuota *ResourceQuota `type:"structure"`
+
+	CustomPlatformQuota *ResourceQuota `type:"structure"`
+
+	EnvironmentQuota *ResourceQuota `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResourceQuotas) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceQuotas) GoString() string {
+	return s.String()
+}
+
+// SetApplicationQuota sets the ApplicationQuota field's value.
+func (s *ResourceQuotas) SetApplicationQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ApplicationQuota = v
+	return s
+}
+
+// SetApplicationVersionQuota sets the ApplicationVersionQuota field's value.
+func (s *ResourceQuotas) SetApplicationVersionQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ApplicationVersionQuota = v
+	return s
+}
+
+// SetConfigurationTemplateQuota sets the ConfigurationTemplateQuota field's value.
+func (s *ResourceQuotas) SetConfigurationTemplateQuota(v *ResourceQuota) *ResourceQuotas {
+	s.ConfigurationTemplateQuota = v
+	return s
+}
+
+// SetCustomPlatformQuota sets the CustomPlatformQuota field's value.
+func (s *ResourceQuotas) SetCustomPlatformQuota(v *ResourceQuota) *ResourceQuotas {
+	s.CustomPlatformQuota = v
+	return s
+}
+
+// SetEnvironmentQuota sets the EnvironmentQuota field's value.
+func (s *ResourceQuotas) SetEnvironmentQuota(v *ResourceQuota) *ResourceQuotas {
+	s.EnvironmentQuota = v
+	return s
 }
 
 type RestartAppServerInput struct {

--- a/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
+++ b/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
@@ -120,6 +120,10 @@ type ElasticBeanstalkAPI interface {
 	DeletePlatformVersionWithContext(aws.Context, *elasticbeanstalk.DeletePlatformVersionInput, ...request.Option) (*elasticbeanstalk.DeletePlatformVersionOutput, error)
 	DeletePlatformVersionRequest(*elasticbeanstalk.DeletePlatformVersionInput) (*request.Request, *elasticbeanstalk.DeletePlatformVersionOutput)
 
+	DescribeAccountAttributes(*elasticbeanstalk.DescribeAccountAttributesInput) (*elasticbeanstalk.DescribeAccountAttributesOutput, error)
+	DescribeAccountAttributesWithContext(aws.Context, *elasticbeanstalk.DescribeAccountAttributesInput, ...request.Option) (*elasticbeanstalk.DescribeAccountAttributesOutput, error)
+	DescribeAccountAttributesRequest(*elasticbeanstalk.DescribeAccountAttributesInput) (*request.Request, *elasticbeanstalk.DescribeAccountAttributesOutput)
+
 	DescribeApplicationVersions(*elasticbeanstalk.DescribeApplicationVersionsInput) (*elasticbeanstalk.DescribeApplicationVersionsOutput, error)
 	DescribeApplicationVersionsWithContext(aws.Context, *elasticbeanstalk.DescribeApplicationVersionsInput, ...request.Option) (*elasticbeanstalk.DescribeApplicationVersionsOutput, error)
 	DescribeApplicationVersionsRequest(*elasticbeanstalk.DescribeApplicationVersionsInput) (*request.Request, *elasticbeanstalk.DescribeApplicationVersionsOutput)


### PR DESCRIPTION
Release v1.13.16 (2018-03-16)
===

### Service Client Updates
* `service/elasticbeanstalk`: Updates service API and documentation
  * AWS Elastic Beanstalk is launching a new public API named DescribeAccountAttributes which allows customers to access account level attributes. In this release, the API will support quotas for resources such as applications, application versions, and environments.

