### PR TITLE
aws/service/rds: Don't auto-sign (preSignUrl) for same region operations

### DIFF
--- a/service/rds/customizations.go
+++ b/service/rds/customizations.go
@@ -48,6 +48,12 @@ func copyDBSnapshotPresign(r *request.Request) {
 	}
 
 	originParams.DestinationRegion = r.Config.Region
+
+	// preSignedUrl is not required for instances in the same region.
+	if *originParams.SourceRegion == *originParams.DestinationRegion {
+		return
+	}
+
 	newParams := awsutil.CopyOf(r.Params).(*CopyDBSnapshotInput)
 	originParams.PreSignedUrl = presignURL(r, originParams.SourceRegion, newParams)
 }
@@ -60,6 +66,11 @@ func createDBInstanceReadReplicaPresign(r *request.Request) {
 	}
 
 	originParams.DestinationRegion = r.Config.Region
+	// preSignedUrl is not required for instances in the same region.
+	if *originParams.SourceRegion == *originParams.DestinationRegion {
+		return
+	}
+
 	newParams := awsutil.CopyOf(r.Params).(*CreateDBInstanceReadReplicaInput)
 	originParams.PreSignedUrl = presignURL(r, originParams.SourceRegion, newParams)
 }
@@ -72,6 +83,11 @@ func copyDBClusterSnapshotPresign(r *request.Request) {
 	}
 
 	originParams.DestinationRegion = r.Config.Region
+	// preSignedUrl is not required for instances in the same region.
+	if *originParams.SourceRegion == *originParams.DestinationRegion {
+		return
+	}
+
 	newParams := awsutil.CopyOf(r.Params).(*CopyDBClusterSnapshotInput)
 	originParams.PreSignedUrl = presignURL(r, originParams.SourceRegion, newParams)
 }
@@ -84,6 +100,11 @@ func createDBClusterPresign(r *request.Request) {
 	}
 
 	originParams.DestinationRegion = r.Config.Region
+	// preSignedUrl is not required for instances in the same region.
+	if *originParams.SourceRegion == *originParams.DestinationRegion {
+		return
+	}
+
 	newParams := awsutil.CopyOf(r.Params).(*CreateDBClusterInput)
 	originParams.PreSignedUrl = presignURL(r, originParams.SourceRegion, newParams)
 }


### PR DESCRIPTION
Hello!

We are using an automation tool that creates read replicas of an instance in different regions, however, it results into an error if we try to create a read replica in the same region. precisely, the sdk causes an error if you indicate a source region for a replica when the source and replica is in the same region.
This commit fixes this issue.

Related issues are #1127 and #1128.


AWS does not like preSignedUrl when it is not required and returns a 400
error:

	Error creating DB Instance: InvalidParameterCombination: Your request
	does not require the preSignedUrl parameter. Please remove the
	preSignedUrl parameter and try your request again.

This commit adds the check to escape auto-sign when a request source
and destination is the same region is the same.