### PR TITLE
service/s3/s3manager: fixing error string and error messages being lost

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -64,7 +64,7 @@ func (err *Error) Error() string {
 	if err.OrigErr != nil {
 		origErr = ":\n" + err.OrigErr.Error()
 	}
-	return fmt.Sprintf("failed to upload %q to %q%s",
+	return fmt.Sprintf("failed to perform batch operation on %q to %q%s",
 		aws.StringValue(err.Key),
 		aws.StringValue(err.Bucket),
 		origErr,

--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -359,6 +359,13 @@ func initDeleteObjectsInput(o *s3.DeleteObjectInput) *s3.DeleteObjectsInput {
 	}
 }
 
+const (
+	// ErrDeleteBatchFailCode represents an error code which will be returned
+	// only when DeleteObjects.Errors has an error that does not contain a code.
+	ErrDeleteBatchFailCode       = "DeleteBatchError"
+	errDefaultDeleteBatchMessage = "failed to delete"
+)
+
 // deleteBatch will delete a batch of items in the objects parameters.
 func deleteBatch(ctx aws.Context, d *BatchDelete, input *s3.DeleteObjectsInput, objects []BatchDeleteObject) []Error {
 	errs := []Error{}
@@ -369,7 +376,16 @@ func deleteBatch(ctx aws.Context, d *BatchDelete, input *s3.DeleteObjectsInput, 
 		}
 	} else if len(result.Errors) > 0 {
 		for i := 0; i < len(result.Errors); i++ {
-			errs = append(errs, newError(err, input.Bucket, result.Errors[i].Key))
+			code := ErrDeleteBatchFailCode
+			msg := errDefaultDeleteBatchMessage
+			if result.Errors[i].Message != nil {
+				msg = *result.Errors[i].Message
+			}
+			if result.Errors[i].Code != nil {
+				code = *result.Errors[i].Code
+			}
+
+			errs = append(errs, newError(awserr.New(code, msg, err), input.Bucket, result.Errors[i].Key))
 		}
 	}
 	for _, object := range objects {

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
@@ -309,16 +310,123 @@ func TestBatchDelete(t *testing.T) {
 	}
 }
 
+func TestBatchDeleteError(t *testing.T) {
+	cases := []struct {
+		objects            []BatchDeleteObject
+		output             s3.DeleteObjectsOutput
+		size               int
+		expectedErrCode    string
+		expectedErrMessage string
+	}{
+		{
+			[]BatchDeleteObject{
+				{
+					Object: &s3.DeleteObjectInput{
+						Key:    aws.String("1"),
+						Bucket: aws.String("bucket1"),
+					},
+				},
+			},
+			s3.DeleteObjectsOutput{
+				Errors: []*s3.Error{
+					&s3.Error{
+						Code:    aws.String("foo code"),
+						Message: aws.String("foo error"),
+					},
+				},
+			},
+			1,
+			"foo code",
+			"foo error",
+		},
+		{
+			[]BatchDeleteObject{
+				{
+					Object: &s3.DeleteObjectInput{
+						Key:    aws.String("1"),
+						Bucket: aws.String("bucket1"),
+					},
+				},
+			},
+			s3.DeleteObjectsOutput{
+				Errors: []*s3.Error{
+					&s3.Error{},
+				},
+			},
+			1,
+			ErrDeleteBatchFailCode,
+			errDefaultDeleteBatchMessage,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	index := 0
+	svc := &mockS3Client{
+		S3: buildS3SvcClient(server.URL),
+		deleteObjects: func(input *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
+			output := &cases[index].output
+			index++
+			return output, nil
+		},
+	}
+	for _, c := range cases {
+		batcher := BatchDelete{
+			Client:    svc,
+			BatchSize: c.size,
+		}
+
+		err := batcher.Delete(aws.BackgroundContext(), &DeleteObjectsIterator{Objects: c.objects})
+		if err == nil {
+			t.Errorf("expected error, but received none")
+		}
+
+		berr := err.(*BatchError)
+
+		if len(berr.Errors) != 1 {
+			t.Errorf("expected 1 error, but received %d", len(berr.Errors))
+		}
+
+		aerr := berr.Errors[0].OrigErr.(awserr.Error)
+		if e, a := c.expectedErrCode, aerr.Code(); e != a {
+			t.Errorf("expected %q, but received %q", e, a)
+		}
+
+		if e, a := c.expectedErrMessage, aerr.Message(); e != a {
+			t.Errorf("expected %q, but received %q", e, a)
+		}
+	}
+}
+
 type mockS3Client struct {
 	*s3.S3
-	index   int
-	objects []*s3.ListObjectsOutput
+	index         int
+	objects       []*s3.ListObjectsOutput
+	deleteObjects func(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
 }
 
 func (client *mockS3Client) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	object := client.objects[client.index]
 	client.index++
 	return object, nil
+}
+
+func (client *mockS3Client) DeleteObjects(input *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
+	if client.deleteObjects == nil {
+		return client.S3.DeleteObjectsWithContext(aws.BackgroundContext(), input)
+	}
+
+	return client.deleteObjects(input)
+}
+
+func (client *mockS3Client) DeleteObjectsWithContext(ctx aws.Context, input *s3.DeleteObjectsInput, opt ...request.Option) (*s3.DeleteObjectsOutput, error) {
+	if client.deleteObjects == nil {
+		return client.S3.DeleteObjectsWithContext(ctx, input)
+	}
+
+	return client.deleteObjects(input)
 }
 
 func TestNilOrigError(t *testing.T) {

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -327,7 +327,7 @@ func TestNilOrigError(t *testing.T) {
 		Key:    aws.String("key"),
 	}
 	errStr := err.Error()
-	const expected1 = `failed to upload "key" to "bucket"`
+	const expected1 = `failed to perform batch operation on "key" to "bucket"`
 	if errStr != expected1 {
 		t.Errorf("Expected %s, but received %s", expected1, errStr)
 	}
@@ -338,7 +338,7 @@ func TestNilOrigError(t *testing.T) {
 		Key:     aws.String("key"),
 	}
 	errStr = err.Error()
-	const expected2 = "failed to upload \"key\" to \"bucket\":\nfoo"
+	const expected2 = "failed to perform batch operation on \"key\" to \"bucket\":\nfoo"
 	if errStr != expected2 {
 		t.Errorf("Expected %s, but received %s", expected2, errStr)
 	}


### PR DESCRIPTION
Amazon S3 error messages from `DeleteObjects` would get dropped and provide no meaningful error message back to the user. This fix will create a new error from that message, if one exists. In addition, `BatchError` had a specific message of uploading even if the operation being performed wasn't uploading. This has been resolved to being more generic.

Fix #1849