### PR TITLE
 aws/endpoints: Use service metadata for fallback signing name

### DIFF
--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -15,6 +15,12 @@ type Config struct {
 	Endpoint      string
 	SigningRegion string
 	SigningName   string
+
+	// States that the signing name did not come from a modeled source but
+	// was derived based on other data. Used by service client constructors
+	// to determine if the signin name can be overriden based on metadata the
+	// service has.
+	SigningNameDerived bool
 }
 
 // ConfigProvider provides a generic way for a service client to receive

--- a/aws/endpoints/decode.go
+++ b/aws/endpoints/decode.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -85,8 +84,6 @@ func decodeV3Endpoints(modelDef modelDefinition, opts DecodeModelOptions) (Resol
 		custAddEC2Metadata(p)
 		custAddS3DualStack(p)
 		custRmIotDataService(p)
-
-		custFixRuntimeSagemakerSigningName(p)
 	}
 
 	return ps, nil
@@ -123,26 +120,6 @@ func custAddEC2Metadata(p *partition) {
 
 func custRmIotDataService(p *partition) {
 	delete(p.Services, "data.iot")
-}
-
-func custFixRuntimeSagemakerSigningName(p *partition) {
-	// Workaround for aws/aws-sdk-go#1836
-
-	s, ok := p.Services["runtime.sagemaker"]
-	if !ok {
-		return
-	}
-
-	if len(s.Defaults.CredentialScope.Service) != 0 {
-		fmt.Fprintf(os.Stderr, "runtime.sagemaker signing name already set, ignoring override.\n")
-		// If the value is already set don't override
-		return
-	}
-
-	s.Defaults.CredentialScope.Service = "sagemaker"
-	fmt.Fprintf(os.Stderr, "sagemaker signing name not set, overriding.\n")
-
-	p.Services["runtime.sagemaker"] = s
 }
 
 type decodeModelError struct {

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1716,11 +1716,7 @@ var awsPartition = partition{
 			},
 		},
 		"runtime.sagemaker": service{
-			Defaults: endpoint{
-				CredentialScope: credentialScope{
-					Service: "sagemaker",
-				},
-			},
+
 			Endpoints: endpoints{
 				"eu-west-1": endpoint{},
 				"us-east-1": endpoint{},

--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -347,6 +347,10 @@ type ResolvedEndpoint struct {
 	// The service name that should be used for signing requests.
 	SigningName string
 
+	// States that the signing name for this endpoint was derived from metadata
+	// passed in, but was not explicitly modeled.
+	SigningNameDerived bool
+
 	// The signing method that should be used for signing requests.
 	SigningMethod string
 }

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -226,16 +226,20 @@ func (e endpoint) resolve(service, region, dnsSuffix string, defs []endpoint, op
 	if len(signingRegion) == 0 {
 		signingRegion = region
 	}
+
 	signingName := e.CredentialScope.Service
+	var signingNameDerived bool
 	if len(signingName) == 0 {
 		signingName = service
+		signingNameDerived = true
 	}
 
 	return ResolvedEndpoint{
-		URL:           u,
-		SigningRegion: signingRegion,
-		SigningName:   signingName,
-		SigningMethod: getByPriority(e.SignatureVersions, signerPriority, defaultSigner),
+		URL:                u,
+		SigningRegion:      signingRegion,
+		SigningName:        signingName,
+		SigningNameDerived: signingNameDerived,
+		SigningMethod:      getByPriority(e.SignatureVersions, signerPriority, defaultSigner),
 	}
 }
 

--- a/aws/endpoints/v3model_test.go
+++ b/aws/endpoints/v3model_test.go
@@ -2,10 +2,9 @@ package endpoints
 
 import (
 	"encoding/json"
+	"reflect"
 	"regexp"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUnmarshalRegionRegex(t *testing.T) {
@@ -16,12 +15,18 @@ func TestUnmarshalRegionRegex(t *testing.T) {
 
 	p := partition{}
 	err := json.Unmarshal(input, &p)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	expectRegexp, err := regexp.Compile(`^(us|eu|ap|sa|ca)\-\w+\-\d+$`)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.Equal(t, expectRegexp.String(), p.RegionRegex.Regexp.String())
+	if e, a := expectRegexp.String(), p.RegionRegex.Regexp.String(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestUnmarshalRegion(t *testing.T) {
@@ -37,16 +42,28 @@ func TestUnmarshalRegion(t *testing.T) {
 
 	rs := regions{}
 	err := json.Unmarshal(input, &rs)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.Len(t, rs, 2)
+	if e, a := 2, len(rs); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
 	r, ok := rs["aws-global"]
-	assert.True(t, ok)
-	assert.Equal(t, "AWS partition-global endpoint", r.Description)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := "AWS partition-global endpoint", r.Description; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	r, ok = rs["us-east-1"]
-	assert.True(t, ok)
-	assert.Equal(t, "US East (N. Virginia)", r.Description)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := "US East (N. Virginia)", r.Description; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestUnmarshalServices(t *testing.T) {
@@ -75,23 +92,45 @@ func TestUnmarshalServices(t *testing.T) {
 
 	ss := services{}
 	err := json.Unmarshal(input, &ss)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.Len(t, ss, 3)
+	if e, a := 3, len(ss); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
 	s, ok := ss["acm"]
-	assert.True(t, ok)
-	assert.Len(t, s.Endpoints, 1)
-	assert.Equal(t, boxedBoolUnset, s.IsRegionalized)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := 1, len(s.Endpoints); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
+	if e, a := boxedBoolUnset, s.IsRegionalized; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	s, ok = ss["apigateway"]
-	assert.True(t, ok)
-	assert.Len(t, s.Endpoints, 2)
-	assert.Equal(t, boxedTrue, s.IsRegionalized)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := 2, len(s.Endpoints); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
+	if e, a := boxedTrue, s.IsRegionalized; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	s, ok = ss["notRegionalized"]
-	assert.True(t, ok)
-	assert.Len(t, s.Endpoints, 2)
-	assert.Equal(t, boxedFalse, s.IsRegionalized)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := 2, len(s.Endpoints); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
+	if e, a := boxedFalse, s.IsRegionalized; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestUnmarshalEndpoints(t *testing.T) {
@@ -115,16 +154,32 @@ func TestUnmarshalEndpoints(t *testing.T) {
 
 	es := endpoints{}
 	err := json.Unmarshal(inputs, &es)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.Len(t, es, 2)
+	if e, a := 2, len(es); e != a {
+		t.Errorf("expect %v len, got %v", e, a)
+	}
 	s, ok := es["aws-global"]
-	assert.True(t, ok)
-	assert.Equal(t, "cloudfront.amazonaws.com", s.Hostname)
-	assert.Equal(t, []string{"http", "https"}, s.Protocols)
-	assert.Equal(t, []string{"v4"}, s.SignatureVersions)
-	assert.Equal(t, credentialScope{"us-east-1", "serviceName"}, s.CredentialScope)
-	assert.Equal(t, "commonName", s.SSLCommonName)
+	if !ok {
+		t.Errorf("expect found, was not")
+	}
+	if e, a := "cloudfront.amazonaws.com", s.Hostname; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := []string{"http", "https"}, s.Protocols; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := []string{"v4"}, s.SignatureVersions; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := (credentialScope{"us-east-1", "serviceName"}), s.CredentialScope; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "commonName", s.SSLCommonName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestEndpointResolve(t *testing.T) {
@@ -155,10 +210,18 @@ func TestEndpointResolve(t *testing.T) {
 		defs, Options{},
 	)
 
-	assert.Equal(t, "https://service.region.dnsSuffix", resolved.URL)
-	assert.Equal(t, "signing_service", resolved.SigningName)
-	assert.Equal(t, "signing_region", resolved.SigningRegion)
-	assert.Equal(t, "v4", resolved.SigningMethod)
+	if e, a := "https://service.region.dnsSuffix", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "signing_service", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "signing_region", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "v4", resolved.SigningMethod; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestEndpointMergeIn(t *testing.T) {
@@ -185,7 +248,9 @@ func TestEndpointMergeIn(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, expected, actual)
+	if e, a := expected, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 var testPartitions = partitions{
@@ -213,6 +278,11 @@ var testPartitions = partitions{
 		Services: services{
 			"s3": service{},
 			"service1": service{
+				Defaults: endpoint{
+					CredentialScope: credentialScope{
+						Service: "service1",
+					},
+				},
 				Endpoints: endpoints{
 					"us-east-1": {},
 					"us-west-2": {
@@ -221,7 +291,13 @@ var testPartitions = partitions{
 					},
 				},
 			},
-			"service2": service{},
+			"service2": service{
+				Defaults: endpoint{
+					CredentialScope: credentialScope{
+						Service: "service2",
+					},
+				},
+			},
 			"httpService": service{
 				Defaults: endpoint{
 					Protocols: []string{"http"},
@@ -246,109 +322,220 @@ var testPartitions = partitions{
 func TestResolveEndpoint(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service2", "us-west-2")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://service2.us-west-2.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-west-2", resolved.SigningRegion)
-	assert.Equal(t, "service2", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://service2.us-west-2.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-west-2", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "service2", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if resolved.SigningNameDerived {
+		t.Errorf("expect the signing name not to be derived, but was")
+	}
 }
 
 func TestResolveEndpoint_DisableSSL(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service2", "us-west-2", DisableSSLOption)
 
-	assert.NoError(t, err)
-	assert.Equal(t, "http://service2.us-west-2.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-west-2", resolved.SigningRegion)
-	assert.Equal(t, "service2", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "http://service2.us-west-2.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-west-2", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "service2", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if resolved.SigningNameDerived {
+		t.Errorf("expect the signing name not to be derived, but was")
+	}
 }
 
 func TestResolveEndpoint_UseDualStack(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service1", "us-west-2", UseDualStackOption)
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://service1.dualstack.us-west-2.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-west-2", resolved.SigningRegion)
-	assert.Equal(t, "service1", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://service1.dualstack.us-west-2.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-west-2", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "service1", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if resolved.SigningNameDerived {
+		t.Errorf("expect the signing name not to be derived, but was")
+	}
 }
 
 func TestResolveEndpoint_HTTPProtocol(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("httpService", "us-west-2")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "http://httpService.us-west-2.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-west-2", resolved.SigningRegion)
-	assert.Equal(t, "httpService", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "http://httpService.us-west-2.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-west-2", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "httpService", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !resolved.SigningNameDerived {
+		t.Errorf("expect the signing name to be derived")
+	}
 }
 
 func TestResolveEndpoint_UnknownService(t *testing.T) {
 	_, err := testPartitions.EndpointFor("unknownservice", "us-west-2")
 
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error, got none")
+	}
 
 	_, ok := err.(UnknownServiceError)
-	assert.True(t, ok, "expect error to be UnknownServiceError")
+	if !ok {
+		t.Errorf("expect error to be UnknownServiceError")
+	}
 }
 
 func TestResolveEndpoint_ResolveUnknownService(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("unknown-service", "us-region-1",
 		ResolveUnknownServiceOption)
 
-	assert.NoError(t, err)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
-	assert.Equal(t, "https://unknown-service.us-region-1.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-region-1", resolved.SigningRegion)
-	assert.Equal(t, "unknown-service", resolved.SigningName)
+	if e, a := "https://unknown-service.us-region-1.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-region-1", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "unknown-service", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !resolved.SigningNameDerived {
+		t.Errorf("expect the signing name to be derived")
+	}
 }
 
 func TestResolveEndpoint_UnknownMatchedRegion(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service2", "us-region-1")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://service2.us-region-1.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-region-1", resolved.SigningRegion)
-	assert.Equal(t, "service2", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://service2.us-region-1.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-region-1", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "service2", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if resolved.SigningNameDerived {
+		t.Errorf("expect the signing name not to be derived, but was")
+	}
 }
 
 func TestResolveEndpoint_UnknownRegion(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("service2", "unknownregion")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://service2.unknownregion.amazonaws.com", resolved.URL)
-	assert.Equal(t, "unknownregion", resolved.SigningRegion)
-	assert.Equal(t, "service2", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://service2.unknownregion.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "unknownregion", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "service2", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if resolved.SigningNameDerived {
+		t.Errorf("expect the signing name not to be derived, but was")
+	}
 }
 
 func TestResolveEndpoint_StrictPartitionUnknownEndpoint(t *testing.T) {
 	_, err := testPartitions[0].EndpointFor("service2", "unknownregion", StrictMatchingOption)
 
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error, got none")
+	}
 
 	_, ok := err.(UnknownEndpointError)
-	assert.True(t, ok, "expect error to be UnknownEndpointError")
+	if !ok {
+		t.Errorf("expect error to be UnknownEndpointError")
+	}
 }
 
 func TestResolveEndpoint_StrictPartitionsUnknownEndpoint(t *testing.T) {
 	_, err := testPartitions.EndpointFor("service2", "us-region-1", StrictMatchingOption)
 
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error, got none")
+	}
 
 	_, ok := err.(UnknownEndpointError)
-	assert.True(t, ok, "expect error to be UnknownEndpointError")
+	if !ok {
+		t.Errorf("expect error to be UnknownEndpointError")
+	}
 }
 
 func TestResolveEndpoint_NotRegionalized(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("globalService", "us-west-2")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://globalService.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-east-1", resolved.SigningRegion)
-	assert.Equal(t, "globalService", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://globalService.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-east-1", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "globalService", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !resolved.SigningNameDerived {
+		t.Errorf("expect the signing name to be derived")
+	}
 }
 
 func TestResolveEndpoint_AwsGlobal(t *testing.T) {
 	resolved, err := testPartitions.EndpointFor("globalService", "aws-global")
 
-	assert.NoError(t, err)
-	assert.Equal(t, "https://globalService.amazonaws.com", resolved.URL)
-	assert.Equal(t, "us-east-1", resolved.SigningRegion)
-	assert.Equal(t, "globalService", resolved.SigningName)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if e, a := "https://globalService.amazonaws.com", resolved.URL; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "us-east-1", resolved.SigningRegion; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "globalService", resolved.SigningName; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !resolved.SigningNameDerived {
+		t.Errorf("expect the signing name to be derived")
+	}
 }

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -571,11 +571,12 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 	}
 
 	return client.Config{
-		Config:        s.Config,
-		Handlers:      s.Handlers,
-		Endpoint:      resolved.URL,
-		SigningRegion: resolved.SigningRegion,
-		SigningName:   resolved.SigningName,
+		Config:             s.Config,
+		Handlers:           s.Handlers,
+		Endpoint:           resolved.URL,
+		SigningRegion:      resolved.SigningRegion,
+		SigningNameDerived: resolved.SigningNameDerived,
+		SigningName:        resolved.SigningName,
 	}, err
 }
 
@@ -595,10 +596,11 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 	}
 
 	return client.Config{
-		Config:        s.Config,
-		Handlers:      s.Handlers,
-		Endpoint:      resolved.URL,
-		SigningRegion: resolved.SigningRegion,
-		SigningName:   resolved.SigningName,
+		Config:             s.Config,
+		Handlers:           s.Handlers,
+		Endpoint:           resolved.URL,
+		SigningRegion:      resolved.SigningRegion,
+		SigningNameDerived: resolved.SigningNameDerived,
+		SigningName:        resolved.SigningName,
 	}
 }

--- a/awstesting/integration/smoke/autoscalingplans/autoscalingplans.feature
+++ b/awstesting/integration/smoke/autoscalingplans/autoscalingplans.feature
@@ -1,0 +1,7 @@
+# language: en
+@autoscalingplans @client
+Feature: AWS Auto Scaling Plans
+
+  Scenario: Making a request
+    When I call the "DescribeScalingPlans" API
+    Then the request should be successful

--- a/awstesting/integration/smoke/autoscalingplans/client.go
+++ b/awstesting/integration/smoke/autoscalingplans/client.go
@@ -1,0 +1,16 @@
+// +build integration
+
+//Package autoscalingplans provides gucumber integration tests support.
+package autoscalingplans
+
+import (
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/autoscalingplans"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	gucumber.Before("@autoscalingplans", func() {
+		gucumber.World["client"] = autoscalingplans.New(smoke.Session)
+	})
+}

--- a/awstesting/integration/smoke/mediastore/client.go
+++ b/awstesting/integration/smoke/mediastore/client.go
@@ -1,0 +1,16 @@
+// +build integration
+
+//Package mediastore provides gucumber integration tests support.
+package mediastore
+
+import (
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	gucumber.Before("@mediastore", func() {
+		gucumber.World["client"] = mediastore.New(smoke.Session)
+	})
+}

--- a/awstesting/integration/smoke/mediastore/mediastore.feature
+++ b/awstesting/integration/smoke/mediastore/mediastore.feature
@@ -1,0 +1,7 @@
+# language: en
+@mediastore @client
+Feature: AWS Elemental MediaStore
+
+  Scenario: Making a request
+    When I call the "ListContainers" API
+    Then the request should be successful

--- a/awstesting/integration/smoke/mediastoredata/client.go
+++ b/awstesting/integration/smoke/mediastoredata/client.go
@@ -1,0 +1,34 @@
+// +build integration
+
+//Package mediastoredata provides gucumber integration tests support.
+package mediastoredata
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/aws/aws-sdk-go/service/mediastoredata"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	const containerName = "awsgosdkteamintegcontainer"
+
+	gucumber.Before("@mediastoredata", func() {
+		mediastoreSvc := mediastore.New(smoke.Session)
+
+		resp, err := mediastoreSvc.DescribeContainer(&mediastore.DescribeContainerInput{
+			ContainerName: aws.String(containerName),
+		})
+		if err != nil {
+			gucumber.World["error"] = fmt.Errorf("failed to get mediastore container endpoint for test, %v", err)
+			return
+		}
+
+		gucumber.World["client"] = mediastoredata.New(smoke.Session, &aws.Config{
+			Endpoint: resp.Container.Endpoint,
+		})
+	})
+}

--- a/awstesting/integration/smoke/mediastoredata/mediastoredata.feature
+++ b/awstesting/integration/smoke/mediastoredata/mediastoredata.feature
@@ -1,0 +1,7 @@
+# language: en
+@mediastoredata @client
+Feature: AWS Elemental MediaStore Data Plane
+
+  Scenario: Making a request
+    When I call the "ListItems" API
+    Then the request should be successful

--- a/awstesting/integration/smoke/mobile/client.go
+++ b/awstesting/integration/smoke/mobile/client.go
@@ -1,0 +1,16 @@
+// +build integration
+
+//Package mobile provides gucumber integration tests support.
+package mobile
+
+import (
+	"github.com/aws/aws-sdk-go/awstesting/integration/smoke"
+	"github.com/aws/aws-sdk-go/service/mobile"
+	"github.com/gucumber/gucumber"
+)
+
+func init() {
+	gucumber.Before("@mobile", func() {
+		gucumber.World["client"] = mobile.New(smoke.Session)
+	})
+}

--- a/awstesting/integration/smoke/mobile/mobile.feature
+++ b/awstesting/integration/smoke/mobile/mobile.feature
@@ -1,0 +1,7 @@
+# language: en
+@mobile @client
+Feature: AWS Mobile
+
+  Scenario: Making a request
+    When I call the "ListBundles" API
+    Then the request should be successful

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -490,7 +490,7 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *{{ .StructName }} {
 	{{- end }}
 
 	{{- if .Metadata.SigningName }}
-		if c.SigningNameDerived {
+		if c.SigningNameDerived || len(c.SigningName) == 0{
 			c.SigningName = "{{ .Metadata.SigningName }}"
 		}
 	{{- end }}

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -488,16 +488,17 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *{{ .StructName }} {
 	{{- else -}}
 		c := p.ClientConfig({{ EndpointsIDValue . }}, cfgs...)
 	{{- end }}
+
+	{{- if .Metadata.SigningName }}
+		if c.SigningNameDerived {
+			c.SigningName = "{{ .Metadata.SigningName }}"
+		}
+	{{- end }}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *{{ .StructName }} {
-	{{- if .Metadata.SigningName }}
-		if len(signingName) == 0 {
-			signingName = "{{ .Metadata.SigningName }}"
-		}
-	{{- end }}
     svc := &{{ .StructName }}{
     	Client: client.New(
     		cfg,

--- a/service/applicationautoscaling/service.go
+++ b/service/applicationautoscaling/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := applicationautoscaling.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ApplicationAutoScaling {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "application-autoscaling"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ApplicationAutoScaling {
-	if len(signingName) == 0 {
-		signingName = "application-autoscaling"
-	}
 	svc := &ApplicationAutoScaling{
 		Client: client.New(
 			cfg,

--- a/service/applicationautoscaling/service.go
+++ b/service/applicationautoscaling/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := applicationautoscaling.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ApplicationAutoScaling {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "application-autoscaling"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/appstream/service.go
+++ b/service/appstream/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := appstream.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AppStream {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "appstream"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *AppStream {
-	if len(signingName) == 0 {
-		signingName = "appstream"
-	}
 	svc := &AppStream{
 		Client: client.New(
 			cfg,

--- a/service/appstream/service.go
+++ b/service/appstream/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := appstream.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AppStream {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "appstream"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/appsync/service.go
+++ b/service/appsync/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := appsync.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AppSync {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "appsync"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *AppSync {
-	if len(signingName) == 0 {
-		signingName = "appsync"
-	}
 	svc := &AppSync{
 		Client: client.New(
 			cfg,

--- a/service/appsync/service.go
+++ b/service/appsync/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := appsync.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AppSync {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "appsync"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/autoscalingplans/service.go
+++ b/service/autoscalingplans/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := autoscalingplans.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AutoScalingPlans {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "autoscaling-plans"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/autoscalingplans/service.go
+++ b/service/autoscalingplans/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := autoscalingplans.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *AutoScalingPlans {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "autoscaling-plans"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *AutoScalingPlans {
-	if len(signingName) == 0 {
-		signingName = "autoscaling-plans"
-	}
 	svc := &AutoScalingPlans{
 		Client: client.New(
 			cfg,

--- a/service/clouddirectory/service.go
+++ b/service/clouddirectory/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := clouddirectory.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudDirectory {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "clouddirectory"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/clouddirectory/service.go
+++ b/service/clouddirectory/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := clouddirectory.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudDirectory {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "clouddirectory"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *CloudDirectory {
-	if len(signingName) == 0 {
-		signingName = "clouddirectory"
-	}
 	svc := &CloudDirectory{
 		Client: client.New(
 			cfg,

--- a/service/cloudhsmv2/service.go
+++ b/service/cloudhsmv2/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := cloudhsmv2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudHSMV2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "cloudhsm"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/cloudhsmv2/service.go
+++ b/service/cloudhsmv2/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := cloudhsmv2.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudHSMV2 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "cloudhsm"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *CloudHSMV2 {
-	if len(signingName) == 0 {
-		signingName = "cloudhsm"
-	}
 	svc := &CloudHSMV2{
 		Client: client.New(
 			cfg,

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -50,7 +50,7 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudSearchDomain {
 	} else {
 		c = p.ClientConfig(EndpointsID, cfgs...)
 	}
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "cloudsearch"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -50,14 +50,14 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *CloudSearchDomain {
 	} else {
 		c = p.ClientConfig(EndpointsID, cfgs...)
 	}
+	if c.SigningNameDerived {
+		c.SigningName = "cloudsearch"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *CloudSearchDomain {
-	if len(signingName) == 0 {
-		signingName = "cloudsearch"
-	}
 	svc := &CloudSearchDomain{
 		Client: client.New(
 			cfg,

--- a/service/comprehend/service.go
+++ b/service/comprehend/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := comprehend.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Comprehend {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "comprehend"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/comprehend/service.go
+++ b/service/comprehend/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := comprehend.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Comprehend {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "comprehend"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Comprehend {
-	if len(signingName) == 0 {
-		signingName = "comprehend"
-	}
 	svc := &Comprehend{
 		Client: client.New(
 			cfg,

--- a/service/costandusagereportservice/service.go
+++ b/service/costandusagereportservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := costandusagereportservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CostandUsageReportService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "cur"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *CostandUsageReportService {
-	if len(signingName) == 0 {
-		signingName = "cur"
-	}
 	svc := &CostandUsageReportService{
 		Client: client.New(
 			cfg,

--- a/service/costandusagereportservice/service.go
+++ b/service/costandusagereportservice/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := costandusagereportservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CostandUsageReportService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "cur"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/costexplorer/service.go
+++ b/service/costexplorer/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := costexplorer.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CostExplorer {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "ce"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/costexplorer/service.go
+++ b/service/costexplorer/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := costexplorer.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *CostExplorer {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "ce"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *CostExplorer {
-	if len(signingName) == 0 {
-		signingName = "ce"
-	}
 	svc := &CostExplorer{
 		Client: client.New(
 			cfg,

--- a/service/dynamodbstreams/service.go
+++ b/service/dynamodbstreams/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := dynamodbstreams.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *DynamoDBStreams {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "dynamodb"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *DynamoDBStreams {
-	if len(signingName) == 0 {
-		signingName = "dynamodb"
-	}
 	svc := &DynamoDBStreams{
 		Client: client.New(
 			cfg,

--- a/service/dynamodbstreams/service.go
+++ b/service/dynamodbstreams/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := dynamodbstreams.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *DynamoDBStreams {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "dynamodb"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/greengrass/service.go
+++ b/service/greengrass/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := greengrass.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Greengrass {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "greengrass"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Greengrass {
-	if len(signingName) == 0 {
-		signingName = "greengrass"
-	}
 	svc := &Greengrass{
 		Client: client.New(
 			cfg,

--- a/service/greengrass/service.go
+++ b/service/greengrass/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := greengrass.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Greengrass {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "greengrass"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/guardduty/service.go
+++ b/service/guardduty/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := guardduty.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *GuardDuty {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "guardduty"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *GuardDuty {
-	if len(signingName) == 0 {
-		signingName = "guardduty"
-	}
 	svc := &GuardDuty{
 		Client: client.New(
 			cfg,

--- a/service/guardduty/service.go
+++ b/service/guardduty/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := guardduty.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *GuardDuty {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "guardduty"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/iot/service.go
+++ b/service/iot/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := iot.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoT {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "execute-api"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *IoT {
-	if len(signingName) == 0 {
-		signingName = "execute-api"
-	}
 	svc := &IoT{
 		Client: client.New(
 			cfg,

--- a/service/iot/service.go
+++ b/service/iot/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := iot.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoT {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "execute-api"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/iotdataplane/service.go
+++ b/service/iotdataplane/service.go
@@ -50,14 +50,14 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoTDataPlane {
 	} else {
 		c = p.ClientConfig(EndpointsID, cfgs...)
 	}
+	if c.SigningNameDerived {
+		c.SigningName = "iotdata"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *IoTDataPlane {
-	if len(signingName) == 0 {
-		signingName = "iotdata"
-	}
 	svc := &IoTDataPlane{
 		Client: client.New(
 			cfg,

--- a/service/iotdataplane/service.go
+++ b/service/iotdataplane/service.go
@@ -50,7 +50,7 @@ func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoTDataPlane {
 	} else {
 		c = p.ClientConfig(EndpointsID, cfgs...)
 	}
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "iotdata"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/iotjobsdataplane/service.go
+++ b/service/iotjobsdataplane/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := iotjobsdataplane.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoTJobsDataPlane {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "iot-jobs-data"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *IoTJobsDataPlane {
-	if len(signingName) == 0 {
-		signingName = "iot-jobs-data"
-	}
 	svc := &IoTJobsDataPlane{
 		Client: client.New(
 			cfg,

--- a/service/iotjobsdataplane/service.go
+++ b/service/iotjobsdataplane/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := iotjobsdataplane.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *IoTJobsDataPlane {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "iot-jobs-data"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/lexmodelbuildingservice/service.go
+++ b/service/lexmodelbuildingservice/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := lexmodelbuildingservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *LexModelBuildingService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "lex"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/lexmodelbuildingservice/service.go
+++ b/service/lexmodelbuildingservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := lexmodelbuildingservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *LexModelBuildingService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "lex"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *LexModelBuildingService {
-	if len(signingName) == 0 {
-		signingName = "lex"
-	}
 	svc := &LexModelBuildingService{
 		Client: client.New(
 			cfg,

--- a/service/lexruntimeservice/service.go
+++ b/service/lexruntimeservice/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := lexruntimeservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *LexRuntimeService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "lex"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/lexruntimeservice/service.go
+++ b/service/lexruntimeservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := lexruntimeservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *LexRuntimeService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "lex"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *LexRuntimeService {
-	if len(signingName) == 0 {
-		signingName = "lex"
-	}
 	svc := &LexRuntimeService{
 		Client: client.New(
 			cfg,

--- a/service/marketplacecommerceanalytics/service.go
+++ b/service/marketplacecommerceanalytics/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := marketplacecommerceanalytics.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceCommerceAnalytics {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "marketplacecommerceanalytics"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MarketplaceCommerceAnalytics {
-	if len(signingName) == 0 {
-		signingName = "marketplacecommerceanalytics"
-	}
 	svc := &MarketplaceCommerceAnalytics{
 		Client: client.New(
 			cfg,

--- a/service/marketplacecommerceanalytics/service.go
+++ b/service/marketplacecommerceanalytics/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := marketplacecommerceanalytics.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceCommerceAnalytics {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "marketplacecommerceanalytics"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/marketplaceentitlementservice/service.go
+++ b/service/marketplaceentitlementservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := marketplaceentitlementservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceEntitlementService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "aws-marketplace"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MarketplaceEntitlementService {
-	if len(signingName) == 0 {
-		signingName = "aws-marketplace"
-	}
 	svc := &MarketplaceEntitlementService{
 		Client: client.New(
 			cfg,

--- a/service/marketplaceentitlementservice/service.go
+++ b/service/marketplaceentitlementservice/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := marketplaceentitlementservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceEntitlementService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "aws-marketplace"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/marketplacemetering/service.go
+++ b/service/marketplacemetering/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := marketplacemetering.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceMetering {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "aws-marketplace"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MarketplaceMetering {
-	if len(signingName) == 0 {
-		signingName = "aws-marketplace"
-	}
 	svc := &MarketplaceMetering{
 		Client: client.New(
 			cfg,

--- a/service/marketplacemetering/service.go
+++ b/service/marketplacemetering/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := marketplacemetering.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MarketplaceMetering {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "aws-marketplace"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mediaconvert/service.go
+++ b/service/mediaconvert/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mediaconvert.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaConvert {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mediaconvert"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mediaconvert/service.go
+++ b/service/mediaconvert/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediaconvert.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaConvert {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mediaconvert"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaConvert {
-	if len(signingName) == 0 {
-		signingName = "mediaconvert"
-	}
 	svc := &MediaConvert{
 		Client: client.New(
 			cfg,

--- a/service/medialive/service.go
+++ b/service/medialive/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := medialive.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaLive {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "medialive"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/medialive/service.go
+++ b/service/medialive/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := medialive.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaLive {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "medialive"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaLive {
-	if len(signingName) == 0 {
-		signingName = "medialive"
-	}
 	svc := &MediaLive{
 		Client: client.New(
 			cfg,

--- a/service/mediapackage/service.go
+++ b/service/mediapackage/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mediapackage.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaPackage {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mediapackage"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mediapackage/service.go
+++ b/service/mediapackage/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediapackage.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaPackage {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mediapackage"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaPackage {
-	if len(signingName) == 0 {
-		signingName = "mediapackage"
-	}
 	svc := &MediaPackage{
 		Client: client.New(
 			cfg,

--- a/service/mediastore/service.go
+++ b/service/mediastore/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediastore.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStore {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mediastore"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaStore {
-	if len(signingName) == 0 {
-		signingName = "mediastore"
-	}
 	svc := &MediaStore{
 		Client: client.New(
 			cfg,

--- a/service/mediastore/service.go
+++ b/service/mediastore/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mediastore.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStore {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mediastore"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mediastoredata/service.go
+++ b/service/mediastoredata/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mediastoredata.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStoreData {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mediastore"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MediaStoreData {
-	if len(signingName) == 0 {
-		signingName = "mediastore"
-	}
 	svc := &MediaStoreData{
 		Client: client.New(
 			cfg,

--- a/service/mediastoredata/service.go
+++ b/service/mediastoredata/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mediastoredata.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MediaStoreData {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mediastore"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mobile/service.go
+++ b/service/mobile/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mobile.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Mobile {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "AWSMobileHubService"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Mobile {
-	if len(signingName) == 0 {
-		signingName = "AWSMobileHubService"
-	}
 	svc := &Mobile{
 		Client: client.New(
 			cfg,

--- a/service/mobile/service.go
+++ b/service/mobile/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mobile.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Mobile {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "AWSMobileHubService"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/mq/service.go
+++ b/service/mq/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := mq.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MQ {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mq"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *MQ {
-	if len(signingName) == 0 {
-		signingName = "mq"
-	}
 	svc := &MQ{
 		Client: client.New(
 			cfg,

--- a/service/mq/service.go
+++ b/service/mq/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := mq.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *MQ {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mq"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/opsworkscm/service.go
+++ b/service/opsworkscm/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := opsworkscm.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *OpsWorksCM {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "opsworks-cm"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OpsWorksCM {
-	if len(signingName) == 0 {
-		signingName = "opsworks-cm"
-	}
 	svc := &OpsWorksCM{
 		Client: client.New(
 			cfg,

--- a/service/opsworkscm/service.go
+++ b/service/opsworkscm/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := opsworkscm.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *OpsWorksCM {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "opsworks-cm"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/pinpoint/service.go
+++ b/service/pinpoint/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := pinpoint.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Pinpoint {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "mobiletargeting"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Pinpoint {
-	if len(signingName) == 0 {
-		signingName = "mobiletargeting"
-	}
 	svc := &Pinpoint{
 		Client: client.New(
 			cfg,

--- a/service/pinpoint/service.go
+++ b/service/pinpoint/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := pinpoint.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Pinpoint {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "mobiletargeting"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/pricing/service.go
+++ b/service/pricing/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := pricing.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Pricing {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "pricing"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Pricing {
-	if len(signingName) == 0 {
-		signingName = "pricing"
-	}
 	svc := &Pricing{
 		Client: client.New(
 			cfg,

--- a/service/pricing/service.go
+++ b/service/pricing/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := pricing.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Pricing {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "pricing"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/resourcegroups/service.go
+++ b/service/resourcegroups/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := resourcegroups.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ResourceGroups {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "resource-groups"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/resourcegroups/service.go
+++ b/service/resourcegroups/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := resourcegroups.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ResourceGroups {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "resource-groups"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ResourceGroups {
-	if len(signingName) == 0 {
-		signingName = "resource-groups"
-	}
 	svc := &ResourceGroups{
 		Client: client.New(
 			cfg,

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -329,7 +329,7 @@ func TestBatchDeleteError(t *testing.T) {
 			},
 			s3.DeleteObjectsOutput{
 				Errors: []*s3.Error{
-					&s3.Error{
+					{
 						Code:    aws.String("foo code"),
 						Message: aws.String("foo error"),
 					},
@@ -350,7 +350,7 @@ func TestBatchDeleteError(t *testing.T) {
 			},
 			s3.DeleteObjectsOutput{
 				Errors: []*s3.Error{
-					&s3.Error{},
+					{},
 				},
 			},
 			1,

--- a/service/sagemaker/service.go
+++ b/service/sagemaker/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := sagemaker.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SageMaker {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "sagemaker"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/sagemaker/service.go
+++ b/service/sagemaker/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := sagemaker.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SageMaker {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "sagemaker"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *SageMaker {
-	if len(signingName) == 0 {
-		signingName = "sagemaker"
-	}
 	svc := &SageMaker{
 		Client: client.New(
 			cfg,

--- a/service/sagemakerruntime/service.go
+++ b/service/sagemakerruntime/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := sagemakerruntime.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SageMakerRuntime {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "sagemaker"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *SageMakerRuntime {
-	if len(signingName) == 0 {
-		signingName = "sagemaker"
-	}
 	svc := &SageMakerRuntime{
 		Client: client.New(
 			cfg,

--- a/service/sagemakerruntime/service.go
+++ b/service/sagemakerruntime/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := sagemakerruntime.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SageMakerRuntime {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "sagemaker"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/serverlessapplicationrepository/service.go
+++ b/service/serverlessapplicationrepository/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := serverlessapplicationrepository.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ServerlessApplicationRepository {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "serverlessrepo"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *ServerlessApplicationRepository {
-	if len(signingName) == 0 {
-		signingName = "serverlessrepo"
-	}
 	svc := &ServerlessApplicationRepository{
 		Client: client.New(
 			cfg,

--- a/service/serverlessapplicationrepository/service.go
+++ b/service/serverlessapplicationrepository/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := serverlessapplicationrepository.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *ServerlessApplicationRepository {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "serverlessrepo"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/ses/service.go
+++ b/service/ses/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := ses.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SES {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "ses"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/ses/service.go
+++ b/service/ses/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := ses.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *SES {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "ses"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *SES {
-	if len(signingName) == 0 {
-		signingName = "ses"
-	}
 	svc := &SES{
 		Client: client.New(
 			cfg,

--- a/service/transcribeservice/service.go
+++ b/service/transcribeservice/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := transcribeservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *TranscribeService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "transcribe"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)

--- a/service/transcribeservice/service.go
+++ b/service/transcribeservice/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := transcribeservice.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *TranscribeService {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "transcribe"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *TranscribeService {
-	if len(signingName) == 0 {
-		signingName = "transcribe"
-	}
 	svc := &TranscribeService{
 		Client: client.New(
 			cfg,

--- a/service/translate/service.go
+++ b/service/translate/service.go
@@ -45,14 +45,14 @@ const (
 //     svc := translate.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Translate {
 	c := p.ClientConfig(EndpointsID, cfgs...)
+	if c.SigningNameDerived {
+		c.SigningName = "translate"
+	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
 func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Translate {
-	if len(signingName) == 0 {
-		signingName = "translate"
-	}
 	svc := &Translate{
 		Client: client.New(
 			cfg,

--- a/service/translate/service.go
+++ b/service/translate/service.go
@@ -45,7 +45,7 @@ const (
 //     svc := translate.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Translate {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	if c.SigningNameDerived {
+	if c.SigningNameDerived || len(c.SigningName) == 0 {
 		c.SigningName = "translate"
 	}
 	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)


### PR DESCRIPTION
Updates the SDK's endpoint resolution to fallback deriving the service's signing name from the service's modeled metadata in addition the the endpoints modeled data.

Removes the need for customizations such as runtime.sagemaker and CloudHSMv2. (#1751, #1838)

Also removes testify from endpoints decode_test.go.

Fix #1850 
