### PR TITLE
v1.13.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+Release v1.13.19 (2018-03-22)
+===
+
+### Service Client Updates
+* `service/appstream`: Updates service API and documentation
+  * Feedback URL allows admins to provide a feedback link or a survey link for collecting user feedback while streaming sessions. When a feedback link is provided, streaming users will see a "Send Feedback" choice in their streaming session toolbar. On selecting this choice, user will be redirected to the link provided in a new browser tab. If a feedback link is not provided, users will not see the "Send Feedback" option.
+* `service/codebuild`: Updates service API and documentation
+  * Adding support for branch filtering when using webhooks with AWS CodeBuild.
+* `service/ecs`: Updates service API and documentation
+  * Amazon Elastic Container Service (ECS) now includes integrated Service Discovery using Route 53 Auto Naming. Customers can now specify a Route 53 Auto Naming service as part of an ECS service. ECS will register task IPs with Route 53, making them available via DNS in your VPC.
+* `aws/endpoints`: Updated Regions and Endpoints metadata.
+
+### SDK Bugs
+* `aws/endpoints`: Use service metadata for fallback signing name ([#1854](https://github.com/aws/aws-sdk-go/pull/1854))
+  * Updates the SDK's endpoint resolution to fallback deriving the service's signing name from the service's modeled metadata in addition the the endpoints modeled data.
+  * Fixes [#1850](https://github.com/aws/aws-sdk-go/issues/1850)
 Release v1.13.18 (2018-03-21)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,3 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* `aws/endpoints`: Use service metadata for fallback signing name ([#1854](https://github.com/aws/aws-sdk-go/pull/1854))
-  * Updates the SDK's endpoint resolution to fallback deriving the service's signing name from the service's modeled metadata in addition the the endpoints modeled data.
-  * Fixes [#1850](https://github.com/aws/aws-sdk-go/issues/1850)

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1423,12 +1423,17 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
@@ -1448,11 +1453,13 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.18"
+const SDKVersion = "1.13.19"

--- a/models/apis/appstream/2016-12-01/api-2.json
+++ b/models/apis/appstream/2016-12-01/api-2.json
@@ -23,6 +23,7 @@
       "output":{"shape":"AssociateFleetResult"},
       "errors":[
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ConcurrentModificationException"},
         {"shape":"IncompatibleImageException"},
@@ -42,6 +43,7 @@
         {"shape":"ResourceNotFoundException"},
         {"shape":"ResourceNotAvailableException"},
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"IncompatibleImageException"}
       ]
     },
@@ -55,7 +57,8 @@
       "output":{"shape":"CreateDirectoryConfigResult"},
       "errors":[
         {"shape":"ResourceAlreadyExistsException"},
-        {"shape":"LimitExceededException"}
+        {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"}
       ]
     },
     "CreateFleet":{
@@ -71,6 +74,7 @@
         {"shape":"ResourceNotAvailableException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"InvalidRoleException"},
         {"shape":"ConcurrentModificationException"},
         {"shape":"InvalidParameterCombinationException"},
@@ -87,6 +91,7 @@
       "output":{"shape":"CreateImageBuilderResult"},
       "errors":[
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"ResourceAlreadyExistsException"},
         {"shape":"ResourceNotAvailableException"},
         {"shape":"ResourceNotFoundException"},
@@ -119,6 +124,7 @@
       "output":{"shape":"CreateStackResult"},
       "errors":[
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"ResourceAlreadyExistsException"},
         {"shape":"ConcurrentModificationException"},
         {"shape":"InvalidRoleException"},
@@ -348,6 +354,7 @@
         {"shape":"ResourceNotFoundException"},
         {"shape":"OperationNotPermittedException"},
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"ConcurrentModificationException"}
       ]
     },
@@ -363,6 +370,7 @@
         {"shape":"ResourceNotAvailableException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ConcurrentModificationException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"IncompatibleImageException"}
       ]
     },
@@ -403,6 +411,7 @@
       "output":{"shape":"TagResourceResponse"},
       "errors":[
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"ResourceNotFoundException"}
       ]
     },
@@ -443,6 +452,7 @@
       "errors":[
         {"shape":"ResourceInUseException"},
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"InvalidRoleException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"ResourceNotAvailableException"},
@@ -466,6 +476,7 @@
         {"shape":"InvalidRoleException"},
         {"shape":"InvalidParameterCombinationException"},
         {"shape":"LimitExceededException"},
+        {"shape":"InvalidAccountStatusException"},
         {"shape":"IncompatibleImageException"}
       ]
     }
@@ -673,7 +684,8 @@
         "Description":{"shape":"Description"},
         "DisplayName":{"shape":"DisplayName"},
         "StorageConnectors":{"shape":"StorageConnectorList"},
-        "RedirectURL":{"shape":"RedirectURL"}
+        "RedirectURL":{"shape":"RedirectURL"},
+        "FeedbackURL":{"shape":"FeedbackURL"}
       }
     },
     "CreateStackResult":{
@@ -922,6 +934,10 @@
       "members":{
       }
     },
+    "FeedbackURL":{
+      "type":"string",
+      "max":1000
+    },
     "Fleet":{
       "type":"structure",
       "required":[
@@ -1135,6 +1151,13 @@
       "exception":true
     },
     "Integer":{"type":"integer"},
+    "InvalidAccountStatusException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"ErrorMessage"}
+      },
+      "exception":true
+    },
     "InvalidParameterCombinationException":{
       "type":"structure",
       "members":{
@@ -1338,6 +1361,7 @@
         "CreatedTime":{"shape":"Timestamp"},
         "StorageConnectors":{"shape":"StorageConnectorList"},
         "RedirectURL":{"shape":"RedirectURL"},
+        "FeedbackURL":{"shape":"FeedbackURL"},
         "StackErrors":{"shape":"StackErrors"}
       }
     },
@@ -1345,7 +1369,9 @@
       "type":"string",
       "enum":[
         "STORAGE_CONNECTORS",
-        "REDIRECT_URL"
+        "REDIRECT_URL",
+        "FEEDBACK_URL",
+        "THEME_NAME"
       ]
     },
     "StackAttributes":{
@@ -1573,6 +1599,7 @@
           "deprecated":true
         },
         "RedirectURL":{"shape":"RedirectURL"},
+        "FeedbackURL":{"shape":"FeedbackURL"},
         "AttributesToDelete":{"shape":"StackAttributes"}
       }
     },

--- a/models/apis/appstream/2016-12-01/docs-2.json
+++ b/models/apis/appstream/2016-12-01/docs-2.json
@@ -395,6 +395,7 @@
       "refs": {
         "ConcurrentModificationException$Message": null,
         "IncompatibleImageException$Message": null,
+        "InvalidAccountStatusException$Message": null,
         "InvalidParameterCombinationException$Message": null,
         "InvalidRoleException$Message": null,
         "LimitExceededException$Message": null,
@@ -413,6 +414,14 @@
     "ExpireSessionResult": {
       "base": null,
       "refs": {
+      }
+    },
+    "FeedbackURL": {
+      "base": null,
+      "refs": {
+        "CreateStackRequest$FeedbackURL": "<p>The URL that users are redirected to after they click the Send Feedback link. If no URL is specified, no Send Feedback link is displayed.</p>",
+        "Stack$FeedbackURL": "<p>The URL that users are redirected to after they click the Send Feedback link. If no URL is specified, no Send Feedback link is displayed.</p>",
+        "UpdateStackRequest$FeedbackURL": "<p>The URL that users are redirected to after they click the Send Feedback link. If no URL is specified, no Send Feedback link is displayed.</p>"
       }
     },
     "Fleet": {
@@ -562,6 +571,11 @@
         "UpdateFleetRequest$DisconnectTimeoutInSeconds": "<p>The time after disconnection when a session is considered to have ended, in seconds. If a user who was disconnected reconnects within this time interval, the user is connected to their previous session. Specify a value between 60 and 57600.</p>"
       }
     },
+    "InvalidAccountStatusException": {
+      "base": "<p>The resource cannot be created because your AWS account is suspended. For assistance, contact AWS Support. </p>",
+      "refs": {
+      }
+    },
     "InvalidParameterCombinationException": {
       "base": "<p>Indicates an incorrect combination of parameters, or a missing parameter.</p>",
       "refs": {
@@ -662,9 +676,9 @@
     "RedirectURL": {
       "base": null,
       "refs": {
-        "CreateStackRequest$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>",
-        "Stack$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>",
-        "UpdateStackRequest$RedirectURL": "<p>The URL the user is redirected to after the streaming session ends.</p>"
+        "CreateStackRequest$RedirectURL": "<p>The URL that users are redirected to after their streaming session ends.</p>",
+        "Stack$RedirectURL": "<p>The URL that users are redirected to after their streaming session ends.</p>",
+        "UpdateStackRequest$RedirectURL": "<p>The URL that users are redirected to after their streaming session ends.</p>"
       }
     },
     "RegionName": {
@@ -861,7 +875,7 @@
         "Application$IconURL": "<p>The URL for the application icon. This URL might be time-limited.</p>",
         "Application$LaunchPath": "<p>The path to the application executable in the instance.</p>",
         "Application$LaunchParameters": "<p>The arguments that are passed to the application at launch.</p>",
-        "AssociateFleetRequest$FleetName": "<p>The name of the fleet.</p>",
+        "AssociateFleetRequest$FleetName": "<p>The name of the fleet. </p>",
         "AssociateFleetRequest$StackName": "<p>The name of the stack.</p>",
         "CreateFleetRequest$ImageName": "<p>The name of the image used to create the fleet.</p>",
         "CreateFleetRequest$InstanceType": "<p>The instance type to use when launching fleet instances. The following instance types are available:</p> <ul> <li> <p>stream.standard.medium</p> </li> <li> <p>stream.standard.large</p> </li> <li> <p>stream.compute.large</p> </li> <li> <p>stream.compute.xlarge</p> </li> <li> <p>stream.compute.2xlarge</p> </li> <li> <p>stream.compute.4xlarge</p> </li> <li> <p>stream.compute.8xlarge</p> </li> <li> <p>stream.memory.large</p> </li> <li> <p>stream.memory.xlarge</p> </li> <li> <p>stream.memory.2xlarge</p> </li> <li> <p>stream.memory.4xlarge</p> </li> <li> <p>stream.memory.8xlarge</p> </li> <li> <p>stream.graphics-design.large</p> </li> <li> <p>stream.graphics-design.xlarge</p> </li> <li> <p>stream.graphics-design.2xlarge</p> </li> <li> <p>stream.graphics-design.4xlarge</p> </li> <li> <p>stream.graphics-desktop.2xlarge</p> </li> <li> <p>stream.graphics-pro.4xlarge</p> </li> <li> <p>stream.graphics-pro.8xlarge</p> </li> <li> <p>stream.graphics-pro.16xlarge</p> </li> </ul>",

--- a/models/apis/codebuild/2016-10-06/api-2.json
+++ b/models/apis/codebuild/2016-10-06/api-2.json
@@ -200,6 +200,20 @@
         {"shape":"InvalidInputException"},
         {"shape":"ResourceNotFoundException"}
       ]
+    },
+    "UpdateWebhook":{
+      "name":"UpdateWebhook",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UpdateWebhookInput"},
+      "output":{"shape":"UpdateWebhookOutput"},
+      "errors":[
+        {"shape":"InvalidInputException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"OAuthProviderException"}
+      ]
     }
   },
   "shapes":{
@@ -405,7 +419,8 @@
       "type":"structure",
       "required":["projectName"],
       "members":{
-        "projectName":{"shape":"ProjectName"}
+        "projectName":{"shape":"ProjectName"},
+        "branchFilter":{"shape":"String"}
       }
     },
     "CreateWebhookOutput":{
@@ -889,6 +904,21 @@
         "project":{"shape":"Project"}
       }
     },
+    "UpdateWebhookInput":{
+      "type":"structure",
+      "required":["projectName"],
+      "members":{
+        "projectName":{"shape":"ProjectName"},
+        "branchFilter":{"shape":"String"},
+        "rotateSecret":{"shape":"Boolean"}
+      }
+    },
+    "UpdateWebhookOutput":{
+      "type":"structure",
+      "members":{
+        "webhook":{"shape":"Webhook"}
+      }
+    },
     "ValueInput":{
       "type":"string",
       "max":255,
@@ -908,7 +938,9 @@
       "members":{
         "url":{"shape":"NonEmptyString"},
         "payloadUrl":{"shape":"NonEmptyString"},
-        "secret":{"shape":"NonEmptyString"}
+        "secret":{"shape":"NonEmptyString"},
+        "branchFilter":{"shape":"String"},
+        "lastModifiedSecret":{"shape":"Timestamp"}
       }
     },
     "WrapperBoolean":{"type":"boolean"},

--- a/models/apis/codebuild/2016-10-06/docs-2.json
+++ b/models/apis/codebuild/2016-10-06/docs-2.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "service": "<fullname>AWS CodeBuild</fullname> <p>AWS CodeBuild is a fully managed build service in the cloud. AWS CodeBuild compiles your source code, runs unit tests, and produces artifacts that are ready to deploy. AWS CodeBuild eliminates the need to provision, manage, and scale your own build servers. It provides prepackaged build environments for the most popular programming languages and build tools, such as Apache Maven, Gradle, and more. You can also fully customize build environments in AWS CodeBuild to use your own build tools. AWS CodeBuild scales automatically to meet peak build requests, and you pay only for the build time you consume. For more information about AWS CodeBuild, see the <i>AWS CodeBuild User Guide</i>.</p> <p>AWS CodeBuild supports these operations:</p> <ul> <li> <p> <code>BatchDeleteBuilds</code>: Deletes one or more builds.</p> </li> <li> <p> <code>BatchGetProjects</code>: Gets information about one or more build projects. A <i>build project</i> defines how AWS CodeBuild will run a build. This includes information such as where to get the source code to build, the build environment to use, the build commands to run, and where to store the build output. A <i>build environment</i> represents a combination of operating system, programming language runtime, and tools that AWS CodeBuild will use to run a build. Also, you can add tags to build projects to help manage your resources and costs.</p> </li> <li> <p> <code>CreateProject</code>: Creates a build project.</p> </li> <li> <p> <code>CreateWebhook</code>: For an existing AWS CodeBuild build project that has its source code stored in a GitHub repository, enables AWS CodeBuild to begin automatically rebuilding the source code every time a code change is pushed to the repository.</p> </li> <li> <p> <code>DeleteProject</code>: Deletes a build project.</p> </li> <li> <p> <code>DeleteWebhook</code>: For an existing AWS CodeBuild build project that has its source code stored in a GitHub repository, stops AWS CodeBuild from automatically rebuilding the source code every time a code change is pushed to the repository.</p> </li> <li> <p> <code>ListProjects</code>: Gets a list of build project names, with each build project name representing a single build project.</p> </li> <li> <p> <code>UpdateProject</code>: Changes the settings of an existing build project.</p> </li> <li> <p> <code>BatchGetBuilds</code>: Gets information about one or more builds.</p> </li> <li> <p> <code>ListBuilds</code>: Gets a list of build IDs, with each build ID representing a single build.</p> </li> <li> <p> <code>ListBuildsForProject</code>: Gets a list of build IDs for the specified build project, with each build ID representing a single build.</p> </li> <li> <p> <code>StartBuild</code>: Starts running a build.</p> </li> <li> <p> <code>StopBuild</code>: Attempts to stop running a build.</p> </li> <li> <p> <code>ListCuratedEnvironmentImages</code>: Gets information about Docker images that are managed by AWS CodeBuild.</p> </li> </ul>",
+  "service": "<fullname>AWS CodeBuild</fullname> <p>AWS CodeBuild is a fully managed build service in the cloud. AWS CodeBuild compiles your source code, runs unit tests, and produces artifacts that are ready to deploy. AWS CodeBuild eliminates the need to provision, manage, and scale your own build servers. It provides prepackaged build environments for the most popular programming languages and build tools, such as Apache Maven, Gradle, and more. You can also fully customize build environments in AWS CodeBuild to use your own build tools. AWS CodeBuild scales automatically to meet peak build requests, and you pay only for the build time you consume. For more information about AWS CodeBuild, see the <i>AWS CodeBuild User Guide</i>.</p> <p>AWS CodeBuild supports these operations:</p> <ul> <li> <p> <code>BatchDeleteBuilds</code>: Deletes one or more builds.</p> </li> <li> <p> <code>BatchGetProjects</code>: Gets information about one or more build projects. A <i>build project</i> defines how AWS CodeBuild will run a build. This includes information such as where to get the source code to build, the build environment to use, the build commands to run, and where to store the build output. A <i>build environment</i> represents a combination of operating system, programming language runtime, and tools that AWS CodeBuild will use to run a build. Also, you can add tags to build projects to help manage your resources and costs.</p> </li> <li> <p> <code>CreateProject</code>: Creates a build project.</p> </li> <li> <p> <code>CreateWebhook</code>: For an existing AWS CodeBuild build project that has its source code stored in a GitHub repository, enables AWS CodeBuild to begin automatically rebuilding the source code every time a code change is pushed to the repository.</p> </li> <li> <p> <code>UpdateWebhook</code>: Changes the settings of an existing webhook.</p> </li> <li> <p> <code>DeleteProject</code>: Deletes a build project.</p> </li> <li> <p> <code>DeleteWebhook</code>: For an existing AWS CodeBuild build project that has its source code stored in a GitHub repository, stops AWS CodeBuild from automatically rebuilding the source code every time a code change is pushed to the repository.</p> </li> <li> <p> <code>ListProjects</code>: Gets a list of build project names, with each build project name representing a single build project.</p> </li> <li> <p> <code>UpdateProject</code>: Changes the settings of an existing build project.</p> </li> <li> <p> <code>BatchGetBuilds</code>: Gets information about one or more builds.</p> </li> <li> <p> <code>ListBuilds</code>: Gets a list of build IDs, with each build ID representing a single build.</p> </li> <li> <p> <code>ListBuildsForProject</code>: Gets a list of build IDs for the specified build project, with each build ID representing a single build.</p> </li> <li> <p> <code>StartBuild</code>: Starts running a build.</p> </li> <li> <p> <code>StopBuild</code>: Attempts to stop running a build.</p> </li> <li> <p> <code>ListCuratedEnvironmentImages</code>: Gets information about Docker images that are managed by AWS CodeBuild.</p> </li> </ul>",
   "operations": {
     "BatchDeleteBuilds": "<p>Deletes one or more builds.</p>",
     "BatchGetBuilds": "<p>Gets information about builds.</p>",
@@ -16,7 +16,8 @@
     "ListProjects": "<p>Gets a list of build project names, with each build project name representing a single build project.</p>",
     "StartBuild": "<p>Starts running a build.</p>",
     "StopBuild": "<p>Attempts to stop running a build.</p>",
-    "UpdateProject": "<p>Changes the settings of a build project.</p>"
+    "UpdateProject": "<p>Changes the settings of a build project.</p>",
+    "UpdateWebhook": "<p> Updates the webhook associated with an AWS CodeBuild build project. </p>"
   },
   "shapes": {
     "AccountLimitExceededException": {
@@ -76,7 +77,8 @@
       "base": null,
       "refs": {
         "Build$buildComplete": "<p>Whether the build has finished. True if completed; otherwise, false.</p>",
-        "ProjectBadge$badgeEnabled": "<p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>"
+        "ProjectBadge$badgeEnabled": "<p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>",
+        "UpdateWebhookInput$rotateSecret": "<p> A boolean value that specifies whether the associated repository's secret token should be updated. </p>"
       }
     },
     "Build": {
@@ -351,15 +353,15 @@
         "Build$id": "<p>The unique ID for the build.</p>",
         "Build$arn": "<p>The Amazon Resource Name (ARN) of the build.</p>",
         "Build$sourceVersion": "<p>Any version identifier for the version of the source code to be built.</p>",
-        "Build$projectName": "<p>The name of the build project.</p>",
+        "Build$projectName": "<p>The name of the AWS CodeBuild project.</p>",
         "BuildIds$member": null,
         "BuildNotDeleted$id": "<p>The ID of the build that could not be successfully deleted.</p>",
         "CreateProjectInput$serviceRole": "<p>The ARN of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.</p>",
         "CreateProjectInput$encryptionKey": "<p>The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build output artifacts.</p> <p>You can specify either the CMK's Amazon Resource Name (ARN) or, if available, the CMK's alias (using the format <code>alias/<i>alias-name</i> </code>).</p>",
         "DeleteProjectInput$name": "<p>The name of the build project.</p>",
         "EnvironmentVariable$name": "<p>The name or key of the environment variable.</p>",
-        "InvalidateProjectCacheInput$projectName": "<p>The name of the build project that the cache will be reset for.</p>",
-        "ListBuildsForProjectInput$projectName": "<p>The name of the build project.</p>",
+        "InvalidateProjectCacheInput$projectName": "<p>The name of the AWS CodeBuild build project that the cache will be reset for.</p>",
+        "ListBuildsForProjectInput$projectName": "<p>The name of the AWS CodeBuild project.</p>",
         "ListProjectsInput$nextToken": "<p>During a previous call, if there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call. To get all of the items in the list, keep calling this operation with each subsequent next token that is returned, until no more next tokens are returned.</p>",
         "NetworkInterface$subnetId": "<p>The ID of the subnet.</p>",
         "NetworkInterface$networkInterfaceId": "<p>The ID of the network interface.</p>",
@@ -368,7 +370,7 @@
         "ProjectEnvironment$image": "<p>The ID of the Docker image to use for this build project.</p>",
         "ProjectNames$member": null,
         "SecurityGroupIds$member": null,
-        "StartBuildInput$projectName": "<p>The name of the build project to start running a build.</p>",
+        "StartBuildInput$projectName": "<p>The name of the AWS CodeBuild build project to start running a build.</p>",
         "StopBuildInput$id": "<p>The ID of the build.</p>",
         "Subnets$member": null,
         "UpdateProjectInput$name": "<p>The name of the build project.</p> <note> <p>You cannot change a build project's name.</p> </note>",
@@ -376,8 +378,8 @@
         "UpdateProjectInput$encryptionKey": "<p>The replacement AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build output artifacts.</p> <p>You can specify either the CMK's Amazon Resource Name (ARN) or, if available, the CMK's alias (using the format <code>alias/<i>alias-name</i> </code>).</p>",
         "VpcConfig$vpcId": "<p>The ID of the Amazon VPC.</p>",
         "Webhook$url": "<p>The URL to the webhook.</p>",
-        "Webhook$payloadUrl": "<p>This is the server endpoint that will receive the webhook payload.</p>",
-        "Webhook$secret": "<p>Use this secret while creating a webhook in GitHub for Enterprise. The secret allows webhook requests sent by GitHub for Enterprise to be authenticated by AWS CodeBuild.</p>"
+        "Webhook$payloadUrl": "<p> The CodeBuild endpoint where webhook events are sent.</p>",
+        "Webhook$secret": "<p> The secret token of the associated repository. </p>"
       }
     },
     "OAuthProviderException": {
@@ -456,9 +458,10 @@
       "base": null,
       "refs": {
         "CreateProjectInput$name": "<p>The name of the build project.</p>",
-        "CreateWebhookInput$projectName": "<p>The name of the build project.</p>",
-        "DeleteWebhookInput$projectName": "<p>The name of the build project.</p>",
-        "Project$name": "<p>The name of the build project.</p>"
+        "CreateWebhookInput$projectName": "<p>The name of the AWS CodeBuild project.</p>",
+        "DeleteWebhookInput$projectName": "<p>The name of the AWS CodeBuild project.</p>",
+        "Project$name": "<p>The name of the build project.</p>",
+        "UpdateWebhookInput$projectName": "<p>The name of the AWS CodeBuild project.</p>"
       }
     },
     "ProjectNames": {
@@ -568,6 +571,7 @@
         "BuildArtifacts$sha256sum": "<p>The SHA-256 hash of the build artifact.</p> <p>You can use this hash along with a checksum tool to confirm both file integrity and authenticity.</p> <note> <p>This value is available only if the build project's <code>packaging</code> value is set to <code>ZIP</code>.</p> </note>",
         "BuildArtifacts$md5sum": "<p>The MD5 hash of the build artifact.</p> <p>You can use this hash along with a checksum tool to confirm both file integrity and authenticity.</p> <note> <p>This value is available only if the build project's <code>packaging</code> value is set to <code>ZIP</code>.</p> </note>",
         "BuildNotDeleted$statusCode": "<p>Additional information about the build that could not be successfully deleted.</p>",
+        "CreateWebhookInput$branchFilter": "<p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>",
         "EnvironmentImage$name": "<p>The name of the Docker image.</p>",
         "EnvironmentImage$description": "<p>The description of the Docker image.</p>",
         "EnvironmentVariable$value": "<p>The value of the environment variable.</p> <important> <p>We strongly discourage using environment variables to store sensitive values, especially AWS secret key IDs and secret access keys. Environment variables can be displayed in plain text using tools such as the AWS CodeBuild console and the AWS Command Line Interface (AWS CLI).</p> </important>",
@@ -593,7 +597,9 @@
         "ProjectSource$buildspec": "<p>The build spec declaration to use for the builds in this build project.</p> <p>If this value is not specified, a build spec must be included along with the source code to be built.</p>",
         "SourceAuth$resource": "<p>The resource value that applies to the specified authorization type.</p>",
         "StartBuildInput$sourceVersion": "<p>A version of the build input to be built, for this build only. If not specified, the latest version will be used. If specified, must be one of:</p> <ul> <li> <p>For AWS CodeCommit: the commit ID to use.</p> </li> <li> <p>For GitHub: the commit ID, pull request ID, branch name, or tag name that corresponds to the version of the source code you want to build. If a pull request ID is specified, it must use the format <code>pr/pull-request-ID</code> (for example <code>pr/25</code>). If a branch name is specified, the branch's HEAD commit ID will be used. If not specified, the default branch's HEAD commit ID will be used.</p> </li> <li> <p>For Bitbucket: the commit ID, branch name, or tag name that corresponds to the version of the source code you want to build. If a branch name is specified, the branch's HEAD commit ID will be used. If not specified, the default branch's HEAD commit ID will be used.</p> </li> <li> <p>For Amazon Simple Storage Service (Amazon S3): the version ID of the object representing the build input ZIP file to use.</p> </li> </ul>",
-        "StartBuildInput$buildspecOverride": "<p>A build spec declaration that overrides, for this build only, the latest one already defined in the build project.</p>"
+        "StartBuildInput$buildspecOverride": "<p>A build spec declaration that overrides, for this build only, the latest one already defined in the build project.</p>",
+        "UpdateWebhookInput$branchFilter": "<p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>",
+        "Webhook$branchFilter": "<p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>"
       }
     },
     "Subnets": {
@@ -633,7 +639,8 @@
         "BuildPhase$startTime": "<p>When the build phase started, expressed in Unix time format.</p>",
         "BuildPhase$endTime": "<p>When the build phase ended, expressed in Unix time format.</p>",
         "Project$created": "<p>When the build project was created, expressed in Unix time format.</p>",
-        "Project$lastModified": "<p>When the build project's settings were last modified, expressed in Unix time format.</p>"
+        "Project$lastModified": "<p>When the build project's settings were last modified, expressed in Unix time format.</p>",
+        "Webhook$lastModifiedSecret": "<p> A timestamp indicating the last time a repository's secret token was modified. </p>"
       }
     },
     "UpdateProjectInput": {
@@ -642,6 +649,16 @@
       }
     },
     "UpdateProjectOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateWebhookInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateWebhookOutput": {
       "base": null,
       "refs": {
       }
@@ -665,14 +682,15 @@
       "base": "<p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>",
       "refs": {
         "CreateWebhookOutput$webhook": "<p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>",
-        "Project$webhook": "<p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>"
+        "Project$webhook": "<p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>",
+        "UpdateWebhookOutput$webhook": "<p> Information about a repository's webhook that is associated with a project in AWS CodeBuild. </p>"
       }
     },
     "WrapperBoolean": {
       "base": null,
       "refs": {
         "CreateProjectInput$badgeEnabled": "<p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>",
-        "ProjectEnvironment$privilegedMode": "<p>If set to true, enables running the Docker daemon inside a Docker container; otherwise, false or not specified (the default). This value must be set to true only if this build project will be used to build Docker images, and the specified build environment image is not one provided by AWS CodeBuild with Docker support. Otherwise, all associated builds that attempt to interact with the Docker daemon will fail. Note that you must also start the Docker daemon so that your builds can interact with it as needed. One way to do this is to initialize the Docker daemon in the install phase of your build spec by running the following build commands. (Do not run the following build commands if the specified build environment image is provided by AWS CodeBuild with Docker support.)</p> <p> <code>- nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 --storage-driver=overlay&amp; - timeout -t 15 sh -c \"until docker info; do echo .; sleep 1; done\"</code> </p>",
+        "ProjectEnvironment$privilegedMode": "<p>Enables running the Docker daemon inside a Docker container. Set to true only if the build project is be used to build Docker images, and the specified build environment image is not provided by AWS CodeBuild with Docker support. Otherwise, all associated builds that attempt to interact with the Docker daemon will fail. Note that you must also start the Docker daemon so that builds can interact with it. One way to do this is to initialize the Docker daemon during the install phase of your build spec by running the following build commands. (Do not run the following build commands if the specified build environment image is provided by AWS CodeBuild with Docker support.)</p> <p> <code>- nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 --storage-driver=overlay&amp; - timeout -t 15 sh -c \"until docker info; do echo .; sleep 1; done\"</code> </p>",
         "ProjectSource$insecureSsl": "<p>Enable this flag to ignore SSL warnings while connecting to the project source code.</p>",
         "UpdateProjectInput$badgeEnabled": "<p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>"
       }

--- a/models/apis/ecs/2014-11-13/api-2.json
+++ b/models/apis/ecs/2014-11-13/api-2.json
@@ -798,6 +798,7 @@
         "serviceName":{"shape":"String"},
         "taskDefinition":{"shape":"String"},
         "loadBalancers":{"shape":"LoadBalancers"},
+        "serviceRegistries":{"shape":"ServiceRegistries"},
         "desiredCount":{"shape":"BoxedInteger"},
         "clientToken":{"shape":"String"},
         "launchType":{"shape":"LaunchType"},
@@ -1529,6 +1530,7 @@
         "serviceName":{"shape":"String"},
         "clusterArn":{"shape":"String"},
         "loadBalancers":{"shape":"LoadBalancers"},
+        "serviceRegistries":{"shape":"ServiceRegistries"},
         "status":{"shape":"String"},
         "desiredCount":{"shape":"Integer"},
         "runningCount":{"shape":"Integer"},
@@ -1570,6 +1572,17 @@
       "members":{
       },
       "exception":true
+    },
+    "ServiceRegistries":{
+      "type":"list",
+      "member":{"shape":"ServiceRegistry"}
+    },
+    "ServiceRegistry":{
+      "type":"structure",
+      "members":{
+        "registryArn":{"shape":"String"},
+        "port":{"shape":"BoxedInteger"}
+      }
     },
     "Services":{
       "type":"list",

--- a/models/apis/ecs/2014-11-13/docs-2.json
+++ b/models/apis/ecs/2014-11-13/docs-2.json
@@ -171,6 +171,7 @@
         "PortMapping$hostPort": "<p>The port number on the container instance to reserve for your container.</p> <p>If using containers in a task with the <code>awsvpc</code> or <code>host</code> network mode, the <code>hostPort</code> can either be left blank or set to the same value as the <code>containerPort</code>.</p> <p>If using containers in a task with the <code>bridge</code> network mode, you can specify a non-reserved host port for your container port mapping, or you can omit the <code>hostPort</code> (or set it to <code>0</code>) while specifying a <code>containerPort</code> and your container automatically receives a port in the ephemeral port range for your container instance operating system and Docker version.</p> <p>The default ephemeral port range for Docker version 1.6.0 and later is listed on the instance under <code>/proc/sys/net/ipv4/ip_local_port_range</code>; if this kernel parameter is unavailable, the default ephemeral port range from 49153 through 65535 is used. You should not attempt to specify a host port in the ephemeral port range as these are reserved for automatic assignment. In general, ports below 32768 are outside of the ephemeral port range.</p> <note> <p>The default ephemeral port range from 49153 through 65535 is always used for Docker versions before 1.6.0.</p> </note> <p>The default reserved ports are 22 for SSH, the Docker ports 2375 and 2376, and the Amazon ECS container agent ports 51678 and 51679. Any host port that was previously specified in a running task is also reserved while the task is running (after a task stops, the host port is released). The current reserved ports are displayed in the <code>remainingResources</code> of <a>DescribeContainerInstances</a> output, and a container instance may have up to 100 reserved ports at a time, including the default reserved ports (automatically assigned ports do not count toward the 100 reserved ports limit).</p>",
         "RunTaskRequest$count": "<p>The number of instantiations of the specified task to place on your cluster. You can specify up to 10 tasks per call.</p>",
         "Service$healthCheckGracePeriodSeconds": "<p>The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started.</p>",
+        "ServiceRegistry$port": "<p>The port value used if your Service Discovery service specified an SRV record.</p>",
         "SubmitContainerStateChangeRequest$exitCode": "<p>The exit code returned for the state change request.</p>",
         "UpdateServiceRequest$desiredCount": "<p>The number of instantiations of the task to place and keep running in your service.</p>",
         "UpdateServiceRequest$healthCheckGracePeriodSeconds": "<p>The period of time, in seconds, that the Amazon ECS service scheduler should ignore unhealthy Elastic Load Balancing target health checks after a task has first started. This is only valid if your service is configured to use a load balancer. If your service's tasks take a while to start and respond to Elastic Load Balancing health checks, you can specify a health check grace period of up to 1,800 seconds during which the ECS service scheduler ignores the Elastic Load Balancing health check status. This grace period can prevent the ECS service scheduler from marking tasks as unhealthy and stopping them before they have time to come up.</p>"
@@ -960,6 +961,19 @@
       "refs": {
       }
     },
+    "ServiceRegistries": {
+      "base": null,
+      "refs": {
+        "CreateServiceRequest$serviceRegistries": "<p>The details of the service discovery registries you want to assign to this service. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonECS/latest/developerguideservice-discovery.html\">Service Discovery</a>.</p>",
+        "Service$serviceRegistries": "<p/>"
+      }
+    },
+    "ServiceRegistry": {
+      "base": "<p>Details of the service registry.</p>",
+      "refs": {
+        "ServiceRegistries$member": null
+      }
+    },
     "Services": {
       "base": null,
       "refs": {
@@ -1134,6 +1148,7 @@
         "Service$roleArn": "<p>The ARN of the IAM role associated with the service that allows the Amazon ECS container agent to register container instances with an Elastic Load Balancing load balancer.</p>",
         "ServiceEvent$id": "<p>The ID string of the event.</p>",
         "ServiceEvent$message": "<p>The event message.</p>",
+        "ServiceRegistry$registryArn": "<p>The Amazon Resource Name (ARN) of the Service Registry. The currently supported service registry is Amazon Route 53 Auto Naming Service. For more information, see <a href=\"https://docs.aws.amazon.com/Route53/latest/APIReference/API_autonaming_Service.html\">Service</a>.</p>",
         "StartTaskRequest$cluster": "<p>The short name or full Amazon Resource Name (ARN) of the cluster on which to start your task. If you do not specify a cluster, the default cluster is assumed.</p>",
         "StartTaskRequest$taskDefinition": "<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or full ARN of the task definition to start. If a <code>revision</code> is not specified, the latest <code>ACTIVE</code> revision is used.</p>",
         "StartTaskRequest$startedBy": "<p>An optional tag specified when a task is started. For example if you automatically trigger a task to run a batch process job, you could apply a unique identifier for that job to your task with the <code>startedBy</code> parameter. You can then identify which tasks belong to that job by filtering the results of a <a>ListTasks</a> call with the <code>startedBy</code> value. Up to 36 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.</p> <p>If a task is started by an Amazon ECS service, then the <code>startedBy</code> parameter contains the deployment ID of the service that starts it.</p>",

--- a/models/endpoints/endpoints.json
+++ b/models/endpoints/endpoints.json
@@ -1169,12 +1169,17 @@
       "mediaconvert" : {
         "endpoints" : {
           "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-west-1" : { },
+          "eu-west-2" : { },
+          "sa-east-1" : { },
           "us-east-1" : { },
+          "us-east-2" : { },
           "us-west-1" : { },
           "us-west-2" : { }
         }
@@ -1192,11 +1197,13 @@
       "mediapackage" : {
         "endpoints" : {
           "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "eu-central-1" : { },
           "eu-west-1" : { },
           "eu-west-3" : { },
+          "sa-east-1" : { },
           "us-east-1" : { },
           "us-west-2" : { }
         }

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -68,6 +68,10 @@ func (c *AppStream) AssociateFleetRequest(input *AssociateFleetInput) (req *requ
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
 //
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
+//
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The specified resource was not found.
 //
@@ -169,6 +173,10 @@ func (c *AppStream) CopyImageRequest(input *CopyImageInput) (req *request.Reques
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
 //
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
+//
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
 //
@@ -253,6 +261,10 @@ func (c *AppStream) CreateDirectoryConfigRequest(input *CreateDirectoryConfigInp
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateDirectoryConfig
 func (c *AppStream) CreateDirectoryConfig(input *CreateDirectoryConfigInput) (*CreateDirectoryConfigOutput, error) {
@@ -341,6 +353,10 @@ func (c *AppStream) CreateFleetRequest(input *CreateFleetInput) (req *request.Re
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 //   * ErrCodeInvalidRoleException "InvalidRoleException"
 //   The specified role is invalid.
@@ -435,6 +451,10 @@ func (c *AppStream) CreateImageBuilderRequest(input *CreateImageBuilderInput) (r
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 //   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
 //   The specified resource already exists.
@@ -617,6 +637,10 @@ func (c *AppStream) CreateStackRequest(input *CreateStackInput) (req *request.Re
 // Returned Error Codes:
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 //   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
 //   The specified resource already exists.
@@ -2103,6 +2127,10 @@ func (c *AppStream) StartFleetRequest(input *StartFleetInput) (req *request.Requ
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
 //
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
+//
 //   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
 //   An API error occurred. Wait a few minutes and try again.
 //
@@ -2190,6 +2218,10 @@ func (c *AppStream) StartImageBuilderRequest(input *StartImageBuilderInput) (req
 //
 //   * ErrCodeConcurrentModificationException "ConcurrentModificationException"
 //   An API error occurred. Wait a few minutes and try again.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
@@ -2450,6 +2482,10 @@ func (c *AppStream) TagResourceRequest(input *TagResourceInput) (req *request.Re
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
 //
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
+//
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The specified resource was not found.
 //
@@ -2709,6 +2745,10 @@ func (c *AppStream) UpdateFleetRequest(input *UpdateFleetInput) (req *request.Re
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
 //
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
+//
 //   * ErrCodeInvalidRoleException "InvalidRoleException"
 //   The specified role is invalid.
 //
@@ -2820,6 +2860,10 @@ func (c *AppStream) UpdateStackRequest(input *UpdateStackInput) (req *request.Re
 //
 //   * ErrCodeLimitExceededException "LimitExceededException"
 //   The requested limit exceeds the permitted limit for an account.
+//
+//   * ErrCodeInvalidAccountStatusException "InvalidAccountStatusException"
+//   The resource cannot be created because your AWS account is suspended. For
+//   assistance, contact AWS Support.
 //
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
@@ -3769,12 +3813,16 @@ type CreateStackInput struct {
 	// The stack name for display.
 	DisplayName *string `type:"string"`
 
+	// The URL that users are redirected to after they click the Send Feedback link.
+	// If no URL is specified, no Send Feedback link is displayed.
+	FeedbackURL *string `type:"string"`
+
 	// The name of the stack.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The URL the user is redirected to after the streaming session ends.
+	// The URL that users are redirected to after their streaming session ends.
 	RedirectURL *string `type:"string"`
 
 	// The storage connectors to enable.
@@ -3826,6 +3874,12 @@ func (s *CreateStackInput) SetDescription(v string) *CreateStackInput {
 // SetDisplayName sets the DisplayName field's value.
 func (s *CreateStackInput) SetDisplayName(v string) *CreateStackInput {
 	s.DisplayName = &v
+	return s
+}
+
+// SetFeedbackURL sets the FeedbackURL field's value.
+func (s *CreateStackInput) SetFeedbackURL(v string) *CreateStackInput {
+	s.FeedbackURL = &v
 	return s
 }
 
@@ -6047,12 +6101,16 @@ type Stack struct {
 	// The stack name for display.
 	DisplayName *string `min:"1" type:"string"`
 
+	// The URL that users are redirected to after they click the Send Feedback link.
+	// If no URL is specified, no Send Feedback link is displayed.
+	FeedbackURL *string `type:"string"`
+
 	// The name of the stack.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The URL the user is redirected to after the streaming session ends.
+	// The URL that users are redirected to after their streaming session ends.
 	RedirectURL *string `type:"string"`
 
 	// The errors for the stack.
@@ -6093,6 +6151,12 @@ func (s *Stack) SetDescription(v string) *Stack {
 // SetDisplayName sets the DisplayName field's value.
 func (s *Stack) SetDisplayName(v string) *Stack {
 	s.DisplayName = &v
+	return s
+}
+
+// SetFeedbackURL sets the FeedbackURL field's value.
+func (s *Stack) SetFeedbackURL(v string) *Stack {
+	s.FeedbackURL = &v
 	return s
 }
 
@@ -6924,12 +6988,16 @@ type UpdateStackInput struct {
 	// The stack name for display.
 	DisplayName *string `type:"string"`
 
+	// The URL that users are redirected to after they click the Send Feedback link.
+	// If no URL is specified, no Send Feedback link is displayed.
+	FeedbackURL *string `type:"string"`
+
 	// The name of the stack.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The URL the user is redirected to after the streaming session ends.
+	// The URL that users are redirected to after their streaming session ends.
 	RedirectURL *string `type:"string"`
 
 	// The storage connectors to enable.
@@ -6993,6 +7061,12 @@ func (s *UpdateStackInput) SetDescription(v string) *UpdateStackInput {
 // SetDisplayName sets the DisplayName field's value.
 func (s *UpdateStackInput) SetDisplayName(v string) *UpdateStackInput {
 	s.DisplayName = &v
+	return s
+}
+
+// SetFeedbackURL sets the FeedbackURL field's value.
+func (s *UpdateStackInput) SetFeedbackURL(v string) *UpdateStackInput {
+	s.FeedbackURL = &v
 	return s
 }
 
@@ -7283,6 +7357,12 @@ const (
 
 	// StackAttributeRedirectUrl is a StackAttribute enum value
 	StackAttributeRedirectUrl = "REDIRECT_URL"
+
+	// StackAttributeFeedbackUrl is a StackAttribute enum value
+	StackAttributeFeedbackUrl = "FEEDBACK_URL"
+
+	// StackAttributeThemeName is a StackAttribute enum value
+	StackAttributeThemeName = "THEME_NAME"
 )
 
 const (

--- a/service/appstream/errors.go
+++ b/service/appstream/errors.go
@@ -16,6 +16,13 @@ const (
 	// The image does not support storage connectors.
 	ErrCodeIncompatibleImageException = "IncompatibleImageException"
 
+	// ErrCodeInvalidAccountStatusException for service response error code
+	// "InvalidAccountStatusException".
+	//
+	// The resource cannot be created because your AWS account is suspended. For
+	// assistance, contact AWS Support.
+	ErrCodeInvalidAccountStatusException = "InvalidAccountStatusException"
+
 	// ErrCodeInvalidParameterCombinationException for service response error code
 	// "InvalidParameterCombinationException".
 	//

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -1247,6 +1247,91 @@ func (c *CodeBuild) UpdateProjectWithContext(ctx aws.Context, input *UpdateProje
 	return out, req.Send()
 }
 
+const opUpdateWebhook = "UpdateWebhook"
+
+// UpdateWebhookRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateWebhook operation. The "output" return
+// value will be populated with the request's response once the request complets
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateWebhook for more information on using the UpdateWebhook
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateWebhookRequest method.
+//    req, resp := client.UpdateWebhookRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/UpdateWebhook
+func (c *CodeBuild) UpdateWebhookRequest(input *UpdateWebhookInput) (req *request.Request, output *UpdateWebhookOutput) {
+	op := &request.Operation{
+		Name:       opUpdateWebhook,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateWebhookInput{}
+	}
+
+	output = &UpdateWebhookOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateWebhook API operation for AWS CodeBuild.
+//
+// Updates the webhook associated with an AWS CodeBuild build project.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CodeBuild's
+// API operation UpdateWebhook for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   The input value that was provided is not valid.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified AWS resource cannot be found.
+//
+//   * ErrCodeOAuthProviderException "OAuthProviderException"
+//   There was a problem with the underlying OAuth provider.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/codebuild-2016-10-06/UpdateWebhook
+func (c *CodeBuild) UpdateWebhook(input *UpdateWebhookInput) (*UpdateWebhookOutput, error) {
+	req, out := c.UpdateWebhookRequest(input)
+	return out, req.Send()
+}
+
+// UpdateWebhookWithContext is the same as UpdateWebhook with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateWebhook for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CodeBuild) UpdateWebhookWithContext(ctx aws.Context, input *UpdateWebhookInput, opts ...request.Option) (*UpdateWebhookOutput, error) {
+	req, out := c.UpdateWebhookRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 type BatchDeleteBuildsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1531,7 +1616,7 @@ type Build struct {
 	// about any current build phase that is not yet complete.
 	Phases []*BuildPhase `locationName:"phases" type:"list"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	ProjectName *string `locationName:"projectName" min:"1" type:"string"`
 
 	// Information about the source code to be built.
@@ -2107,7 +2192,13 @@ func (s *CreateProjectOutput) SetProject(v *Project) *CreateProjectOutput {
 type CreateWebhookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project.
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
@@ -2137,6 +2228,12 @@ func (s *CreateWebhookInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *CreateWebhookInput) SetBranchFilter(v string) *CreateWebhookInput {
+	s.BranchFilter = &v
+	return s
 }
 
 // SetProjectName sets the ProjectName field's value.
@@ -2227,7 +2324,7 @@ func (s DeleteProjectOutput) GoString() string {
 type DeleteWebhookInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
@@ -2467,7 +2564,8 @@ func (s *EnvironmentVariable) SetValue(v string) *EnvironmentVariable {
 type InvalidateProjectCacheInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the build project that the cache will be reset for.
+	// The name of the AWS CodeBuild build project that the cache will be reset
+	// for.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -2530,7 +2628,7 @@ type ListBuildsForProjectInput struct {
 	// until no more next tokens are returned.
 	NextToken *string `locationName:"nextToken" type:"string"`
 
-	// The name of the build project.
+	// The name of the AWS CodeBuild project.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -3414,17 +3512,15 @@ type ProjectEnvironment struct {
 	// Image is a required field
 	Image *string `locationName:"image" min:"1" type:"string" required:"true"`
 
-	// If set to true, enables running the Docker daemon inside a Docker container;
-	// otherwise, false or not specified (the default). This value must be set to
-	// true only if this build project will be used to build Docker images, and
-	// the specified build environment image is not one provided by AWS CodeBuild
-	// with Docker support. Otherwise, all associated builds that attempt to interact
-	// with the Docker daemon will fail. Note that you must also start the Docker
-	// daemon so that your builds can interact with it as needed. One way to do
-	// this is to initialize the Docker daemon in the install phase of your build
-	// spec by running the following build commands. (Do not run the following build
-	// commands if the specified build environment image is provided by AWS CodeBuild
-	// with Docker support.)
+	// Enables running the Docker daemon inside a Docker container. Set to true
+	// only if the build project is be used to build Docker images, and the specified
+	// build environment image is not provided by AWS CodeBuild with Docker support.
+	// Otherwise, all associated builds that attempt to interact with the Docker
+	// daemon will fail. Note that you must also start the Docker daemon so that
+	// builds can interact with it. One way to do this is to initialize the Docker
+	// daemon during the install phase of your build spec by running the following
+	// build commands. (Do not run the following build commands if the specified
+	// build environment image is provided by AWS CodeBuild with Docker support.)
 	//
 	// - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375
 	// --storage-driver=overlay& - timeout -t 15 sh -c "until docker info; do echo
@@ -3737,7 +3833,7 @@ type StartBuildInput struct {
 	// for this build only, any previous depth of history defined in the build project.
 	GitCloneDepthOverride *int64 `locationName:"gitCloneDepthOverride" type:"integer"`
 
-	// The name of the build project to start running a build.
+	// The name of the AWS CodeBuild build project to start running a build.
 	//
 	// ProjectName is a required field
 	ProjectName *string `locationName:"projectName" min:"1" type:"string" required:"true"`
@@ -4215,6 +4311,93 @@ func (s *UpdateProjectOutput) SetProject(v *Project) *UpdateProjectOutput {
 	return s
 }
 
+type UpdateWebhookInput struct {
+	_ struct{} `type:"structure"`
+
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// The name of the AWS CodeBuild project.
+	//
+	// ProjectName is a required field
+	ProjectName *string `locationName:"projectName" min:"2" type:"string" required:"true"`
+
+	// A boolean value that specifies whether the associated repository's secret
+	// token should be updated.
+	RotateSecret *bool `locationName:"rotateSecret" type:"boolean"`
+}
+
+// String returns the string representation
+func (s UpdateWebhookInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWebhookInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateWebhookInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateWebhookInput"}
+	if s.ProjectName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ProjectName"))
+	}
+	if s.ProjectName != nil && len(*s.ProjectName) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectName", 2))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *UpdateWebhookInput) SetBranchFilter(v string) *UpdateWebhookInput {
+	s.BranchFilter = &v
+	return s
+}
+
+// SetProjectName sets the ProjectName field's value.
+func (s *UpdateWebhookInput) SetProjectName(v string) *UpdateWebhookInput {
+	s.ProjectName = &v
+	return s
+}
+
+// SetRotateSecret sets the RotateSecret field's value.
+func (s *UpdateWebhookInput) SetRotateSecret(v bool) *UpdateWebhookInput {
+	s.RotateSecret = &v
+	return s
+}
+
+type UpdateWebhookOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about a repository's webhook that is associated with a project
+	// in AWS CodeBuild.
+	Webhook *Webhook `locationName:"webhook" type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateWebhookOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWebhookOutput) GoString() string {
+	return s.String()
+}
+
+// SetWebhook sets the Webhook field's value.
+func (s *UpdateWebhookOutput) SetWebhook(v *Webhook) *UpdateWebhookOutput {
+	s.Webhook = v
+	return s
+}
+
 // Information about the VPC configuration that AWS CodeBuild will access.
 type VpcConfig struct {
 	_ struct{} `type:"structure"`
@@ -4275,12 +4458,19 @@ func (s *VpcConfig) SetVpcId(v string) *VpcConfig {
 type Webhook struct {
 	_ struct{} `type:"structure"`
 
-	// This is the server endpoint that will receive the webhook payload.
+	// A regular expression used to determine which branches in a repository are
+	// built when a webhook is triggered. If the name of a branch matches the regular
+	// expression, then it is built. If it doesn't match, then it is not. If branchFilter
+	// is empty, then all branches are built.
+	BranchFilter *string `locationName:"branchFilter" type:"string"`
+
+	// A timestamp indicating the last time a repository's secret token was modified.
+	LastModifiedSecret *time.Time `locationName:"lastModifiedSecret" type:"timestamp" timestampFormat:"unix"`
+
+	// The CodeBuild endpoint where webhook events are sent.
 	PayloadUrl *string `locationName:"payloadUrl" min:"1" type:"string"`
 
-	// Use this secret while creating a webhook in GitHub for Enterprise. The secret
-	// allows webhook requests sent by GitHub for Enterprise to be authenticated
-	// by AWS CodeBuild.
+	// The secret token of the associated repository.
 	Secret *string `locationName:"secret" min:"1" type:"string"`
 
 	// The URL to the webhook.
@@ -4295,6 +4485,18 @@ func (s Webhook) String() string {
 // GoString returns the string representation
 func (s Webhook) GoString() string {
 	return s.String()
+}
+
+// SetBranchFilter sets the BranchFilter field's value.
+func (s *Webhook) SetBranchFilter(v string) *Webhook {
+	s.BranchFilter = &v
+	return s
+}
+
+// SetLastModifiedSecret sets the LastModifiedSecret field's value.
+func (s *Webhook) SetLastModifiedSecret(v time.Time) *Webhook {
+	s.LastModifiedSecret = &v
+	return s
 }
 
 // SetPayloadUrl sets the PayloadUrl field's value.

--- a/service/codebuild/codebuildiface/interface.go
+++ b/service/codebuild/codebuildiface/interface.go
@@ -119,6 +119,10 @@ type CodeBuildAPI interface {
 	UpdateProject(*codebuild.UpdateProjectInput) (*codebuild.UpdateProjectOutput, error)
 	UpdateProjectWithContext(aws.Context, *codebuild.UpdateProjectInput, ...request.Option) (*codebuild.UpdateProjectOutput, error)
 	UpdateProjectRequest(*codebuild.UpdateProjectInput) (*request.Request, *codebuild.UpdateProjectOutput)
+
+	UpdateWebhook(*codebuild.UpdateWebhookInput) (*codebuild.UpdateWebhookOutput, error)
+	UpdateWebhookWithContext(aws.Context, *codebuild.UpdateWebhookInput, ...request.Option) (*codebuild.UpdateWebhookOutput, error)
+	UpdateWebhookRequest(*codebuild.UpdateWebhookInput) (*request.Request, *codebuild.UpdateWebhookOutput)
 }
 
 var _ CodeBuildAPI = (*codebuild.CodeBuild)(nil)

--- a/service/codebuild/doc.go
+++ b/service/codebuild/doc.go
@@ -33,6 +33,8 @@
 //    begin automatically rebuilding the source code every time a code change
 //    is pushed to the repository.
 //
+//    * UpdateWebhook: Changes the settings of an existing webhook.
+//
 //    * DeleteProject: Deletes a build project.
 //
 //    * DeleteWebhook: For an existing AWS CodeBuild build project that has

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5129,6 +5129,10 @@ type CreateServiceInput struct {
 	// ServiceName is a required field
 	ServiceName *string `locationName:"serviceName" type:"string" required:"true"`
 
+	// The details of the service discovery registries you want to assign to this
+	// service. For more information, see Service Discovery (http://docs.aws.amazon.com/AmazonECS/latest/developerguideservice-discovery.html).
+	ServiceRegistries []*ServiceRegistry `locationName:"serviceRegistries" type:"list"`
+
 	// The family and revision (family:revision) or full ARN of the task definition
 	// to run in your service. If a revision is not specified, the latest ACTIVE
 	// revision is used.
@@ -5246,6 +5250,12 @@ func (s *CreateServiceInput) SetRole(v string) *CreateServiceInput {
 // SetServiceName sets the ServiceName field's value.
 func (s *CreateServiceInput) SetServiceName(v string) *CreateServiceInput {
 	s.ServiceName = &v
+	return s
+}
+
+// SetServiceRegistries sets the ServiceRegistries field's value.
+func (s *CreateServiceInput) SetServiceRegistries(v []*ServiceRegistry) *CreateServiceInput {
+	s.ServiceRegistries = v
 	return s
 }
 
@@ -8861,6 +8871,8 @@ type Service struct {
 	// within a region or across multiple regions.
 	ServiceName *string `locationName:"serviceName" type:"string"`
 
+	ServiceRegistries []*ServiceRegistry `locationName:"serviceRegistries" type:"list"`
+
 	// The status of the service. The valid values are ACTIVE, DRAINING, or INACTIVE.
 	Status *string `locationName:"status" type:"string"`
 
@@ -8988,6 +9000,12 @@ func (s *Service) SetServiceName(v string) *Service {
 	return s
 }
 
+// SetServiceRegistries sets the ServiceRegistries field's value.
+func (s *Service) SetServiceRegistries(v []*ServiceRegistry) *Service {
+	s.ServiceRegistries = v
+	return s
+}
+
 // SetStatus sets the Status field's value.
 func (s *Service) SetStatus(v string) *Service {
 	s.Status = &v
@@ -9039,6 +9057,41 @@ func (s *ServiceEvent) SetId(v string) *ServiceEvent {
 // SetMessage sets the Message field's value.
 func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
 	s.Message = &v
+	return s
+}
+
+// Details of the service registry.
+type ServiceRegistry struct {
+	_ struct{} `type:"structure"`
+
+	// The port value used if your Service Discovery service specified an SRV record.
+	Port *int64 `locationName:"port" type:"integer"`
+
+	// The Amazon Resource Name (ARN) of the Service Registry. The currently supported
+	// service registry is Amazon Route 53 Auto Naming Service. For more information,
+	// see Service (https://docs.aws.amazon.com/Route53/latest/APIReference/API_autonaming_Service.html).
+	RegistryArn *string `locationName:"registryArn" type:"string"`
+}
+
+// String returns the string representation
+func (s ServiceRegistry) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ServiceRegistry) GoString() string {
+	return s.String()
+}
+
+// SetPort sets the Port field's value.
+func (s *ServiceRegistry) SetPort(v int64) *ServiceRegistry {
+	s.Port = &v
+	return s
+}
+
+// SetRegistryArn sets the RegistryArn field's value.
+func (s *ServiceRegistry) SetRegistryArn(v string) *ServiceRegistry {
+	s.RegistryArn = &v
 	return s
 }
 


### PR DESCRIPTION
Release v1.13.19 (2018-03-22)
===

### Service Client Updates
* `service/appstream`: Updates service API and documentation
  * Feedback URL allows admins to provide a feedback link or a survey link for collecting user feedback while streaming sessions. When a feedback link is provided, streaming users will see a "Send Feedback" choice in their streaming session toolbar. On selecting this choice, user will be redirected to the link provided in a new browser tab. If a feedback link is not provided, users will not see the "Send Feedback" option.
* `service/codebuild`: Updates service API and documentation
  * Adding support for branch filtering when using webhooks with AWS CodeBuild.
* `service/ecs`: Updates service API and documentation
  * Amazon Elastic Container Service (ECS) now includes integrated Service Discovery using Route 53 Auto Naming. Customers can now specify a Route 53 Auto Naming service as part of an ECS service. ECS will register task IPs with Route 53, making them available via DNS in your VPC.
* `aws/endpoints`: Updated Regions and Endpoints metadata.

### SDK Bugs
* `aws/endpoints`: Use service metadata for fallback signing name ([#1854](https://github.com/aws/aws-sdk-go/pull/1854))
  * Updates the SDK's endpoint resolution to fallback deriving the service's signing name from the service's modeled metadata in addition the the endpoints modeled data.
  * Fixes [#1850](https://github.com/aws/aws-sdk-go/issues/1850)
