### PR TITLE
private/model/api: Add suppression of Eventstream models

### DIFF
--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -1,0 +1,28 @@
+// +build codegen
+
+package api
+
+func (a *API) suppressEventStreams() {
+	const eventStreamMemberName = "EventStream"
+
+	for name, op := range a.Operations {
+		outbound := hasEventStream(op.InputRef.Shape)
+		inbound := hasEventStream(op.OutputRef.Shape)
+
+		if !(outbound || inbound) {
+			continue
+		}
+
+		a.removeOperation(name)
+	}
+}
+
+func hasEventStream(topShape *Shape) bool {
+	for _, ref := range topShape.MemberRefs {
+		if ref.Shape.IsEventStream {
+			return true
+		}
+	}
+
+	return false
+}

--- a/private/model/api/eventstream_test.go
+++ b/private/model/api/eventstream_test.go
@@ -1,4 +1,4 @@
-// +build codegen
+// +build go1.6,codegen
 
 package api
 

--- a/private/model/api/eventstream_test.go
+++ b/private/model/api/eventstream_test.go
@@ -1,0 +1,79 @@
+// +build codegen
+
+package api
+
+import (
+	"testing"
+)
+
+func TestSuppressEventStream(t *testing.T) {
+	cases := []struct {
+		API    *API
+		Ops    []string
+		Shapes []string
+	}{
+		{
+			API: &API{
+				Operations: map[string]*Operation{
+					"abc": {
+						InputRef: ShapeRef{
+							ShapeName: "abcRequest",
+						},
+						OutputRef: ShapeRef{
+							ShapeName: "abcResponse",
+						},
+					},
+					"eventStreamOp": {
+						InputRef: ShapeRef{
+							ShapeName: "eventStreamOpRequest",
+						},
+						OutputRef: ShapeRef{
+							ShapeName: "eventStreamOpResponse",
+						},
+					},
+				},
+				Shapes: map[string]*Shape{
+					"abcRequest":           {},
+					"abcResponse":          {},
+					"eventStreamOpRequest": {},
+					"eventStreamOpResponse": {
+						MemberRefs: map[string]*ShapeRef{
+							"eventStreamShape": {
+								ShapeName: "eventStreamShape",
+							},
+						},
+					},
+					"eventStreamShape": {
+						IsEventStream: true,
+					},
+				},
+			},
+			Ops:    []string{"Abc"},
+			Shapes: []string{"AbcInput", "AbcOutput"},
+		},
+	}
+
+	for _, c := range cases {
+		c.API.Setup()
+		if e, a := c.Ops, c.API.OperationNames(); !stringsEqual(e, a) {
+			t.Errorf("expect %v ops, got %v", e, a)
+		}
+
+		if e, a := c.Shapes, c.API.ShapeNames(); !stringsEqual(e, a) {
+			t.Errorf("expect %v ops, got %v", e, a)
+		}
+	}
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -9,21 +9,6 @@ import (
 	"path/filepath"
 )
 
-// Load takes a set of files for each filetype and returns an API pointer.
-// The API will be initialized once all files have been loaded and parsed.
-//
-// Will panic if any failure opening the definition JSON files, or there
-// are unrecognized exported names.
-func Load(api, docs, paginators, waiters string) *API {
-	a := API{}
-	a.Attach(api)
-	a.Attach(docs)
-	a.Attach(paginators)
-	a.Attach(waiters)
-	a.Setup()
-	return &a
-}
-
 // Attach opens a file by name, and unmarshal its JSON data.
 // Will proceed to setup the API if not already done so.
 func (a *API) Attach(filename string) {
@@ -62,6 +47,7 @@ func (a *API) Setup() {
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()
 	a.createInputOutputShapes()
+	a.suppressEventStreams()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -85,25 +85,29 @@ func (r *referenceResolver) resolveReference(ref *ShapeRef) {
 		return
 	}
 
-	if shape, ok := r.API.Shapes[ref.ShapeName]; ok {
-		if ref.JSONValue {
-			ref.ShapeName = "JSONValue"
-			r.API.Shapes[ref.ShapeName] = jsonvalueShape
-		}
-
-		ref.API = r.API   // resolve reference back to API
-		ref.Shape = shape // resolve shape reference
-
-		if r.visited[ref] {
-			return
-		}
-		r.visited[ref] = true
-
-		shape.refs = append(shape.refs, ref) // register the ref
-
-		// resolve shape's references, if it has any
-		r.resolveShape(shape)
+	shape, ok := r.API.Shapes[ref.ShapeName]
+	if !ok {
+		panic(fmt.Sprintf("unable resolve reference, %s", ref.ShapeName))
+		return
 	}
+
+	if ref.JSONValue {
+		ref.ShapeName = "JSONValue"
+		r.API.Shapes[ref.ShapeName] = jsonvalueShape
+	}
+
+	ref.API = r.API   // resolve reference back to API
+	ref.Shape = shape // resolve shape reference
+
+	if r.visited[ref] {
+		return
+	}
+	r.visited[ref] = true
+
+	shape.refs = append(shape.refs, ref) // register the ref
+
+	// resolve shape's references, if it has any
+	r.resolveShape(shape)
 }
 
 // resolveShape resolves a shape's Member Key Value, and nested member
@@ -322,9 +326,9 @@ func (a *API) makeIOShape(name string) *Shape {
 // removeUnusedShapes removes shapes from the API which are not referenced by any
 // other shape in the API.
 func (a *API) removeUnusedShapes() {
-	for n, s := range a.Shapes {
+	for _, s := range a.Shapes {
 		if len(s.refs) == 0 {
-			delete(a.Shapes, n)
+			a.removeShape(s)
 		}
 	}
 }

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -55,9 +55,9 @@ type Shape struct {
 	ShapeName        string
 	Documentation    string
 	MemberRefs       map[string]*ShapeRef `json:"members"`
-	MemberRef        ShapeRef             `json:"member"`
-	KeyRef           ShapeRef             `json:"key"`
-	ValueRef         ShapeRef             `json:"value"`
+	MemberRef        ShapeRef             `json:"member"` // List ref
+	KeyRef           ShapeRef             `json:"key"`    // map key ref
+	ValueRef         ShapeRef             `json:"value"`  // map value ref
 	Required         []string
 	Payload          string
 	Type             string
@@ -72,6 +72,8 @@ type Shape struct {
 	XMLNamespace     XMLInfo
 	Min              float64 // optional Minimum length (string, list) or value (number)
 	Max              float64 // optional Maximum length (string, list) or value (number)
+
+	IsEventStream bool `json:"eventstream"`
 
 	refs       []*ShapeRef // References to this shape
 	resolvePkg string      // use this package in the goType() if present


### PR DESCRIPTION
Supresses API operations decorated with EventStream traits. This
suppression is needed until the SDK implements support for event streams.