### PR TITLE
private/model/api: Fix typo in docs.

### DIFF
--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -72,7 +72,7 @@ const op{{ .ExportedName }} = "{{ .Name }}"
 
 // {{ .ExportedName }}Request generates a "aws/request.Request" representing the
 // client's request for the {{ .ExportedName }} operation. The "output" return
-// value will be populated with the request's response once the request complets
+// value will be populated with the request's response once the request completes
 // successfuly.
 //
 // Use "Send" method on the returned Request to send the API call to the service.


### PR DESCRIPTION
Typo: "complets" -> "completes"
