### PR TITLE
v1.13.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Release v1.13.34 (2018-04-20)
+===
+
+### Service Client Updates
+* `service/firehose`: Updates service API and documentation
+  * With this release, Amazon Kinesis Data Firehose allows you to tag your delivery streams. Tags are metadata that you can create and use to manage your delivery streams. For more information about tagging, see AWS Tagging Strategies. For technical documentation, look for the tagging operations in the Amazon Kinesis Firehose API reference.
+* `service/medialive`: Updates service API and documentation
+  * With AWS Elemental MediaLive you can now output live channels as RTMP (Real-Time Messaging Protocol) and RTMPS as the encrypted version of the protocol (Secure, over SSL/TLS). RTMP is the preferred protocol for sending live streams to popular social platforms which  means you can send live channel content to social and sharing platforms in a secure and reliable way while continuing to stream to your own website, app or network.
+
 Release v1.13.33 (2018-04-19)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.33"
+const SDKVersion = "1.13.34"

--- a/models/apis/firehose/2015-08-04/api-2.json
+++ b/models/apis/firehose/2015-08-04/api-2.json
@@ -61,6 +61,20 @@
       "input":{"shape":"ListDeliveryStreamsInput"},
       "output":{"shape":"ListDeliveryStreamsOutput"}
     },
+    "ListTagsForDeliveryStream":{
+      "name":"ListTagsForDeliveryStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ListTagsForDeliveryStreamInput"},
+      "output":{"shape":"ListTagsForDeliveryStreamOutput"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"LimitExceededException"}
+      ]
+    },
     "PutRecord":{
       "name":"PutRecord",
       "http":{
@@ -87,6 +101,36 @@
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidArgumentException"},
         {"shape":"ServiceUnavailableException"}
+      ]
+    },
+    "TagDeliveryStream":{
+      "name":"TagDeliveryStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"TagDeliveryStreamInput"},
+      "output":{"shape":"TagDeliveryStreamOutput"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"LimitExceededException"}
+      ]
+    },
+    "UntagDeliveryStream":{
+      "name":"UntagDeliveryStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UntagDeliveryStreamInput"},
+      "output":{"shape":"UntagDeliveryStreamOutput"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"LimitExceededException"}
       ]
     },
     "UpdateDestination":{
@@ -583,6 +627,37 @@
         "HasMoreDeliveryStreams":{"shape":"BooleanObject"}
       }
     },
+    "ListTagsForDeliveryStreamInput":{
+      "type":"structure",
+      "required":["DeliveryStreamName"],
+      "members":{
+        "DeliveryStreamName":{"shape":"DeliveryStreamName"},
+        "ExclusiveStartTagKey":{"shape":"TagKey"},
+        "Limit":{"shape":"ListTagsForDeliveryStreamInputLimit"}
+      }
+    },
+    "ListTagsForDeliveryStreamInputLimit":{
+      "type":"integer",
+      "max":50,
+      "min":1
+    },
+    "ListTagsForDeliveryStreamOutput":{
+      "type":"structure",
+      "required":[
+        "Tags",
+        "HasMoreTags"
+      ],
+      "members":{
+        "Tags":{"shape":"ListTagsForDeliveryStreamOutputTagList"},
+        "HasMoreTags":{"shape":"BooleanObject"}
+      }
+    },
+    "ListTagsForDeliveryStreamOutputTagList":{
+      "type":"list",
+      "member":{"shape":"Tag"},
+      "max":50,
+      "min":0
+    },
     "LogGroupName":{"type":"string"},
     "LogStreamName":{"type":"string"},
     "NoEncryptionConfig":{
@@ -962,7 +1037,69 @@
         "AllEvents"
       ]
     },
+    "Tag":{
+      "type":"structure",
+      "required":["Key"],
+      "members":{
+        "Key":{"shape":"TagKey"},
+        "Value":{"shape":"TagValue"}
+      }
+    },
+    "TagDeliveryStreamInput":{
+      "type":"structure",
+      "required":[
+        "DeliveryStreamName",
+        "Tags"
+      ],
+      "members":{
+        "DeliveryStreamName":{"shape":"DeliveryStreamName"},
+        "Tags":{"shape":"TagDeliveryStreamInputTagList"}
+      }
+    },
+    "TagDeliveryStreamInputTagList":{
+      "type":"list",
+      "member":{"shape":"Tag"},
+      "max":50,
+      "min":1
+    },
+    "TagDeliveryStreamOutput":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "TagKey":{
+      "type":"string",
+      "max":128,
+      "min":1
+    },
+    "TagKeyList":{
+      "type":"list",
+      "member":{"shape":"TagKey"},
+      "max":50,
+      "min":1
+    },
+    "TagValue":{
+      "type":"string",
+      "max":256,
+      "min":0
+    },
     "Timestamp":{"type":"timestamp"},
+    "UntagDeliveryStreamInput":{
+      "type":"structure",
+      "required":[
+        "DeliveryStreamName",
+        "TagKeys"
+      ],
+      "members":{
+        "DeliveryStreamName":{"shape":"DeliveryStreamName"},
+        "TagKeys":{"shape":"TagKeyList"}
+      }
+    },
+    "UntagDeliveryStreamOutput":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "UpdateDestinationInput":{
       "type":"structure",
       "required":[

--- a/models/apis/firehose/2015-08-04/docs-2.json
+++ b/models/apis/firehose/2015-08-04/docs-2.json
@@ -1,20 +1,23 @@
 {
   "version": "2.0",
-  "service": "<fullname>Amazon Kinesis Firehose API Reference</fullname> <p>Amazon Kinesis Firehose is a fully managed service that delivers real-time streaming data to destinations such as Amazon Simple Storage Service (Amazon S3), Amazon Elasticsearch Service (Amazon ES), and Amazon Redshift.</p>",
+  "service": "<fullname>Amazon Kinesis Data Firehose API Reference</fullname> <p>Amazon Kinesis Data Firehose is a fully managed service that delivers real-time streaming data to destinations such as Amazon Simple Storage Service (Amazon S3), Amazon Elasticsearch Service (Amazon ES), Amazon Redshift, and Splunk.</p>",
   "operations": {
-    "CreateDeliveryStream": "<p>Creates a delivery stream.</p> <p>By default, you can create up to 20 delivery streams per region.</p> <p>This is an asynchronous operation that immediately returns. The initial status of the delivery stream is <code>CREATING</code>. After the delivery stream is created, its status is <code>ACTIVE</code> and it now accepts data. Attempts to send data to a delivery stream that is not in the <code>ACTIVE</code> state cause an exception. To check the state of a delivery stream, use <a>DescribeDeliveryStream</a>.</p> <p>A Kinesis Firehose delivery stream can be configured to receive records directly from providers using <a>PutRecord</a> or <a>PutRecordBatch</a>, or it can be configured to use an existing Kinesis stream as its source. To specify a Kinesis stream as input, set the <code>DeliveryStreamType</code> parameter to <code>KinesisStreamAsSource</code>, and provide the Kinesis stream ARN and role ARN in the <code>KinesisStreamSourceConfiguration</code> parameter.</p> <p>A delivery stream is configured with a single destination: Amazon S3, Amazon ES, or Amazon Redshift. You must specify only one of the following destination configuration parameters: <b>ExtendedS3DestinationConfiguration</b>, <b>S3DestinationConfiguration</b>, <b>ElasticsearchDestinationConfiguration</b>, or <b>RedshiftDestinationConfiguration</b>.</p> <p>When you specify <b>S3DestinationConfiguration</b>, you can also provide the following optional values: <b>BufferingHints</b>, <b>EncryptionConfiguration</b>, and <b>CompressionFormat</b>. By default, if no <b>BufferingHints</b> value is provided, Kinesis Firehose buffers data up to 5 MB or for 5 minutes, whichever condition is satisfied first. Note that <b>BufferingHints</b> is a hint, so there are some cases where the service cannot adhere to these conditions strictly; for example, record boundaries are such that the size is a little over or under the configured buffering size. By default, no encryption is performed. We strongly recommend that you enable encryption to ensure secure data storage in Amazon S3.</p> <p>A few notes about Amazon Redshift as a destination:</p> <ul> <li> <p>An Amazon Redshift destination requires an S3 bucket as intermediate location, as Kinesis Firehose first delivers data to S3 and then uses <code>COPY</code> syntax to load data into an Amazon Redshift table. This is specified in the <b>RedshiftDestinationConfiguration.S3Configuration</b> parameter.</p> </li> <li> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <b>RedshiftDestinationConfiguration.S3Configuration</b> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p> </li> <li> <p>We strongly recommend that you use the user name and password you provide exclusively with Kinesis Firehose, and that the permissions for the account are restricted for Amazon Redshift <code>INSERT</code> permissions.</p> </li> </ul> <p>Kinesis Firehose assumes the IAM role that is configured as part of the destination. The role should allow the Kinesis Firehose principal to assume the role, and the role should have permissions that allow the service to deliver the data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Amazon S3 Bucket Access</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
+    "CreateDeliveryStream": "<p>Creates a delivery stream.</p> <p>By default, you can create up to 50 delivery streams per AWS Region.</p> <p>This is an asynchronous operation that immediately returns. The initial status of the delivery stream is <code>CREATING</code>. After the delivery stream is created, its status is <code>ACTIVE</code> and it now accepts data. Attempts to send data to a delivery stream that is not in the <code>ACTIVE</code> state cause an exception. To check the state of a delivery stream, use <a>DescribeDeliveryStream</a>.</p> <p>A Kinesis Data Firehose delivery stream can be configured to receive records directly from providers using <a>PutRecord</a> or <a>PutRecordBatch</a>, or it can be configured to use an existing Kinesis data stream as its source. To specify a Kinesis data stream as input, set the <code>DeliveryStreamType</code> parameter to <code>KinesisStreamAsSource</code>, and provide the Kinesis data stream Amazon Resource Name (ARN) and role ARN in the <code>KinesisStreamSourceConfiguration</code> parameter.</p> <p>A delivery stream is configured with a single destination: Amazon S3, Amazon ES, Amazon Redshift, or Splunk. Specify only one of the following destination configuration parameters: <code>ExtendedS3DestinationConfiguration</code>, <code>S3DestinationConfiguration</code>, <code>ElasticsearchDestinationConfiguration</code>, <code>RedshiftDestinationConfiguration</code>, or <code>SplunkDestinationConfiguration</code>.</p> <p>When you specify <code>S3DestinationConfiguration</code>, you can also provide the following optional values: <code>BufferingHints</code>, <code>EncryptionConfiguration</code>, and <code>CompressionFormat</code>. By default, if no <code>BufferingHints</code> value is provided, Kinesis Data Firehose buffers data up to 5 MB or for 5 minutes, whichever condition is satisfied first. <code>BufferingHints</code> is a hint, so there are some cases where the service cannot adhere to these conditions strictly. For example, record boundaries are such that the size is a little over or under the configured buffering size. By default, no encryption is performed. We strongly recommend that you enable encryption to ensure secure data storage in Amazon S3.</p> <p>A few notes about Amazon Redshift as a destination:</p> <ul> <li> <p>An Amazon Redshift destination requires an S3 bucket as intermediate location. This is because Kinesis Data Firehose first delivers data to Amazon S3 and then uses <code>COPY</code> syntax to load data into an Amazon Redshift table. This is specified in the <code>RedshiftDestinationConfiguration.S3Configuration</code> parameter.</p> </li> <li> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <code>RedshiftDestinationConfiguration.S3Configuration</code> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p> </li> <li> <p>We strongly recommend that you use the user name and password that you provide exclusively with Kinesis Data Firehose. In addition, the permissions for the account should be restricted for Amazon Redshift <code>INSERT</code> permissions.</p> </li> </ul> <p>Kinesis Data Firehose assumes the IAM role that is configured as part of the destination. The role should allow the Kinesis Data Firehose principal to assume the role, and the role should have permissions that allow the service to deliver the data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Kinesis Firehose Access to an Amazon S3 Destination</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
     "DeleteDeliveryStream": "<p>Deletes a delivery stream and its data.</p> <p>You can delete a delivery stream only if it is in <code>ACTIVE</code> or <code>DELETING</code> state, and not in the <code>CREATING</code> state. While the deletion request is in process, the delivery stream is in the <code>DELETING</code> state.</p> <p>To check the state of a delivery stream, use <a>DescribeDeliveryStream</a>.</p> <p>While the delivery stream is <code>DELETING</code> state, the service may continue to accept the records, but the service doesn't make any guarantees with respect to delivering the data. Therefore, as a best practice, you should first stop any applications that are sending records before deleting a delivery stream.</p>",
-    "DescribeDeliveryStream": "<p>Describes the specified delivery stream and gets the status. For example, after your delivery stream is created, call <a>DescribeDeliveryStream</a> to see if the delivery stream is <code>ACTIVE</code> and therefore ready for data to be sent to it.</p>",
-    "ListDeliveryStreams": "<p>Lists your delivery streams.</p> <p>The number of delivery streams might be too large to return using a single call to <a>ListDeliveryStreams</a>. You can limit the number of delivery streams returned, using the <b>Limit</b> parameter. To determine whether there are more delivery streams to list, check the value of <b>HasMoreDeliveryStreams</b> in the output. If there are more delivery streams to list, you can request them by specifying the name of the last delivery stream returned in the call in the <b>ExclusiveStartDeliveryStreamName</b> parameter of a subsequent call.</p>",
-    "PutRecord": "<p>Writes a single data record into an Amazon Kinesis Firehose delivery stream. To write multiple data records into a delivery stream, use <a>PutRecordBatch</a>. Applications using these operations are referred to as producers.</p> <p>By default, each delivery stream can take in up to 2,000 transactions per second, 5,000 records per second, or 5 MB per second. Note that if you use <a>PutRecord</a> and <a>PutRecordBatch</a>, the limits are an aggregate across these two operations for each delivery stream. For more information about limits and how to request an increase, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Firehose Limits</a>. </p> <p>You must specify the name of the delivery stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000 KB in size, and any kind of data, for example, a segment from a log file, geographic location data, website clickstream data, and so on.</p> <p>Kinesis Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (<code>\\n</code>) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.</p> <p>The <a>PutRecord</a> operation returns a <b>RecordId</b>, which is a unique string assigned to each record. Producer applications can use this ID for purposes such as auditability and investigation.</p> <p>If the <a>PutRecord</a> operation throws a <b>ServiceUnavailableException</b>, back off and retry. If the exception persists, it is possible that the throughput limits have been exceeded for the delivery stream. </p> <p>Data records sent to Kinesis Firehose are stored for 24 hours from the time they are added to a delivery stream as it attempts to send the records to the destination. If the destination is unreachable for more than 24 hours, the data is no longer available.</p>",
-    "PutRecordBatch": "<p>Writes multiple data records into a delivery stream in a single call, which can achieve higher throughput per producer than when writing single records. To write single data records into a delivery stream, use <a>PutRecord</a>. Applications using these operations are referred to as producers.</p> <p>By default, each delivery stream can take in up to 2,000 transactions per second, 5,000 records per second, or 5 MB per second. If you use <a>PutRecord</a> and <a>PutRecordBatch</a>, the limits are an aggregate across these two operations for each delivery stream. For more information about limits, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Firehose Limits</a>.</p> <p>Each <a>PutRecordBatch</a> request supports up to 500 records. Each record in the request can be as large as 1,000 KB (before 64-bit encoding), up to a limit of 4 MB for the entire request. These limits cannot be changed.</p> <p>You must specify the name of the delivery stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000 KB in size, and any kind of data. For example, it could be a segment from a log file, geographic location data, web site clickstream data, and so on.</p> <p>Kinesis Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (<code>\\n</code>) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.</p> <p>The <a>PutRecordBatch</a> response includes a count of failed records, <b>FailedPutCount</b>, and an array of responses, <b>RequestResponses</b>. Each entry in the <b>RequestResponses</b> array provides additional information about the processed record. It directly correlates with a record in the request array using the same ordering, from the top to the bottom. The response array always includes the same number of records as the request array. <b>RequestResponses</b> includes both successfully and unsuccessfully processed records. Kinesis Firehose attempts to process all records in each <a>PutRecordBatch</a> request. A single record failure does not stop the processing of subsequent records.</p> <p>A successfully processed record includes a <b>RecordId</b> value, which is unique for the record. An unsuccessfully processed record includes <b>ErrorCode</b> and <b>ErrorMessage</b> values. <b>ErrorCode</b> reflects the type of error, and is one of the following values: <code>ServiceUnavailable</code> or <code>InternalFailure</code>. <b>ErrorMessage</b> provides more detailed information about the error.</p> <p>If there is an internal server error or a timeout, the write might have completed or it might have failed. If <b>FailedPutCount</b> is greater than 0, retry the request, resending only those records that might have failed processing. This minimizes the possible duplicate records and also reduces the total bytes sent (and corresponding charges). We recommend that you handle any duplicates at the destination.</p> <p>If <a>PutRecordBatch</a> throws <b>ServiceUnavailableException</b>, back off and retry. If the exception persists, it is possible that the throughput limits have been exceeded for the delivery stream.</p> <p>Data records sent to Kinesis Firehose are stored for 24 hours from the time they are added to a delivery stream as it attempts to send the records to the destination. If the destination is unreachable for more than 24 hours, the data is no longer available.</p>",
-    "UpdateDestination": "<p>Updates the specified destination of the specified delivery stream.</p> <p>You can use this operation to change the destination type (for example, to replace the Amazon S3 destination with Amazon Redshift) or change the parameters associated with a destination (for example, to change the bucket name of the Amazon S3 destination). The update might not occur immediately. The target delivery stream remains active while the configurations are updated, so data writes to the delivery stream can continue during this process. The updated configurations are usually effective within a few minutes.</p> <p>Note that switching between Amazon ES and other services is not supported. For an Amazon ES destination, you can only update to another Amazon ES destination.</p> <p>If the destination type is the same, Kinesis Firehose merges the configuration parameters specified with the destination configuration that already exists on the delivery stream. If any of the parameters are not specified in the call, the existing values are retained. For example, in the Amazon S3 destination, if <a>EncryptionConfiguration</a> is not specified, then the existing <a>EncryptionConfiguration</a> is maintained on the destination.</p> <p>If the destination type is not the same, for example, changing the destination from Amazon S3 to Amazon Redshift, Kinesis Firehose does not merge any parameters. In this case, all parameters must be specified.</p> <p>Kinesis Firehose uses <b>CurrentDeliveryStreamVersionId</b> to avoid race conditions and conflicting merges. This is a required field, and the service updates the configuration only if the existing configuration has a version ID that matches. After the update is applied successfully, the version ID is updated, and can be retrieved using <a>DescribeDeliveryStream</a>. Use the new version ID to set <b>CurrentDeliveryStreamVersionId</b> in the next call.</p>"
+    "DescribeDeliveryStream": "<p>Describes the specified delivery stream and gets the status. For example, after your delivery stream is created, call <code>DescribeDeliveryStream</code> to see whether the delivery stream is <code>ACTIVE</code> and therefore ready for data to be sent to it.</p>",
+    "ListDeliveryStreams": "<p>Lists your delivery streams.</p> <p>The number of delivery streams might be too large to return using a single call to <code>ListDeliveryStreams</code>. You can limit the number of delivery streams returned, using the <b>Limit</b> parameter. To determine whether there are more delivery streams to list, check the value of <code>HasMoreDeliveryStreams</code> in the output. If there are more delivery streams to list, you can request them by specifying the name of the last delivery stream returned in the call in the <code>ExclusiveStartDeliveryStreamName</code> parameter of a subsequent call.</p>",
+    "ListTagsForDeliveryStream": "<p>Lists the tags for the specified delivery stream. This operation has a limit of five transactions per second per account. </p>",
+    "PutRecord": "<p>Writes a single data record into an Amazon Kinesis Data Firehose delivery stream. To write multiple data records into a delivery stream, use <a>PutRecordBatch</a>. Applications using these operations are referred to as producers.</p> <p>By default, each delivery stream can take in up to 2,000 transactions per second, 5,000 records per second, or 5 MB per second. Note that if you use <code>PutRecord</code> and <a>PutRecordBatch</a>, the limits are an aggregate across these two operations for each delivery stream. For more information about limits and how to request an increase, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Data Firehose Limits</a>. </p> <p>You must specify the name of the delivery stream and the data record when using <code>PutRecord</code>. The data record consists of a data blob that can be up to 1,000 KB in size and any kind of data. For example, it can be a segment from a log file, geographic location data, website clickstream data, and so on.</p> <p>Kinesis Data Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (<code>\\n</code>) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.</p> <p>The <code>PutRecord</code> operation returns a <code>RecordId</code>, which is a unique string assigned to each record. Producer applications can use this ID for purposes such as auditability and investigation.</p> <p>If the <code>PutRecord</code> operation throws a <code>ServiceUnavailableException</code>, back off and retry. If the exception persists, it is possible that the throughput limits have been exceeded for the delivery stream. </p> <p>Data records sent to Kinesis Data Firehose are stored for 24 hours from the time they are added to a delivery stream as it attempts to send the records to the destination. If the destination is unreachable for more than 24 hours, the data is no longer available.</p>",
+    "PutRecordBatch": "<p>Writes multiple data records into a delivery stream in a single call, which can achieve higher throughput per producer than when writing single records. To write single data records into a delivery stream, use <a>PutRecord</a>. Applications using these operations are referred to as producers.</p> <p>By default, each delivery stream can take in up to 2,000 transactions per second, 5,000 records per second, or 5 MB per second. If you use <a>PutRecord</a> and <code>PutRecordBatch</code>, the limits are an aggregate across these two operations for each delivery stream. For more information about limits, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Data Firehose Limits</a>.</p> <p>Each <code>PutRecordBatch</code> request supports up to 500 records. Each record in the request can be as large as 1,000 KB (before 64-bit encoding), up to a limit of 4 MB for the entire request. These limits cannot be changed.</p> <p>You must specify the name of the delivery stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000 KB in size and any kind of data. For example, it could be a segment from a log file, geographic location data, website clickstream data, and so on.</p> <p>Kinesis Data Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (<code>\\n</code>) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.</p> <p>The <code>PutRecordBatch</code> response includes a count of failed records, <code>FailedPutCount</code>, and an array of responses, <code>RequestResponses</code>. Each entry in the <code>RequestResponses</code> array provides additional information about the processed record. It directly correlates with a record in the request array using the same ordering, from the top to the bottom. The response array always includes the same number of records as the request array. <code>RequestResponses</code> includes both successfully and unsuccessfully processed records. Kinesis Data Firehose attempts to process all records in each <code>PutRecordBatch</code> request. A single record failure does not stop the processing of subsequent records.</p> <p>A successfully processed record includes a <code>RecordId</code> value, which is unique for the record. An unsuccessfully processed record includes <code>ErrorCode</code> and <code>ErrorMessage</code> values. <code>ErrorCode</code> reflects the type of error, and is one of the following values: <code>ServiceUnavailable</code> or <code>InternalFailure</code>. <code>ErrorMessage</code> provides more detailed information about the error.</p> <p>If there is an internal server error or a timeout, the write might have completed or it might have failed. If <code>FailedPutCount</code> is greater than 0, retry the request, resending only those records that might have failed processing. This minimizes the possible duplicate records and also reduces the total bytes sent (and corresponding charges). We recommend that you handle any duplicates at the destination.</p> <p>If <code>PutRecordBatch</code> throws <code>ServiceUnavailableException</code>, back off and retry. If the exception persists, it is possible that the throughput limits have been exceeded for the delivery stream.</p> <p>Data records sent to Kinesis Data Firehose are stored for 24 hours from the time they are added to a delivery stream as it attempts to send the records to the destination. If the destination is unreachable for more than 24 hours, the data is no longer available.</p>",
+    "TagDeliveryStream": "<p>Adds or updates tags for the specified delivery stream. A tag is a key-value pair (the value is optional) that you can define and assign to AWS resources. If you specify a tag that already exists, the tag value is replaced with the value that you specify in the request. Tags are metadata. For example, you can add friendly names and descriptions or other types of information that can help you distinguish the delivery stream. For more information about tags, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html\">Using Cost Allocation Tags</a> in the <i>AWS Billing and Cost Management User Guide</i>. </p> <p> Each delivery stream can have up to 50 tags. </p> <p> This operation has a limit of five transactions per second per account. </p>",
+    "UntagDeliveryStream": "<p>Removes tags from the specified delivery stream. Removed tags are deleted, and you can't recover them after this operation successfully completes.</p> <p>If you specify a tag that doesn't exist, the operation ignores it.</p> <p>This operation has a limit of five transactions per second per account. </p>",
+    "UpdateDestination": "<p>Updates the specified destination of the specified delivery stream.</p> <p>Use this operation to change the destination type (for example, to replace the Amazon S3 destination with Amazon Redshift) or change the parameters associated with a destination (for example, to change the bucket name of the Amazon S3 destination). The update might not occur immediately. The target delivery stream remains active while the configurations are updated, so data writes to the delivery stream can continue during this process. The updated configurations are usually effective within a few minutes.</p> <p>Switching between Amazon ES and other services is not supported. For an Amazon ES destination, you can only update to another Amazon ES destination.</p> <p>If the destination type is the same, Kinesis Data Firehose merges the configuration parameters specified with the destination configuration that already exists on the delivery stream. If any of the parameters are not specified in the call, the existing values are retained. For example, in the Amazon S3 destination, if <a>EncryptionConfiguration</a> is not specified, then the existing <code>EncryptionConfiguration</code> is maintained on the destination.</p> <p>If the destination type is not the same, for example, changing the destination from Amazon S3 to Amazon Redshift, Kinesis Data Firehose does not merge any parameters. In this case, all parameters must be specified.</p> <p>Kinesis Data Firehose uses <code>CurrentDeliveryStreamVersionId</code> to avoid race conditions and conflicting merges. This is a required field, and the service updates the configuration only if the existing configuration has a version ID that matches. After the update is applied successfully, the version ID is updated, and you can retrieve it using <a>DescribeDeliveryStream</a>. Use the new version ID to set <code>CurrentDeliveryStreamVersionId</code> in the next call.</p>"
   },
   "shapes": {
     "AWSKMSKeyARN": {
       "base": null,
       "refs": {
-        "KMSEncryptionConfig$AWSKMSKeyARN": "<p>The ARN of the encryption key. Must belong to the same region as the destination Amazon S3 bucket.</p>"
+        "KMSEncryptionConfig$AWSKMSKeyARN": "<p>The Amazon Resource Name (ARN) of the encryption key. Must belong to the same AWS Region as the destination Amazon S3 bucket.</p>"
       }
     },
     "BooleanObject": {
@@ -23,6 +26,7 @@
         "CloudWatchLoggingOptions$Enabled": "<p>Enables or disables CloudWatch logging.</p>",
         "DeliveryStreamDescription$HasMoreDestinations": "<p>Indicates whether there are more destinations available to list.</p>",
         "ListDeliveryStreamsOutput$HasMoreDeliveryStreams": "<p>Indicates whether there are more delivery streams available to list.</p>",
+        "ListTagsForDeliveryStreamOutput$HasMoreTags": "<p>If this is <code>true</code> in the response, more tags are available. To list the remaining tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned and call <code>ListTagsForDeliveryStream</code> again.</p>",
         "ProcessingConfiguration$Enabled": "<p>Enables or disables data processing.</p>"
       }
     },
@@ -38,14 +42,14 @@
       }
     },
     "BufferingHints": {
-      "base": "<p>Describes hints for the buffering to perform before delivering data to the destination. Please note that these options are treated as hints, and therefore Kinesis Firehose may choose to use different values when it is optimal.</p>",
+      "base": "<p>Describes hints for the buffering to perform before delivering data to the destination. These options are treated as hints, and therefore Kinesis Data Firehose might choose to use different values whenever it is optimal.</p>",
       "refs": {
         "ExtendedS3DestinationConfiguration$BufferingHints": "<p>The buffering option.</p>",
         "ExtendedS3DestinationDescription$BufferingHints": "<p>The buffering option.</p>",
         "ExtendedS3DestinationUpdate$BufferingHints": "<p>The buffering option.</p>",
-        "S3DestinationConfiguration$BufferingHints": "<p>The buffering option. If no value is specified, <b>BufferingHints</b> object default values are used.</p>",
-        "S3DestinationDescription$BufferingHints": "<p>The buffering option. If no value is specified, <b>BufferingHints</b> object default values are used.</p>",
-        "S3DestinationUpdate$BufferingHints": "<p>The buffering option. If no value is specified, <b>BufferingHints</b> object default values are used.</p>"
+        "S3DestinationConfiguration$BufferingHints": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object default values are used.</p>",
+        "S3DestinationDescription$BufferingHints": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object default values are used.</p>",
+        "S3DestinationUpdate$BufferingHints": "<p>The buffering option. If no value is specified, <code>BufferingHints</code> object default values are used.</p>"
       }
     },
     "CloudWatchLoggingOptions": {
@@ -103,7 +107,7 @@
     "CopyOptions": {
       "base": null,
       "refs": {
-        "CopyCommand$CopyOptions": "<p>Optional parameters to use with the Amazon Redshift <code>COPY</code> command. For more information, see the \"Optional Parameters\" section of <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html\">Amazon Redshift COPY command</a>. Some possible examples that would apply to Kinesis Firehose are as follows:</p> <p> <code>delimiter '\\t' lzop;</code> - fields are delimited with \"\\t\" (TAB character) and compressed using lzop.</p> <p> <code>delimiter '|'</code> - fields are delimited with \"|\" (this is the default delimiter).</p> <p> <code>delimiter '|' escape</code> - the delimiter should be escaped.</p> <p> <code>fixedwidth 'venueid:3,venuename:25,venuecity:12,venuestate:2,venueseats:6'</code> - fields are fixed width in the source, with each width specified after every column in the table.</p> <p> <code>JSON 's3://mybucket/jsonpaths.txt'</code> - data is in JSON format, and the path specified is the format of the data.</p> <p>For more examples, see <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_COPY_command_examples.html\">Amazon Redshift COPY command examples</a>.</p>"
+        "CopyCommand$CopyOptions": "<p>Optional parameters to use with the Amazon Redshift <code>COPY</code> command. For more information, see the \"Optional Parameters\" section of <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html\">Amazon Redshift COPY command</a>. Some possible examples that would apply to Kinesis Data Firehose are as follows:</p> <p> <code>delimiter '\\t' lzop;</code> - fields are delimited with \"\\t\" (TAB character) and compressed using lzop.</p> <p> <code>delimiter '|'</code> - fields are delimited with \"|\" (this is the default delimiter).</p> <p> <code>delimiter '|' escape</code> - the delimiter should be escaped.</p> <p> <code>fixedwidth 'venueid:3,venuename:25,venuecity:12,venuestate:2,venueseats:6'</code> - fields are fixed width in the source, with each width specified after every column in the table.</p> <p> <code>JSON 's3://mybucket/jsonpaths.txt'</code> - data is in JSON format, and the path specified is the format of the data.</p> <p>For more examples, see <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_COPY_command_examples.html\">Amazon Redshift COPY command examples</a>.</p>"
       }
     },
     "CreateDeliveryStreamInput": {
@@ -147,7 +151,7 @@
     "DeliveryStartTimestamp": {
       "base": null,
       "refs": {
-        "KinesisStreamSourceDescription$DeliveryStartTimestamp": "<p>Kinesis Firehose starts retrieving records from the Kinesis stream starting with this time stamp.</p>"
+        "KinesisStreamSourceDescription$DeliveryStartTimestamp": "<p>Kinesis Data Firehose starts retrieving records from the Kinesis data stream starting with this time stamp.</p>"
       }
     },
     "DeliveryStreamARN": {
@@ -166,14 +170,17 @@
     "DeliveryStreamName": {
       "base": null,
       "refs": {
-        "CreateDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream. This name must be unique per AWS account in the same region. If the delivery streams are in different accounts or different regions, you can have multiple delivery streams with the same name.</p>",
+        "CreateDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream. This name must be unique per AWS account in the same Region. If the delivery streams are in different accounts or different Regions, you can have multiple delivery streams with the same name.</p>",
         "DeleteDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
         "DeliveryStreamDescription$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
         "DeliveryStreamNameList$member": null,
         "DescribeDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
         "ListDeliveryStreamsInput$ExclusiveStartDeliveryStreamName": "<p>The name of the delivery stream to start the list with.</p>",
+        "ListTagsForDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream whose tags you want to list.</p>",
         "PutRecordBatchInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
         "PutRecordInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
+        "TagDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream to which you want to add the tags.</p>",
+        "UntagDeliveryStreamInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>",
         "UpdateDestinationInput$DeliveryStreamName": "<p>The name of the delivery stream.</p>"
       }
     },
@@ -192,16 +199,16 @@
     "DeliveryStreamType": {
       "base": null,
       "refs": {
-        "CreateDeliveryStreamInput$DeliveryStreamType": "<p>The delivery stream type. This parameter can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis stream as a source.</p> </li> </ul>",
-        "DeliveryStreamDescription$DeliveryStreamType": "<p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis stream as a source.</p> </li> </ul>",
-        "ListDeliveryStreamsInput$DeliveryStreamType": "<p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis stream as a source.</p> </li> </ul> <p>This parameter is optional. If this parameter is omitted, delivery streams of all types are returned.</p>"
+        "CreateDeliveryStreamInput$DeliveryStreamType": "<p>The delivery stream type. This parameter can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis data stream as a source.</p> </li> </ul>",
+        "DeliveryStreamDescription$DeliveryStreamType": "<p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis data stream as a source.</p> </li> </ul>",
+        "ListDeliveryStreamsInput$DeliveryStreamType": "<p>The delivery stream type. This can be one of the following values:</p> <ul> <li> <p> <code>DirectPut</code>: Provider applications access the delivery stream directly.</p> </li> <li> <p> <code>KinesisStreamAsSource</code>: The delivery stream uses a Kinesis data stream as a source.</p> </li> </ul> <p>This parameter is optional. If this parameter is omitted, delivery streams of all types are returned.</p>"
       }
     },
     "DeliveryStreamVersionId": {
       "base": null,
       "refs": {
         "DeliveryStreamDescription$VersionId": "<p>Each time the destination is updated for a delivery stream, the version ID is changed, and the current version ID is required when updating the destination. This is so that the service knows it is applying the changes to the correct version of the delivery stream.</p>",
-        "UpdateDestinationInput$CurrentDeliveryStreamVersionId": "<p>Obtain this value from the <b>VersionId</b> result of <a>DeliveryStreamDescription</a>. This value is required, and helps the service to perform conditional operations. For example, if there is an interleaving update and this value is null, then the update destination fails. After the update is successful, the <b>VersionId</b> value is updated. The service then performs a merge of the old configuration with the new configuration.</p>"
+        "UpdateDestinationInput$CurrentDeliveryStreamVersionId": "<p>Obtain this value from the <code>VersionId</code> result of <a>DeliveryStreamDescription</a>. This value is required, and it helps the service perform conditional operations. For example, if there is an interleaving update and this value is null, then the update destination fails. After the update is successful, the <code>VersionId</code> value is updated. The service then performs a merge of the old configuration with the new configuration.</p>"
       }
     },
     "DescribeDeliveryStreamInput": {
@@ -235,7 +242,7 @@
     "DestinationId": {
       "base": null,
       "refs": {
-        "DescribeDeliveryStreamInput$ExclusiveStartDestinationId": "<p>The ID of the destination to start returning the destination information. Currently, Kinesis Firehose supports one destination per delivery stream.</p>",
+        "DescribeDeliveryStreamInput$ExclusiveStartDestinationId": "<p>The ID of the destination to start returning the destination information. Currently, Kinesis Data Firehose supports one destination per delivery stream.</p>",
         "DestinationDescription$DestinationId": "<p>The ID of the destination.</p>",
         "UpdateDestinationInput$DestinationId": "<p>The ID of the destination.</p>"
       }
@@ -243,9 +250,9 @@
     "ElasticsearchBufferingHints": {
       "base": "<p>Describes the buffering to perform before delivering data to the Amazon ES destination.</p>",
       "refs": {
-        "ElasticsearchDestinationConfiguration$BufferingHints": "<p>The buffering options. If no value is specified, the default values for <b>ElasticsearchBufferingHints</b> are used.</p>",
+        "ElasticsearchDestinationConfiguration$BufferingHints": "<p>The buffering options. If no value is specified, the default values for <code>ElasticsearchBufferingHints</code> are used.</p>",
         "ElasticsearchDestinationDescription$BufferingHints": "<p>The buffering options.</p>",
-        "ElasticsearchDestinationUpdate$BufferingHints": "<p>The buffering options. If no value is specified, <b>ElasticsearchBufferingHints</b> object default values are used. </p>"
+        "ElasticsearchDestinationUpdate$BufferingHints": "<p>The buffering options. If no value is specified, <code>ElasticsearchBufferingHints</code> object default values are used. </p>"
       }
     },
     "ElasticsearchBufferingIntervalInSeconds": {
@@ -281,9 +288,9 @@
     "ElasticsearchDomainARN": {
       "base": null,
       "refs": {
-        "ElasticsearchDestinationConfiguration$DomainARN": "<p>The ARN of the Amazon ES domain. The IAM role must have permissions for <code>DescribeElasticsearchDomain</code>, <code>DescribeElasticsearchDomains</code>, and <code>DescribeElasticsearchDomainConfig</code> after assuming the role specified in <b>RoleARN</b>.</p>",
+        "ElasticsearchDestinationConfiguration$DomainARN": "<p>The ARN of the Amazon ES domain. The IAM role must have permissions for <code>DescribeElasticsearchDomain</code>, <code>DescribeElasticsearchDomains</code>, and <code>DescribeElasticsearchDomainConfig</code> after assuming the role specified in <code>RoleARN</code>.</p>",
         "ElasticsearchDestinationDescription$DomainARN": "<p>The ARN of the Amazon ES domain.</p>",
-        "ElasticsearchDestinationUpdate$DomainARN": "<p>The ARN of the Amazon ES domain. The IAM role must have permissions for <code>DescribeElasticsearchDomain</code>, <code>DescribeElasticsearchDomains</code>, and <code>DescribeElasticsearchDomainConfig</code> after assuming the IAM role specified in <b>RoleARN</b>.</p>"
+        "ElasticsearchDestinationUpdate$DomainARN": "<p>The ARN of the Amazon ES domain. The IAM role must have permissions for <code>DescribeElasticsearchDomain</code>, <code>DescribeElasticsearchDomains</code>, and <code>DescribeElasticsearchDomainConfig</code> after assuming the IAM role specified in <code>RoleARN</code>.</p>"
       }
     },
     "ElasticsearchIndexName": {
@@ -297,29 +304,29 @@
     "ElasticsearchIndexRotationPeriod": {
       "base": null,
       "refs": {
-        "ElasticsearchDestinationConfiguration$IndexRotationPeriod": "<p>The Elasticsearch index rotation period. Index rotation appends a time stamp to the IndexName to facilitate the expiration of old data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for Amazon Elasticsearch Service Destination</a>. The default value is <code>OneDay</code>.</p>",
+        "ElasticsearchDestinationConfiguration$IndexRotationPeriod": "<p>The Elasticsearch index rotation period. Index rotation appends a time stamp to the IndexName to facilitate the expiration of old data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for the Amazon ES Destination</a>. The default value is <code>OneDay</code>.</p>",
         "ElasticsearchDestinationDescription$IndexRotationPeriod": "<p>The Elasticsearch index rotation period</p>",
-        "ElasticsearchDestinationUpdate$IndexRotationPeriod": "<p>The Elasticsearch index rotation period. Index rotation appends a time stamp to IndexName to facilitate the expiration of old data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for Amazon Elasticsearch Service Destination</a>. Default value is <code>OneDay</code>.</p>"
+        "ElasticsearchDestinationUpdate$IndexRotationPeriod": "<p>The Elasticsearch index rotation period. Index rotation appends a time stamp to IndexName to facilitate the expiration of old data. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation\">Index Rotation for the Amazon ES Destination</a>. Default value is <code>OneDay</code>.</p>"
       }
     },
     "ElasticsearchRetryDurationInSeconds": {
       "base": null,
       "refs": {
-        "ElasticsearchRetryOptions$DurationInSeconds": "<p>After an initial failure to deliver to Amazon ES, the total amount of time during which Kinesis Firehose re-attempts delivery (including the first attempt). After this time has elapsed, the failed documents are written to Amazon S3. Default value is 300 seconds (5 minutes). A value of 0 (zero) results in no retries.</p>"
+        "ElasticsearchRetryOptions$DurationInSeconds": "<p>After an initial failure to deliver to Amazon ES, the total amount of time during which Kinesis Data Firehose re-attempts delivery (including the first attempt). After this time has elapsed, the failed documents are written to Amazon S3. Default value is 300 seconds (5 minutes). A value of 0 (zero) results in no retries.</p>"
       }
     },
     "ElasticsearchRetryOptions": {
-      "base": "<p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon ES.</p>",
+      "base": "<p>Configures retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon ES.</p>",
       "refs": {
-        "ElasticsearchDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon ES. The default value is 300 (5 minutes).</p>",
+        "ElasticsearchDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon ES. The default value is 300 (5 minutes).</p>",
         "ElasticsearchDestinationDescription$RetryOptions": "<p>The Amazon ES retry options.</p>",
-        "ElasticsearchDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon ES. The default value is 300 (5 minutes).</p>"
+        "ElasticsearchDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon ES. The default value is 300 (5 minutes).</p>"
       }
     },
     "ElasticsearchS3BackupMode": {
       "base": null,
       "refs": {
-        "ElasticsearchDestinationConfiguration$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly, Kinesis Firehose writes any documents that could not be indexed to the configured Amazon S3 destination, with elasticsearch-failed/ appended to the key prefix. When set to AllDocuments, Kinesis Firehose delivers all incoming records to Amazon S3, and also writes failed documents with elasticsearch-failed/ appended to the prefix. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-s3-backup\">Amazon S3 Backup for Amazon Elasticsearch Service Destination</a>. Default value is FailedDocumentsOnly.</p>",
+        "ElasticsearchDestinationConfiguration$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Data Firehose writes any documents that could not be indexed to the configured Amazon S3 destination, with <code>elasticsearch-failed/</code> appended to the key prefix. When set to <code>AllDocuments</code>, Kinesis Data Firehose delivers all incoming records to Amazon S3, and also writes failed documents with <code>elasticsearch-failed/</code> appended to the prefix. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#retry\">Data Delivery Failure Handling</a>. Default value is <code>FailedDocumentsOnly</code>.</p>",
         "ElasticsearchDestinationDescription$S3BackupMode": "<p>The Amazon S3 backup mode.</p>"
       }
     },
@@ -381,33 +388,33 @@
     "HECAcknowledgmentTimeoutInSeconds": {
       "base": null,
       "refs": {
-        "SplunkDestinationConfiguration$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data. At the end of the timeout period Kinesis Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>",
-        "SplunkDestinationDescription$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data. At the end of the timeout period Kinesis Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>",
-        "SplunkDestinationUpdate$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Firehose waits to receive an acknowledgment from Splunk after it sends it data. At the end of the timeout period Kinesis Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>"
+        "SplunkDestinationConfiguration$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Data Firehose waits to receive an acknowledgment from Splunk after it sends it data. At the end of the timeout period, Kinesis Data Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>",
+        "SplunkDestinationDescription$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Data Firehose waits to receive an acknowledgment from Splunk after it sends it data. At the end of the timeout period, Kinesis Data Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>",
+        "SplunkDestinationUpdate$HECAcknowledgmentTimeoutInSeconds": "<p>The amount of time that Kinesis Data Firehose waits to receive an acknowledgment from Splunk after it sends data. At the end of the timeout period, Kinesis Data Firehose either tries to send the data again or considers it an error, based on your retry settings.</p>"
       }
     },
     "HECEndpoint": {
       "base": null,
       "refs": {
-        "SplunkDestinationConfiguration$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.</p>",
-        "SplunkDestinationDescription$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.</p>",
-        "SplunkDestinationUpdate$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.</p>"
+        "SplunkDestinationConfiguration$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends your data.</p>",
+        "SplunkDestinationDescription$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends your data.</p>",
+        "SplunkDestinationUpdate$HECEndpoint": "<p>The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends your data.</p>"
       }
     },
     "HECEndpointType": {
       "base": null,
       "refs": {
-        "SplunkDestinationConfiguration$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event\".</p>",
-        "SplunkDestinationDescription$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event\".</p>",
-        "SplunkDestinationUpdate$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event\".</p>"
+        "SplunkDestinationConfiguration$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event.\"</p>",
+        "SplunkDestinationDescription$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event.\"</p>",
+        "SplunkDestinationUpdate$HECEndpointType": "<p>This type can be either \"Raw\" or \"Event.\"</p>"
       }
     },
     "HECToken": {
       "base": null,
       "refs": {
-        "SplunkDestinationConfiguration$HECToken": "<p>This is a GUID you obtain from your Splunk cluster when you create a new HEC endpoint.</p>",
+        "SplunkDestinationConfiguration$HECToken": "<p>This is a GUID that you obtain from your Splunk cluster when you create a new HEC endpoint.</p>",
         "SplunkDestinationDescription$HECToken": "<p>This is a GUID you obtain from your Splunk cluster when you create a new HEC endpoint.</p>",
-        "SplunkDestinationUpdate$HECToken": "<p>This is a GUID you obtain from your Splunk cluster when you create a new HEC endpoint.</p>"
+        "SplunkDestinationUpdate$HECToken": "<p>A GUID that you obtain from your Splunk cluster when you create a new HEC endpoint.</p>"
       }
     },
     "IntervalInSeconds": {
@@ -430,20 +437,20 @@
     "KinesisStreamARN": {
       "base": null,
       "refs": {
-        "KinesisStreamSourceConfiguration$KinesisStreamARN": "<p>The ARN of the source Kinesis stream.</p>",
-        "KinesisStreamSourceDescription$KinesisStreamARN": "<p>The ARN of the source Kinesis stream.</p>"
+        "KinesisStreamSourceConfiguration$KinesisStreamARN": "<p>The ARN of the source Kinesis data stream.</p>",
+        "KinesisStreamSourceDescription$KinesisStreamARN": "<p>The Amazon Resource Name (ARN) of the source Kinesis data stream.</p>"
       }
     },
     "KinesisStreamSourceConfiguration": {
-      "base": "<p>The stream and role ARNs for a Kinesis stream used as the source for a delivery stream.</p>",
+      "base": "<p>The stream and role Amazon Resource Names (ARNs) for a Kinesis data stream used as the source for a delivery stream.</p>",
       "refs": {
-        "CreateDeliveryStreamInput$KinesisStreamSourceConfiguration": "<p>When a Kinesis stream is used as the source for the delivery stream, a <a>KinesisStreamSourceConfiguration</a> containing the Kinesis stream ARN and the role ARN for the source stream.</p>"
+        "CreateDeliveryStreamInput$KinesisStreamSourceConfiguration": "<p>When a Kinesis data stream is used as the source for the delivery stream, a <a>KinesisStreamSourceConfiguration</a> containing the Kinesis data stream Amazon Resource Name (ARN) and the role ARN for the source stream.</p>"
       }
     },
     "KinesisStreamSourceDescription": {
-      "base": "<p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>",
+      "base": "<p>Details about a Kinesis data stream used as the source for a Kinesis Data Firehose delivery stream.</p>",
       "refs": {
-        "SourceDescription$KinesisStreamSourceDescription": "<p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis stream.</p>"
+        "SourceDescription$KinesisStreamSourceDescription": "<p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis data stream.</p>"
       }
     },
     "LimitExceededException": {
@@ -465,6 +472,28 @@
     "ListDeliveryStreamsOutput": {
       "base": null,
       "refs": {
+      }
+    },
+    "ListTagsForDeliveryStreamInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTagsForDeliveryStreamInputLimit": {
+      "base": null,
+      "refs": {
+        "ListTagsForDeliveryStreamInput$Limit": "<p>The number of tags to return. If this number is less than the total number of tags associated with the delivery stream, <code>HasMoreTags</code> is set to <code>true</code> in the response. To list additional tags, set <code>ExclusiveStartTagKey</code> to the last key in the response. </p>"
+      }
+    },
+    "ListTagsForDeliveryStreamOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ListTagsForDeliveryStreamOutputTagList": {
+      "base": null,
+      "refs": {
+        "ListTagsForDeliveryStreamOutput$Tags": "<p>A list of tags associated with <code>DeliveryStreamName</code>, starting with the first tag after <code>ExclusiveStartTagKey</code> and up to the specified <code>Limit</code>.</p>"
       }
     },
     "LogGroupName": {
@@ -501,12 +530,12 @@
     "Prefix": {
       "base": null,
       "refs": {
-        "ExtendedS3DestinationConfiguration$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
-        "ExtendedS3DestinationDescription$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
-        "ExtendedS3DestinationUpdate$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
-        "S3DestinationConfiguration$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
-        "S3DestinationDescription$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>",
-        "S3DestinationUpdate$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Firehose Developer Guide</i>.</p>"
+        "ExtendedS3DestinationConfiguration$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
+        "ExtendedS3DestinationDescription$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
+        "ExtendedS3DestinationUpdate$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
+        "S3DestinationConfiguration$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
+        "S3DestinationDescription$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>",
+        "S3DestinationUpdate$Prefix": "<p>The \"YYYY/MM/DD/HH\" time format prefix is automatically used for delivered Amazon S3 files. You can specify an extra prefix to be added in front of the time format prefix. If the prefix ends with a slash, it appears as a folder in the S3 bucket. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name\">Amazon S3 Object Name Format</a> in the <i>Amazon Kinesis Data Firehose Developer Guide</i>.</p>"
       }
     },
     "ProcessingConfiguration": {
@@ -641,15 +670,15 @@
     "RedshiftRetryDurationInSeconds": {
       "base": null,
       "refs": {
-        "RedshiftRetryOptions$DurationInSeconds": "<p>The length of time during which Kinesis Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Kinesis Firehose does not retry if the value of <code>DurationInSeconds</code> is 0 (zero) or if the first delivery attempt takes longer than the current value.</p>"
+        "RedshiftRetryOptions$DurationInSeconds": "<p>The length of time during which Kinesis Data Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Kinesis Data Firehose does not retry if the value of <code>DurationInSeconds</code> is 0 (zero) or if the first delivery attempt takes longer than the current value.</p>"
       }
     },
     "RedshiftRetryOptions": {
-      "base": "<p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon Redshift.</p>",
+      "base": "<p>Configures retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon Redshift.</p>",
       "refs": {
-        "RedshiftDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>",
-        "RedshiftDestinationDescription$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>",
-        "RedshiftDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>"
+        "RedshiftDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>",
+        "RedshiftDestinationDescription$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>",
+        "RedshiftDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver documents to Amazon Redshift. Default value is 3600 (60 minutes).</p>"
       }
     },
     "RedshiftS3BackupMode": {
@@ -673,20 +702,20 @@
     "RoleARN": {
       "base": null,
       "refs": {
-        "ElasticsearchDestinationConfiguration$RoleARN": "<p>The ARN of the IAM role to be assumed by Kinesis Firehose for calling the Amazon ES Configuration API and for indexing documents. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Amazon S3 Bucket Access</a>.</p>",
-        "ElasticsearchDestinationDescription$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "ElasticsearchDestinationUpdate$RoleARN": "<p>The ARN of the IAM role to be assumed by Kinesis Firehose for calling the Amazon ES Configuration API and for indexing documents. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Amazon S3 Bucket Access</a>.</p>",
-        "ExtendedS3DestinationConfiguration$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "ExtendedS3DestinationDescription$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "ExtendedS3DestinationUpdate$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "KinesisStreamSourceConfiguration$RoleARN": "<p>The ARN of the role that provides access to the source Kinesis stream.</p>",
-        "KinesisStreamSourceDescription$RoleARN": "<p>The ARN of the role used by the source Kinesis stream.</p>",
-        "RedshiftDestinationConfiguration$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "RedshiftDestinationDescription$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "RedshiftDestinationUpdate$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "S3DestinationConfiguration$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "S3DestinationDescription$RoleARN": "<p>The ARN of the AWS credentials.</p>",
-        "S3DestinationUpdate$RoleARN": "<p>The ARN of the AWS credentials.</p>"
+        "ElasticsearchDestinationConfiguration$RoleARN": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data Firehose for calling the Amazon ES Configuration API and for indexing documents. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Kinesis Data Firehose Access to an Amazon Destination</a>.</p>",
+        "ElasticsearchDestinationDescription$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "ElasticsearchDestinationUpdate$RoleARN": "<p>The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data Firehose for calling the Amazon ES Configuration API and for indexing documents. For more information, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3\">Grant Kinesis Data Firehose Access to an Amazon S3 Destination</a>.</p>",
+        "ExtendedS3DestinationConfiguration$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "ExtendedS3DestinationDescription$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "ExtendedS3DestinationUpdate$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "KinesisStreamSourceConfiguration$RoleARN": "<p>The ARN of the role that provides access to the source Kinesis data stream.</p>",
+        "KinesisStreamSourceDescription$RoleARN": "<p>The ARN of the role used by the source Kinesis data stream.</p>",
+        "RedshiftDestinationConfiguration$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "RedshiftDestinationDescription$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "RedshiftDestinationUpdate$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "S3DestinationConfiguration$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "S3DestinationDescription$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>",
+        "S3DestinationUpdate$RoleARN": "<p>The Amazon Resource Name (ARN) of the AWS credentials.</p>"
       }
     },
     "S3BackupMode": {
@@ -703,7 +732,7 @@
         "CreateDeliveryStreamInput$S3DestinationConfiguration": "<p>[Deprecated] The destination in Amazon S3. You can specify only one destination.</p>",
         "ElasticsearchDestinationConfiguration$S3Configuration": "<p>The configuration for the backup Amazon S3 location.</p>",
         "ExtendedS3DestinationConfiguration$S3BackupConfiguration": "<p>The configuration for backup in Amazon S3.</p>",
-        "RedshiftDestinationConfiguration$S3Configuration": "<p>The configuration for the intermediate Amazon S3 location from which Amazon Redshift obtains data. Restrictions are described in the topic for <a>CreateDeliveryStream</a>.</p> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <b>RedshiftDestinationConfiguration.S3Configuration</b> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p>",
+        "RedshiftDestinationConfiguration$S3Configuration": "<p>The configuration for the intermediate Amazon S3 location from which Amazon Redshift obtains data. Restrictions are described in the topic for <a>CreateDeliveryStream</a>.</p> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <code>RedshiftDestinationConfiguration.S3Configuration</code> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p>",
         "RedshiftDestinationConfiguration$S3BackupConfiguration": "<p>The configuration for backup in Amazon S3.</p>",
         "SplunkDestinationConfiguration$S3Configuration": "<p>The configuration for the backup Amazon S3 location.</p>"
       }
@@ -724,14 +753,14 @@
       "refs": {
         "ElasticsearchDestinationUpdate$S3Update": "<p>The Amazon S3 destination.</p>",
         "ExtendedS3DestinationUpdate$S3BackupUpdate": "<p>The Amazon S3 destination for backup.</p>",
-        "RedshiftDestinationUpdate$S3Update": "<p>The Amazon S3 destination.</p> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <b>RedshiftDestinationUpdate.S3Update</b> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p>",
+        "RedshiftDestinationUpdate$S3Update": "<p>The Amazon S3 destination.</p> <p>The compression formats <code>SNAPPY</code> or <code>ZIP</code> cannot be specified in <code>RedshiftDestinationUpdate.S3Update</code> because the Amazon Redshift <code>COPY</code> operation that reads from the S3 bucket doesn't support these compression formats.</p>",
         "RedshiftDestinationUpdate$S3BackupUpdate": "<p>The Amazon S3 destination for backup.</p>",
         "SplunkDestinationUpdate$S3Update": "<p>Your update to the configuration of the backup Amazon S3 location.</p>",
         "UpdateDestinationInput$S3DestinationUpdate": "<p>[Deprecated] Describes an update for a destination in Amazon S3.</p>"
       }
     },
     "ServiceUnavailableException": {
-      "base": "<p>The service is unavailable, back off and retry the operation. If you continue to see the exception, throughput limits for the delivery stream may have been exceeded. For more information about limits and how to request an increase, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Firehose Limits</a>.</p>",
+      "base": "<p>The service is unavailable. Back off and retry the operation. If you continue to see the exception, throughput limits for the delivery stream may have been exceeded. For more information about limits and how to request an increase, see <a href=\"http://docs.aws.amazon.com/firehose/latest/dev/limits.html\">Amazon Kinesis Data Firehose Limits</a>.</p>",
       "refs": {
       }
     },
@@ -742,9 +771,9 @@
       }
     },
     "SourceDescription": {
-      "base": "<p>Details about a Kinesis stream used as the source for a Kinesis Firehose delivery stream.</p>",
+      "base": "<p>Details about a Kinesis data stream used as the source for a Kinesis Data Firehose delivery stream.</p>",
       "refs": {
-        "DeliveryStreamDescription$Source": "<p>If the <code>DeliveryStreamType</code> parameter is <code>KinesisStreamAsSource</code>, a <a>SourceDescription</a> object describing the source Kinesis stream.</p>"
+        "DeliveryStreamDescription$Source": "<p>If the <code>DeliveryStreamType</code> parameter is <code>KinesisStreamAsSource</code>, a <a>SourceDescription</a> object describing the source Kinesis data stream.</p>"
       }
     },
     "SplunkDestinationConfiguration": {
@@ -768,23 +797,66 @@
     "SplunkRetryDurationInSeconds": {
       "base": null,
       "refs": {
-        "SplunkRetryOptions$DurationInSeconds": "<p>The total amount of time that Kinesis Firehose spends on retries. This duration starts after the initial attempt to send data to Splunk fails and doesn't include the periods during which Kinesis Firehose waits for acknowledgment from Splunk after each attempt.</p>"
+        "SplunkRetryOptions$DurationInSeconds": "<p>The total amount of time that Kinesis Data Firehose spends on retries. This duration starts after the initial attempt to send data to Splunk fails. It doesn't include the periods during which Kinesis Data Firehose waits for acknowledgment from Splunk after each attempt.</p>"
       }
     },
     "SplunkRetryOptions": {
-      "base": "<p>Configures retry behavior in case Kinesis Firehose is unable to deliver documents to Splunk or if it doesn't receive an acknowledgment from Splunk.</p>",
+      "base": "<p>Configures retry behavior in case Kinesis Data Firehose is unable to deliver documents to Splunk, or if it doesn't receive an acknowledgment from Splunk.</p>",
       "refs": {
-        "SplunkDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver data to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.</p>",
-        "SplunkDestinationDescription$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver data to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.</p>",
-        "SplunkDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Firehose is unable to deliver data to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.</p>"
+        "SplunkDestinationConfiguration$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver data to Splunk, or if it doesn't receive an acknowledgment of receipt from Splunk.</p>",
+        "SplunkDestinationDescription$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver data to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.</p>",
+        "SplunkDestinationUpdate$RetryOptions": "<p>The retry behavior in case Kinesis Data Firehose is unable to deliver data to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.</p>"
       }
     },
     "SplunkS3BackupMode": {
       "base": null,
       "refs": {
-        "SplunkDestinationConfiguration$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>",
-        "SplunkDestinationDescription$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>",
-        "SplunkDestinationUpdate$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>"
+        "SplunkDestinationConfiguration$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Data Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Data Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>",
+        "SplunkDestinationDescription$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Data Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Data Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>",
+        "SplunkDestinationUpdate$S3BackupMode": "<p>Defines how documents should be delivered to Amazon S3. When set to <code>FailedDocumentsOnly</code>, Kinesis Data Firehose writes any data that could not be indexed to the configured Amazon S3 destination. When set to <code>AllDocuments</code>, Kinesis Data Firehose delivers all incoming records to Amazon S3, and also writes failed documents to Amazon S3. Default value is <code>FailedDocumentsOnly</code>. </p>"
+      }
+    },
+    "Tag": {
+      "base": "<p>Metadata that you can assign to a delivery stream, consisting of a key-value pair.</p>",
+      "refs": {
+        "ListTagsForDeliveryStreamOutputTagList$member": null,
+        "TagDeliveryStreamInputTagList$member": null
+      }
+    },
+    "TagDeliveryStreamInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "TagDeliveryStreamInputTagList": {
+      "base": null,
+      "refs": {
+        "TagDeliveryStreamInput$Tags": "<p>A set of key-value pairs to use to create the tags.</p>"
+      }
+    },
+    "TagDeliveryStreamOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "TagKey": {
+      "base": null,
+      "refs": {
+        "ListTagsForDeliveryStreamInput$ExclusiveStartTagKey": "<p>The key to use as the starting point for the list of tags. If you set this parameter, <code>ListTagsForDeliveryStream</code> gets all tags that occur after <code>ExclusiveStartTagKey</code>.</p>",
+        "Tag$Key": "<p>A unique identifier for the tag. Maximum length: 128 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - % @</p>",
+        "TagKeyList$member": null
+      }
+    },
+    "TagKeyList": {
+      "base": null,
+      "refs": {
+        "UntagDeliveryStreamInput$TagKeys": "<p>A list of tag keys. Each corresponding tag is removed from the delivery stream.</p>"
+      }
+    },
+    "TagValue": {
+      "base": null,
+      "refs": {
+        "Tag$Value": "<p>An optional string, which you can use to describe or define the tag. Maximum length: 256 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - % @</p>"
       }
     },
     "Timestamp": {
@@ -792,6 +864,16 @@
       "refs": {
         "DeliveryStreamDescription$CreateTimestamp": "<p>The date and time that the delivery stream was created.</p>",
         "DeliveryStreamDescription$LastUpdateTimestamp": "<p>The date and time that the delivery stream was last updated.</p>"
+      }
+    },
+    "UntagDeliveryStreamInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UntagDeliveryStreamOutput": {
+      "base": null,
+      "refs": {
       }
     },
     "UpdateDestinationInput": {

--- a/models/apis/firehose/2015-08-04/smoke.json
+++ b/models/apis/firehose/2015-08-04/smoke.json
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "defaultRegion": "us-west-2",
+    "testCases": [
+        {
+            "operationName": "ListDeliveryStreams",
+            "input": {},
+            "errorExpectedFromService": false
+        },
+        {
+            "operationName": "DescribeDeliveryStream",
+            "input": {
+                "DeliveryStreamName": "bogus-stream-name"
+            },
+            "errorExpectedFromService": true
+        }
+    ]
+}

--- a/models/apis/medialive/2017-10-14/api-2.json
+++ b/models/apis/medialive/2017-10-14/api-2.json
@@ -1121,6 +1121,13 @@
         "VISUAL_IMPAIRED_COMMENTARY"
       ]
     },
+    "AuthenticationScheme": {
+      "type": "string",
+      "enum": [
+        "AKAMAI",
+        "COMMON"
+      ]
+    },
     "AvailBlanking": {
       "type": "structure",
       "members": {
@@ -1406,6 +1413,10 @@
           "shape": "EmbeddedPlusScte20DestinationSettings",
           "locationName": "embeddedPlusScte20DestinationSettings"
         },
+        "RtmpCaptionInfoDestinationSettings": {
+          "shape": "RtmpCaptionInfoDestinationSettings",
+          "locationName": "rtmpCaptionInfoDestinationSettings"
+        },
         "Scte20PlusEmbeddedDestinationSettings": {
           "shape": "Scte20PlusEmbeddedDestinationSettings",
           "locationName": "scte20PlusEmbeddedDestinationSettings"
@@ -1677,7 +1688,7 @@
         "Reserved": {
           "shape": "__string",
           "locationName": "reserved",
-          "deprecated" : true
+          "deprecated": true
         },
         "RoleArn": {
           "shape": "__string",
@@ -4423,6 +4434,10 @@
           "shape": "M3u8TimedMetadataBehavior",
           "locationName": "timedMetadataBehavior"
         },
+        "TimedMetadataPid": {
+          "shape": "__string",
+          "locationName": "timedMetadataPid"
+        },
         "TransportStreamId": {
           "shape": "__integerMin0Max65535",
           "locationName": "transportStreamId"
@@ -4643,6 +4658,10 @@
           "shape": "__string",
           "locationName": "passwordParam"
         },
+        "StreamName": {
+          "shape": "__string",
+          "locationName": "streamName"
+        },
         "Url": {
           "shape": "__string",
           "locationName": "url"
@@ -4689,6 +4708,10 @@
           "shape": "MsSmoothGroupSettings",
           "locationName": "msSmoothGroupSettings"
         },
+        "RtmpGroupSettings": {
+          "shape": "RtmpGroupSettings",
+          "locationName": "rtmpGroupSettings"
+        },
         "UdpGroupSettings": {
           "shape": "UdpGroupSettings",
           "locationName": "udpGroupSettings"
@@ -4718,6 +4741,10 @@
         "MsSmoothOutputSettings": {
           "shape": "MsSmoothOutputSettings",
           "locationName": "msSmoothOutputSettings"
+        },
+        "RtmpOutputSettings": {
+          "shape": "RtmpOutputSettings",
+          "locationName": "rtmpOutputSettings"
         },
         "UdpOutputSettings": {
           "shape": "UdpOutputSettings",
@@ -4767,6 +4794,82 @@
           "locationName": "message"
         }
       }
+    },
+    "RtmpCacheFullBehavior": {
+      "type": "string",
+      "enum": [
+        "DISCONNECT_IMMEDIATELY",
+        "WAIT_FOR_SERVER"
+      ]
+    },
+    "RtmpCaptionData": {
+      "type": "string",
+      "enum": [
+        "ALL",
+        "FIELD1_608",
+        "FIELD1_AND_FIELD2_608"
+      ]
+    },
+    "RtmpCaptionInfoDestinationSettings": {
+      "type": "structure",
+      "members": {
+      }
+    },
+    "RtmpGroupSettings": {
+      "type": "structure",
+      "members": {
+        "AuthenticationScheme": {
+          "shape": "AuthenticationScheme",
+          "locationName": "authenticationScheme"
+        },
+        "CacheFullBehavior": {
+          "shape": "RtmpCacheFullBehavior",
+          "locationName": "cacheFullBehavior"
+        },
+        "CacheLength": {
+          "shape": "__integerMin30",
+          "locationName": "cacheLength"
+        },
+        "CaptionData": {
+          "shape": "RtmpCaptionData",
+          "locationName": "captionData"
+        },
+        "RestartDelay": {
+          "shape": "__integerMin0",
+          "locationName": "restartDelay"
+        }
+      }
+    },
+    "RtmpOutputCertificateMode": {
+      "type": "string",
+      "enum": [
+        "SELF_SIGNED",
+        "VERIFY_AUTHENTICITY"
+      ]
+    },
+    "RtmpOutputSettings": {
+      "type": "structure",
+      "members": {
+        "CertificateMode": {
+          "shape": "RtmpOutputCertificateMode",
+          "locationName": "certificateMode"
+        },
+        "ConnectionRetryInterval": {
+          "shape": "__integerMin1",
+          "locationName": "connectionRetryInterval"
+        },
+        "Destination": {
+          "shape": "OutputLocationRef",
+          "locationName": "destination"
+        },
+        "NumRetries": {
+          "shape": "__integerMin0",
+          "locationName": "numRetries"
+        }
+      },
+      "required": [
+        "Destination"
+      ]
     },
     "Scte20Convert608To708": {
       "type": "string",
@@ -5731,6 +5834,10 @@
     "__integerMin3": {
       "type": "integer",
       "min": 3
+    },
+    "__integerMin30": {
+      "type": "integer",
+      "min": 30
     },
     "__integerMin4Max20": {
       "type": "integer",

--- a/models/apis/medialive/2017-10-14/docs-2.json
+++ b/models/apis/medialive/2017-10-14/docs-2.json
@@ -242,6 +242,12 @@
         "AudioDescription$AudioType": "Applies only if audioTypeControl is useConfigured. The values for audioType are defined in ISO-IEC 13818-1."
       }
     },
+    "AuthenticationScheme": {
+      "base": null,
+      "refs": {
+        "RtmpGroupSettings$AuthenticationScheme": "Authentication scheme to use when connecting with CDN"
+      }
+    },
     "AvailBlanking": {
       "base": null,
       "refs": {
@@ -1417,6 +1423,7 @@
         "ArchiveGroupSettings$Destination": "A directory and base filename where archive files should be written.  If the base filename portion of the URI is left blank, the base filename of the first input will be automatically inserted.",
         "HlsGroupSettings$Destination": "A directory or HTTP destination for the HLS segments, manifest files, and encryption keys (if enabled).",
         "MsSmoothGroupSettings$Destination": "Smooth Streaming publish point on an IIS server. Elemental Live acts as a \"Push\" encoder to IIS.",
+        "RtmpOutputSettings$Destination": "The RTMP endpoint excluding the stream name (eg. rtmp://host/appname). For connection to Akamai, a username and password must be supplied. URI fields accept format identifiers.",
         "UdpOutputSettings$Destination": "Destination address and port number for RTP or UDP packets. Can be unicast or multicast RTP or UDP (eg. rtp://239.10.10.10:5001 or udp://10.100.100.100:5002)."
       }
     },
@@ -1446,6 +1453,42 @@
     "ResourceNotFound": {
       "base": null,
       "refs": {
+      }
+    },
+    "RtmpCacheFullBehavior": {
+      "base": null,
+      "refs": {
+        "RtmpGroupSettings$CacheFullBehavior": "Controls behavior when content cache fills up. If remote origin server stalls the RTMP connection and does not accept content fast enough the 'Media Cache' will fill up. When the cache reaches the duration specified by cacheLength the cache will stop accepting new content. If set to disconnectImmediately, the RTMP output will force a disconnect. Clear the media cache, and reconnect after restartDelay seconds. If set to waitForServer, the RTMP output will wait up to 5 minutes to allow the origin server to begin accepting data again."
+      }
+    },
+    "RtmpCaptionData": {
+      "base": null,
+      "refs": {
+        "RtmpGroupSettings$CaptionData": "Controls the types of data that passes to onCaptionInfo outputs.  If set to 'all' then 608 and 708 carried DTVCC data will be passed.  If set to 'field1AndField2608' then DTVCC data will be stripped out, but 608 data from both fields will be passed. If set to 'field1608' then only the data carried in 608 from field 1 video will be passed."
+      }
+    },
+    "RtmpCaptionInfoDestinationSettings": {
+      "base": null,
+      "refs": {
+        "CaptionDestinationSettings$RtmpCaptionInfoDestinationSettings": null
+      }
+    },
+    "RtmpGroupSettings": {
+      "base": null,
+      "refs": {
+        "OutputGroupSettings$RtmpGroupSettings": null
+      }
+    },
+    "RtmpOutputCertificateMode": {
+      "base": null,
+      "refs": {
+        "RtmpOutputSettings$CertificateMode": "If set to verifyAuthenticity, verify the tls certificate chain to a trusted Certificate Authority (CA).  This will cause rtmps outputs with self-signed certificates to fail."
+      }
+    },
+    "RtmpOutputSettings": {
+      "base": null,
+      "refs": {
+        "OutputSettings$RtmpOutputSettings": null
       }
     },
     "Scte20Convert608To708": {
@@ -1523,7 +1566,7 @@
     "SmoothGroupCertificateMode": {
       "base": null,
       "refs": {
-        "MsSmoothGroupSettings$CertificateMode": "If set to verifyAuthenticity, verify the https certificate chain to a trusted Certificate Authority (CA).  This will cause https outputs to self-signed certificates to fail unless those certificates are manually added to the OS trusted keystore."
+        "MsSmoothGroupSettings$CertificateMode": "If set to verifyAuthenticity, verify the https certificate chain to a trusted Certificate Authority (CA).  This will cause https outputs to self-signed certificates to fail."
       }
     },
     "SmoothGroupEventIdMode": {
@@ -1829,6 +1872,8 @@
         "MsSmoothGroupSettings$FilecacheDuration": "Size in seconds of file cache for streaming outputs.",
         "MsSmoothGroupSettings$NumRetries": "Number of retry attempts.",
         "MsSmoothGroupSettings$RestartDelay": "Number of seconds before initiating a restart due to output failure, due to exhausting the numRetries on one segment, or exceeding filecacheDuration.",
+        "RtmpGroupSettings$RestartDelay": "If a streaming output fails, number of seconds to wait until a restart is initiated. A value of 0 means never restart.",
+        "RtmpOutputSettings$NumRetries": "Number of retry attempts.",
         "UdpGroupSettings$TimedMetadataId3Period": "Timed Metadata interval in seconds."
       }
     },
@@ -1965,6 +2010,7 @@
         "HlsGroupSettings$SegmentLength": "Length of MPEG-2 Transport Stream segments to create (in seconds). Note that segments will end on the next keyframe after this number of seconds, so actual segment length may be longer.",
         "HlsGroupSettings$SegmentsPerSubdirectory": "Number of segments to write to a subdirectory before starting a new one. directoryStructure must be subdirectoryPerStream for this setting to have an effect.",
         "MsSmoothGroupSettings$FragmentLength": "Length of mp4 fragments to generate (in seconds). Fragment length must be compatible with GOP size and framerate.",
+        "RtmpOutputSettings$ConnectionRetryInterval": "Number of seconds to wait before retrying a connection to the Flash Media server if the connection is lost.",
         "Scte27SourceSettings$Pid": "The pid field is used in conjunction with the caption selector languageCode field as follows:\n  - Specify PID and Language: Extracts captions from that PID; the language is \"informational\".\n  - Specify PID and omit Language: Extracts the specified PID.\n  - Omit PID and specify Language: Extracts the specified language, whichever PID that happens to be.\n  - Omit PID and omit Language: Valid only if source is DVB-Sub that is being passed through; all languages will be passed through."
       }
     },
@@ -2055,6 +2101,12 @@
       "base": null,
       "refs": {
         "HlsGroupSettings$IndexNSegments": "If mode is \"live\", the number of segments to retain in the manifest (.m3u8) file. This number must be less than or equal to keepSegments. If mode is \"vod\", this parameter has no effect."
+      }
+    },
+    "__integerMin30": {
+      "base": null,
+      "refs": {
+        "RtmpGroupSettings$CacheLength": "Cache length, in seconds, is used to calculate buffer size."
       }
     },
     "__integerMin4Max20": {
@@ -2314,7 +2366,7 @@
         "InputDestination$Url": "This represents the endpoint that the customer stream will be\npushed to.\n",
         "InputDestinationRequest$StreamName": "A unique name for the location the RTMP stream is being pushed\nto.\n",
         "InputLocation$PasswordParam": "key used to extract the password from EC2 Parameter store",
-        "InputLocation$Uri": "Uniform Resource Identifier - This should be a path to a file accessible to the Live system (eg. a http:// URI) depending on the output type. For example, a rtmpEndpoint should have a uri simliar to: \"rtmp://fmsserver/live\".",
+        "InputLocation$Uri": "Uniform Resource Identifier - This should be a path to a file accessible to the Live system (eg. a http:// URI) depending on the output type. For example, a RTMP destination should have a uri simliar to: \"rtmp://fmsserver/live\".",
         "InputLocation$Username": "Username if credentials are required to access a file or publishing point.  This can be either a plaintext username, or a reference to an AWS parameter store name from which the username can be retrieved.  AWS Parameter store format: \"ssm://<parameter name>\"",
         "InputSecurityGroup$Arn": "Unique ARN of Input Security Group",
         "InputSecurityGroup$Id": "The Id of the Input Security Group",
@@ -2351,6 +2403,7 @@
         "M3u8Settings$PcrPid": "Packet Identifier (PID) of the Program Clock Reference (PCR) in the transport stream. When no value is given, the encoder will assign the same value as the Video PID. Can be entered as a decimal or hexadecimal value.",
         "M3u8Settings$PmtPid": "Packet Identifier (PID) for the Program Map Table (PMT) in the transport stream. Can be entered as a decimal or hexadecimal value.",
         "M3u8Settings$Scte35Pid": "Packet Identifier (PID) of the SCTE-35 stream in the transport stream. Can be entered as a decimal or hexadecimal value.",
+        "M3u8Settings$TimedMetadataPid": "Packet Identifier (PID) of the timed metadata stream in the transport stream. Can be entered as a decimal or hexadecimal value.  Valid values are 32 (or 0x20)..8182 (or 0x1ff6).",
         "M3u8Settings$VideoPid": "Packet Identifier (PID) of the elementary video stream in the transport stream. Can be entered as a decimal or hexadecimal value.",
         "MsSmoothGroupSettings$AcquisitionPointId": "The value of the \"Acquisition Point Identity\" element used in each message placed in the sparse track.  Only enabled if sparseTrackType is not \"none\".",
         "MsSmoothGroupSettings$EventId": "MS Smooth event ID to be sent to the IIS server.\n\nShould only be specified if eventIdMode is set to useConfigured.",
@@ -2359,6 +2412,7 @@
         "Output$VideoDescriptionName": "The name of the VideoDescription used as the source for this output.",
         "OutputDestination$Id": "User-specified id. This is used in an output group or an output.",
         "OutputDestinationSettings$PasswordParam": "key used to extract the password from EC2 Parameter store",
+        "OutputDestinationSettings$StreamName": "Stream name for RTMP destinations (URLs of type rtmp://)",
         "OutputDestinationSettings$Url": "A URL specifying a destination",
         "OutputDestinationSettings$Username": "username for destination",
         "OutputLocationRef$DestinationRefId": null,

--- a/service/firehose/api.go
+++ b/service/firehose/api.go
@@ -57,7 +57,7 @@ func (c *Firehose) CreateDeliveryStreamRequest(input *CreateDeliveryStreamInput)
 //
 // Creates a delivery stream.
 //
-// By default, you can create up to 20 delivery streams per region.
+// By default, you can create up to 50 delivery streams per AWS Region.
 //
 // This is an asynchronous operation that immediately returns. The initial status
 // of the delivery stream is CREATING. After the delivery stream is created,
@@ -65,24 +65,25 @@ func (c *Firehose) CreateDeliveryStreamRequest(input *CreateDeliveryStreamInput)
 // delivery stream that is not in the ACTIVE state cause an exception. To check
 // the state of a delivery stream, use DescribeDeliveryStream.
 //
-// A Kinesis Firehose delivery stream can be configured to receive records directly
-// from providers using PutRecord or PutRecordBatch, or it can be configured
-// to use an existing Kinesis stream as its source. To specify a Kinesis stream
-// as input, set the DeliveryStreamType parameter to KinesisStreamAsSource,
-// and provide the Kinesis stream ARN and role ARN in the KinesisStreamSourceConfiguration
-// parameter.
+// A Kinesis Data Firehose delivery stream can be configured to receive records
+// directly from providers using PutRecord or PutRecordBatch, or it can be configured
+// to use an existing Kinesis data stream as its source. To specify a Kinesis
+// data stream as input, set the DeliveryStreamType parameter to KinesisStreamAsSource,
+// and provide the Kinesis data stream Amazon Resource Name (ARN) and role ARN
+// in the KinesisStreamSourceConfiguration parameter.
 //
 // A delivery stream is configured with a single destination: Amazon S3, Amazon
-// ES, or Amazon Redshift. You must specify only one of the following destination
+// ES, Amazon Redshift, or Splunk. Specify only one of the following destination
 // configuration parameters: ExtendedS3DestinationConfiguration, S3DestinationConfiguration,
-// ElasticsearchDestinationConfiguration, or RedshiftDestinationConfiguration.
+// ElasticsearchDestinationConfiguration, RedshiftDestinationConfiguration,
+// or SplunkDestinationConfiguration.
 //
 // When you specify S3DestinationConfiguration, you can also provide the following
 // optional values: BufferingHints, EncryptionConfiguration, and CompressionFormat.
-// By default, if no BufferingHints value is provided, Kinesis Firehose buffers
-// data up to 5 MB or for 5 minutes, whichever condition is satisfied first.
-// Note that BufferingHints is a hint, so there are some cases where the service
-// cannot adhere to these conditions strictly; for example, record boundaries
+// By default, if no BufferingHints value is provided, Kinesis Data Firehose
+// buffers data up to 5 MB or for 5 minutes, whichever condition is satisfied
+// first. BufferingHints is a hint, so there are some cases where the service
+// cannot adhere to these conditions strictly. For example, record boundaries
 // are such that the size is a little over or under the configured buffering
 // size. By default, no encryption is performed. We strongly recommend that
 // you enable encryption to ensure secure data storage in Amazon S3.
@@ -90,23 +91,25 @@ func (c *Firehose) CreateDeliveryStreamRequest(input *CreateDeliveryStreamInput)
 // A few notes about Amazon Redshift as a destination:
 //
 //    * An Amazon Redshift destination requires an S3 bucket as intermediate
-//    location, as Kinesis Firehose first delivers data to S3 and then uses
-//    COPY syntax to load data into an Amazon Redshift table. This is specified
-//    in the RedshiftDestinationConfiguration.S3Configuration parameter.
+//    location. This is because Kinesis Data Firehose first delivers data to
+//    Amazon S3 and then uses COPY syntax to load data into an Amazon Redshift
+//    table. This is specified in the RedshiftDestinationConfiguration.S3Configuration
+//    parameter.
 //
 //    * The compression formats SNAPPY or ZIP cannot be specified in RedshiftDestinationConfiguration.S3Configuration
 //    because the Amazon Redshift COPY operation that reads from the S3 bucket
 //    doesn't support these compression formats.
 //
-//    * We strongly recommend that you use the user name and password you provide
-//    exclusively with Kinesis Firehose, and that the permissions for the account
-//    are restricted for Amazon Redshift INSERT permissions.
+//    * We strongly recommend that you use the user name and password that you
+//    provide exclusively with Kinesis Data Firehose. In addition, the permissions
+//    for the account should be restricted for Amazon Redshift INSERT permissions.
 //
-// Kinesis Firehose assumes the IAM role that is configured as part of the destination.
-// The role should allow the Kinesis Firehose principal to assume the role,
-// and the role should have permissions that allow the service to deliver the
-// data. For more information, see Amazon S3 Bucket Access (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3)
-// in the Amazon Kinesis Firehose Developer Guide.
+// Kinesis Data Firehose assumes the IAM role that is configured as part of
+// the destination. The role should allow the Kinesis Data Firehose principal
+// to assume the role, and the role should have permissions that allow the service
+// to deliver the data. For more information, see Grant Kinesis Firehose Access
+// to an Amazon S3 Destination (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3)
+// in the Amazon Kinesis Data Firehose Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -286,8 +289,8 @@ func (c *Firehose) DescribeDeliveryStreamRequest(input *DescribeDeliveryStreamIn
 //
 // Describes the specified delivery stream and gets the status. For example,
 // after your delivery stream is created, call DescribeDeliveryStream to see
-// if the delivery stream is ACTIVE and therefore ready for data to be sent
-// to it.
+// whether the delivery stream is ACTIVE and therefore ready for data to be
+// sent to it.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -404,6 +407,92 @@ func (c *Firehose) ListDeliveryStreamsWithContext(ctx aws.Context, input *ListDe
 	return out, req.Send()
 }
 
+const opListTagsForDeliveryStream = "ListTagsForDeliveryStream"
+
+// ListTagsForDeliveryStreamRequest generates a "aws/request.Request" representing the
+// client's request for the ListTagsForDeliveryStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListTagsForDeliveryStream for more information on using the ListTagsForDeliveryStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListTagsForDeliveryStreamRequest method.
+//    req, resp := client.ListTagsForDeliveryStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/ListTagsForDeliveryStream
+func (c *Firehose) ListTagsForDeliveryStreamRequest(input *ListTagsForDeliveryStreamInput) (req *request.Request, output *ListTagsForDeliveryStreamOutput) {
+	op := &request.Operation{
+		Name:       opListTagsForDeliveryStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListTagsForDeliveryStreamInput{}
+	}
+
+	output = &ListTagsForDeliveryStreamOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTagsForDeliveryStream API operation for Amazon Kinesis Firehose.
+//
+// Lists the tags for the specified delivery stream. This operation has a limit
+// of five transactions per second per account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Firehose's
+// API operation ListTagsForDeliveryStream for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   The specified input parameter has a value that is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   You have already reached the limit for a requested resource.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/ListTagsForDeliveryStream
+func (c *Firehose) ListTagsForDeliveryStream(input *ListTagsForDeliveryStreamInput) (*ListTagsForDeliveryStreamOutput, error) {
+	req, out := c.ListTagsForDeliveryStreamRequest(input)
+	return out, req.Send()
+}
+
+// ListTagsForDeliveryStreamWithContext is the same as ListTagsForDeliveryStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTagsForDeliveryStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Firehose) ListTagsForDeliveryStreamWithContext(ctx aws.Context, input *ListTagsForDeliveryStreamInput, opts ...request.Option) (*ListTagsForDeliveryStreamOutput, error) {
+	req, out := c.ListTagsForDeliveryStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opPutRecord = "PutRecord"
 
 // PutRecordRequest generates a "aws/request.Request" representing the
@@ -448,22 +537,22 @@ func (c *Firehose) PutRecordRequest(input *PutRecordInput) (req *request.Request
 
 // PutRecord API operation for Amazon Kinesis Firehose.
 //
-// Writes a single data record into an Amazon Kinesis Firehose delivery stream.
-// To write multiple data records into a delivery stream, use PutRecordBatch.
+// Writes a single data record into an Amazon Kinesis Data Firehose delivery
+// stream. To write multiple data records into a delivery stream, use PutRecordBatch.
 // Applications using these operations are referred to as producers.
 //
 // By default, each delivery stream can take in up to 2,000 transactions per
 // second, 5,000 records per second, or 5 MB per second. Note that if you use
 // PutRecord and PutRecordBatch, the limits are an aggregate across these two
 // operations for each delivery stream. For more information about limits and
-// how to request an increase, see Amazon Kinesis Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
+// how to request an increase, see Amazon Kinesis Data Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 //
 // You must specify the name of the delivery stream and the data record when
 // using PutRecord. The data record consists of a data blob that can be up to
-// 1,000 KB in size, and any kind of data, for example, a segment from a log
-// file, geographic location data, website clickstream data, and so on.
+// 1,000 KB in size and any kind of data. For example, it can be a segment from
+// a log file, geographic location data, website clickstream data, and so on.
 //
-// Kinesis Firehose buffers records before delivering them to the destination.
+// Kinesis Data Firehose buffers records before delivering them to the destination.
 // To disambiguate the data blobs at the destination, a common solution is to
 // use delimiters in the data, such as a newline (\n) or some other character
 // unique within the data. This allows the consumer application to parse individual
@@ -477,9 +566,9 @@ func (c *Firehose) PutRecordRequest(input *PutRecordInput) (req *request.Request
 // and retry. If the exception persists, it is possible that the throughput
 // limits have been exceeded for the delivery stream.
 //
-// Data records sent to Kinesis Firehose are stored for 24 hours from the time
-// they are added to a delivery stream as it attempts to send the records to
-// the destination. If the destination is unreachable for more than 24 hours,
+// Data records sent to Kinesis Data Firehose are stored for 24 hours from the
+// time they are added to a delivery stream as it attempts to send the records
+// to the destination. If the destination is unreachable for more than 24 hours,
 // the data is no longer available.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -497,10 +586,10 @@ func (c *Firehose) PutRecordRequest(input *PutRecordInput) (req *request.Request
 //   The specified input parameter has a value that is not valid.
 //
 //   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
-//   The service is unavailable, back off and retry the operation. If you continue
+//   The service is unavailable. Back off and retry the operation. If you continue
 //   to see the exception, throughput limits for the delivery stream may have
 //   been exceeded. For more information about limits and how to request an increase,
-//   see Amazon Kinesis Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
+//   see Amazon Kinesis Data Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/PutRecord
 func (c *Firehose) PutRecord(input *PutRecordInput) (*PutRecordOutput, error) {
@@ -577,7 +666,7 @@ func (c *Firehose) PutRecordBatchRequest(input *PutRecordBatchInput) (req *reque
 // second, 5,000 records per second, or 5 MB per second. If you use PutRecord
 // and PutRecordBatch, the limits are an aggregate across these two operations
 // for each delivery stream. For more information about limits, see Amazon Kinesis
-// Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
+// Data Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 //
 // Each PutRecordBatch request supports up to 500 records. Each record in the
 // request can be as large as 1,000 KB (before 64-bit encoding), up to a limit
@@ -585,11 +674,11 @@ func (c *Firehose) PutRecordBatchRequest(input *PutRecordBatchInput) (req *reque
 //
 // You must specify the name of the delivery stream and the data record when
 // using PutRecord. The data record consists of a data blob that can be up to
-// 1,000 KB in size, and any kind of data. For example, it could be a segment
-// from a log file, geographic location data, web site clickstream data, and
+// 1,000 KB in size and any kind of data. For example, it could be a segment
+// from a log file, geographic location data, website clickstream data, and
 // so on.
 //
-// Kinesis Firehose buffers records before delivering them to the destination.
+// Kinesis Data Firehose buffers records before delivering them to the destination.
 // To disambiguate the data blobs at the destination, a common solution is to
 // use delimiters in the data, such as a newline (\n) or some other character
 // unique within the data. This allows the consumer application to parse individual
@@ -601,7 +690,7 @@ func (c *Firehose) PutRecordBatchRequest(input *PutRecordBatchInput) (req *reque
 // correlates with a record in the request array using the same ordering, from
 // the top to the bottom. The response array always includes the same number
 // of records as the request array. RequestResponses includes both successfully
-// and unsuccessfully processed records. Kinesis Firehose attempts to process
+// and unsuccessfully processed records. Kinesis Data Firehose attempts to process
 // all records in each PutRecordBatch request. A single record failure does
 // not stop the processing of subsequent records.
 //
@@ -622,9 +711,9 @@ func (c *Firehose) PutRecordBatchRequest(input *PutRecordBatchInput) (req *reque
 // If the exception persists, it is possible that the throughput limits have
 // been exceeded for the delivery stream.
 //
-// Data records sent to Kinesis Firehose are stored for 24 hours from the time
-// they are added to a delivery stream as it attempts to send the records to
-// the destination. If the destination is unreachable for more than 24 hours,
+// Data records sent to Kinesis Data Firehose are stored for 24 hours from the
+// time they are added to a delivery stream as it attempts to send the records
+// to the destination. If the destination is unreachable for more than 24 hours,
 // the data is no longer available.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -642,10 +731,10 @@ func (c *Firehose) PutRecordBatchRequest(input *PutRecordBatchInput) (req *reque
 //   The specified input parameter has a value that is not valid.
 //
 //   * ErrCodeServiceUnavailableException "ServiceUnavailableException"
-//   The service is unavailable, back off and retry the operation. If you continue
+//   The service is unavailable. Back off and retry the operation. If you continue
 //   to see the exception, throughput limits for the delivery stream may have
 //   been exceeded. For more information about limits and how to request an increase,
-//   see Amazon Kinesis Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
+//   see Amazon Kinesis Data Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/PutRecordBatch
 func (c *Firehose) PutRecordBatch(input *PutRecordBatchInput) (*PutRecordBatchOutput, error) {
@@ -664,6 +753,198 @@ func (c *Firehose) PutRecordBatch(input *PutRecordBatchInput) (*PutRecordBatchOu
 // for more information on using Contexts.
 func (c *Firehose) PutRecordBatchWithContext(ctx aws.Context, input *PutRecordBatchInput, opts ...request.Option) (*PutRecordBatchOutput, error) {
 	req, out := c.PutRecordBatchRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opTagDeliveryStream = "TagDeliveryStream"
+
+// TagDeliveryStreamRequest generates a "aws/request.Request" representing the
+// client's request for the TagDeliveryStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TagDeliveryStream for more information on using the TagDeliveryStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TagDeliveryStreamRequest method.
+//    req, resp := client.TagDeliveryStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/TagDeliveryStream
+func (c *Firehose) TagDeliveryStreamRequest(input *TagDeliveryStreamInput) (req *request.Request, output *TagDeliveryStreamOutput) {
+	op := &request.Operation{
+		Name:       opTagDeliveryStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TagDeliveryStreamInput{}
+	}
+
+	output = &TagDeliveryStreamOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// TagDeliveryStream API operation for Amazon Kinesis Firehose.
+//
+// Adds or updates tags for the specified delivery stream. A tag is a key-value
+// pair (the value is optional) that you can define and assign to AWS resources.
+// If you specify a tag that already exists, the tag value is replaced with
+// the value that you specify in the request. Tags are metadata. For example,
+// you can add friendly names and descriptions or other types of information
+// that can help you distinguish the delivery stream. For more information about
+// tags, see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+// in the AWS Billing and Cost Management User Guide.
+//
+// Each delivery stream can have up to 50 tags.
+//
+// This operation has a limit of five transactions per second per account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Firehose's
+// API operation TagDeliveryStream for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   The resource is already in use and not available for this operation.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   The specified input parameter has a value that is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   You have already reached the limit for a requested resource.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/TagDeliveryStream
+func (c *Firehose) TagDeliveryStream(input *TagDeliveryStreamInput) (*TagDeliveryStreamOutput, error) {
+	req, out := c.TagDeliveryStreamRequest(input)
+	return out, req.Send()
+}
+
+// TagDeliveryStreamWithContext is the same as TagDeliveryStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TagDeliveryStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Firehose) TagDeliveryStreamWithContext(ctx aws.Context, input *TagDeliveryStreamInput, opts ...request.Option) (*TagDeliveryStreamOutput, error) {
+	req, out := c.TagDeliveryStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUntagDeliveryStream = "UntagDeliveryStream"
+
+// UntagDeliveryStreamRequest generates a "aws/request.Request" representing the
+// client's request for the UntagDeliveryStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UntagDeliveryStream for more information on using the UntagDeliveryStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UntagDeliveryStreamRequest method.
+//    req, resp := client.UntagDeliveryStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/UntagDeliveryStream
+func (c *Firehose) UntagDeliveryStreamRequest(input *UntagDeliveryStreamInput) (req *request.Request, output *UntagDeliveryStreamOutput) {
+	op := &request.Operation{
+		Name:       opUntagDeliveryStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UntagDeliveryStreamInput{}
+	}
+
+	output = &UntagDeliveryStreamOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UntagDeliveryStream API operation for Amazon Kinesis Firehose.
+//
+// Removes tags from the specified delivery stream. Removed tags are deleted,
+// and you can't recover them after this operation successfully completes.
+//
+// If you specify a tag that doesn't exist, the operation ignores it.
+//
+// This operation has a limit of five transactions per second per account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Firehose's
+// API operation UntagDeliveryStream for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource could not be found.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//   The resource is already in use and not available for this operation.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   The specified input parameter has a value that is not valid.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   You have already reached the limit for a requested resource.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04/UntagDeliveryStream
+func (c *Firehose) UntagDeliveryStream(input *UntagDeliveryStreamInput) (*UntagDeliveryStreamOutput, error) {
+	req, out := c.UntagDeliveryStreamRequest(input)
+	return out, req.Send()
+}
+
+// UntagDeliveryStreamWithContext is the same as UntagDeliveryStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UntagDeliveryStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Firehose) UntagDeliveryStreamWithContext(ctx aws.Context, input *UntagDeliveryStreamInput, opts ...request.Option) (*UntagDeliveryStreamOutput, error) {
+	req, out := c.UntagDeliveryStreamRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -715,18 +996,18 @@ func (c *Firehose) UpdateDestinationRequest(input *UpdateDestinationInput) (req 
 //
 // Updates the specified destination of the specified delivery stream.
 //
-// You can use this operation to change the destination type (for example, to
-// replace the Amazon S3 destination with Amazon Redshift) or change the parameters
+// Use this operation to change the destination type (for example, to replace
+// the Amazon S3 destination with Amazon Redshift) or change the parameters
 // associated with a destination (for example, to change the bucket name of
 // the Amazon S3 destination). The update might not occur immediately. The target
 // delivery stream remains active while the configurations are updated, so data
 // writes to the delivery stream can continue during this process. The updated
 // configurations are usually effective within a few minutes.
 //
-// Note that switching between Amazon ES and other services is not supported.
-// For an Amazon ES destination, you can only update to another Amazon ES destination.
+// Switching between Amazon ES and other services is not supported. For an Amazon
+// ES destination, you can only update to another Amazon ES destination.
 //
-// If the destination type is the same, Kinesis Firehose merges the configuration
+// If the destination type is the same, Kinesis Data Firehose merges the configuration
 // parameters specified with the destination configuration that already exists
 // on the delivery stream. If any of the parameters are not specified in the
 // call, the existing values are retained. For example, in the Amazon S3 destination,
@@ -734,15 +1015,15 @@ func (c *Firehose) UpdateDestinationRequest(input *UpdateDestinationInput) (req 
 // is maintained on the destination.
 //
 // If the destination type is not the same, for example, changing the destination
-// from Amazon S3 to Amazon Redshift, Kinesis Firehose does not merge any parameters.
-// In this case, all parameters must be specified.
+// from Amazon S3 to Amazon Redshift, Kinesis Data Firehose does not merge any
+// parameters. In this case, all parameters must be specified.
 //
-// Kinesis Firehose uses CurrentDeliveryStreamVersionId to avoid race conditions
+// Kinesis Data Firehose uses CurrentDeliveryStreamVersionId to avoid race conditions
 // and conflicting merges. This is a required field, and the service updates
 // the configuration only if the existing configuration has a version ID that
 // matches. After the update is applied successfully, the version ID is updated,
-// and can be retrieved using DescribeDeliveryStream. Use the new version ID
-// to set CurrentDeliveryStreamVersionId in the next call.
+// and you can retrieve it using DescribeDeliveryStream. Use the new version
+// ID to set CurrentDeliveryStreamVersionId in the next call.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -788,8 +1069,8 @@ func (c *Firehose) UpdateDestinationWithContext(ctx aws.Context, input *UpdateDe
 }
 
 // Describes hints for the buffering to perform before delivering data to the
-// destination. Please note that these options are treated as hints, and therefore
-// Kinesis Firehose may choose to use different values when it is optimal.
+// destination. These options are treated as hints, and therefore Kinesis Data
+// Firehose might choose to use different values whenever it is optimal.
 type BufferingHints struct {
 	_ struct{} `type:"structure"`
 
@@ -895,7 +1176,7 @@ type CopyCommand struct {
 	// Optional parameters to use with the Amazon Redshift COPY command. For more
 	// information, see the "Optional Parameters" section of Amazon Redshift COPY
 	// command (http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html). Some
-	// possible examples that would apply to Kinesis Firehose are as follows:
+	// possible examples that would apply to Kinesis Data Firehose are as follows:
 	//
 	// delimiter '\t' lzop; - fields are delimited with "\t" (TAB character) and
 	// compressed using lzop.
@@ -971,8 +1252,8 @@ type CreateDeliveryStreamInput struct {
 	_ struct{} `type:"structure"`
 
 	// The name of the delivery stream. This name must be unique per AWS account
-	// in the same region. If the delivery streams are in different accounts or
-	// different regions, you can have multiple delivery streams with the same name.
+	// in the same Region. If the delivery streams are in different accounts or
+	// different Regions, you can have multiple delivery streams with the same name.
 	//
 	// DeliveryStreamName is a required field
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
@@ -981,8 +1262,8 @@ type CreateDeliveryStreamInput struct {
 	//
 	//    * DirectPut: Provider applications access the delivery stream directly.
 	//
-	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis stream as
-	//    a source.
+	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis data stream
+	//    as a source.
 	DeliveryStreamType *string `type:"string" enum:"DeliveryStreamType"`
 
 	// The destination in Amazon ES. You can specify only one destination.
@@ -991,8 +1272,9 @@ type CreateDeliveryStreamInput struct {
 	// The destination in Amazon S3. You can specify only one destination.
 	ExtendedS3DestinationConfiguration *ExtendedS3DestinationConfiguration `type:"structure"`
 
-	// When a Kinesis stream is used as the source for the delivery stream, a KinesisStreamSourceConfiguration
-	// containing the Kinesis stream ARN and the role ARN for the source stream.
+	// When a Kinesis data stream is used as the source for the delivery stream,
+	// a KinesisStreamSourceConfiguration containing the Kinesis data stream Amazon
+	// Resource Name (ARN) and the role ARN for the source stream.
 	KinesisStreamSourceConfiguration *KinesisStreamSourceConfiguration `type:"structure"`
 
 	// The destination in Amazon Redshift. You can specify only one destination.
@@ -1213,8 +1495,8 @@ type DeliveryStreamDescription struct {
 	//
 	//    * DirectPut: Provider applications access the delivery stream directly.
 	//
-	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis stream as
-	//    a source.
+	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis data stream
+	//    as a source.
 	//
 	// DeliveryStreamType is a required field
 	DeliveryStreamType *string `type:"string" required:"true" enum:"DeliveryStreamType"`
@@ -1233,7 +1515,7 @@ type DeliveryStreamDescription struct {
 	LastUpdateTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// If the DeliveryStreamType parameter is KinesisStreamAsSource, a SourceDescription
-	// object describing the source Kinesis stream.
+	// object describing the source Kinesis data stream.
 	Source *SourceDescription `type:"structure"`
 
 	// Each time the destination is updated for a delivery stream, the version ID
@@ -1324,7 +1606,7 @@ type DescribeDeliveryStreamInput struct {
 	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
 
 	// The ID of the destination to start returning the destination information.
-	// Currently, Kinesis Firehose supports one destination per delivery stream.
+	// Currently, Kinesis Data Firehose supports one destination per delivery stream.
 	ExclusiveStartDestinationId *string `min:"1" type:"string"`
 
 	// The limit on the number of destinations to return. Currently, you can have
@@ -1559,31 +1841,32 @@ type ElasticsearchDestinationConfiguration struct {
 
 	// The Elasticsearch index rotation period. Index rotation appends a time stamp
 	// to the IndexName to facilitate the expiration of old data. For more information,
-	// see Index Rotation for Amazon Elasticsearch Service Destination (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation).
+	// see Index Rotation for the Amazon ES Destination (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation).
 	// The default value is OneDay.
 	IndexRotationPeriod *string `type:"string" enum:"ElasticsearchIndexRotationPeriod"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver documents
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver documents
 	// to Amazon ES. The default value is 300 (5 minutes).
 	RetryOptions *ElasticsearchRetryOptions `type:"structure"`
 
-	// The ARN of the IAM role to be assumed by Kinesis Firehose for calling the
-	// Amazon ES Configuration API and for indexing documents. For more information,
-	// see Amazon S3 Bucket Access (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
+	// The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data
+	// Firehose for calling the Amazon ES Configuration API and for indexing documents.
+	// For more information, see Grant Kinesis Data Firehose Access to an Amazon
+	// Destination (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
 
 	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
-	// Kinesis Firehose writes any documents that could not be indexed to the configured
-	// Amazon S3 destination, with elasticsearch-failed/ appended to the key prefix.
-	// When set to AllDocuments, Kinesis Firehose delivers all incoming records
-	// to Amazon S3, and also writes failed documents with elasticsearch-failed/
-	// appended to the prefix. For more information, see Amazon S3 Backup for Amazon
-	// Elasticsearch Service Destination (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-s3-backup).
+	// Kinesis Data Firehose writes any documents that could not be indexed to the
+	// configured Amazon S3 destination, with elasticsearch-failed/ appended to
+	// the key prefix. When set to AllDocuments, Kinesis Data Firehose delivers
+	// all incoming records to Amazon S3, and also writes failed documents with
+	// elasticsearch-failed/ appended to the prefix. For more information, see Data
+	// Delivery Failure Handling (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#retry).
 	// Default value is FailedDocumentsOnly.
 	S3BackupMode *string `type:"string" enum:"ElasticsearchS3BackupMode"`
 
@@ -1751,7 +2034,7 @@ type ElasticsearchDestinationDescription struct {
 	// The Amazon ES retry options.
 	RetryOptions *ElasticsearchRetryOptions `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
 
 	// The Amazon S3 backup mode.
@@ -1861,20 +2144,21 @@ type ElasticsearchDestinationUpdate struct {
 
 	// The Elasticsearch index rotation period. Index rotation appends a time stamp
 	// to IndexName to facilitate the expiration of old data. For more information,
-	// see Index Rotation for Amazon Elasticsearch Service Destination (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation).
+	// see Index Rotation for the Amazon ES Destination (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#es-index-rotation).
 	// Default value is OneDay.
 	IndexRotationPeriod *string `type:"string" enum:"ElasticsearchIndexRotationPeriod"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver documents
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver documents
 	// to Amazon ES. The default value is 300 (5 minutes).
 	RetryOptions *ElasticsearchRetryOptions `type:"structure"`
 
-	// The ARN of the IAM role to be assumed by Kinesis Firehose for calling the
-	// Amazon ES Configuration API and for indexing documents. For more information,
-	// see Amazon S3 Bucket Access (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
+	// The Amazon Resource Name (ARN) of the IAM role to be assumed by Kinesis Data
+	// Firehose for calling the Amazon ES Configuration API and for indexing documents.
+	// For more information, see Grant Kinesis Data Firehose Access to an Amazon
+	// S3 Destination (http://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-s3).
 	RoleARN *string `min:"1" type:"string"`
 
 	// The Amazon S3 destination.
@@ -1991,16 +2275,16 @@ func (s *ElasticsearchDestinationUpdate) SetTypeName(v string) *ElasticsearchDes
 	return s
 }
 
-// Configures retry behavior in case Kinesis Firehose is unable to deliver documents
-// to Amazon ES.
+// Configures retry behavior in case Kinesis Data Firehose is unable to deliver
+// documents to Amazon ES.
 type ElasticsearchRetryOptions struct {
 	_ struct{} `type:"structure"`
 
 	// After an initial failure to deliver to Amazon ES, the total amount of time
-	// during which Kinesis Firehose re-attempts delivery (including the first attempt).
-	// After this time has elapsed, the failed documents are written to Amazon S3.
-	// Default value is 300 seconds (5 minutes). A value of 0 (zero) results in
-	// no retries.
+	// during which Kinesis Data Firehose re-attempts delivery (including the first
+	// attempt). After this time has elapsed, the failed documents are written to
+	// Amazon S3. Default value is 300 seconds (5 minutes). A value of 0 (zero)
+	// results in no retries.
 	DurationInSeconds *int64 `type:"integer"`
 }
 
@@ -2092,16 +2376,17 @@ type ExtendedS3DestinationConfiguration struct {
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
-	// S3 files. You can specify an extra prefix to be added in front of the time
-	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// Amazon S3 files. You can specify an extra prefix to be added in front of
+	// the time format prefix. If the prefix ends with a slash, it appears as a
+	// folder in the S3 bucket. For more information, see Amazon S3 Object Name
+	// Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -2256,14 +2541,14 @@ type ExtendedS3DestinationDescription struct {
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
 	// S3 files. You can specify an extra prefix to be added in front of the time
 	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -2366,16 +2651,17 @@ type ExtendedS3DestinationUpdate struct {
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
-	// S3 files. You can specify an extra prefix to be added in front of the time
-	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// Amazon S3 files. You can specify an extra prefix to be added in front of
+	// the time format prefix. If the prefix ends with a slash, it appears as a
+	// folder in the S3 bucket. For more information, see Amazon S3 Object Name
+	// Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
 
 	// Enables or disables Amazon S3 backup mode.
@@ -2495,8 +2781,8 @@ func (s *ExtendedS3DestinationUpdate) SetS3BackupUpdate(v *S3DestinationUpdate) 
 type KMSEncryptionConfig struct {
 	_ struct{} `type:"structure"`
 
-	// The ARN of the encryption key. Must belong to the same region as the destination
-	// Amazon S3 bucket.
+	// The Amazon Resource Name (ARN) of the encryption key. Must belong to the
+	// same AWS Region as the destination Amazon S3 bucket.
 	//
 	// AWSKMSKeyARN is a required field
 	AWSKMSKeyARN *string `min:"1" type:"string" required:"true"`
@@ -2534,17 +2820,17 @@ func (s *KMSEncryptionConfig) SetAWSKMSKeyARN(v string) *KMSEncryptionConfig {
 	return s
 }
 
-// The stream and role ARNs for a Kinesis stream used as the source for a delivery
-// stream.
+// The stream and role Amazon Resource Names (ARNs) for a Kinesis data stream
+// used as the source for a delivery stream.
 type KinesisStreamSourceConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// The ARN of the source Kinesis stream.
+	// The ARN of the source Kinesis data stream.
 	//
 	// KinesisStreamARN is a required field
 	KinesisStreamARN *string `min:"1" type:"string" required:"true"`
 
-	// The ARN of the role that provides access to the source Kinesis stream.
+	// The ARN of the role that provides access to the source Kinesis data stream.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -2594,19 +2880,19 @@ func (s *KinesisStreamSourceConfiguration) SetRoleARN(v string) *KinesisStreamSo
 	return s
 }
 
-// Details about a Kinesis stream used as the source for a Kinesis Firehose
-// delivery stream.
+// Details about a Kinesis data stream used as the source for a Kinesis Data
+// Firehose delivery stream.
 type KinesisStreamSourceDescription struct {
 	_ struct{} `type:"structure"`
 
-	// Kinesis Firehose starts retrieving records from the Kinesis stream starting
-	// with this time stamp.
+	// Kinesis Data Firehose starts retrieving records from the Kinesis data stream
+	// starting with this time stamp.
 	DeliveryStartTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The ARN of the source Kinesis stream.
+	// The Amazon Resource Name (ARN) of the source Kinesis data stream.
 	KinesisStreamARN *string `min:"1" type:"string"`
 
-	// The ARN of the role used by the source Kinesis stream.
+	// The ARN of the role used by the source Kinesis data stream.
 	RoleARN *string `min:"1" type:"string"`
 }
 
@@ -2645,8 +2931,8 @@ type ListDeliveryStreamsInput struct {
 	//
 	//    * DirectPut: Provider applications access the delivery stream directly.
 	//
-	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis stream as
-	//    a source.
+	//    * KinesisStreamAsSource: The delivery stream uses a Kinesis data stream
+	//    as a source.
 	//
 	// This parameter is optional. If this parameter is omitted, delivery streams
 	// of all types are returned.
@@ -2736,6 +3022,114 @@ func (s *ListDeliveryStreamsOutput) SetDeliveryStreamNames(v []*string) *ListDel
 // SetHasMoreDeliveryStreams sets the HasMoreDeliveryStreams field's value.
 func (s *ListDeliveryStreamsOutput) SetHasMoreDeliveryStreams(v bool) *ListDeliveryStreamsOutput {
 	s.HasMoreDeliveryStreams = &v
+	return s
+}
+
+type ListTagsForDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the delivery stream whose tags you want to list.
+	//
+	// DeliveryStreamName is a required field
+	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
+
+	// The key to use as the starting point for the list of tags. If you set this
+	// parameter, ListTagsForDeliveryStream gets all tags that occur after ExclusiveStartTagKey.
+	ExclusiveStartTagKey *string `min:"1" type:"string"`
+
+	// The number of tags to return. If this number is less than the total number
+	// of tags associated with the delivery stream, HasMoreTags is set to true in
+	// the response. To list additional tags, set ExclusiveStartTagKey to the last
+	// key in the response.
+	Limit *int64 `min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s ListTagsForDeliveryStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForDeliveryStreamInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.ExclusiveStartTagKey != nil && len(*s.ExclusiveStartTagKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExclusiveStartTagKey", 1))
+	}
+	if s.Limit != nil && *s.Limit < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Limit", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *ListTagsForDeliveryStreamInput) SetDeliveryStreamName(v string) *ListTagsForDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetExclusiveStartTagKey sets the ExclusiveStartTagKey field's value.
+func (s *ListTagsForDeliveryStreamInput) SetExclusiveStartTagKey(v string) *ListTagsForDeliveryStreamInput {
+	s.ExclusiveStartTagKey = &v
+	return s
+}
+
+// SetLimit sets the Limit field's value.
+func (s *ListTagsForDeliveryStreamInput) SetLimit(v int64) *ListTagsForDeliveryStreamInput {
+	s.Limit = &v
+	return s
+}
+
+type ListTagsForDeliveryStreamOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If this is true in the response, more tags are available. To list the remaining
+	// tags, set ExclusiveStartTagKey to the key of the last tag returned and call
+	// ListTagsForDeliveryStream again.
+	//
+	// HasMoreTags is a required field
+	HasMoreTags *bool `type:"boolean" required:"true"`
+
+	// A list of tags associated with DeliveryStreamName, starting with the first
+	// tag after ExclusiveStartTagKey and up to the specified Limit.
+	//
+	// Tags is a required field
+	Tags []*Tag `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTagsForDeliveryStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForDeliveryStreamOutput) GoString() string {
+	return s.String()
+}
+
+// SetHasMoreTags sets the HasMoreTags field's value.
+func (s *ListTagsForDeliveryStreamOutput) SetHasMoreTags(v bool) *ListTagsForDeliveryStreamOutput {
+	s.HasMoreTags = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForDeliveryStreamOutput) SetTags(v []*Tag) *ListTagsForDeliveryStreamOutput {
+	s.Tags = v
 	return s
 }
 
@@ -3208,11 +3602,11 @@ type RedshiftDestinationConfiguration struct {
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver documents
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver documents
 	// to Amazon Redshift. Default value is 3600 (60 minutes).
 	RetryOptions *RedshiftRetryOptions `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -3395,11 +3789,11 @@ type RedshiftDestinationDescription struct {
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver documents
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver documents
 	// to Amazon Redshift. Default value is 3600 (60 minutes).
 	RetryOptions *RedshiftRetryOptions `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -3510,11 +3904,11 @@ type RedshiftDestinationUpdate struct {
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver documents
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver documents
 	// to Amazon Redshift. Default value is 3600 (60 minutes).
 	RetryOptions *RedshiftRetryOptions `type:"structure"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
 
 	// The Amazon S3 backup mode.
@@ -3652,15 +4046,15 @@ func (s *RedshiftDestinationUpdate) SetUsername(v string) *RedshiftDestinationUp
 	return s
 }
 
-// Configures retry behavior in case Kinesis Firehose is unable to deliver documents
-// to Amazon Redshift.
+// Configures retry behavior in case Kinesis Data Firehose is unable to deliver
+// documents to Amazon Redshift.
 type RedshiftRetryOptions struct {
 	_ struct{} `type:"structure"`
 
-	// The length of time during which Kinesis Firehose retries delivery after a
-	// failure, starting from the initial request and including the first attempt.
-	// The default value is 3600 seconds (60 minutes). Kinesis Firehose does not
-	// retry if the value of DurationInSeconds is 0 (zero) or if the first delivery
+	// The length of time during which Kinesis Data Firehose retries delivery after
+	// a failure, starting from the initial request and including the first attempt.
+	// The default value is 3600 seconds (60 minutes). Kinesis Data Firehose does
+	// not retry if the value of DurationInSeconds is 0 (zero) or if the first delivery
 	// attempt takes longer than the current value.
 	DurationInSeconds *int64 `type:"integer"`
 }
@@ -3709,13 +4103,14 @@ type S3DestinationConfiguration struct {
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
-	// S3 files. You can specify an extra prefix to be added in front of the time
-	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// Amazon S3 files. You can specify an extra prefix to be added in front of
+	// the time format prefix. If the prefix ends with a slash, it appears as a
+	// folder in the S3 bucket. For more information, see Amazon S3 Object Name
+	// Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -3835,13 +4230,14 @@ type S3DestinationDescription struct {
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure" required:"true"`
 
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
-	// S3 files. You can specify an extra prefix to be added in front of the time
-	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// Amazon S3 files. You can specify an extra prefix to be added in front of
+	// the time format prefix. If the prefix ends with a slash, it appears as a
+	// folder in the S3 bucket. For more information, see Amazon S3 Object Name
+	// Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	//
 	// RoleARN is a required field
 	RoleARN *string `min:"1" type:"string" required:"true"`
@@ -3925,13 +4321,14 @@ type S3DestinationUpdate struct {
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered
-	// S3 files. You can specify an extra prefix to be added in front of the time
-	// format prefix. If the prefix ends with a slash, it appears as a folder in
-	// the S3 bucket. For more information, see Amazon S3 Object Name Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)
-	// in the Amazon Kinesis Firehose Developer Guide.
+	// Amazon S3 files. You can specify an extra prefix to be added in front of
+	// the time format prefix. If the prefix ends with a slash, it appears as a
+	// folder in the S3 bucket. For more information, see Amazon S3 Object Name
+	// Format (http://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#s3-object-name)
+	// in the Amazon Kinesis Data Firehose Developer Guide.
 	Prefix *string `type:"string"`
 
-	// The ARN of the AWS credentials.
+	// The Amazon Resource Name (ARN) of the AWS credentials.
 	RoleARN *string `min:"1" type:"string"`
 }
 
@@ -4013,12 +4410,12 @@ func (s *S3DestinationUpdate) SetRoleARN(v string) *S3DestinationUpdate {
 	return s
 }
 
-// Details about a Kinesis stream used as the source for a Kinesis Firehose
-// delivery stream.
+// Details about a Kinesis data stream used as the source for a Kinesis Data
+// Firehose delivery stream.
 type SourceDescription struct {
 	_ struct{} `type:"structure"`
 
-	// The KinesisStreamSourceDescription value for the source Kinesis stream.
+	// The KinesisStreamSourceDescription value for the source Kinesis data stream.
 	KinesisStreamSourceDescription *KinesisStreamSourceDescription `type:"structure"`
 }
 
@@ -4045,25 +4442,25 @@ type SplunkDestinationConfiguration struct {
 	// The CloudWatch logging options for your delivery stream.
 	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
 
-	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
-	// from Splunk after it sends it data. At the end of the timeout period Kinesis
-	// Firehose either tries to send the data again or considers it an error, based
-	// on your retry settings.
+	// The amount of time that Kinesis Data Firehose waits to receive an acknowledgment
+	// from Splunk after it sends it data. At the end of the timeout period, Kinesis
+	// Data Firehose either tries to send the data again or considers it an error,
+	// based on your retry settings.
 	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
 
-	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
-	// data.
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends
+	// your data.
 	//
 	// HECEndpoint is a required field
 	HECEndpoint *string `type:"string" required:"true"`
 
-	// This type can be either "Raw" or "Event".
+	// This type can be either "Raw" or "Event."
 	//
 	// HECEndpointType is a required field
 	HECEndpointType *string `type:"string" required:"true" enum:"HECEndpointType"`
 
-	// This is a GUID you obtain from your Splunk cluster when you create a new
-	// HEC endpoint.
+	// This is a GUID that you obtain from your Splunk cluster when you create a
+	// new HEC endpoint.
 	//
 	// HECToken is a required field
 	HECToken *string `type:"string" required:"true"`
@@ -4071,13 +4468,13 @@ type SplunkDestinationConfiguration struct {
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver data to
-	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver data
+	// to Splunk, or if it doesn't receive an acknowledgment of receipt from Splunk.
 	RetryOptions *SplunkRetryOptions `type:"structure"`
 
 	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
-	// Kinesis Firehose writes any data that could not be indexed to the configured
-	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// Kinesis Data Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Data Firehose delivers
 	// all incoming records to Amazon S3, and also writes failed documents to Amazon
 	// S3. Default value is FailedDocumentsOnly.
 	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
@@ -4194,17 +4591,17 @@ type SplunkDestinationDescription struct {
 	// The CloudWatch logging options for your delivery stream.
 	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
 
-	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
-	// from Splunk after it sends it data. At the end of the timeout period Kinesis
-	// Firehose either tries to send the data again or considers it an error, based
-	// on your retry settings.
+	// The amount of time that Kinesis Data Firehose waits to receive an acknowledgment
+	// from Splunk after it sends it data. At the end of the timeout period, Kinesis
+	// Data Firehose either tries to send the data again or considers it an error,
+	// based on your retry settings.
 	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
 
-	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
-	// data.
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends
+	// your data.
 	HECEndpoint *string `type:"string"`
 
-	// This type can be either "Raw" or "Event".
+	// This type can be either "Raw" or "Event."
 	HECEndpointType *string `type:"string" enum:"HECEndpointType"`
 
 	// This is a GUID you obtain from your Splunk cluster when you create a new
@@ -4214,13 +4611,13 @@ type SplunkDestinationDescription struct {
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver data to
-	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver data
+	// to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
 	RetryOptions *SplunkRetryOptions `type:"structure"`
 
 	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
-	// Kinesis Firehose writes any data that could not be indexed to the configured
-	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// Kinesis Data Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Data Firehose delivers
 	// all incoming records to Amazon S3, and also writes failed documents to Amazon
 	// S3. Default value is FailedDocumentsOnly.
 	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
@@ -4300,33 +4697,33 @@ type SplunkDestinationUpdate struct {
 	// The CloudWatch logging options for your delivery stream.
 	CloudWatchLoggingOptions *CloudWatchLoggingOptions `type:"structure"`
 
-	// The amount of time that Kinesis Firehose waits to receive an acknowledgment
-	// from Splunk after it sends it data. At the end of the timeout period Kinesis
-	// Firehose either tries to send the data again or considers it an error, based
-	// on your retry settings.
+	// The amount of time that Kinesis Data Firehose waits to receive an acknowledgment
+	// from Splunk after it sends data. At the end of the timeout period, Kinesis
+	// Data Firehose either tries to send the data again or considers it an error,
+	// based on your retry settings.
 	HECAcknowledgmentTimeoutInSeconds *int64 `min:"180" type:"integer"`
 
-	// The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your
-	// data.
+	// The HTTP Event Collector (HEC) endpoint to which Kinesis Data Firehose sends
+	// your data.
 	HECEndpoint *string `type:"string"`
 
-	// This type can be either "Raw" or "Event".
+	// This type can be either "Raw" or "Event."
 	HECEndpointType *string `type:"string" enum:"HECEndpointType"`
 
-	// This is a GUID you obtain from your Splunk cluster when you create a new
-	// HEC endpoint.
+	// A GUID that you obtain from your Splunk cluster when you create a new HEC
+	// endpoint.
 	HECToken *string `type:"string"`
 
 	// The data processing configuration.
 	ProcessingConfiguration *ProcessingConfiguration `type:"structure"`
 
-	// The retry behavior in case Kinesis Firehose is unable to deliver data to
-	// Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
+	// The retry behavior in case Kinesis Data Firehose is unable to deliver data
+	// to Splunk or if it doesn't receive an acknowledgment of receipt from Splunk.
 	RetryOptions *SplunkRetryOptions `type:"structure"`
 
 	// Defines how documents should be delivered to Amazon S3. When set to FailedDocumentsOnly,
-	// Kinesis Firehose writes any data that could not be indexed to the configured
-	// Amazon S3 destination. When set to AllDocuments, Kinesis Firehose delivers
+	// Kinesis Data Firehose writes any data that could not be indexed to the configured
+	// Amazon S3 destination. When set to AllDocuments, Kinesis Data Firehose delivers
 	// all incoming records to Amazon S3, and also writes failed documents to Amazon
 	// S3. Default value is FailedDocumentsOnly.
 	S3BackupMode *string `type:"string" enum:"SplunkS3BackupMode"`
@@ -4422,15 +4819,15 @@ func (s *SplunkDestinationUpdate) SetS3Update(v *S3DestinationUpdate) *SplunkDes
 	return s
 }
 
-// Configures retry behavior in case Kinesis Firehose is unable to deliver documents
-// to Splunk or if it doesn't receive an acknowledgment from Splunk.
+// Configures retry behavior in case Kinesis Data Firehose is unable to deliver
+// documents to Splunk, or if it doesn't receive an acknowledgment from Splunk.
 type SplunkRetryOptions struct {
 	_ struct{} `type:"structure"`
 
-	// The total amount of time that Kinesis Firehose spends on retries. This duration
-	// starts after the initial attempt to send data to Splunk fails and doesn't
-	// include the periods during which Kinesis Firehose waits for acknowledgment
-	// from Splunk after each attempt.
+	// The total amount of time that Kinesis Data Firehose spends on retries. This
+	// duration starts after the initial attempt to send data to Splunk fails. It
+	// doesn't include the periods during which Kinesis Data Firehose waits for
+	// acknowledgment from Splunk after each attempt.
 	DurationInSeconds *int64 `type:"integer"`
 }
 
@@ -4450,11 +4847,220 @@ func (s *SplunkRetryOptions) SetDurationInSeconds(v int64) *SplunkRetryOptions {
 	return s
 }
 
+// Metadata that you can assign to a delivery stream, consisting of a key-value
+// pair.
+type Tag struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for the tag. Maximum length: 128 characters. Valid characters:
+	// Unicode letters, digits, white space, _ . / = + - % @
+	//
+	// Key is a required field
+	Key *string `min:"1" type:"string" required:"true"`
+
+	// An optional string, which you can use to describe or define the tag. Maximum
+	// length: 256 characters. Valid characters: Unicode letters, digits, white
+	// space, _ . / = + - % @
+	Value *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Tag) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Tag"}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
+type TagDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the delivery stream to which you want to add the tags.
+	//
+	// DeliveryStreamName is a required field
+	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
+
+	// A set of key-value pairs to use to create the tags.
+	//
+	// Tags is a required field
+	Tags []*Tag `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s TagDeliveryStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagDeliveryStreamInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+	if s.Tags != nil && len(s.Tags) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Tags", 1))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *TagDeliveryStreamInput) SetDeliveryStreamName(v string) *TagDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagDeliveryStreamInput) SetTags(v []*Tag) *TagDeliveryStreamInput {
+	s.Tags = v
+	return s
+}
+
+type TagDeliveryStreamOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagDeliveryStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagDeliveryStreamOutput) GoString() string {
+	return s.String()
+}
+
+type UntagDeliveryStreamInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the delivery stream.
+	//
+	// DeliveryStreamName is a required field
+	DeliveryStreamName *string `min:"1" type:"string" required:"true"`
+
+	// A list of tag keys. Each corresponding tag is removed from the delivery stream.
+	//
+	// TagKeys is a required field
+	TagKeys []*string `min:"1" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UntagDeliveryStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagDeliveryStreamInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UntagDeliveryStreamInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UntagDeliveryStreamInput"}
+	if s.DeliveryStreamName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DeliveryStreamName"))
+	}
+	if s.DeliveryStreamName != nil && len(*s.DeliveryStreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeliveryStreamName", 1))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+	if s.TagKeys != nil && len(s.TagKeys) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TagKeys", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDeliveryStreamName sets the DeliveryStreamName field's value.
+func (s *UntagDeliveryStreamInput) SetDeliveryStreamName(v string) *UntagDeliveryStreamInput {
+	s.DeliveryStreamName = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagDeliveryStreamInput) SetTagKeys(v []*string) *UntagDeliveryStreamInput {
+	s.TagKeys = v
+	return s
+}
+
+type UntagDeliveryStreamOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagDeliveryStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagDeliveryStreamOutput) GoString() string {
+	return s.String()
+}
+
 type UpdateDestinationInput struct {
 	_ struct{} `type:"structure"`
 
 	// Obtain this value from the VersionId result of DeliveryStreamDescription.
-	// This value is required, and helps the service to perform conditional operations.
+	// This value is required, and it helps the service perform conditional operations.
 	// For example, if there is an interleaving update and this value is null, then
 	// the update destination fails. After the update is successful, the VersionId
 	// value is updated. The service then performs a merge of the old configuration

--- a/service/firehose/doc.go
+++ b/service/firehose/doc.go
@@ -3,9 +3,9 @@
 // Package firehose provides the client and types for making API
 // requests to Amazon Kinesis Firehose.
 //
-// Amazon Kinesis Firehose is a fully managed service that delivers real-time
+// Amazon Kinesis Data Firehose is a fully managed service that delivers real-time
 // streaming data to destinations such as Amazon Simple Storage Service (Amazon
-// S3), Amazon Elasticsearch Service (Amazon ES), and Amazon Redshift.
+// S3), Amazon Elasticsearch Service (Amazon ES), Amazon Redshift, and Splunk.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/firehose-2015-08-04 for more information on this service.
 //

--- a/service/firehose/errors.go
+++ b/service/firehose/errors.go
@@ -38,9 +38,9 @@ const (
 	// ErrCodeServiceUnavailableException for service response error code
 	// "ServiceUnavailableException".
 	//
-	// The service is unavailable, back off and retry the operation. If you continue
+	// The service is unavailable. Back off and retry the operation. If you continue
 	// to see the exception, throughput limits for the delivery stream may have
 	// been exceeded. For more information about limits and how to request an increase,
-	// see Amazon Kinesis Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
+	// see Amazon Kinesis Data Firehose Limits (http://docs.aws.amazon.com/firehose/latest/dev/limits.html).
 	ErrCodeServiceUnavailableException = "ServiceUnavailableException"
 )

--- a/service/firehose/firehoseiface/interface.go
+++ b/service/firehose/firehoseiface/interface.go
@@ -76,6 +76,10 @@ type FirehoseAPI interface {
 	ListDeliveryStreamsWithContext(aws.Context, *firehose.ListDeliveryStreamsInput, ...request.Option) (*firehose.ListDeliveryStreamsOutput, error)
 	ListDeliveryStreamsRequest(*firehose.ListDeliveryStreamsInput) (*request.Request, *firehose.ListDeliveryStreamsOutput)
 
+	ListTagsForDeliveryStream(*firehose.ListTagsForDeliveryStreamInput) (*firehose.ListTagsForDeliveryStreamOutput, error)
+	ListTagsForDeliveryStreamWithContext(aws.Context, *firehose.ListTagsForDeliveryStreamInput, ...request.Option) (*firehose.ListTagsForDeliveryStreamOutput, error)
+	ListTagsForDeliveryStreamRequest(*firehose.ListTagsForDeliveryStreamInput) (*request.Request, *firehose.ListTagsForDeliveryStreamOutput)
+
 	PutRecord(*firehose.PutRecordInput) (*firehose.PutRecordOutput, error)
 	PutRecordWithContext(aws.Context, *firehose.PutRecordInput, ...request.Option) (*firehose.PutRecordOutput, error)
 	PutRecordRequest(*firehose.PutRecordInput) (*request.Request, *firehose.PutRecordOutput)
@@ -83,6 +87,14 @@ type FirehoseAPI interface {
 	PutRecordBatch(*firehose.PutRecordBatchInput) (*firehose.PutRecordBatchOutput, error)
 	PutRecordBatchWithContext(aws.Context, *firehose.PutRecordBatchInput, ...request.Option) (*firehose.PutRecordBatchOutput, error)
 	PutRecordBatchRequest(*firehose.PutRecordBatchInput) (*request.Request, *firehose.PutRecordBatchOutput)
+
+	TagDeliveryStream(*firehose.TagDeliveryStreamInput) (*firehose.TagDeliveryStreamOutput, error)
+	TagDeliveryStreamWithContext(aws.Context, *firehose.TagDeliveryStreamInput, ...request.Option) (*firehose.TagDeliveryStreamOutput, error)
+	TagDeliveryStreamRequest(*firehose.TagDeliveryStreamInput) (*request.Request, *firehose.TagDeliveryStreamOutput)
+
+	UntagDeliveryStream(*firehose.UntagDeliveryStreamInput) (*firehose.UntagDeliveryStreamOutput, error)
+	UntagDeliveryStreamWithContext(aws.Context, *firehose.UntagDeliveryStreamInput, ...request.Option) (*firehose.UntagDeliveryStreamOutput, error)
+	UntagDeliveryStreamRequest(*firehose.UntagDeliveryStreamInput) (*request.Request, *firehose.UntagDeliveryStreamOutput)
 
 	UpdateDestination(*firehose.UpdateDestinationInput) (*firehose.UpdateDestinationOutput, error)
 	UpdateDestinationWithContext(aws.Context, *firehose.UpdateDestinationInput, ...request.Option) (*firehose.UpdateDestinationOutput, error)

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -3248,6 +3248,8 @@ type CaptionDestinationSettings struct {
 
 	EmbeddedPlusScte20DestinationSettings *EmbeddedPlusScte20DestinationSettings `locationName:"embeddedPlusScte20DestinationSettings" type:"structure"`
 
+	RtmpCaptionInfoDestinationSettings *RtmpCaptionInfoDestinationSettings `locationName:"rtmpCaptionInfoDestinationSettings" type:"structure"`
+
 	Scte20PlusEmbeddedDestinationSettings *Scte20PlusEmbeddedDestinationSettings `locationName:"scte20PlusEmbeddedDestinationSettings" type:"structure"`
 
 	Scte27DestinationSettings *Scte27DestinationSettings `locationName:"scte27DestinationSettings" type:"structure"`
@@ -3318,6 +3320,12 @@ func (s *CaptionDestinationSettings) SetEmbeddedDestinationSettings(v *EmbeddedD
 // SetEmbeddedPlusScte20DestinationSettings sets the EmbeddedPlusScte20DestinationSettings field's value.
 func (s *CaptionDestinationSettings) SetEmbeddedPlusScte20DestinationSettings(v *EmbeddedPlusScte20DestinationSettings) *CaptionDestinationSettings {
 	s.EmbeddedPlusScte20DestinationSettings = v
+	return s
+}
+
+// SetRtmpCaptionInfoDestinationSettings sets the RtmpCaptionInfoDestinationSettings field's value.
+func (s *CaptionDestinationSettings) SetRtmpCaptionInfoDestinationSettings(v *RtmpCaptionInfoDestinationSettings) *CaptionDestinationSettings {
+	s.RtmpCaptionInfoDestinationSettings = v
 	return s
 }
 
@@ -7353,7 +7361,7 @@ type InputLocation struct {
 
 	// Uniform Resource Identifier - This should be a path to a file accessible
 	// to the Live system (eg. a http:// URI) depending on the output type. For
-	// example, a rtmpEndpoint should have a uri simliar to: "rtmp://fmsserver/live".
+	// example, a RTMP destination should have a uri simliar to: "rtmp://fmsserver/live".
 	//
 	// Uri is a required field
 	Uri *string `locationName:"uri" type:"string" required:"true"`
@@ -8705,6 +8713,11 @@ type M3u8Settings struct {
 	// When set to passthrough, timed metadata is passed through from input to output.
 	TimedMetadataBehavior *string `locationName:"timedMetadataBehavior" type:"string" enum:"M3u8TimedMetadataBehavior"`
 
+	// Packet Identifier (PID) of the timed metadata stream in the transport stream.
+	// Can be entered as a decimal or hexadecimal value. Valid values are 32 (or
+	// 0x20)..8182 (or 0x1ff6).
+	TimedMetadataPid *string `locationName:"timedMetadataPid" type:"string"`
+
 	// The value of the transport stream ID field in the Program Map Table.
 	TransportStreamId *int64 `locationName:"transportStreamId" type:"integer"`
 
@@ -8801,6 +8814,12 @@ func (s *M3u8Settings) SetTimedMetadataBehavior(v string) *M3u8Settings {
 	return s
 }
 
+// SetTimedMetadataPid sets the TimedMetadataPid field's value.
+func (s *M3u8Settings) SetTimedMetadataPid(v string) *M3u8Settings {
+	s.TimedMetadataPid = &v
+	return s
+}
+
 // SetTransportStreamId sets the TransportStreamId field's value.
 func (s *M3u8Settings) SetTransportStreamId(v int64) *M3u8Settings {
 	s.TransportStreamId = &v
@@ -8869,8 +8888,7 @@ type MsSmoothGroupSettings struct {
 
 	// If set to verifyAuthenticity, verify the https certificate chain to a trusted
 	// Certificate Authority (CA). This will cause https outputs to self-signed
-	// certificates to fail unless those certificates are manually added to the
-	// OS trusted keystore.
+	// certificates to fail.
 	CertificateMode *string `locationName:"certificateMode" type:"string" enum:"SmoothGroupCertificateMode"`
 
 	// Number of seconds to wait before retrying connection to the IIS server if
@@ -9273,6 +9291,9 @@ type OutputDestinationSettings struct {
 	// key used to extract the password from EC2 Parameter store
 	PasswordParam *string `locationName:"passwordParam" type:"string"`
 
+	// Stream name for RTMP destinations (URLs of type rtmp://)
+	StreamName *string `locationName:"streamName" type:"string"`
+
 	// A URL specifying a destination
 	Url *string `locationName:"url" type:"string"`
 
@@ -9293,6 +9314,12 @@ func (s OutputDestinationSettings) GoString() string {
 // SetPasswordParam sets the PasswordParam field's value.
 func (s *OutputDestinationSettings) SetPasswordParam(v string) *OutputDestinationSettings {
 	s.PasswordParam = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *OutputDestinationSettings) SetStreamName(v string) *OutputDestinationSettings {
+	s.StreamName = &v
 	return s
 }
 
@@ -9394,6 +9421,8 @@ type OutputGroupSettings struct {
 
 	MsSmoothGroupSettings *MsSmoothGroupSettings `locationName:"msSmoothGroupSettings" type:"structure"`
 
+	RtmpGroupSettings *RtmpGroupSettings `locationName:"rtmpGroupSettings" type:"structure"`
+
 	UdpGroupSettings *UdpGroupSettings `locationName:"udpGroupSettings" type:"structure"`
 }
 
@@ -9425,6 +9454,11 @@ func (s *OutputGroupSettings) Validate() error {
 			invalidParams.AddNested("MsSmoothGroupSettings", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.RtmpGroupSettings != nil {
+		if err := s.RtmpGroupSettings.Validate(); err != nil {
+			invalidParams.AddNested("RtmpGroupSettings", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9447,6 +9481,12 @@ func (s *OutputGroupSettings) SetHlsGroupSettings(v *HlsGroupSettings) *OutputGr
 // SetMsSmoothGroupSettings sets the MsSmoothGroupSettings field's value.
 func (s *OutputGroupSettings) SetMsSmoothGroupSettings(v *MsSmoothGroupSettings) *OutputGroupSettings {
 	s.MsSmoothGroupSettings = v
+	return s
+}
+
+// SetRtmpGroupSettings sets the RtmpGroupSettings field's value.
+func (s *OutputGroupSettings) SetRtmpGroupSettings(v *RtmpGroupSettings) *OutputGroupSettings {
+	s.RtmpGroupSettings = v
 	return s
 }
 
@@ -9488,6 +9528,8 @@ type OutputSettings struct {
 
 	MsSmoothOutputSettings *MsSmoothOutputSettings `locationName:"msSmoothOutputSettings" type:"structure"`
 
+	RtmpOutputSettings *RtmpOutputSettings `locationName:"rtmpOutputSettings" type:"structure"`
+
 	UdpOutputSettings *UdpOutputSettings `locationName:"udpOutputSettings" type:"structure"`
 }
 
@@ -9512,6 +9554,11 @@ func (s *OutputSettings) Validate() error {
 	if s.HlsOutputSettings != nil {
 		if err := s.HlsOutputSettings.Validate(); err != nil {
 			invalidParams.AddNested("HlsOutputSettings", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RtmpOutputSettings != nil {
+		if err := s.RtmpOutputSettings.Validate(); err != nil {
+			invalidParams.AddNested("RtmpOutputSettings", err.(request.ErrInvalidParams))
 		}
 	}
 	if s.UdpOutputSettings != nil {
@@ -9541,6 +9588,12 @@ func (s *OutputSettings) SetHlsOutputSettings(v *HlsOutputSettings) *OutputSetti
 // SetMsSmoothOutputSettings sets the MsSmoothOutputSettings field's value.
 func (s *OutputSettings) SetMsSmoothOutputSettings(v *MsSmoothOutputSettings) *OutputSettings {
 	s.MsSmoothOutputSettings = v
+	return s
+}
+
+// SetRtmpOutputSettings sets the RtmpOutputSettings field's value.
+func (s *OutputSettings) SetRtmpOutputSettings(v *RtmpOutputSettings) *OutputSettings {
+	s.RtmpOutputSettings = v
 	return s
 }
 
@@ -9633,6 +9686,176 @@ func (s *RemixSettings) SetChannelsIn(v int64) *RemixSettings {
 // SetChannelsOut sets the ChannelsOut field's value.
 func (s *RemixSettings) SetChannelsOut(v int64) *RemixSettings {
 	s.ChannelsOut = &v
+	return s
+}
+
+type RtmpCaptionInfoDestinationSettings struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s RtmpCaptionInfoDestinationSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RtmpCaptionInfoDestinationSettings) GoString() string {
+	return s.String()
+}
+
+type RtmpGroupSettings struct {
+	_ struct{} `type:"structure"`
+
+	// Authentication scheme to use when connecting with CDN
+	AuthenticationScheme *string `locationName:"authenticationScheme" type:"string" enum:"AuthenticationScheme"`
+
+	// Controls behavior when content cache fills up. If remote origin server stalls
+	// the RTMP connection and does not accept content fast enough the 'Media Cache'
+	// will fill up. When the cache reaches the duration specified by cacheLength
+	// the cache will stop accepting new content. If set to disconnectImmediately,
+	// the RTMP output will force a disconnect. Clear the media cache, and reconnect
+	// after restartDelay seconds. If set to waitForServer, the RTMP output will
+	// wait up to 5 minutes to allow the origin server to begin accepting data again.
+	CacheFullBehavior *string `locationName:"cacheFullBehavior" type:"string" enum:"RtmpCacheFullBehavior"`
+
+	// Cache length, in seconds, is used to calculate buffer size.
+	CacheLength *int64 `locationName:"cacheLength" min:"30" type:"integer"`
+
+	// Controls the types of data that passes to onCaptionInfo outputs. If set to
+	// 'all' then 608 and 708 carried DTVCC data will be passed. If set to 'field1AndField2608'
+	// then DTVCC data will be stripped out, but 608 data from both fields will
+	// be passed. If set to 'field1608' then only the data carried in 608 from field
+	// 1 video will be passed.
+	CaptionData *string `locationName:"captionData" type:"string" enum:"RtmpCaptionData"`
+
+	// If a streaming output fails, number of seconds to wait until a restart is
+	// initiated. A value of 0 means never restart.
+	RestartDelay *int64 `locationName:"restartDelay" type:"integer"`
+}
+
+// String returns the string representation
+func (s RtmpGroupSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RtmpGroupSettings) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RtmpGroupSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RtmpGroupSettings"}
+	if s.CacheLength != nil && *s.CacheLength < 30 {
+		invalidParams.Add(request.NewErrParamMinValue("CacheLength", 30))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAuthenticationScheme sets the AuthenticationScheme field's value.
+func (s *RtmpGroupSettings) SetAuthenticationScheme(v string) *RtmpGroupSettings {
+	s.AuthenticationScheme = &v
+	return s
+}
+
+// SetCacheFullBehavior sets the CacheFullBehavior field's value.
+func (s *RtmpGroupSettings) SetCacheFullBehavior(v string) *RtmpGroupSettings {
+	s.CacheFullBehavior = &v
+	return s
+}
+
+// SetCacheLength sets the CacheLength field's value.
+func (s *RtmpGroupSettings) SetCacheLength(v int64) *RtmpGroupSettings {
+	s.CacheLength = &v
+	return s
+}
+
+// SetCaptionData sets the CaptionData field's value.
+func (s *RtmpGroupSettings) SetCaptionData(v string) *RtmpGroupSettings {
+	s.CaptionData = &v
+	return s
+}
+
+// SetRestartDelay sets the RestartDelay field's value.
+func (s *RtmpGroupSettings) SetRestartDelay(v int64) *RtmpGroupSettings {
+	s.RestartDelay = &v
+	return s
+}
+
+type RtmpOutputSettings struct {
+	_ struct{} `type:"structure"`
+
+	// If set to verifyAuthenticity, verify the tls certificate chain to a trusted
+	// Certificate Authority (CA). This will cause rtmps outputs with self-signed
+	// certificates to fail.
+	CertificateMode *string `locationName:"certificateMode" type:"string" enum:"RtmpOutputCertificateMode"`
+
+	// Number of seconds to wait before retrying a connection to the Flash Media
+	// server if the connection is lost.
+	ConnectionRetryInterval *int64 `locationName:"connectionRetryInterval" min:"1" type:"integer"`
+
+	// The RTMP endpoint excluding the stream name (eg. rtmp://host/appname). For
+	// connection to Akamai, a username and password must be supplied. URI fields
+	// accept format identifiers.
+	//
+	// Destination is a required field
+	Destination *OutputLocationRef `locationName:"destination" type:"structure" required:"true"`
+
+	// Number of retry attempts.
+	NumRetries *int64 `locationName:"numRetries" type:"integer"`
+}
+
+// String returns the string representation
+func (s RtmpOutputSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RtmpOutputSettings) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RtmpOutputSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RtmpOutputSettings"}
+	if s.ConnectionRetryInterval != nil && *s.ConnectionRetryInterval < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("ConnectionRetryInterval", 1))
+	}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCertificateMode sets the CertificateMode field's value.
+func (s *RtmpOutputSettings) SetCertificateMode(v string) *RtmpOutputSettings {
+	s.CertificateMode = &v
+	return s
+}
+
+// SetConnectionRetryInterval sets the ConnectionRetryInterval field's value.
+func (s *RtmpOutputSettings) SetConnectionRetryInterval(v int64) *RtmpOutputSettings {
+	s.ConnectionRetryInterval = &v
+	return s
+}
+
+// SetDestination sets the Destination field's value.
+func (s *RtmpOutputSettings) SetDestination(v *OutputLocationRef) *RtmpOutputSettings {
+	s.Destination = v
+	return s
+}
+
+// SetNumRetries sets the NumRetries field's value.
+func (s *RtmpOutputSettings) SetNumRetries(v int64) *RtmpOutputSettings {
+	s.NumRetries = &v
 	return s
 }
 
@@ -11363,6 +11586,14 @@ const (
 )
 
 const (
+	// AuthenticationSchemeAkamai is a AuthenticationScheme enum value
+	AuthenticationSchemeAkamai = "AKAMAI"
+
+	// AuthenticationSchemeCommon is a AuthenticationScheme enum value
+	AuthenticationSchemeCommon = "COMMON"
+)
+
+const (
 	// AvailBlankingStateDisabled is a AvailBlankingState enum value
 	AvailBlankingStateDisabled = "DISABLED"
 
@@ -12566,6 +12797,33 @@ const (
 
 	// NetworkInputServerValidationCheckCryptographyOnly is a NetworkInputServerValidation enum value
 	NetworkInputServerValidationCheckCryptographyOnly = "CHECK_CRYPTOGRAPHY_ONLY"
+)
+
+const (
+	// RtmpCacheFullBehaviorDisconnectImmediately is a RtmpCacheFullBehavior enum value
+	RtmpCacheFullBehaviorDisconnectImmediately = "DISCONNECT_IMMEDIATELY"
+
+	// RtmpCacheFullBehaviorWaitForServer is a RtmpCacheFullBehavior enum value
+	RtmpCacheFullBehaviorWaitForServer = "WAIT_FOR_SERVER"
+)
+
+const (
+	// RtmpCaptionDataAll is a RtmpCaptionData enum value
+	RtmpCaptionDataAll = "ALL"
+
+	// RtmpCaptionDataField1608 is a RtmpCaptionData enum value
+	RtmpCaptionDataField1608 = "FIELD1_608"
+
+	// RtmpCaptionDataField1AndField2608 is a RtmpCaptionData enum value
+	RtmpCaptionDataField1AndField2608 = "FIELD1_AND_FIELD2_608"
+)
+
+const (
+	// RtmpOutputCertificateModeSelfSigned is a RtmpOutputCertificateMode enum value
+	RtmpOutputCertificateModeSelfSigned = "SELF_SIGNED"
+
+	// RtmpOutputCertificateModeVerifyAuthenticity is a RtmpOutputCertificateMode enum value
+	RtmpOutputCertificateModeVerifyAuthenticity = "VERIFY_AUTHENTICITY"
 )
 
 const (


### PR DESCRIPTION
Release v1.13.34 (2018-04-20)
===

### Service Client Updates
* `service/firehose`: Updates service API and documentation
  * With this release, Amazon Kinesis Data Firehose allows you to tag your delivery streams. Tags are metadata that you can create and use to manage your delivery streams. For more information about tagging, see AWS Tagging Strategies. For technical documentation, look for the tagging operations in the Amazon Kinesis Firehose API reference.
* `service/medialive`: Updates service API and documentation
  * With AWS Elemental MediaLive you can now output live channels as RTMP (Real-Time Messaging Protocol) and RTMPS as the encrypted version of the protocol (Secure, over SSL/TLS). RTMP is the preferred protocol for sending live streams to popular social platforms which  means you can send live channel content to social and sharing platforms in a secure and reliable way while continuing to stream to your own website, app or network.

