### PR TITLE
Fix infinite loop on cloudwatchlogs GetLogEventsPages

### DIFF
--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -37,6 +37,7 @@ type Pagination struct {
 	NewRequest func() (*Request, error)
 
 	started    bool
+	prevTokens []interface{}
 	nextTokens []interface{}
 
 	err     error
@@ -49,7 +50,7 @@ type Pagination struct {
 //
 // Will always return true if Next has not been called yet.
 func (p *Pagination) HasNextPage() bool {
-	return !(p.started && len(p.nextTokens) == 0)
+	return !(p.started && (len(p.nextTokens) == 0 || awsutil.DeepEqual(p.nextTokens, p.prevTokens)))
 }
 
 // Err returns the error Pagination encountered when retrieving the next page.
@@ -96,6 +97,7 @@ func (p *Pagination) Next() bool {
 		return false
 	}
 
+	p.prevTokens = p.nextTokens
 	p.nextTokens = req.nextPageTokens()
 	p.curPage = req.Data
 

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -477,6 +477,11 @@ func TestPagination_Standalone(t *testing.T) {
 			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
 			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), aws.String("")},
 		},
+		{
+			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+			testCase{nil, aws.String("SecondToken"), aws.String("SecondToken")},
+		},
 	}
 
 	for _, c := range cases {

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -468,7 +468,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("1"),
 				},
 			},
-			NextMarker:  aws.String("marker"),
+			NextMarker:  aws.String("1stMarker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{
@@ -477,7 +477,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("2"),
 				},
 			},
-			NextMarker:  aws.String("marker"),
+			NextMarker:  aws.String("2ndMarker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{


### PR DESCRIPTION
Cloudwatch log event responses always include the next token even when there are no more results and pagination will never terminate.

More details https://github.com/aws/aws-sdk-ruby/issues/712

This replicates a similar fix applied to the ruby aws-sdk https://github.com/aws/aws-sdk-ruby/pull/730
