### PR TITLE
aws/endpoints: Add Get Region description

### DIFF
--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -206,9 +206,10 @@ func (p Partition) EndpointFor(service, region string, opts ...func(*Options)) (
 // enumerating over the regions in a partition.
 func (p Partition) Regions() map[string]Region {
 	rs := map[string]Region{}
-	for id := range p.p.Regions {
+	for id, r := range p.p.Regions {
 		rs[id] = Region{
 			id: id,
+			desc: r.Description,
 			p:  p.p,
 		}
 	}
@@ -239,6 +240,10 @@ type Region struct {
 
 // ID returns the region's identifier.
 func (r Region) ID() string { return r.id }
+
+// Description returns the region's description. The region description
+// is free text, it can be empty, and it may change between SDK releases.
+func (r Region) Description() string { return r.desc }
 
 // ResolveEndpoint resolves an endpoint from the context of the region given
 // a service. See Partition.EndpointFor for usage and errors that can be returned.
@@ -284,9 +289,10 @@ func (s Service) ResolveEndpoint(region string, opts ...func(*Options)) (Resolve
 func (s Service) Regions() map[string]Region {
 	rs := map[string]Region{}
 	for id := range s.p.Services[s.id].Endpoints {
-		if _, ok := s.p.Regions[id]; ok {
+		if r, ok := s.p.Regions[id]; ok {
 			rs[id] = Region{
 				id: id,
+				desc: r.Description,
 				p:  s.p,
 			}
 		}

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -65,6 +65,10 @@ func TestEnumRegionServices(t *testing.T) {
 		t.Errorf("expect %q region ID, got %q", e, a)
 	}
 
+	if a, e := r.Description(), "region description"; a != e {
+		t.Errorf("expect %q region Description, got %q", e, a)
+	}
+
 	ss := r.Services()
 	if a, e := len(ss), 1; a != e {
 		t.Errorf("expect %d services for us-east-1, got %d", e, a)
@@ -290,6 +294,9 @@ func TestRegionsForService(t *testing.T) {
 		}
 		if _, ok := expect[id]; !ok {
 			t.Errorf("expect %s region to be found", id)
+		}
+		if a, e := r.Description(), expect[id].desc; a != e {
+			t.Errorf("expect %q region Description, got %q", e, a)
 		}
 	}
 }


### PR DESCRIPTION
Exposing the description field of the Region struct.
Issue for this PR is: https://github.com/aws/aws-sdk-go/issues/1194