### PR TITLE
v1.13.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Release v1.13.43 (2018-05-07)
+===
+
+### Service Client Updates
+* `service/alexaforbusiness`: Updates service API
+* `service/budgets`: Updates service API and documentation
+  * "With this release, customers can use AWS Budgets to monitor how much of their Amazon EC2, Amazon RDS, Amazon Redshift, and Amazon ElastiCache instance usage is covered by reservations, and receive alerts when their coverage falls below the threshold they define."
+* `aws/endpoints`: Updated Regions and Endpoints metadata.
+* `service/es`: Updates service API, documentation, and paginators
+  * This change brings support for Reserved Instances to AWS Elasticsearch.
+* `service/s3`: Updates service API and documentation
+  * Added BytesReturned details for Progress and Stats Events for Amazon S3 Select .
+
 Release v1.13.42 (2018-05-04)
 ===
 

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1437,12 +1437,15 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
@@ -2268,6 +2271,7 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"eu-west-1": endpoint{},
 				"us-east-1": endpoint{},
 				"us-east-2": endpoint{},
 				"us-west-2": endpoint{},
@@ -2294,6 +2298,7 @@ var awsPartition = partition{
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.42"
+const SDKVersion = "1.13.43"

--- a/models/apis/alexaforbusiness/2017-11-09/api-2.json
+++ b/models/apis/alexaforbusiness/2017-11-09/api-2.json
@@ -966,7 +966,10 @@
     },
     "DeviceEventType":{
       "type":"string",
-      "enum":["CONNECTION_STATUS"]
+      "enum":[
+        "CONNECTION_STATUS",
+        "DEVICE_STATUS"
+      ]
     },
     "DeviceEventValue":{"type":"string"},
     "DeviceName":{
@@ -984,7 +987,8 @@
       "enum":[
         "READY",
         "PENDING",
-        "WAS_OFFLINE"
+        "WAS_OFFLINE",
+        "DEREGISTERED"
       ]
     },
     "DeviceStatusDetail":{

--- a/models/apis/budgets/2016-10-20/api-2.json
+++ b/models/apis/budgets/2016-10-20/api-2.json
@@ -242,7 +242,8 @@
       "enum":[
         "USAGE",
         "COST",
-        "RI_UTILIZATION"
+        "RI_UTILIZATION",
+        "RI_COVERAGE"
       ]
     },
     "Budgets":{

--- a/models/apis/budgets/2016-10-20/docs-2.json
+++ b/models/apis/budgets/2016-10-20/docs-2.json
@@ -1,28 +1,28 @@
 {
   "version": "2.0",
-  "service": "<p>Budgets enable you to plan your service usage, service costs, and your RI utilization. You can also track how close your plan is to your budgeted amount or to the free tier limits. Budgets provide you with a quick way to see your usage-to-date and current estimated charges from AWS and to see how much your predicted usage accrues in charges by the end of the month. Budgets also compare current estimates and charges to the amount that you indicated you want to use or spend and lets you see how much of your budget has been used. AWS updates your budget status several times a day. Budgets track your unblended costs, subscriptions, and refunds. You can create the following types of budgets:</p> <ul> <li> <p>Cost budgets allow you to say how much you want to spend on a service.</p> </li> <li> <p>Usage budgets allow you to say how many hours you want to use for one or more services.</p> </li> <li> <p>RI utilization budgets allow you to define a utilization threshold and receive alerts when RIs are tracking below that threshold.</p> </li> </ul> <p>You can create up to 20,000 budgets per AWS master account. Your first two budgets are free of charge. Each additional budget costs $0.02 per day. You can set up optional notifications that warn you if you exceed, or are forecasted to exceed, your budgeted amount. You can have notifications sent to an Amazon SNS topic, to an email address, or to both. For more information, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-sns-policy.html\">Creating an Amazon SNS Topic for Budget Notifications</a>. AWS Free Tier usage alerts via AWS Budgets are provided for you, and do not count toward your budget limits.</p> <p>Service Endpoint</p> <p>The AWS Budgets API provides the following endpoint:</p> <ul> <li> <p>https://budgets.us-east-1.amazonaws.com</p> </li> </ul>",
+  "service": "<p>The AWS Budgets API enables you to use AWS Budgets to plan your service usage, service costs, and instance reservations. The API reference provides descriptions, syntax, and usage examples for each of the actions and data types for AWS Budgets. </p> <p>Budgets provide you with a way to see the following information:</p> <ul> <li> <p>How close your plan is to your budgeted amount or to the free tier limits</p> </li> <li> <p>Your usage-to-date, including how much you've used of your Reserved Instances (RIs)</p> </li> <li> <p>Your current estimated charges from AWS, and how much your predicted usage will accrue in charges by the end of the month</p> </li> <li> <p>How much of your budget has been used</p> </li> </ul> <p>AWS updates your budget status several times a day. Budgets track your unblended costs, subscriptions, refunds, and RIs. You can create the following types of budgets:</p> <ul> <li> <p> <b>Cost budgets</b> - Plan how much you want to spend on a service.</p> </li> <li> <p> <b>Usage budgets</b> - Plan how much you want to use one or more services.</p> </li> <li> <p> <b>RI utilization budgets</b> - Define a utilization threshold, and receive alerts when your RI usage falls below that threshold. This lets you see if your RIs are unused or under-utilized.</p> </li> <li> <p> <b>RI coverage budgets</b> - Define a coverage threshold, and receive alerts when the number of your instance hours that are covered by RIs fall below that threshold. This lets you see how much of your instance usage is covered by a reservation.</p> </li> </ul> <p>Service Endpoint</p> <p>The AWS Budgets API provides the following endpoint:</p> <ul> <li> <p>https://budgets.amazonaws.com</p> </li> </ul> <p>For information about costs that are associated with the AWS Budgets API, see <a href=\"https://aws.amazon.com/aws-cost-management/pricing/\">AWS Cost Management Pricing</a>.</p>",
   "operations": {
     "CreateBudget": "<p>Creates a budget and, if included, notifications and subscribers. </p>",
     "CreateNotification": "<p>Creates a notification. You must create the budget before you create the associated notification.</p>",
     "CreateSubscriber": "<p>Creates a subscriber. You must create the associated budget and notification before you create the subscriber.</p>",
-    "DeleteBudget": "<p>Deletes a budget. You can delete your budget at any time.</p> <p> <b>Deleting a budget also deletes the notifications and subscribers associated with that budget.</b> </p>",
-    "DeleteNotification": "<p>Deletes a notification.</p> <p> <b>Deleting a notification also deletes the subscribers associated with the notification.</b> </p>",
-    "DeleteSubscriber": "<p>Deletes a subscriber.</p> <p> <b>Deleting the last subscriber to a notification also deletes the notification.</b> </p>",
+    "DeleteBudget": "<p>Deletes a budget. You can delete your budget at any time.</p> <important> <p>Deleting a budget also deletes the notifications and subscribers that are associated with that budget.</p> </important>",
+    "DeleteNotification": "<p>Deletes a notification.</p> <important> <p>Deleting a notification also deletes the subscribers that are associated with the notification.</p> </important>",
+    "DeleteSubscriber": "<p>Deletes a subscriber.</p> <important> <p>Deleting the last subscriber to a notification also deletes the notification.</p> </important>",
     "DescribeBudget": "<p>Describes a budget.</p>",
-    "DescribeBudgets": "<p>Lists the budgets associated with an account.</p>",
-    "DescribeNotificationsForBudget": "<p>Lists the notifications associated with a budget.</p>",
-    "DescribeSubscribersForNotification": "<p>Lists the subscribers associated with a notification.</p>",
-    "UpdateBudget": "<p>Updates a budget. You can change every part of a budget except for the <code>budgetName</code> and the <code>calculatedSpend</code>. When a budget is modified, the <code>calculatedSpend</code> drops to zero until AWS has new usage data to use for forecasting.</p>",
+    "DescribeBudgets": "<p>Lists the budgets that are associated with an account.</p>",
+    "DescribeNotificationsForBudget": "<p>Lists the notifications that are associated with a budget.</p>",
+    "DescribeSubscribersForNotification": "<p>Lists the subscribers that are associated with a notification.</p>",
+    "UpdateBudget": "<p>Updates a budget. You can change every part of a budget except for the <code>budgetName</code> and the <code>calculatedSpend</code>. When you modify a budget, the <code>calculatedSpend</code> drops to zero until AWS has new usage data to use for forecasting.</p>",
     "UpdateNotification": "<p>Updates a notification.</p>",
     "UpdateSubscriber": "<p>Updates a subscriber.</p>"
   },
   "shapes": {
     "AccountId": {
-      "base": "<p>The account ID of the customer. It should be a 12 digit number.</p>",
+      "base": "<p>The account ID of the user. It should be a 12-digit number.</p>",
       "refs": {
         "CreateBudgetRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget.</p>",
         "CreateNotificationRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget that you want to create a notification for.</p>",
-        "CreateSubscriberRequest$AccountId": "<p>The <code>accountId</code> associated with the budget that you want to create a subscriber for.</p>",
+        "CreateSubscriberRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget that you want to create a subscriber for.</p>",
         "DeleteBudgetRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget that you want to delete.</p>",
         "DeleteNotificationRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget whose notification you want to delete.</p>",
         "DeleteSubscriberRequest$AccountId": "<p>The <code>accountId</code> that is associated with the budget whose subscriber you want to delete.</p>",
@@ -36,7 +36,7 @@
       }
     },
     "Budget": {
-      "base": "<p>Represents the output of the <code>CreateBudget</code> operation. The content consists of the detailed metadata and data file information, and the current status of the <code>budget</code>.</p> <p>The ARN pattern for a budget is: <code>arn:aws:budgetservice::AccountId:budget/budgetName</code> </p>",
+      "base": "<p>Represents the output of the <code>CreateBudget</code> operation. The content consists of the detailed metadata and data file information, and the current status of the <code>budget</code> object.</p> <p>This is the ARN pattern for a budget: </p> <p> <code>arn:aws:budgetservice::AccountId:budget/budgetName</code> </p>",
       "refs": {
         "Budgets$member": null,
         "CreateBudgetRequest$Budget": "<p>The budget object that you want to create.</p>",
@@ -45,10 +45,10 @@
       }
     },
     "BudgetName": {
-      "base": "<p> A string represents the budget name. No \":\" and \"\\\" character is allowed.</p>",
+      "base": "<p> A string that represents the budget name. The \":\" and \"\\\" characters are not allowed.</p>",
       "refs": {
-        "Budget$BudgetName": "<p>The name of a budget. Unique within accounts. <code>:</code> and <code>\\</code> characters are not allowed in the <code>BudgetName</code>.</p>",
-        "CreateNotificationRequest$BudgetName": "<p>The name of the budget that you want AWS to notified you about. Budget names must be unique within an account.</p>",
+        "Budget$BudgetName": "<p>The name of a budget. The name must be unique within accounts. The <code>:</code> and <code>\\</code> characters are not allowed in <code>BudgetName</code>.</p>",
+        "CreateNotificationRequest$BudgetName": "<p>The name of the budget that you want AWS to notify you about. Budget names must be unique within an account.</p>",
         "CreateSubscriberRequest$BudgetName": "<p>The name of the budget that you want to subscribe to. Budget names must be unique within an account.</p>",
         "DeleteBudgetRequest$BudgetName": "<p>The name of the budget that you want to delete.</p>",
         "DeleteNotificationRequest$BudgetName": "<p>The name of the budget whose notification you want to delete.</p>",
@@ -61,39 +61,39 @@
       }
     },
     "BudgetType": {
-      "base": "<p> The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.</p>",
+      "base": "<p> The type of a budget. It must be one of the following types: </p> <p> <code>COST</code>, <code>USAGE</code>, <code>RI_UTILIZATION</code>, or <code>RI_COVERAGE</code>.</p>",
       "refs": {
-        "Budget$BudgetType": "<p>Whether this budget tracks monetary costs, usage, or RI utilization.</p>"
+        "Budget$BudgetType": "<p>Whether this budget tracks monetary costs, usage, RI utilization, or RI coverage.</p>"
       }
     },
     "Budgets": {
-      "base": "<p> A list of budgets</p>",
+      "base": "<p> A list of budgets.</p>",
       "refs": {
         "DescribeBudgetsResponse$Budgets": "<p>A list of budgets.</p>"
       }
     },
     "CalculatedSpend": {
-      "base": "<p>The spend objects associated with this budget. The <code>actualSpend</code> tracks how much you've used, cost, usage, or RI units, and the <code>forecastedSpend</code> tracks how much you are predicted to spend if your current usage remains steady.</p> <p>For example, if it is the 20th of the month and you have spent <code>50</code> dollars on Amazon EC2, your <code>actualSpend</code> is <code>50 USD</code>, and your <code>forecastedSpend</code> is <code>75 USD</code>.</p>",
+      "base": "<p>The spend objects that are associated with this budget. The <code>actualSpend</code> tracks how much you've used, cost, usage, or RI units, and the <code>forecastedSpend</code> tracks how much you are predicted to spend if your current usage remains steady.</p> <p>For example, if it is the 20th of the month and you have spent <code>50</code> dollars on Amazon EC2, your <code>actualSpend</code> is <code>50 USD</code>, and your <code>forecastedSpend</code> is <code>75 USD</code>.</p>",
       "refs": {
-        "Budget$CalculatedSpend": "<p>The actual and forecasted cost or usage being tracked by a budget.</p>"
+        "Budget$CalculatedSpend": "<p>The actual and forecasted cost or usage that the budget tracks.</p>"
       }
     },
     "ComparisonOperator": {
-      "base": "<p> The comparison operator of a notification. Currently we support less than, equal to and greater than.</p>",
+      "base": "<p> The comparison operator of a notification. Currently the service supports the following operators:</p> <p> <code>GREATER_THAN</code>, <code>LESS_THAN</code>, <code>EQUAL_TO</code> </p>",
       "refs": {
-        "Notification$ComparisonOperator": "<p>The comparison used for this notification.</p>"
+        "Notification$ComparisonOperator": "<p>The comparison that is used for this notification.</p>"
       }
     },
     "CostFilters": {
-      "base": "<p> A map that represents the cost filters applied to the budget.</p>",
+      "base": "<p> A map that represents the cost filters that are applied to the budget.</p>",
       "refs": {
-        "Budget$CostFilters": "<p>The cost filters applied to a budget, such as service or region.</p>"
+        "Budget$CostFilters": "<p>The cost filters, such as service or region, that are applied to a budget.</p>"
       }
     },
     "CostTypes": {
-      "base": "<p>The types of cost included in a budget, such as tax and subscriptions.</p>",
+      "base": "<p>The types of cost that are included in a <code>COST</code> budget, such as tax and subscriptions.</p> <p> <code>USAGE</code>, <code>RI_UTILIZATION</code>, and <code>RI_COVERAGE</code> budgets do not have <code>CostTypes</code>.</p>",
       "refs": {
-        "Budget$CostTypes": "<p>The types of costs included in this budget.</p>"
+        "Budget$CostTypes": "<p>The types of costs that are included in this <code>COST</code> budget.</p> <p> <code>USAGE</code>, <code>RI_UTILIZATION</code>, and <code>RI_COVERAGE</code> budgets do not have <code>CostTypes</code>.</p>"
       }
     },
     "CreateBudgetRequest": {
@@ -218,22 +218,22 @@
       }
     },
     "GenericString": {
-      "base": "<p> A generic String.</p>",
+      "base": "<p> A generic string.</p>",
       "refs": {
         "CostFilters$key": null,
-        "DescribeBudgetsRequest$NextToken": "<p>The pagination token that indicates the next set of results to retrieve.</p>",
-        "DescribeBudgetsResponse$NextToken": "<p>The pagination token that indicates the next set of results that you can retrieve.</p>",
-        "DescribeNotificationsForBudgetRequest$NextToken": "<p>The pagination token that indicates the next set of results to retrieve.</p>",
-        "DescribeNotificationsForBudgetResponse$NextToken": "<p>The pagination token that indicates the next set of results that you can retrieve.</p>",
-        "DescribeSubscribersForNotificationRequest$NextToken": "<p>The pagination token that indicates the next set of results to retrieve.</p>",
-        "DescribeSubscribersForNotificationResponse$NextToken": "<p>The pagination token that indicates the next set of results that you can retrieve.</p>",
+        "DescribeBudgetsRequest$NextToken": "<p>The pagination token that you include in your request to indicate the next set of results that you want to retrieve.</p>",
+        "DescribeBudgetsResponse$NextToken": "<p>The pagination token in the service response that indicates the next set of results that you can retrieve.</p>",
+        "DescribeNotificationsForBudgetRequest$NextToken": "<p>The pagination token that you include in your request to indicate the next set of results that you want to retrieve.</p>",
+        "DescribeNotificationsForBudgetResponse$NextToken": "<p>The pagination token in the service response that indicates the next set of results that you can retrieve.</p>",
+        "DescribeSubscribersForNotificationRequest$NextToken": "<p>The pagination token that you include in your request to indicate the next set of results that you want to retrieve.</p>",
+        "DescribeSubscribersForNotificationResponse$NextToken": "<p>The pagination token in the service response that indicates the next set of results that you can retrieve.</p>",
         "DimensionValues$member": null
       }
     },
     "GenericTimestamp": {
-      "base": "<p> A generic timestamp. In Java it is transformed to a Date object.</p>",
+      "base": "<p> A generic time stamp. In Java, it is transformed to a <code>Date</code> object.</p>",
       "refs": {
-        "TimePeriod$Start": "<p>The start date for a budget. If you created your budget and didn't specify a start date, AWS defaults to the start of your chosen time period (i.e. DAILY, MONTHLY, QUARTERLY, ANNUALLY). For example, if you created your budget on January 24th 2018, chose <code>DAILY</code>, and didn't set a start date, AWS set your start date to <code>01/24/18 00:00 UTC</code>. If you chose <code>MONTHLY</code>, AWS set your start date to <code>01/01/18 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API.</p> <p>You can change your start date with the <code>UpdateBudget</code> operation.</p>",
+        "TimePeriod$Start": "<p>The start date for a budget. If you created your budget and didn't specify a start date, AWS defaults to the start of your chosen time period (DAILY, MONTHLY, QUARTERLY, or ANNUALLY). For example, if you created your budget on January 24, 2018, chose <code>DAILY</code>, and didn't set a start date, AWS set your start date to <code>01/24/18 00:00 UTC</code>. If you chose <code>MONTHLY</code>, AWS set your start date to <code>01/01/18 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API.</p> <p>You can change your start date with the <code>UpdateBudget</code> operation.</p>",
         "TimePeriod$End": "<p>The end date for a budget. If you didn't specify an end date, AWS set your end date to <code>06/15/87 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API.</p> <p>After the end date, AWS deletes the budget and all associated notifications and subscribers. You can change your end date with the <code>UpdateBudget</code> operation.</p>"
       }
     },
@@ -253,11 +253,11 @@
       }
     },
     "MaxResults": {
-      "base": "<p> An integer to represent how many entries a paginated response contains. Maximum is set to 100.</p>",
+      "base": "<p> An integer that represents how many entries a paginated response contains. The maximum is 100.</p>",
       "refs": {
-        "DescribeBudgetsRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in response.</p>",
-        "DescribeNotificationsForBudgetRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in response.</p>",
-        "DescribeSubscribersForNotificationRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in response.</p>"
+        "DescribeBudgetsRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in a response.</p>",
+        "DescribeNotificationsForBudgetRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in a response.</p>",
+        "DescribeSubscribersForNotificationRequest$MaxResults": "<p>Optional integer. Specifies the maximum number of results to return in a response.</p>"
       }
     },
     "NotFoundException": {
@@ -266,48 +266,48 @@
       }
     },
     "Notification": {
-      "base": "<p>A notification associated with a budget. A budget can have up to five notifications. </p> <p>Each notification must have at least one subscriber. A notification can have one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.</p> <p>For example, if you have a budget for 200 dollars and you want to be notified when you go over 160 dollars, create a notification with the following parameters:</p> <ul> <li> <p>A notificationType of <code>ACTUAL</code> </p> </li> <li> <p>A comparisonOperator of <code>GREATER_THAN</code> </p> </li> <li> <p>A notification threshold of <code>80</code> </p> </li> </ul>",
+      "base": "<p>A notification that is associated with a budget. A budget can have up to five notifications. </p> <p>Each notification must have at least one subscriber. A notification can have one SNS subscriber and up to 10 email subscribers, for a total of 11 subscribers.</p> <p>For example, if you have a budget for 200 dollars and you want to be notified when you go over 160 dollars, create a notification with the following parameters:</p> <ul> <li> <p>A <code>notificationType</code> of <code>ACTUAL</code> </p> </li> <li> <p>A <code>comparisonOperator</code> of <code>GREATER_THAN</code> </p> </li> <li> <p>A notification threshold of <code>80</code> </p> </li> </ul>",
       "refs": {
         "CreateNotificationRequest$Notification": "<p>The notification that you want to create.</p>",
         "CreateSubscriberRequest$Notification": "<p>The notification that you want to create a subscriber for.</p>",
         "DeleteNotificationRequest$Notification": "<p>The notification that you want to delete.</p>",
         "DeleteSubscriberRequest$Notification": "<p>The notification whose subscriber you want to delete.</p>",
         "DescribeSubscribersForNotificationRequest$Notification": "<p>The notification whose subscribers you want to list.</p>",
-        "NotificationWithSubscribers$Notification": "<p>The notification associated with a budget.</p>",
+        "NotificationWithSubscribers$Notification": "<p>The notification that is associated with a budget.</p>",
         "Notifications$member": null,
-        "UpdateNotificationRequest$OldNotification": "<p>The previous notification associated with a budget.</p>",
+        "UpdateNotificationRequest$OldNotification": "<p>The previous notification that is associated with a budget.</p>",
         "UpdateNotificationRequest$NewNotification": "<p>The updated notification to be associated with a budget.</p>",
         "UpdateSubscriberRequest$Notification": "<p>The notification whose subscriber you want to update.</p>"
       }
     },
     "NotificationThreshold": {
-      "base": "<p> The threshold of a notification. It should be a number between 0 and 1,000,000,000.</p>",
+      "base": "<p> The threshold of a notification. It must be a number between 0 and 1,000,000,000.</p>",
       "refs": {
-        "Notification$Threshold": "<p>The threshold associated with a notification. Thresholds are always a percentage.</p>"
+        "Notification$Threshold": "<p>The threshold that is associated with a notification. Thresholds are always a percentage.</p>"
       }
     },
     "NotificationType": {
-      "base": "<p> The type of a notification. It should be ACTUAL or FORECASTED.</p>",
+      "base": "<p> The type of a notification. It must be ACTUAL or FORECASTED.</p>",
       "refs": {
         "Notification$NotificationType": "<p>Whether the notification is for how much you have spent (<code>ACTUAL</code>) or for how much you are forecasted to spend (<code>FORECASTED</code>).</p>"
       }
     },
     "NotificationWithSubscribers": {
-      "base": "<p>A notification with subscribers. A notification can have one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.</p>",
+      "base": "<p>A notification with subscribers. A notification can have one SNS subscriber and up to 10 email subscribers, for a total of 11 subscribers.</p>",
       "refs": {
         "NotificationWithSubscribersList$member": null
       }
     },
     "NotificationWithSubscribersList": {
-      "base": "<p> A list of Notifications, each with a list of subscribers.</p>",
+      "base": "<p> A list of notifications, each with a list of subscribers.</p>",
       "refs": {
-        "CreateBudgetRequest$NotificationsWithSubscribers": "<p>A notification that you want to associate with a budget. A budget can have up to five notifications, and each notification can have one SNS subscriber and up to ten email subscribers. If you include notifications and subscribers in your <code>CreateBudget</code> call, AWS creates the notifications and subscribers for you.</p>"
+        "CreateBudgetRequest$NotificationsWithSubscribers": "<p>A notification that you want to associate with a budget. A budget can have up to five notifications, and each notification can have one SNS subscriber and up to 10 email subscribers. If you include notifications and subscribers in your <code>CreateBudget</code> call, AWS creates the notifications and subscribers for you.</p>"
       }
     },
     "Notifications": {
       "base": "<p> A list of notifications.</p>",
       "refs": {
-        "DescribeNotificationsForBudgetResponse$Notifications": "<p>A list of notifications associated with a budget.</p>"
+        "DescribeNotificationsForBudgetResponse$Notifications": "<p>A list of notifications that are associated with a budget.</p>"
       }
     },
     "NullableBoolean": {
@@ -315,7 +315,7 @@
       "refs": {
         "CostTypes$IncludeTax": "<p>Specifies whether a budget includes taxes.</p> <p>The default value is <code>true</code>.</p>",
         "CostTypes$IncludeSubscription": "<p>Specifies whether a budget includes subscriptions.</p> <p>The default value is <code>true</code>.</p>",
-        "CostTypes$UseBlended": "<p>Specifies whether a budget uses blended rate.</p> <p>The default value is <code>false</code>.</p>",
+        "CostTypes$UseBlended": "<p>Specifies whether a budget uses a blended rate.</p> <p>The default value is <code>false</code>.</p>",
         "CostTypes$IncludeRefund": "<p>Specifies whether a budget includes refunds.</p> <p>The default value is <code>true</code>.</p>",
         "CostTypes$IncludeCredit": "<p>Specifies whether a budget includes credits.</p> <p>The default value is <code>true</code>.</p>",
         "CostTypes$IncludeUpfront": "<p>Specifies whether a budget includes upfront RI costs.</p> <p>The default value is <code>true</code>.</p>",
@@ -327,31 +327,31 @@
       }
     },
     "NumericValue": {
-      "base": "<p> A string to represent NumericValue.</p>",
+      "base": "<p> A string that represents a numeric value.</p>",
       "refs": {
-        "Spend$Amount": "<p>The cost or usage amount associated with a budget forecast, actual spend, or budget threshold.</p>"
+        "Spend$Amount": "<p>The cost or usage amount that is associated with a budget forecast, actual spend, or budget threshold.</p>"
       }
     },
     "Spend": {
-      "base": "<p>The amount of cost or usage being measured for a budget.</p> <p>For example, a <code>Spend</code> for <code>3 GB</code> of S3 usage would have the following parameters:</p> <ul> <li> <p>An <code>Amount</code> of <code>3</code> </p> </li> <li> <p>A <code>unit</code> of <code>GB</code> </p> </li> </ul>",
+      "base": "<p>The amount of cost or usage that is measured for a budget.</p> <p>For example, a <code>Spend</code> for <code>3 GB</code> of S3 usage would have the following parameters:</p> <ul> <li> <p>An <code>Amount</code> of <code>3</code> </p> </li> <li> <p>A <code>unit</code> of <code>GB</code> </p> </li> </ul>",
       "refs": {
-        "Budget$BudgetLimit": "<p>The total amount of cost, usage, or RI utilization that you want to track with your budget.</p> <p> <code>BudgetLimit</code> is required for cost or usage budgets, but optional for RI utilization budgets. RI utilization budgets default to the only valid value for RI utilization budgets, which is <code>100</code>.</p>",
+        "Budget$BudgetLimit": "<p>The total amount of cost, usage, RI utilization, or RI coverage that you want to track with your budget.</p> <p> <code>BudgetLimit</code> is required for cost or usage budgets, but optional for RI utilization or coverage budgets. RI utilization or coverage budgets default to <code>100</code>, which is the only valid value for RI utilization or coverage budgets.</p>",
         "CalculatedSpend$ActualSpend": "<p>The amount of cost, usage, or RI units that you have used.</p>",
         "CalculatedSpend$ForecastedSpend": "<p>The amount of cost, usage, or RI units that you are forecasted to use.</p>"
       }
     },
     "Subscriber": {
-      "base": "<p>The subscriber to a budget notification. The subscriber consists of a subscription type and either an Amazon Simple Notification Service topic or an email address.</p> <p>For example, an email subscriber would have the following parameters:</p> <ul> <li> <p>A <code>subscriptionType</code> of <code>EMAIL</code> </p> </li> <li> <p>An <code>address</code> of <code>example@example.com</code> </p> </li> </ul>",
+      "base": "<p>The subscriber to a budget notification. The subscriber consists of a subscription type and either an Amazon SNS topic or an email address.</p> <p>For example, an email subscriber would have the following parameters:</p> <ul> <li> <p>A <code>subscriptionType</code> of <code>EMAIL</code> </p> </li> <li> <p>An <code>address</code> of <code>example@example.com</code> </p> </li> </ul>",
       "refs": {
         "CreateSubscriberRequest$Subscriber": "<p>The subscriber that you want to associate with a budget notification.</p>",
         "DeleteSubscriberRequest$Subscriber": "<p>The subscriber that you want to delete.</p>",
         "Subscribers$member": null,
-        "UpdateSubscriberRequest$OldSubscriber": "<p>The previous subscriber associated with a budget notification.</p>",
-        "UpdateSubscriberRequest$NewSubscriber": "<p>The updated subscriber associated with a budget notification.</p>"
+        "UpdateSubscriberRequest$OldSubscriber": "<p>The previous subscriber that is associated with a budget notification.</p>",
+        "UpdateSubscriberRequest$NewSubscriber": "<p>The updated subscriber that is associated with a budget notification.</p>"
       }
     },
     "SubscriberAddress": {
-      "base": "<p> String containing email or sns topic for the subscriber address.</p>",
+      "base": "<p> A string that contains an email address or SNS topic for the subscriber's address.</p>",
       "refs": {
         "Subscriber$Address": "<p>The address that AWS sends budget notifications to, either an SNS topic or an email.</p>"
       }
@@ -359,8 +359,8 @@
     "Subscribers": {
       "base": "<p> A list of subscribers.</p>",
       "refs": {
-        "CreateNotificationRequest$Subscribers": "<p>A list of subscribers that you want to associate with the notification. Each notification can have one SNS subscriber and up to ten email subscribers.</p>",
-        "DescribeSubscribersForNotificationResponse$Subscribers": "<p>A list of subscribers associated with a notification.</p>",
+        "CreateNotificationRequest$Subscribers": "<p>A list of subscribers that you want to associate with the notification. Each notification can have one SNS subscriber and up to 10 email subscribers.</p>",
+        "DescribeSubscribersForNotificationResponse$Subscribers": "<p>A list of subscribers that are associated with a notification.</p>",
         "NotificationWithSubscribers$Subscribers": "<p>A list of subscribers who are subscribed to this notification.</p>"
       }
     },
@@ -373,25 +373,25 @@
     "ThresholdType": {
       "base": "<p> The type of threshold for a notification. It can be PERCENTAGE or ABSOLUTE_VALUE.</p>",
       "refs": {
-        "Notification$ThresholdType": "<p>The type of threshold for a notification. For <code>ACTUAL</code> thresholds, AWS notifies you when you go over the threshold, and for <code>FORECASTED</code> thresholds AWS notifies you when you are forecasted to go over the threshold.</p>"
+        "Notification$ThresholdType": "<p>The type of threshold for a notification. For <code>ACTUAL</code> thresholds, AWS notifies you when you go over the threshold. For <code>FORECASTED</code> thresholds, AWS notifies you when you are forecasted to go over the threshold.</p>"
       }
     },
     "TimePeriod": {
-      "base": "<p>The period of time covered by a budget. Has a start date and an end date. The start date must come before the end date. There are no restrictions on the end date. </p>",
+      "base": "<p>The period of time that is covered by a budget. The period has a start date and an end date. The start date must come before the end date. There are no restrictions on the end date. </p>",
       "refs": {
-        "Budget$TimePeriod": "<p>The period of time covered by a budget. Has a start date and an end date. The start date must come before the end date. There are no restrictions on the end date. </p> <p>If you created your budget and didn't specify a start date, AWS defaults to the start of your chosen time period (i.e. DAILY, MONTHLY, QUARTERLY, ANNUALLY). For example, if you created your budget on January 24th 2018, chose <code>DAILY</code>, and didn't set a start date, AWS set your start date to <code>01/24/18 00:00 UTC</code>. If you chose <code>MONTHLY</code>, AWS set your start date to <code>01/01/18 00:00 UTC</code>. If you didn't specify an end date, AWS set your end date to <code>06/15/87 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API. </p> <p>You can change either date with the <code>UpdateBudget</code> operation.</p> <p>After the end date, AWS deletes the budget and all associated notifications and subscribers.</p>"
+        "Budget$TimePeriod": "<p>The period of time that is covered by a budget. The period has a start date and an end date. The start date must come before the end date. The end date must come before <code>06/15/87 00:00 UTC</code>. </p> <p>If you create your budget and don't specify a start date, AWS defaults to the start of your chosen time period (DAILY, MONTHLY, QUARTERLY, or ANNUALLY). For example, if you created your budget on January 24, 2018, chose <code>DAILY</code>, and didn't set a start date, AWS set your start date to <code>01/24/18 00:00 UTC</code>. If you chose <code>MONTHLY</code>, AWS set your start date to <code>01/01/18 00:00 UTC</code>. If you didn't specify an end date, AWS set your end date to <code>06/15/87 00:00 UTC</code>. The defaults are the same for the AWS Billing and Cost Management console and the API. </p> <p>You can change either date with the <code>UpdateBudget</code> operation.</p> <p>After the end date, AWS deletes the budget and all associated notifications and subscribers.</p>"
       }
     },
     "TimeUnit": {
-      "base": "<p> The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.</p>",
+      "base": "<p> The time unit of the budget, such as MONTHLY or QUARTERLY.</p>",
       "refs": {
-        "Budget$TimeUnit": "<p>The length of time until a budget resets the actual and forecasted spend.</p>"
+        "Budget$TimeUnit": "<p>The length of time until a budget resets the actual and forecasted spend. <code>DAILY</code> is available only for <code>RI_UTILIZATION</code> and <code>RI_COVERAGE</code> budgets.</p>"
       }
     },
     "UnitValue": {
-      "base": "<p> A string to represent budget spend unit. It should be not null and not empty.</p>",
+      "base": "<p> A string that represents the spend unit of a budget. It can't be null or empty.</p>",
       "refs": {
-        "Spend$Unit": "<p>The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB.</p>"
+        "Spend$Unit": "<p>The unit of measurement that is used for the budget forecast, actual spend, or budget threshold, such as dollars or GB.</p>"
       }
     },
     "UpdateBudgetRequest": {

--- a/models/apis/es/2015-01-01/api-2.json
+++ b/models/apis/es/2015-01-01/api-2.json
@@ -130,6 +130,36 @@
         {"shape":"ValidationException"}
       ]
     },
+    "DescribeReservedElasticsearchInstanceOfferings":{
+      "name":"DescribeReservedElasticsearchInstanceOfferings",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2015-01-01/es/reservedInstanceOfferings"
+      },
+      "input":{"shape":"DescribeReservedElasticsearchInstanceOfferingsRequest"},
+      "output":{"shape":"DescribeReservedElasticsearchInstanceOfferingsResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ValidationException"},
+        {"shape":"DisabledOperationException"},
+        {"shape":"InternalException"}
+      ]
+    },
+    "DescribeReservedElasticsearchInstances":{
+      "name":"DescribeReservedElasticsearchInstances",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2015-01-01/es/reservedInstances"
+      },
+      "input":{"shape":"DescribeReservedElasticsearchInstancesRequest"},
+      "output":{"shape":"DescribeReservedElasticsearchInstancesResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InternalException"},
+        {"shape":"ValidationException"},
+        {"shape":"DisabledOperationException"}
+      ]
+    },
     "ListDomainNames":{
       "name":"ListDomainNames",
       "http":{
@@ -183,6 +213,23 @@
       "errors":[
         {"shape":"BaseException"},
         {"shape":"ResourceNotFoundException"},
+        {"shape":"ValidationException"},
+        {"shape":"InternalException"}
+      ]
+    },
+    "PurchaseReservedElasticsearchInstanceOffering":{
+      "name":"PurchaseReservedElasticsearchInstanceOffering",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2015-01-01/es/purchaseReservedInstanceOffering"
+      },
+      "input":{"shape":"PurchaseReservedElasticsearchInstanceOfferingRequest"},
+      "output":{"shape":"PurchaseReservedElasticsearchInstanceOfferingResponse"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceAlreadyExistsException"},
+        {"shape":"LimitExceededException"},
+        {"shape":"DisabledOperationException"},
         {"shape":"ValidationException"},
         {"shape":"InternalException"}
       ]
@@ -418,6 +465,60 @@
         "LimitsByRole":{"shape":"LimitsByRole"}
       }
     },
+    "DescribeReservedElasticsearchInstanceOfferingsRequest":{
+      "type":"structure",
+      "members":{
+        "ReservedElasticsearchInstanceOfferingId":{
+          "shape":"GUID",
+          "location":"querystring",
+          "locationName":"offeringId"
+        },
+        "MaxResults":{
+          "shape":"MaxResults",
+          "location":"querystring",
+          "locationName":"maxResults"
+        },
+        "NextToken":{
+          "shape":"NextToken",
+          "location":"querystring",
+          "locationName":"nextToken"
+        }
+      }
+    },
+    "DescribeReservedElasticsearchInstanceOfferingsResponse":{
+      "type":"structure",
+      "members":{
+        "NextToken":{"shape":"NextToken"},
+        "ReservedElasticsearchInstanceOfferings":{"shape":"ReservedElasticsearchInstanceOfferingList"}
+      }
+    },
+    "DescribeReservedElasticsearchInstancesRequest":{
+      "type":"structure",
+      "members":{
+        "ReservedElasticsearchInstanceId":{
+          "shape":"GUID",
+          "location":"querystring",
+          "locationName":"reservationId"
+        },
+        "MaxResults":{
+          "shape":"MaxResults",
+          "location":"querystring",
+          "locationName":"maxResults"
+        },
+        "NextToken":{
+          "shape":"NextToken",
+          "location":"querystring",
+          "locationName":"nextToken"
+        }
+      }
+    },
+    "DescribeReservedElasticsearchInstancesResponse":{
+      "type":"structure",
+      "members":{
+        "NextToken":{"shape":"String"},
+        "ReservedElasticsearchInstances":{"shape":"ReservedElasticsearchInstanceList"}
+      }
+    },
     "DisabledOperationException":{
       "type":"structure",
       "members":{
@@ -450,6 +551,7 @@
       "type":"list",
       "member":{"shape":"DomainName"}
     },
+    "Double":{"type":"double"},
     "EBSOptions":{
       "type":"structure",
       "members":{
@@ -629,11 +731,19 @@
       "value":{"shape":"ServiceUrl"}
     },
     "ErrorMessage":{"type":"string"},
+    "GUID":{
+      "type":"string",
+      "pattern":"\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}"
+    },
     "IdentityPoolId":{
       "type":"string",
       "max":55,
       "min":1,
       "pattern":"[\\w-]+:[0-9a-f-]+"
+    },
+    "InstanceCount":{
+      "type":"integer",
+      "min":1
     },
     "InstanceCountLimits":{
       "type":"structure",
@@ -649,6 +759,7 @@
       }
     },
     "InstanceRole":{"type":"string"},
+    "Integer":{"type":"integer"},
     "IntegerClass":{"type":"integer"},
     "InternalException":{
       "type":"structure",
@@ -830,6 +941,36 @@
       }
     },
     "PolicyDocument":{"type":"string"},
+    "PurchaseReservedElasticsearchInstanceOfferingRequest":{
+      "type":"structure",
+      "required":[
+        "ReservedElasticsearchInstanceOfferingId",
+        "ReservationName"
+      ],
+      "members":{
+        "ReservedElasticsearchInstanceOfferingId":{"shape":"GUID"},
+        "ReservationName":{"shape":"ReservationToken"},
+        "InstanceCount":{"shape":"InstanceCount"}
+      }
+    },
+    "PurchaseReservedElasticsearchInstanceOfferingResponse":{
+      "type":"structure",
+      "members":{
+        "ReservedElasticsearchInstanceId":{"shape":"GUID"},
+        "ReservationName":{"shape":"ReservationToken"}
+      }
+    },
+    "RecurringCharge":{
+      "type":"structure",
+      "members":{
+        "RecurringChargeAmount":{"shape":"Double"},
+        "RecurringChargeFrequency":{"shape":"String"}
+      }
+    },
+    "RecurringChargeList":{
+      "type":"list",
+      "member":{"shape":"RecurringCharge"}
+    },
     "RemoveTagsRequest":{
       "type":"structure",
       "required":[
@@ -840,6 +981,58 @@
         "ARN":{"shape":"ARN"},
         "TagKeys":{"shape":"StringList"}
       }
+    },
+    "ReservationToken":{
+      "type":"string",
+      "max":64,
+      "min":5
+    },
+    "ReservedElasticsearchInstance":{
+      "type":"structure",
+      "members":{
+        "ReservationName":{"shape":"ReservationToken"},
+        "ReservedElasticsearchInstanceId":{"shape":"GUID"},
+        "ReservedElasticsearchInstanceOfferingId":{"shape":"String"},
+        "ElasticsearchInstanceType":{"shape":"ESPartitionInstanceType"},
+        "StartTime":{"shape":"UpdateTimestamp"},
+        "Duration":{"shape":"Integer"},
+        "FixedPrice":{"shape":"Double"},
+        "UsagePrice":{"shape":"Double"},
+        "CurrencyCode":{"shape":"String"},
+        "ElasticsearchInstanceCount":{"shape":"Integer"},
+        "State":{"shape":"String"},
+        "PaymentOption":{"shape":"ReservedElasticsearchInstancePaymentOption"},
+        "RecurringCharges":{"shape":"RecurringChargeList"}
+      }
+    },
+    "ReservedElasticsearchInstanceList":{
+      "type":"list",
+      "member":{"shape":"ReservedElasticsearchInstance"}
+    },
+    "ReservedElasticsearchInstanceOffering":{
+      "type":"structure",
+      "members":{
+        "ReservedElasticsearchInstanceOfferingId":{"shape":"GUID"},
+        "ElasticsearchInstanceType":{"shape":"ESPartitionInstanceType"},
+        "Duration":{"shape":"Integer"},
+        "FixedPrice":{"shape":"Double"},
+        "UsagePrice":{"shape":"Double"},
+        "CurrencyCode":{"shape":"String"},
+        "PaymentOption":{"shape":"ReservedElasticsearchInstancePaymentOption"},
+        "RecurringCharges":{"shape":"RecurringChargeList"}
+      }
+    },
+    "ReservedElasticsearchInstanceOfferingList":{
+      "type":"list",
+      "member":{"shape":"ReservedElasticsearchInstanceOffering"}
+    },
+    "ReservedElasticsearchInstancePaymentOption":{
+      "type":"string",
+      "enum":[
+        "ALL_UPFRONT",
+        "PARTIAL_UPFRONT",
+        "NO_UPFRONT"
+      ]
     },
     "ResourceAlreadyExistsException":{
       "type":"structure",

--- a/models/apis/es/2015-01-01/docs-2.json
+++ b/models/apis/es/2015-01-01/docs-2.json
@@ -10,10 +10,13 @@
     "DescribeElasticsearchDomainConfig": "<p>Provides cluster configuration information about the specified Elasticsearch domain, such as the state, creation date, update version, and update date for cluster options.</p>",
     "DescribeElasticsearchDomains": "<p>Returns domain configuration information about the specified Elasticsearch domains, including the domain ID, domain endpoint, and domain ARN.</p>",
     "DescribeElasticsearchInstanceTypeLimits": "<p> Describe Elasticsearch Limits for a given InstanceType and ElasticsearchVersion. When modifying existing Domain, specify the <code> <a>DomainName</a> </code> to know what Limits are supported for modifying. </p>",
+    "DescribeReservedElasticsearchInstanceOfferings": "<p>Lists available reserved Elasticsearch instance offerings.</p>",
+    "DescribeReservedElasticsearchInstances": "<p>Returns information about reserved Elasticsearch instances for this account.</p>",
     "ListDomainNames": "<p>Returns the name of all Elasticsearch domains owned by the current user's account. </p>",
     "ListElasticsearchInstanceTypes": "<p>List all Elasticsearch instance types that are supported for given ElasticsearchVersion</p>",
     "ListElasticsearchVersions": "<p>List all supported Elasticsearch versions</p>",
     "ListTags": "<p>Returns all tags for the given Elasticsearch domain.</p>",
+    "PurchaseReservedElasticsearchInstanceOffering": "<p>Allows you to purchase reserved Elasticsearch instances.</p>",
     "RemoveTags": "<p>Removes the specified set of tags from the specified Elasticsearch domain.</p>",
     "UpdateElasticsearchDomainConfig": "<p>Modifies the cluster configuration of the specified Elasticsearch domain, setting as setting the instance type and the number of instances. </p>"
   },
@@ -166,6 +169,26 @@
       "refs": {
       }
     },
+    "DescribeReservedElasticsearchInstanceOfferingsRequest": {
+      "base": "<p>Container for parameters to <code>DescribeReservedElasticsearchInstanceOfferings</code></p>",
+      "refs": {
+      }
+    },
+    "DescribeReservedElasticsearchInstanceOfferingsResponse": {
+      "base": "<p>Container for results from <code>DescribeReservedElasticsearchInstanceOfferings</code></p>",
+      "refs": {
+      }
+    },
+    "DescribeReservedElasticsearchInstancesRequest": {
+      "base": "<p>Container for parameters to <code>DescribeReservedElasticsearchInstances</code></p>",
+      "refs": {
+      }
+    },
+    "DescribeReservedElasticsearchInstancesResponse": {
+      "base": "<p>Container for results from <code>DescribeReservedElasticsearchInstances</code></p>",
+      "refs": {
+      }
+    },
     "DisabledOperationException": {
       "base": "<p>An error occured because the client wanted to access a not supported operation. Gives http status code of 409.</p>",
       "refs": {
@@ -210,6 +233,16 @@
         "DescribeElasticsearchDomainsRequest$DomainNames": "<p>The Elasticsearch domains for which you want information.</p>"
       }
     },
+    "Double": {
+      "base": null,
+      "refs": {
+        "RecurringCharge$RecurringChargeAmount": "<p>The monetary amount of the recurring charge.</p>",
+        "ReservedElasticsearchInstance$FixedPrice": "<p>The upfront fixed charge you will paid to purchase the specific reserved Elasticsearch instance offering. </p>",
+        "ReservedElasticsearchInstance$UsagePrice": "<p>The rate you are charged for each hour for the domain that is using this reserved instance.</p>",
+        "ReservedElasticsearchInstanceOffering$FixedPrice": "<p>The upfront fixed charge you will pay to purchase the specific reserved Elasticsearch instance offering. </p>",
+        "ReservedElasticsearchInstanceOffering$UsagePrice": "<p>The rate you are charged for each hour the domain that is using the offering is running.</p>"
+      }
+    },
     "EBSOptions": {
       "base": "<p>Options to enable, disable, and specify the properties of EBS storage volumes. For more information, see <a href=\"http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-ebs\" target=\"_blank\"> Configuring EBS-based Storage</a>.</p>",
       "refs": {
@@ -231,7 +264,9 @@
         "DescribeElasticsearchInstanceTypeLimitsRequest$InstanceType": "<p> The instance type for an Elasticsearch cluster for which Elasticsearch <code> <a>Limits</a> </code> are needed. </p>",
         "ElasticsearchClusterConfig$InstanceType": "<p>The instance type for an Elasticsearch cluster.</p>",
         "ElasticsearchClusterConfig$DedicatedMasterType": "<p>The instance type for a dedicated master node.</p>",
-        "ElasticsearchInstanceTypeList$member": null
+        "ElasticsearchInstanceTypeList$member": null,
+        "ReservedElasticsearchInstance$ElasticsearchInstanceType": "<p>The Elasticsearch instance type offered by the reserved instance offering.</p>",
+        "ReservedElasticsearchInstanceOffering$ElasticsearchInstanceType": "<p>The Elasticsearch instance type offered by the reserved instance offering.</p>"
       }
     },
     "ElasticsearchClusterConfig": {
@@ -326,10 +361,27 @@
         "BaseException$message": "<p>A description of the error.</p>"
       }
     },
+    "GUID": {
+      "base": null,
+      "refs": {
+        "DescribeReservedElasticsearchInstanceOfferingsRequest$ReservedElasticsearchInstanceOfferingId": "<p>The offering identifier filter value. Use this parameter to show only the available offering that matches the specified reservation identifier.</p>",
+        "DescribeReservedElasticsearchInstancesRequest$ReservedElasticsearchInstanceId": "<p>The reserved instance identifier filter value. Use this parameter to show only the reservation that matches the specified reserved Elasticsearch instance ID.</p>",
+        "PurchaseReservedElasticsearchInstanceOfferingRequest$ReservedElasticsearchInstanceOfferingId": "<p>The ID of the reserved Elasticsearch instance offering to purchase.</p>",
+        "PurchaseReservedElasticsearchInstanceOfferingResponse$ReservedElasticsearchInstanceId": "<p>Details of the reserved Elasticsearch instance which was purchased.</p>",
+        "ReservedElasticsearchInstance$ReservedElasticsearchInstanceId": "<p>The unique identifier for the reservation.</p>",
+        "ReservedElasticsearchInstanceOffering$ReservedElasticsearchInstanceOfferingId": "<p>The Elasticsearch reserved instance offering identifier.</p>"
+      }
+    },
     "IdentityPoolId": {
       "base": null,
       "refs": {
         "CognitoOptions$IdentityPoolId": "<p>Specifies the Cognito identity pool ID for Kibana authentication.</p>"
+      }
+    },
+    "InstanceCount": {
+      "base": "<p>Specifies the number of EC2 instances in the Elasticsearch domain.</p>",
+      "refs": {
+        "PurchaseReservedElasticsearchInstanceOfferingRequest$InstanceCount": "<p>The number of Elasticsearch instances to reserve.</p>"
       }
     },
     "InstanceCountLimits": {
@@ -348,6 +400,14 @@
       "base": null,
       "refs": {
         "LimitsByRole$key": null
+      }
+    },
+    "Integer": {
+      "base": null,
+      "refs": {
+        "ReservedElasticsearchInstance$Duration": "<p>The duration, in seconds, for which the Elasticsearch instance is reserved.</p>",
+        "ReservedElasticsearchInstance$ElasticsearchInstanceCount": "<p>The number of Elasticsearch instances that have been reserved.</p>",
+        "ReservedElasticsearchInstanceOffering$Duration": "<p>The duration, in seconds, for which the offering will reserve the Elasticsearch instance.</p>"
       }
     },
     "IntegerClass": {
@@ -478,6 +538,8 @@
     "MaxResults": {
       "base": "<p> Set this value to limit the number of results returned. </p>",
       "refs": {
+        "DescribeReservedElasticsearchInstanceOfferingsRequest$MaxResults": "<p>Set this value to limit the number of results returned. If not specified, defaults to 100.</p>",
+        "DescribeReservedElasticsearchInstancesRequest$MaxResults": "<p>Set this value to limit the number of results returned. If not specified, defaults to 100.</p>",
         "ListElasticsearchInstanceTypesRequest$MaxResults": "<p> Set this value to limit the number of results returned. Value provided must be greater than 30 else it wont be honored. </p>",
         "ListElasticsearchVersionsRequest$MaxResults": "<p> Set this value to limit the number of results returned. Value provided must be greater than 10 else it wont be honored. </p>"
       }
@@ -497,6 +559,9 @@
     "NextToken": {
       "base": "<p> Paginated APIs accepts NextToken input to returns next page results and provides a NextToken output in the response which can be used by the client to retrieve more results. </p>",
       "refs": {
+        "DescribeReservedElasticsearchInstanceOfferingsRequest$NextToken": "<p>NextToken should be sent in case if earlier API call produced result containing NextToken. It is used for pagination.</p>",
+        "DescribeReservedElasticsearchInstanceOfferingsResponse$NextToken": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
+        "DescribeReservedElasticsearchInstancesRequest$NextToken": "<p>NextToken should be sent in case if earlier API call produced result containing NextToken. It is used for pagination.</p>",
         "ListElasticsearchInstanceTypesRequest$NextToken": "<p>NextToken should be sent in case if earlier API call produced result containing NextToken. It is used for pagination. </p>",
         "ListElasticsearchInstanceTypesResponse$NextToken": "<p>In case if there are more results available NextToken would be present, make further request to the same API with received NextToken to paginate remaining results. </p>",
         "ListElasticsearchVersionsRequest$NextToken": null,
@@ -533,9 +598,71 @@
         "UpdateElasticsearchDomainConfigRequest$AccessPolicies": "<p>IAM access policy as a JSON-formatted string.</p>"
       }
     },
+    "PurchaseReservedElasticsearchInstanceOfferingRequest": {
+      "base": "<p>Container for parameters to <code>PurchaseReservedElasticsearchInstanceOffering</code></p>",
+      "refs": {
+      }
+    },
+    "PurchaseReservedElasticsearchInstanceOfferingResponse": {
+      "base": "<p>Represents the output of a <code>PurchaseReservedElasticsearchInstanceOffering</code> operation.</p>",
+      "refs": {
+      }
+    },
+    "RecurringCharge": {
+      "base": "<p>Contains the specific price and frequency of a recurring charges for a reserved Elasticsearch instance, or for a reserved Elasticsearch instance offering.</p>",
+      "refs": {
+        "RecurringChargeList$member": null
+      }
+    },
+    "RecurringChargeList": {
+      "base": null,
+      "refs": {
+        "ReservedElasticsearchInstance$RecurringCharges": "<p>The charge to your account regardless of whether you are creating any domains using the instance offering.</p>",
+        "ReservedElasticsearchInstanceOffering$RecurringCharges": "<p>The charge to your account regardless of whether you are creating any domains using the instance offering.</p>"
+      }
+    },
     "RemoveTagsRequest": {
       "base": "<p>Container for the parameters to the <code><a>RemoveTags</a></code> operation. Specify the <code>ARN</code> for the Elasticsearch domain from which you want to remove the specified <code>TagKey</code>.</p>",
       "refs": {
+      }
+    },
+    "ReservationToken": {
+      "base": null,
+      "refs": {
+        "PurchaseReservedElasticsearchInstanceOfferingRequest$ReservationName": "<p>A customer-specified identifier to track this reservation.</p>",
+        "PurchaseReservedElasticsearchInstanceOfferingResponse$ReservationName": "<p>The customer-specified identifier used to track this reservation.</p>",
+        "ReservedElasticsearchInstance$ReservationName": "<p>The customer-specified identifier to track this reservation.</p>"
+      }
+    },
+    "ReservedElasticsearchInstance": {
+      "base": "<p>Details of a reserved Elasticsearch instance.</p>",
+      "refs": {
+        "ReservedElasticsearchInstanceList$member": null
+      }
+    },
+    "ReservedElasticsearchInstanceList": {
+      "base": null,
+      "refs": {
+        "DescribeReservedElasticsearchInstancesResponse$ReservedElasticsearchInstances": "<p>List of reserved Elasticsearch instances.</p>"
+      }
+    },
+    "ReservedElasticsearchInstanceOffering": {
+      "base": "<p>Details of a reserved Elasticsearch instance offering.</p>",
+      "refs": {
+        "ReservedElasticsearchInstanceOfferingList$member": null
+      }
+    },
+    "ReservedElasticsearchInstanceOfferingList": {
+      "base": null,
+      "refs": {
+        "DescribeReservedElasticsearchInstanceOfferingsResponse$ReservedElasticsearchInstanceOfferings": "<p>List of reserved Elasticsearch instance offerings</p>"
+      }
+    },
+    "ReservedElasticsearchInstancePaymentOption": {
+      "base": null,
+      "refs": {
+        "ReservedElasticsearchInstance$PaymentOption": "<p>The payment option as defined in the reserved Elasticsearch instance offering.</p>",
+        "ReservedElasticsearchInstanceOffering$PaymentOption": "<p>Payment option for the reserved Elasticsearch instance offering</p>"
       }
     },
     "ResourceAlreadyExistsException": {
@@ -617,7 +744,13 @@
       "refs": {
         "AdvancedOptions$key": null,
         "AdvancedOptions$value": null,
+        "DescribeReservedElasticsearchInstancesResponse$NextToken": "<p>Provides an identifier to allow retrieval of paginated results.</p>",
         "EndpointsMap$key": null,
+        "RecurringCharge$RecurringChargeFrequency": "<p>The frequency of the recurring charge.</p>",
+        "ReservedElasticsearchInstance$ReservedElasticsearchInstanceOfferingId": "<p>The offering identifier.</p>",
+        "ReservedElasticsearchInstance$CurrencyCode": "<p>The currency code for the reserved Elasticsearch instance offering.</p>",
+        "ReservedElasticsearchInstance$State": "<p>The state of the reserved Elasticsearch instance.</p>",
+        "ReservedElasticsearchInstanceOffering$CurrencyCode": "<p>The currency code for the reserved Elasticsearch instance offering.</p>",
         "StringList$member": null,
         "VPCDerivedInfo$VPCId": "<p>The VPC Id for the Elasticsearch domain. Exists only if the domain was created with VPCOptions.</p>"
       }
@@ -678,7 +811,8 @@
       "base": null,
       "refs": {
         "OptionStatus$CreationDate": "<p>Timestamp which tells the creation date for the entity.</p>",
-        "OptionStatus$UpdateDate": "<p>Timestamp which tells the last updated time for the entity.</p>"
+        "OptionStatus$UpdateDate": "<p>Timestamp which tells the last updated time for the entity.</p>",
+        "ReservedElasticsearchInstance$StartTime": "<p>The time the reservation started.</p>"
       }
     },
     "UserPoolId": {

--- a/models/apis/es/2015-01-01/paginators-1.json
+++ b/models/apis/es/2015-01-01/paginators-1.json
@@ -1,5 +1,15 @@
 {
   "pagination": {
+    "DescribeReservedElasticsearchInstanceOfferings": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "DescribeReservedElasticsearchInstances": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
     "ListElasticsearchInstanceTypes": {
       "input_token": "NextToken",
       "output_token": "NextToken",

--- a/models/apis/s3/2006-03-01/api-2.json
+++ b/models/apis/s3/2006-03-01/api-2.json
@@ -1030,6 +1030,7 @@
       }
     },
     "BytesProcessed":{"type":"long"},
+    "BytesReturned":{"type":"long"},
     "BytesScanned":{"type":"long"},
     "CORSConfiguration":{
       "type":"structure",
@@ -4183,7 +4184,8 @@
       "type":"structure",
       "members":{
         "BytesScanned":{"shape":"BytesScanned"},
-        "BytesProcessed":{"shape":"BytesProcessed"}
+        "BytesProcessed":{"shape":"BytesProcessed"},
+        "BytesReturned":{"shape":"BytesReturned"}
       }
     },
     "ProgressEvent":{
@@ -5432,7 +5434,8 @@
       "type":"structure",
       "members":{
         "BytesScanned":{"shape":"BytesScanned"},
-        "BytesProcessed":{"shape":"BytesProcessed"}
+        "BytesProcessed":{"shape":"BytesProcessed"},
+        "BytesReturned":{"shape":"BytesReturned"}
       }
     },
     "StatsEvent":{

--- a/models/apis/s3/2006-03-01/docs-2.json
+++ b/models/apis/s3/2006-03-01/docs-2.json
@@ -414,6 +414,13 @@
         "Stats$BytesProcessed": "Total number of uncompressed object bytes processed."
       }
     },
+    "BytesReturned": {
+      "base": null,
+      "refs": {
+        "Progress$BytesReturned": "Current number of bytes of records payload data returned.",
+        "Stats$BytesReturned": "Total number of bytes of records payload data returned."
+      }
+    },
     "BytesScanned": {
       "base": null,
       "refs": {

--- a/models/endpoints/endpoints.json
+++ b/models/endpoints/endpoints.json
@@ -1184,12 +1184,15 @@
       "lightsail" : {
         "endpoints" : {
           "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
+          "eu-west-3" : { },
           "us-east-1" : { },
           "us-east-2" : { },
           "us-west-2" : { }
@@ -1980,6 +1983,7 @@
           "protocols" : [ "https" ]
         },
         "endpoints" : {
+          "eu-west-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
           "us-west-2" : { }
@@ -2004,6 +2008,7 @@
           "eu-central-1" : { },
           "eu-west-1" : { },
           "us-east-1" : { },
+          "us-east-2" : { },
           "us-west-1" : { },
           "us-west-2" : { }
         }

--- a/service/alexaforbusiness/api.go
+++ b/service/alexaforbusiness/api.go
@@ -9673,6 +9673,9 @@ const (
 const (
 	// DeviceEventTypeConnectionStatus is a DeviceEventType enum value
 	DeviceEventTypeConnectionStatus = "CONNECTION_STATUS"
+
+	// DeviceEventTypeDeviceStatus is a DeviceEventType enum value
+	DeviceEventTypeDeviceStatus = "DEVICE_STATUS"
 )
 
 const (
@@ -9684,6 +9687,9 @@ const (
 
 	// DeviceStatusWasOffline is a DeviceStatus enum value
 	DeviceStatusWasOffline = "WAS_OFFLINE"
+
+	// DeviceStatusDeregistered is a DeviceStatus enum value
+	DeviceStatusDeregistered = "DEREGISTERED"
 )
 
 const (

--- a/service/budgets/api.go
+++ b/service/budgets/api.go
@@ -324,8 +324,8 @@ func (c *Budgets) DeleteBudgetRequest(input *DeleteBudgetInput) (req *request.Re
 //
 // Deletes a budget. You can delete your budget at any time.
 //
-// Deleting a budget also deletes the notifications and subscribers associated
-// with that budget.
+// Deleting a budget also deletes the notifications and subscribers that are
+// associated with that budget.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -411,8 +411,8 @@ func (c *Budgets) DeleteNotificationRequest(input *DeleteNotificationInput) (req
 //
 // Deletes a notification.
 //
-// Deleting a notification also deletes the subscribers associated with the
-// notification.
+// Deleting a notification also deletes the subscribers that are associated
+// with the notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -666,7 +666,7 @@ func (c *Budgets) DescribeBudgetsRequest(input *DescribeBudgetsInput) (req *requ
 
 // DescribeBudgets API operation for AWS Budgets.
 //
-// Lists the budgets associated with an account.
+// Lists the budgets that are associated with an account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -756,7 +756,7 @@ func (c *Budgets) DescribeNotificationsForBudgetRequest(input *DescribeNotificat
 
 // DescribeNotificationsForBudget API operation for AWS Budgets.
 //
-// Lists the notifications associated with a budget.
+// Lists the notifications that are associated with a budget.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -846,7 +846,7 @@ func (c *Budgets) DescribeSubscribersForNotificationRequest(input *DescribeSubsc
 
 // DescribeSubscribersForNotification API operation for AWS Budgets.
 //
-// Lists the subscribers associated with a notification.
+// Lists the subscribers that are associated with a notification.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -937,7 +937,7 @@ func (c *Budgets) UpdateBudgetRequest(input *UpdateBudgetInput) (req *request.Re
 // UpdateBudget API operation for AWS Budgets.
 //
 // Updates a budget. You can change every part of a budget except for the budgetName
-// and the calculatedSpend. When a budget is modified, the calculatedSpend drops
+// and the calculatedSpend. When you modify a budget, the calculatedSpend drops
 // to zero until AWS has new usage data to use for forecasting.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1156,52 +1156,56 @@ func (c *Budgets) UpdateSubscriberWithContext(ctx aws.Context, input *UpdateSubs
 
 // Represents the output of the CreateBudget operation. The content consists
 // of the detailed metadata and data file information, and the current status
-// of the budget.
+// of the budget object.
 //
-// The ARN pattern for a budget is: arn:aws:budgetservice::AccountId:budget/budgetName
+// This is the ARN pattern for a budget:
+//
+// arn:aws:budgetservice::AccountId:budget/budgetName
 type Budget struct {
 	_ struct{} `type:"structure"`
 
-	// The total amount of cost, usage, or RI utilization that you want to track
-	// with your budget.
+	// The total amount of cost, usage, RI utilization, or RI coverage that you
+	// want to track with your budget.
 	//
 	// BudgetLimit is required for cost or usage budgets, but optional for RI utilization
-	// budgets. RI utilization budgets default to the only valid value for RI utilization
-	// budgets, which is 100.
+	// or coverage budgets. RI utilization or coverage budgets default to 100, which
+	// is the only valid value for RI utilization or coverage budgets.
 	BudgetLimit *Spend `type:"structure"`
 
-	// The name of a budget. Unique within accounts. : and \ characters are not
-	// allowed in the BudgetName.
+	// The name of a budget. The name must be unique within accounts. The : and
+	// \ characters are not allowed in BudgetName.
 	//
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Whether this budget tracks monetary costs, usage, or RI utilization.
+	// Whether this budget tracks monetary costs, usage, RI utilization, or RI coverage.
 	//
 	// BudgetType is a required field
 	BudgetType *string `type:"string" required:"true" enum:"BudgetType"`
 
-	// The actual and forecasted cost or usage being tracked by a budget.
+	// The actual and forecasted cost or usage that the budget tracks.
 	CalculatedSpend *CalculatedSpend `type:"structure"`
 
-	// The cost filters applied to a budget, such as service or region.
+	// The cost filters, such as service or region, that are applied to a budget.
 	CostFilters map[string][]*string `type:"map"`
 
-	// The types of costs included in this budget.
+	// The types of costs that are included in this COST budget.
+	//
+	// USAGE, RI_UTILIZATION, and RI_COVERAGE budgets do not have CostTypes.
 	CostTypes *CostTypes `type:"structure"`
 
-	// The period of time covered by a budget. Has a start date and an end date.
-	// The start date must come before the end date. There are no restrictions on
-	// the end date.
+	// The period of time that is covered by a budget. The period has a start date
+	// and an end date. The start date must come before the end date. The end date
+	// must come before 06/15/87 00:00 UTC.
 	//
-	// If you created your budget and didn't specify a start date, AWS defaults
-	// to the start of your chosen time period (i.e. DAILY, MONTHLY, QUARTERLY,
-	// ANNUALLY). For example, if you created your budget on January 24th 2018,
-	// chose DAILY, and didn't set a start date, AWS set your start date to 01/24/18
-	// 00:00 UTC. If you chose MONTHLY, AWS set your start date to 01/01/18 00:00
-	// UTC. If you didn't specify an end date, AWS set your end date to 06/15/87
-	// 00:00 UTC. The defaults are the same for the AWS Billing and Cost Management
-	// console and the API.
+	// If you create your budget and don't specify a start date, AWS defaults to
+	// the start of your chosen time period (DAILY, MONTHLY, QUARTERLY, or ANNUALLY).
+	// For example, if you created your budget on January 24, 2018, chose DAILY,
+	// and didn't set a start date, AWS set your start date to 01/24/18 00:00 UTC.
+	// If you chose MONTHLY, AWS set your start date to 01/01/18 00:00 UTC. If you
+	// didn't specify an end date, AWS set your end date to 06/15/87 00:00 UTC.
+	// The defaults are the same for the AWS Billing and Cost Management console
+	// and the API.
 	//
 	// You can change either date with the UpdateBudget operation.
 	//
@@ -1210,6 +1214,7 @@ type Budget struct {
 	TimePeriod *TimePeriod `type:"structure"`
 
 	// The length of time until a budget resets the actual and forecasted spend.
+	// DAILY is available only for RI_UTILIZATION and RI_COVERAGE budgets.
 	//
 	// TimeUnit is a required field
 	TimeUnit *string `type:"string" required:"true" enum:"TimeUnit"`
@@ -1302,8 +1307,8 @@ func (s *Budget) SetTimeUnit(v string) *Budget {
 	return s
 }
 
-// The spend objects associated with this budget. The actualSpend tracks how
-// much you've used, cost, usage, or RI units, and the forecastedSpend tracks
+// The spend objects that are associated with this budget. The actualSpend tracks
+// how much you've used, cost, usage, or RI units, and the forecastedSpend tracks
 // how much you are predicted to spend if your current usage remains steady.
 //
 // For example, if it is the 20th of the month and you have spent 50 dollars
@@ -1366,7 +1371,9 @@ func (s *CalculatedSpend) SetForecastedSpend(v *Spend) *CalculatedSpend {
 	return s
 }
 
-// The types of cost included in a budget, such as tax and subscriptions.
+// The types of cost that are included in a COST budget, such as tax and subscriptions.
+//
+// USAGE, RI_UTILIZATION, and RI_COVERAGE budgets do not have CostTypes.
 type CostTypes struct {
 	_ struct{} `type:"structure"`
 
@@ -1420,7 +1427,7 @@ type CostTypes struct {
 	// The default value is false.
 	UseAmortized *bool `type:"boolean"`
 
-	// Specifies whether a budget uses blended rate.
+	// Specifies whether a budget uses a blended rate.
 	//
 	// The default value is false.
 	UseBlended *bool `type:"boolean"`
@@ -1518,7 +1525,7 @@ type CreateBudgetInput struct {
 
 	// A notification that you want to associate with a budget. A budget can have
 	// up to five notifications, and each notification can have one SNS subscriber
-	// and up to ten email subscribers. If you include notifications and subscribers
+	// and up to 10 email subscribers. If you include notifications and subscribers
 	// in your CreateBudget call, AWS creates the notifications and subscribers
 	// for you.
 	NotificationsWithSubscribers []*NotificationWithSubscribers `type:"list"`
@@ -1611,7 +1618,7 @@ type CreateNotificationInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// The name of the budget that you want AWS to notified you about. Budget names
+	// The name of the budget that you want AWS to notify you about. Budget names
 	// must be unique within an account.
 	//
 	// BudgetName is a required field
@@ -1623,7 +1630,7 @@ type CreateNotificationInput struct {
 	Notification *Notification `type:"structure" required:"true"`
 
 	// A list of subscribers that you want to associate with the notification. Each
-	// notification can have one SNS subscriber and up to ten email subscribers.
+	// notification can have one SNS subscriber and up to 10 email subscribers.
 	//
 	// Subscribers is a required field
 	Subscribers []*Subscriber `min:"1" type:"list" required:"true"`
@@ -1725,8 +1732,8 @@ func (s CreateNotificationOutput) GoString() string {
 type CreateSubscriberInput struct {
 	_ struct{} `type:"structure"`
 
-	// The accountId associated with the budget that you want to create a subscriber
-	// for.
+	// The accountId that is associated with the budget that you want to create
+	// a subscriber for.
 	//
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
@@ -2195,10 +2202,12 @@ type DescribeBudgetsInput struct {
 	// AccountId is a required field
 	AccountId *string `min:"12" type:"string" required:"true"`
 
-	// Optional integer. Specifies the maximum number of results to return in response.
+	// Optional integer. Specifies the maximum number of results to return in a
+	// response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// The pagination token that indicates the next set of results to retrieve.
+	// The pagination token that you include in your request to indicate the next
+	// set of results that you want to retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2256,8 +2265,8 @@ type DescribeBudgetsOutput struct {
 	// A list of budgets.
 	Budgets []*Budget `type:"list"`
 
-	// The pagination token that indicates the next set of results that you can
-	// retrieve.
+	// The pagination token in the service response that indicates the next set
+	// of results that you can retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2298,10 +2307,12 @@ type DescribeNotificationsForBudgetInput struct {
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Optional integer. Specifies the maximum number of results to return in response.
+	// Optional integer. Specifies the maximum number of results to return in a
+	// response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// The pagination token that indicates the next set of results to retrieve.
+	// The pagination token that you include in your request to indicate the next
+	// set of results that you want to retrieve.
 	NextToken *string `type:"string"`
 }
 
@@ -2365,11 +2376,11 @@ func (s *DescribeNotificationsForBudgetInput) SetNextToken(v string) *DescribeNo
 type DescribeNotificationsForBudgetOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The pagination token that indicates the next set of results that you can
-	// retrieve.
+	// The pagination token in the service response that indicates the next set
+	// of results that you can retrieve.
 	NextToken *string `type:"string"`
 
-	// A list of notifications associated with a budget.
+	// A list of notifications that are associated with a budget.
 	Notifications []*Notification `type:"list"`
 }
 
@@ -2410,10 +2421,12 @@ type DescribeSubscribersForNotificationInput struct {
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// Optional integer. Specifies the maximum number of results to return in response.
+	// Optional integer. Specifies the maximum number of results to return in a
+	// response.
 	MaxResults *int64 `min:"1" type:"integer"`
 
-	// The pagination token that indicates the next set of results to retrieve.
+	// The pagination token that you include in your request to indicate the next
+	// set of results that you want to retrieve.
 	NextToken *string `type:"string"`
 
 	// The notification whose subscribers you want to list.
@@ -2496,11 +2509,11 @@ func (s *DescribeSubscribersForNotificationInput) SetNotification(v *Notificatio
 type DescribeSubscribersForNotificationOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The pagination token that indicates the next set of results that you can
-	// retrieve.
+	// The pagination token in the service response that indicates the next set
+	// of results that you can retrieve.
 	NextToken *string `type:"string"`
 
-	// A list of subscribers associated with a notification.
+	// A list of subscribers that are associated with a notification.
 	Subscribers []*Subscriber `min:"1" type:"list"`
 }
 
@@ -2526,10 +2539,11 @@ func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscribe
 	return s
 }
 
-// A notification associated with a budget. A budget can have up to five notifications.
+// A notification that is associated with a budget. A budget can have up to
+// five notifications.
 //
 // Each notification must have at least one subscriber. A notification can have
-// one SNS subscriber and up to ten email subscribers, for a total of 11 subscribers.
+// one SNS subscriber and up to 10 email subscribers, for a total of 11 subscribers.
 //
 // For example, if you have a budget for 200 dollars and you want to be notified
 // when you go over 160 dollars, create a notification with the following parameters:
@@ -2542,7 +2556,7 @@ func (s *DescribeSubscribersForNotificationOutput) SetSubscribers(v []*Subscribe
 type Notification struct {
 	_ struct{} `type:"structure"`
 
-	// The comparison used for this notification.
+	// The comparison that is used for this notification.
 	//
 	// ComparisonOperator is a required field
 	ComparisonOperator *string `type:"string" required:"true" enum:"ComparisonOperator"`
@@ -2553,13 +2567,14 @@ type Notification struct {
 	// NotificationType is a required field
 	NotificationType *string `type:"string" required:"true" enum:"NotificationType"`
 
-	// The threshold associated with a notification. Thresholds are always a percentage.
+	// The threshold that is associated with a notification. Thresholds are always
+	// a percentage.
 	//
 	// Threshold is a required field
 	Threshold *float64 `min:"0.1" type:"double" required:"true"`
 
 	// The type of threshold for a notification. For ACTUAL thresholds, AWS notifies
-	// you when you go over the threshold, and for FORECASTED thresholds AWS notifies
+	// you when you go over the threshold. For FORECASTED thresholds, AWS notifies
 	// you when you are forecasted to go over the threshold.
 	ThresholdType *string `type:"string" enum:"ThresholdType"`
 }
@@ -2621,11 +2636,11 @@ func (s *Notification) SetThresholdType(v string) *Notification {
 }
 
 // A notification with subscribers. A notification can have one SNS subscriber
-// and up to ten email subscribers, for a total of 11 subscribers.
+// and up to 10 email subscribers, for a total of 11 subscribers.
 type NotificationWithSubscribers struct {
 	_ struct{} `type:"structure"`
 
-	// The notification associated with a budget.
+	// The notification that is associated with a budget.
 	//
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
@@ -2692,7 +2707,7 @@ func (s *NotificationWithSubscribers) SetSubscribers(v []*Subscriber) *Notificat
 	return s
 }
 
-// The amount of cost or usage being measured for a budget.
+// The amount of cost or usage that is measured for a budget.
 //
 // For example, a Spend for 3 GB of S3 usage would have the following parameters:
 //
@@ -2702,14 +2717,14 @@ func (s *NotificationWithSubscribers) SetSubscribers(v []*Subscriber) *Notificat
 type Spend struct {
 	_ struct{} `type:"structure"`
 
-	// The cost or usage amount associated with a budget forecast, actual spend,
-	// or budget threshold.
+	// The cost or usage amount that is associated with a budget forecast, actual
+	// spend, or budget threshold.
 	//
 	// Amount is a required field
 	Amount *string `type:"string" required:"true"`
 
-	// The unit of measurement used for the budget forecast, actual spend, or budget
-	// threshold, such as dollars or GB.
+	// The unit of measurement that is used for the budget forecast, actual spend,
+	// or budget threshold, such as dollars or GB.
 	//
 	// Unit is a required field
 	Unit *string `min:"1" type:"string" required:"true"`
@@ -2757,7 +2772,7 @@ func (s *Spend) SetUnit(v string) *Spend {
 }
 
 // The subscriber to a budget notification. The subscriber consists of a subscription
-// type and either an Amazon Simple Notification Service topic or an email address.
+// type and either an Amazon SNS topic or an email address.
 //
 // For example, an email subscriber would have the following parameters:
 //
@@ -2820,9 +2835,9 @@ func (s *Subscriber) SetSubscriptionType(v string) *Subscriber {
 	return s
 }
 
-// The period of time covered by a budget. Has a start date and an end date.
-// The start date must come before the end date. There are no restrictions on
-// the end date.
+// The period of time that is covered by a budget. The period has a start date
+// and an end date. The start date must come before the end date. There are
+// no restrictions on the end date.
 type TimePeriod struct {
 	_ struct{} `type:"structure"`
 
@@ -2835,9 +2850,9 @@ type TimePeriod struct {
 	End *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// The start date for a budget. If you created your budget and didn't specify
-	// a start date, AWS defaults to the start of your chosen time period (i.e.
-	// DAILY, MONTHLY, QUARTERLY, ANNUALLY). For example, if you created your budget
-	// on January 24th 2018, chose DAILY, and didn't set a start date, AWS set your
+	// a start date, AWS defaults to the start of your chosen time period (DAILY,
+	// MONTHLY, QUARTERLY, or ANNUALLY). For example, if you created your budget
+	// on January 24, 2018, chose DAILY, and didn't set a start date, AWS set your
 	// start date to 01/24/18 00:00 UTC. If you chose MONTHLY, AWS set your start
 	// date to 01/01/18 00:00 UTC. The defaults are the same for the AWS Billing
 	// and Cost Management console and the API.
@@ -2964,7 +2979,7 @@ type UpdateNotificationInput struct {
 	// NewNotification is a required field
 	NewNotification *Notification `type:"structure" required:"true"`
 
-	// The previous notification associated with a budget.
+	// The previous notification that is associated with a budget.
 	//
 	// OldNotification is a required field
 	OldNotification *Notification `type:"structure" required:"true"`
@@ -3069,7 +3084,7 @@ type UpdateSubscriberInput struct {
 	// BudgetName is a required field
 	BudgetName *string `type:"string" required:"true"`
 
-	// The updated subscriber associated with a budget notification.
+	// The updated subscriber that is associated with a budget notification.
 	//
 	// NewSubscriber is a required field
 	NewSubscriber *Subscriber `type:"structure" required:"true"`
@@ -3079,7 +3094,7 @@ type UpdateSubscriberInput struct {
 	// Notification is a required field
 	Notification *Notification `type:"structure" required:"true"`
 
-	// The previous subscriber associated with a budget notification.
+	// The previous subscriber that is associated with a budget notification.
 	//
 	// OldSubscriber is a required field
 	OldSubscriber *Subscriber `type:"structure" required:"true"`
@@ -3183,7 +3198,9 @@ func (s UpdateSubscriberOutput) GoString() string {
 	return s.String()
 }
 
-// The type of a budget. It should be COST, USAGE, or RI_UTILIZATION.
+// The type of a budget. It must be one of the following types:
+//
+// COST, USAGE, RI_UTILIZATION, or RI_COVERAGE.
 const (
 	// BudgetTypeUsage is a BudgetType enum value
 	BudgetTypeUsage = "USAGE"
@@ -3193,10 +3210,15 @@ const (
 
 	// BudgetTypeRiUtilization is a BudgetType enum value
 	BudgetTypeRiUtilization = "RI_UTILIZATION"
+
+	// BudgetTypeRiCoverage is a BudgetType enum value
+	BudgetTypeRiCoverage = "RI_COVERAGE"
 )
 
-// The comparison operator of a notification. Currently we support less than,
-// equal to and greater than.
+// The comparison operator of a notification. Currently the service supports
+// the following operators:
+//
+// GREATER_THAN, LESS_THAN, EQUAL_TO
 const (
 	// ComparisonOperatorGreaterThan is a ComparisonOperator enum value
 	ComparisonOperatorGreaterThan = "GREATER_THAN"
@@ -3208,7 +3230,7 @@ const (
 	ComparisonOperatorEqualTo = "EQUAL_TO"
 )
 
-// The type of a notification. It should be ACTUAL or FORECASTED.
+// The type of a notification. It must be ACTUAL or FORECASTED.
 const (
 	// NotificationTypeActual is a NotificationType enum value
 	NotificationTypeActual = "ACTUAL"
@@ -3235,7 +3257,7 @@ const (
 	ThresholdTypeAbsoluteValue = "ABSOLUTE_VALUE"
 )
 
-// The time unit of the budget. e.g. MONTHLY, QUARTERLY, etc.
+// The time unit of the budget, such as MONTHLY or QUARTERLY.
 const (
 	// TimeUnitDaily is a TimeUnit enum value
 	TimeUnitDaily = "DAILY"

--- a/service/budgets/doc.go
+++ b/service/budgets/doc.go
@@ -3,39 +3,48 @@
 // Package budgets provides the client and types for making API
 // requests to AWS Budgets.
 //
-// Budgets enable you to plan your service usage, service costs, and your RI
-// utilization. You can also track how close your plan is to your budgeted amount
-// or to the free tier limits. Budgets provide you with a quick way to see your
-// usage-to-date and current estimated charges from AWS and to see how much
-// your predicted usage accrues in charges by the end of the month. Budgets
-// also compare current estimates and charges to the amount that you indicated
-// you want to use or spend and lets you see how much of your budget has been
-// used. AWS updates your budget status several times a day. Budgets track your
-// unblended costs, subscriptions, and refunds. You can create the following
-// types of budgets:
+// The AWS Budgets API enables you to use AWS Budgets to plan your service usage,
+// service costs, and instance reservations. The API reference provides descriptions,
+// syntax, and usage examples for each of the actions and data types for AWS
+// Budgets.
 //
-//    * Cost budgets allow you to say how much you want to spend on a service.
+// Budgets provide you with a way to see the following information:
 //
-//    * Usage budgets allow you to say how many hours you want to use for one
-//    or more services.
+//    * How close your plan is to your budgeted amount or to the free tier limits
 //
-//    * RI utilization budgets allow you to define a utilization threshold and
-//    receive alerts when RIs are tracking below that threshold.
+//    * Your usage-to-date, including how much you've used of your Reserved
+//    Instances (RIs)
 //
-// You can create up to 20,000 budgets per AWS master account. Your first two
-// budgets are free of charge. Each additional budget costs $0.02 per day. You
-// can set up optional notifications that warn you if you exceed, or are forecasted
-// to exceed, your budgeted amount. You can have notifications sent to an Amazon
-// SNS topic, to an email address, or to both. For more information, see Creating
-// an Amazon SNS Topic for Budget Notifications (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-sns-policy.html).
-// AWS Free Tier usage alerts via AWS Budgets are provided for you, and do not
-// count toward your budget limits.
+//    * Your current estimated charges from AWS, and how much your predicted
+//    usage will accrue in charges by the end of the month
+//
+//    * How much of your budget has been used
+//
+// AWS updates your budget status several times a day. Budgets track your unblended
+// costs, subscriptions, refunds, and RIs. You can create the following types
+// of budgets:
+//
+//    * Cost budgets - Plan how much you want to spend on a service.
+//
+//    * Usage budgets - Plan how much you want to use one or more services.
+//
+//    * RI utilization budgets - Define a utilization threshold, and receive
+//    alerts when your RI usage falls below that threshold. This lets you see
+//    if your RIs are unused or under-utilized.
+//
+//    * RI coverage budgets - Define a coverage threshold, and receive alerts
+//    when the number of your instance hours that are covered by RIs fall below
+//    that threshold. This lets you see how much of your instance usage is covered
+//    by a reservation.
 //
 // Service Endpoint
 //
 // The AWS Budgets API provides the following endpoint:
 //
-//    * https://budgets.us-east-1.amazonaws.com
+//    * https://budgets.amazonaws.com
+//
+// For information about costs that are associated with the AWS Budgets API,
+// see AWS Cost Management Pricing (https://aws.amazon.com/aws-cost-management/pricing/).
 //
 // See budgets package documentation for more information.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/budgets/

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -756,6 +756,298 @@ func (c *ElasticsearchService) DescribeElasticsearchInstanceTypeLimitsWithContex
 	return out, req.Send()
 }
 
+const opDescribeReservedElasticsearchInstanceOfferings = "DescribeReservedElasticsearchInstanceOfferings"
+
+// DescribeReservedElasticsearchInstanceOfferingsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeReservedElasticsearchInstanceOfferings operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeReservedElasticsearchInstanceOfferings for more information on using the DescribeReservedElasticsearchInstanceOfferings
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeReservedElasticsearchInstanceOfferingsRequest method.
+//    req, resp := client.DescribeReservedElasticsearchInstanceOfferingsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstanceOfferingsRequest(input *DescribeReservedElasticsearchInstanceOfferingsInput) (req *request.Request, output *DescribeReservedElasticsearchInstanceOfferingsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeReservedElasticsearchInstanceOfferings,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/reservedInstanceOfferings",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeReservedElasticsearchInstanceOfferingsInput{}
+	}
+
+	output = &DescribeReservedElasticsearchInstanceOfferingsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeReservedElasticsearchInstanceOfferings API operation for Amazon Elasticsearch Service.
+//
+// Lists available reserved Elasticsearch instance offerings.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation DescribeReservedElasticsearchInstanceOfferings for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstanceOfferings(input *DescribeReservedElasticsearchInstanceOfferingsInput) (*DescribeReservedElasticsearchInstanceOfferingsOutput, error) {
+	req, out := c.DescribeReservedElasticsearchInstanceOfferingsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeReservedElasticsearchInstanceOfferingsWithContext is the same as DescribeReservedElasticsearchInstanceOfferings with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeReservedElasticsearchInstanceOfferings for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstanceOfferingsWithContext(ctx aws.Context, input *DescribeReservedElasticsearchInstanceOfferingsInput, opts ...request.Option) (*DescribeReservedElasticsearchInstanceOfferingsOutput, error) {
+	req, out := c.DescribeReservedElasticsearchInstanceOfferingsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeReservedElasticsearchInstanceOfferingsPages iterates over the pages of a DescribeReservedElasticsearchInstanceOfferings operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReservedElasticsearchInstanceOfferings method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReservedElasticsearchInstanceOfferings operation.
+//    pageNum := 0
+//    err := client.DescribeReservedElasticsearchInstanceOfferingsPages(params,
+//        func(page *DescribeReservedElasticsearchInstanceOfferingsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstanceOfferingsPages(input *DescribeReservedElasticsearchInstanceOfferingsInput, fn func(*DescribeReservedElasticsearchInstanceOfferingsOutput, bool) bool) error {
+	return c.DescribeReservedElasticsearchInstanceOfferingsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReservedElasticsearchInstanceOfferingsPagesWithContext same as DescribeReservedElasticsearchInstanceOfferingsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstanceOfferingsPagesWithContext(ctx aws.Context, input *DescribeReservedElasticsearchInstanceOfferingsInput, fn func(*DescribeReservedElasticsearchInstanceOfferingsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReservedElasticsearchInstanceOfferingsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReservedElasticsearchInstanceOfferingsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReservedElasticsearchInstanceOfferingsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opDescribeReservedElasticsearchInstances = "DescribeReservedElasticsearchInstances"
+
+// DescribeReservedElasticsearchInstancesRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeReservedElasticsearchInstances operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeReservedElasticsearchInstances for more information on using the DescribeReservedElasticsearchInstances
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeReservedElasticsearchInstancesRequest method.
+//    req, resp := client.DescribeReservedElasticsearchInstancesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstancesRequest(input *DescribeReservedElasticsearchInstancesInput) (req *request.Request, output *DescribeReservedElasticsearchInstancesOutput) {
+	op := &request.Operation{
+		Name:       opDescribeReservedElasticsearchInstances,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/reservedInstances",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeReservedElasticsearchInstancesInput{}
+	}
+
+	output = &DescribeReservedElasticsearchInstancesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeReservedElasticsearchInstances API operation for Amazon Elasticsearch Service.
+//
+// Returns information about reserved Elasticsearch instances for this account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation DescribeReservedElasticsearchInstances for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstances(input *DescribeReservedElasticsearchInstancesInput) (*DescribeReservedElasticsearchInstancesOutput, error) {
+	req, out := c.DescribeReservedElasticsearchInstancesRequest(input)
+	return out, req.Send()
+}
+
+// DescribeReservedElasticsearchInstancesWithContext is the same as DescribeReservedElasticsearchInstances with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeReservedElasticsearchInstances for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstancesWithContext(ctx aws.Context, input *DescribeReservedElasticsearchInstancesInput, opts ...request.Option) (*DescribeReservedElasticsearchInstancesOutput, error) {
+	req, out := c.DescribeReservedElasticsearchInstancesRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeReservedElasticsearchInstancesPages iterates over the pages of a DescribeReservedElasticsearchInstances operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeReservedElasticsearchInstances method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeReservedElasticsearchInstances operation.
+//    pageNum := 0
+//    err := client.DescribeReservedElasticsearchInstancesPages(params,
+//        func(page *DescribeReservedElasticsearchInstancesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstancesPages(input *DescribeReservedElasticsearchInstancesInput, fn func(*DescribeReservedElasticsearchInstancesOutput, bool) bool) error {
+	return c.DescribeReservedElasticsearchInstancesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeReservedElasticsearchInstancesPagesWithContext same as DescribeReservedElasticsearchInstancesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) DescribeReservedElasticsearchInstancesPagesWithContext(ctx aws.Context, input *DescribeReservedElasticsearchInstancesInput, fn func(*DescribeReservedElasticsearchInstancesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeReservedElasticsearchInstancesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeReservedElasticsearchInstancesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeReservedElasticsearchInstancesOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opListDomainNames = "ListDomainNames"
 
 // ListDomainNamesRequest generates a "aws/request.Request" representing the
@@ -1211,6 +1503,104 @@ func (c *ElasticsearchService) ListTags(input *ListTagsInput) (*ListTagsOutput, 
 // for more information on using Contexts.
 func (c *ElasticsearchService) ListTagsWithContext(ctx aws.Context, input *ListTagsInput, opts ...request.Option) (*ListTagsOutput, error) {
 	req, out := c.ListTagsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPurchaseReservedElasticsearchInstanceOffering = "PurchaseReservedElasticsearchInstanceOffering"
+
+// PurchaseReservedElasticsearchInstanceOfferingRequest generates a "aws/request.Request" representing the
+// client's request for the PurchaseReservedElasticsearchInstanceOffering operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PurchaseReservedElasticsearchInstanceOffering for more information on using the PurchaseReservedElasticsearchInstanceOffering
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PurchaseReservedElasticsearchInstanceOfferingRequest method.
+//    req, resp := client.PurchaseReservedElasticsearchInstanceOfferingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) PurchaseReservedElasticsearchInstanceOfferingRequest(input *PurchaseReservedElasticsearchInstanceOfferingInput) (req *request.Request, output *PurchaseReservedElasticsearchInstanceOfferingOutput) {
+	op := &request.Operation{
+		Name:       opPurchaseReservedElasticsearchInstanceOffering,
+		HTTPMethod: "POST",
+		HTTPPath:   "/2015-01-01/es/purchaseReservedInstanceOffering",
+	}
+
+	if input == nil {
+		input = &PurchaseReservedElasticsearchInstanceOfferingInput{}
+	}
+
+	output = &PurchaseReservedElasticsearchInstanceOfferingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PurchaseReservedElasticsearchInstanceOffering API operation for Amazon Elasticsearch Service.
+//
+// Allows you to purchase reserved Elasticsearch instances.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation PurchaseReservedElasticsearchInstanceOffering for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   An exception for creating a resource that already exists. Gives http status
+//   code of 400.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   An exception for trying to create more than allowed resources or sub-resources.
+//   Gives http status code of 409.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) PurchaseReservedElasticsearchInstanceOffering(input *PurchaseReservedElasticsearchInstanceOfferingInput) (*PurchaseReservedElasticsearchInstanceOfferingOutput, error) {
+	req, out := c.PurchaseReservedElasticsearchInstanceOfferingRequest(input)
+	return out, req.Send()
+}
+
+// PurchaseReservedElasticsearchInstanceOfferingWithContext is the same as PurchaseReservedElasticsearchInstanceOffering with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PurchaseReservedElasticsearchInstanceOffering for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) PurchaseReservedElasticsearchInstanceOfferingWithContext(ctx aws.Context, input *PurchaseReservedElasticsearchInstanceOfferingInput, opts ...request.Option) (*PurchaseReservedElasticsearchInstanceOfferingOutput, error) {
+	req, out := c.PurchaseReservedElasticsearchInstanceOfferingRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2296,6 +2686,163 @@ func (s DescribeElasticsearchInstanceTypeLimitsOutput) GoString() string {
 // SetLimitsByRole sets the LimitsByRole field's value.
 func (s *DescribeElasticsearchInstanceTypeLimitsOutput) SetLimitsByRole(v map[string]*Limits) *DescribeElasticsearchInstanceTypeLimitsOutput {
 	s.LimitsByRole = v
+	return s
+}
+
+// Container for parameters to DescribeReservedElasticsearchInstanceOfferings
+type DescribeReservedElasticsearchInstanceOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Set this value to limit the number of results returned. If not specified,
+	// defaults to 100.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+
+	// NextToken should be sent in case if earlier API call produced result containing
+	// NextToken. It is used for pagination.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The offering identifier filter value. Use this parameter to show only the
+	// available offering that matches the specified reservation identifier.
+	ReservedElasticsearchInstanceOfferingId *string `location:"querystring" locationName:"offeringId" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeReservedElasticsearchInstanceOfferingsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedElasticsearchInstanceOfferingsInput) GoString() string {
+	return s.String()
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeReservedElasticsearchInstanceOfferingsInput) SetMaxResults(v int64) *DescribeReservedElasticsearchInstanceOfferingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedElasticsearchInstanceOfferingsInput) SetNextToken(v string) *DescribeReservedElasticsearchInstanceOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceOfferingId sets the ReservedElasticsearchInstanceOfferingId field's value.
+func (s *DescribeReservedElasticsearchInstanceOfferingsInput) SetReservedElasticsearchInstanceOfferingId(v string) *DescribeReservedElasticsearchInstanceOfferingsInput {
+	s.ReservedElasticsearchInstanceOfferingId = &v
+	return s
+}
+
+// Container for results from DescribeReservedElasticsearchInstanceOfferings
+type DescribeReservedElasticsearchInstanceOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Provides an identifier to allow retrieval of paginated results.
+	NextToken *string `type:"string"`
+
+	// List of reserved Elasticsearch instance offerings
+	ReservedElasticsearchInstanceOfferings []*ReservedElasticsearchInstanceOffering `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeReservedElasticsearchInstanceOfferingsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedElasticsearchInstanceOfferingsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedElasticsearchInstanceOfferingsOutput) SetNextToken(v string) *DescribeReservedElasticsearchInstanceOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceOfferings sets the ReservedElasticsearchInstanceOfferings field's value.
+func (s *DescribeReservedElasticsearchInstanceOfferingsOutput) SetReservedElasticsearchInstanceOfferings(v []*ReservedElasticsearchInstanceOffering) *DescribeReservedElasticsearchInstanceOfferingsOutput {
+	s.ReservedElasticsearchInstanceOfferings = v
+	return s
+}
+
+// Container for parameters to DescribeReservedElasticsearchInstances
+type DescribeReservedElasticsearchInstancesInput struct {
+	_ struct{} `type:"structure"`
+
+	// Set this value to limit the number of results returned. If not specified,
+	// defaults to 100.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+
+	// NextToken should be sent in case if earlier API call produced result containing
+	// NextToken. It is used for pagination.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	// The reserved instance identifier filter value. Use this parameter to show
+	// only the reservation that matches the specified reserved Elasticsearch instance
+	// ID.
+	ReservedElasticsearchInstanceId *string `location:"querystring" locationName:"reservationId" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeReservedElasticsearchInstancesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedElasticsearchInstancesInput) GoString() string {
+	return s.String()
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeReservedElasticsearchInstancesInput) SetMaxResults(v int64) *DescribeReservedElasticsearchInstancesInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedElasticsearchInstancesInput) SetNextToken(v string) *DescribeReservedElasticsearchInstancesInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceId sets the ReservedElasticsearchInstanceId field's value.
+func (s *DescribeReservedElasticsearchInstancesInput) SetReservedElasticsearchInstanceId(v string) *DescribeReservedElasticsearchInstancesInput {
+	s.ReservedElasticsearchInstanceId = &v
+	return s
+}
+
+// Container for results from DescribeReservedElasticsearchInstances
+type DescribeReservedElasticsearchInstancesOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Provides an identifier to allow retrieval of paginated results.
+	NextToken *string `type:"string"`
+
+	// List of reserved Elasticsearch instances.
+	ReservedElasticsearchInstances []*ReservedElasticsearchInstance `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeReservedElasticsearchInstancesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedElasticsearchInstancesOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeReservedElasticsearchInstancesOutput) SetNextToken(v string) *DescribeReservedElasticsearchInstancesOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservedElasticsearchInstances sets the ReservedElasticsearchInstances field's value.
+func (s *DescribeReservedElasticsearchInstancesOutput) SetReservedElasticsearchInstances(v []*ReservedElasticsearchInstance) *DescribeReservedElasticsearchInstancesOutput {
+	s.ReservedElasticsearchInstances = v
 	return s
 }
 
@@ -3491,6 +4038,142 @@ func (s *OptionStatus) SetUpdateVersion(v int64) *OptionStatus {
 	return s
 }
 
+// Container for parameters to PurchaseReservedElasticsearchInstanceOffering
+type PurchaseReservedElasticsearchInstanceOfferingInput struct {
+	_ struct{} `type:"structure"`
+
+	// The number of Elasticsearch instances to reserve.
+	InstanceCount *int64 `min:"1" type:"integer"`
+
+	// A customer-specified identifier to track this reservation.
+	//
+	// ReservationName is a required field
+	ReservationName *string `min:"5" type:"string" required:"true"`
+
+	// The ID of the reserved Elasticsearch instance offering to purchase.
+	//
+	// ReservedElasticsearchInstanceOfferingId is a required field
+	ReservedElasticsearchInstanceOfferingId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedElasticsearchInstanceOfferingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedElasticsearchInstanceOfferingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseReservedElasticsearchInstanceOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseReservedElasticsearchInstanceOfferingInput"}
+	if s.InstanceCount != nil && *s.InstanceCount < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("InstanceCount", 1))
+	}
+	if s.ReservationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservationName"))
+	}
+	if s.ReservationName != nil && len(*s.ReservationName) < 5 {
+		invalidParams.Add(request.NewErrParamMinLen("ReservationName", 5))
+	}
+	if s.ReservedElasticsearchInstanceOfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservedElasticsearchInstanceOfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *PurchaseReservedElasticsearchInstanceOfferingInput) SetInstanceCount(v int64) *PurchaseReservedElasticsearchInstanceOfferingInput {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetReservationName sets the ReservationName field's value.
+func (s *PurchaseReservedElasticsearchInstanceOfferingInput) SetReservationName(v string) *PurchaseReservedElasticsearchInstanceOfferingInput {
+	s.ReservationName = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceOfferingId sets the ReservedElasticsearchInstanceOfferingId field's value.
+func (s *PurchaseReservedElasticsearchInstanceOfferingInput) SetReservedElasticsearchInstanceOfferingId(v string) *PurchaseReservedElasticsearchInstanceOfferingInput {
+	s.ReservedElasticsearchInstanceOfferingId = &v
+	return s
+}
+
+// Represents the output of a PurchaseReservedElasticsearchInstanceOffering
+// operation.
+type PurchaseReservedElasticsearchInstanceOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The customer-specified identifier used to track this reservation.
+	ReservationName *string `min:"5" type:"string"`
+
+	// Details of the reserved Elasticsearch instance which was purchased.
+	ReservedElasticsearchInstanceId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedElasticsearchInstanceOfferingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedElasticsearchInstanceOfferingOutput) GoString() string {
+	return s.String()
+}
+
+// SetReservationName sets the ReservationName field's value.
+func (s *PurchaseReservedElasticsearchInstanceOfferingOutput) SetReservationName(v string) *PurchaseReservedElasticsearchInstanceOfferingOutput {
+	s.ReservationName = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceId sets the ReservedElasticsearchInstanceId field's value.
+func (s *PurchaseReservedElasticsearchInstanceOfferingOutput) SetReservedElasticsearchInstanceId(v string) *PurchaseReservedElasticsearchInstanceOfferingOutput {
+	s.ReservedElasticsearchInstanceId = &v
+	return s
+}
+
+// Contains the specific price and frequency of a recurring charges for a reserved
+// Elasticsearch instance, or for a reserved Elasticsearch instance offering.
+type RecurringCharge struct {
+	_ struct{} `type:"structure"`
+
+	// The monetary amount of the recurring charge.
+	RecurringChargeAmount *float64 `type:"double"`
+
+	// The frequency of the recurring charge.
+	RecurringChargeFrequency *string `type:"string"`
+}
+
+// String returns the string representation
+func (s RecurringCharge) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RecurringCharge) GoString() string {
+	return s.String()
+}
+
+// SetRecurringChargeAmount sets the RecurringChargeAmount field's value.
+func (s *RecurringCharge) SetRecurringChargeAmount(v float64) *RecurringCharge {
+	s.RecurringChargeAmount = &v
+	return s
+}
+
+// SetRecurringChargeFrequency sets the RecurringChargeFrequency field's value.
+func (s *RecurringCharge) SetRecurringChargeFrequency(v string) *RecurringCharge {
+	s.RecurringChargeFrequency = &v
+	return s
+}
+
 // Container for the parameters to the RemoveTags operation. Specify the ARN
 // for the Elasticsearch domain from which you want to remove the specified
 // TagKey.
@@ -3560,6 +4243,232 @@ func (s RemoveTagsOutput) String() string {
 // GoString returns the string representation
 func (s RemoveTagsOutput) GoString() string {
 	return s.String()
+}
+
+// Details of a reserved Elasticsearch instance.
+type ReservedElasticsearchInstance struct {
+	_ struct{} `type:"structure"`
+
+	// The currency code for the reserved Elasticsearch instance offering.
+	CurrencyCode *string `type:"string"`
+
+	// The duration, in seconds, for which the Elasticsearch instance is reserved.
+	Duration *int64 `type:"integer"`
+
+	// The number of Elasticsearch instances that have been reserved.
+	ElasticsearchInstanceCount *int64 `type:"integer"`
+
+	// The Elasticsearch instance type offered by the reserved instance offering.
+	ElasticsearchInstanceType *string `type:"string" enum:"ESPartitionInstanceType"`
+
+	// The upfront fixed charge you will paid to purchase the specific reserved
+	// Elasticsearch instance offering.
+	FixedPrice *float64 `type:"double"`
+
+	// The payment option as defined in the reserved Elasticsearch instance offering.
+	PaymentOption *string `type:"string" enum:"ReservedElasticsearchInstancePaymentOption"`
+
+	// The charge to your account regardless of whether you are creating any domains
+	// using the instance offering.
+	RecurringCharges []*RecurringCharge `type:"list"`
+
+	// The customer-specified identifier to track this reservation.
+	ReservationName *string `min:"5" type:"string"`
+
+	// The unique identifier for the reservation.
+	ReservedElasticsearchInstanceId *string `type:"string"`
+
+	// The offering identifier.
+	ReservedElasticsearchInstanceOfferingId *string `type:"string"`
+
+	// The time the reservation started.
+	StartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The state of the reserved Elasticsearch instance.
+	State *string `type:"string"`
+
+	// The rate you are charged for each hour for the domain that is using this
+	// reserved instance.
+	UsagePrice *float64 `type:"double"`
+}
+
+// String returns the string representation
+func (s ReservedElasticsearchInstance) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReservedElasticsearchInstance) GoString() string {
+	return s.String()
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedElasticsearchInstance) SetCurrencyCode(v string) *ReservedElasticsearchInstance {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedElasticsearchInstance) SetDuration(v int64) *ReservedElasticsearchInstance {
+	s.Duration = &v
+	return s
+}
+
+// SetElasticsearchInstanceCount sets the ElasticsearchInstanceCount field's value.
+func (s *ReservedElasticsearchInstance) SetElasticsearchInstanceCount(v int64) *ReservedElasticsearchInstance {
+	s.ElasticsearchInstanceCount = &v
+	return s
+}
+
+// SetElasticsearchInstanceType sets the ElasticsearchInstanceType field's value.
+func (s *ReservedElasticsearchInstance) SetElasticsearchInstanceType(v string) *ReservedElasticsearchInstance {
+	s.ElasticsearchInstanceType = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedElasticsearchInstance) SetFixedPrice(v float64) *ReservedElasticsearchInstance {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetPaymentOption sets the PaymentOption field's value.
+func (s *ReservedElasticsearchInstance) SetPaymentOption(v string) *ReservedElasticsearchInstance {
+	s.PaymentOption = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedElasticsearchInstance) SetRecurringCharges(v []*RecurringCharge) *ReservedElasticsearchInstance {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservationName sets the ReservationName field's value.
+func (s *ReservedElasticsearchInstance) SetReservationName(v string) *ReservedElasticsearchInstance {
+	s.ReservationName = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceId sets the ReservedElasticsearchInstanceId field's value.
+func (s *ReservedElasticsearchInstance) SetReservedElasticsearchInstanceId(v string) *ReservedElasticsearchInstance {
+	s.ReservedElasticsearchInstanceId = &v
+	return s
+}
+
+// SetReservedElasticsearchInstanceOfferingId sets the ReservedElasticsearchInstanceOfferingId field's value.
+func (s *ReservedElasticsearchInstance) SetReservedElasticsearchInstanceOfferingId(v string) *ReservedElasticsearchInstance {
+	s.ReservedElasticsearchInstanceOfferingId = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ReservedElasticsearchInstance) SetStartTime(v time.Time) *ReservedElasticsearchInstance {
+	s.StartTime = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *ReservedElasticsearchInstance) SetState(v string) *ReservedElasticsearchInstance {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedElasticsearchInstance) SetUsagePrice(v float64) *ReservedElasticsearchInstance {
+	s.UsagePrice = &v
+	return s
+}
+
+// Details of a reserved Elasticsearch instance offering.
+type ReservedElasticsearchInstanceOffering struct {
+	_ struct{} `type:"structure"`
+
+	// The currency code for the reserved Elasticsearch instance offering.
+	CurrencyCode *string `type:"string"`
+
+	// The duration, in seconds, for which the offering will reserve the Elasticsearch
+	// instance.
+	Duration *int64 `type:"integer"`
+
+	// The Elasticsearch instance type offered by the reserved instance offering.
+	ElasticsearchInstanceType *string `type:"string" enum:"ESPartitionInstanceType"`
+
+	// The upfront fixed charge you will pay to purchase the specific reserved Elasticsearch
+	// instance offering.
+	FixedPrice *float64 `type:"double"`
+
+	// Payment option for the reserved Elasticsearch instance offering
+	PaymentOption *string `type:"string" enum:"ReservedElasticsearchInstancePaymentOption"`
+
+	// The charge to your account regardless of whether you are creating any domains
+	// using the instance offering.
+	RecurringCharges []*RecurringCharge `type:"list"`
+
+	// The Elasticsearch reserved instance offering identifier.
+	ReservedElasticsearchInstanceOfferingId *string `type:"string"`
+
+	// The rate you are charged for each hour the domain that is using the offering
+	// is running.
+	UsagePrice *float64 `type:"double"`
+}
+
+// String returns the string representation
+func (s ReservedElasticsearchInstanceOffering) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReservedElasticsearchInstanceOffering) GoString() string {
+	return s.String()
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetCurrencyCode(v string) *ReservedElasticsearchInstanceOffering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetDuration(v int64) *ReservedElasticsearchInstanceOffering {
+	s.Duration = &v
+	return s
+}
+
+// SetElasticsearchInstanceType sets the ElasticsearchInstanceType field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetElasticsearchInstanceType(v string) *ReservedElasticsearchInstanceOffering {
+	s.ElasticsearchInstanceType = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetFixedPrice(v float64) *ReservedElasticsearchInstanceOffering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetPaymentOption sets the PaymentOption field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetPaymentOption(v string) *ReservedElasticsearchInstanceOffering {
+	s.PaymentOption = &v
+	return s
+}
+
+// SetRecurringCharges sets the RecurringCharges field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetRecurringCharges(v []*RecurringCharge) *ReservedElasticsearchInstanceOffering {
+	s.RecurringCharges = v
+	return s
+}
+
+// SetReservedElasticsearchInstanceOfferingId sets the ReservedElasticsearchInstanceOfferingId field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetReservedElasticsearchInstanceOfferingId(v string) *ReservedElasticsearchInstanceOffering {
+	s.ReservedElasticsearchInstanceOfferingId = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *ReservedElasticsearchInstanceOffering) SetUsagePrice(v float64) *ReservedElasticsearchInstanceOffering {
+	s.UsagePrice = &v
+	return s
 }
 
 // Specifies the time, in UTC format, when the service takes a daily automated
@@ -4208,6 +5117,17 @@ const (
 
 	// OptionStateActive is a OptionState enum value
 	OptionStateActive = "Active"
+)
+
+const (
+	// ReservedElasticsearchInstancePaymentOptionAllUpfront is a ReservedElasticsearchInstancePaymentOption enum value
+	ReservedElasticsearchInstancePaymentOptionAllUpfront = "ALL_UPFRONT"
+
+	// ReservedElasticsearchInstancePaymentOptionPartialUpfront is a ReservedElasticsearchInstancePaymentOption enum value
+	ReservedElasticsearchInstancePaymentOptionPartialUpfront = "PARTIAL_UPFRONT"
+
+	// ReservedElasticsearchInstancePaymentOptionNoUpfront is a ReservedElasticsearchInstancePaymentOption enum value
+	ReservedElasticsearchInstancePaymentOptionNoUpfront = "NO_UPFRONT"
 )
 
 // The type of EBS volume, standard, gp2, or io1. See Configuring EBS-based

--- a/service/elasticsearchservice/elasticsearchserviceiface/interface.go
+++ b/service/elasticsearchservice/elasticsearchserviceiface/interface.go
@@ -92,6 +92,20 @@ type ElasticsearchServiceAPI interface {
 	DescribeElasticsearchInstanceTypeLimitsWithContext(aws.Context, *elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsInput, ...request.Option) (*elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsOutput, error)
 	DescribeElasticsearchInstanceTypeLimitsRequest(*elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsInput) (*request.Request, *elasticsearchservice.DescribeElasticsearchInstanceTypeLimitsOutput)
 
+	DescribeReservedElasticsearchInstanceOfferings(*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsInput) (*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsOutput, error)
+	DescribeReservedElasticsearchInstanceOfferingsWithContext(aws.Context, *elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsInput, ...request.Option) (*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsOutput, error)
+	DescribeReservedElasticsearchInstanceOfferingsRequest(*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsInput) (*request.Request, *elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsOutput)
+
+	DescribeReservedElasticsearchInstanceOfferingsPages(*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsInput, func(*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsOutput, bool) bool) error
+	DescribeReservedElasticsearchInstanceOfferingsPagesWithContext(aws.Context, *elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsInput, func(*elasticsearchservice.DescribeReservedElasticsearchInstanceOfferingsOutput, bool) bool, ...request.Option) error
+
+	DescribeReservedElasticsearchInstances(*elasticsearchservice.DescribeReservedElasticsearchInstancesInput) (*elasticsearchservice.DescribeReservedElasticsearchInstancesOutput, error)
+	DescribeReservedElasticsearchInstancesWithContext(aws.Context, *elasticsearchservice.DescribeReservedElasticsearchInstancesInput, ...request.Option) (*elasticsearchservice.DescribeReservedElasticsearchInstancesOutput, error)
+	DescribeReservedElasticsearchInstancesRequest(*elasticsearchservice.DescribeReservedElasticsearchInstancesInput) (*request.Request, *elasticsearchservice.DescribeReservedElasticsearchInstancesOutput)
+
+	DescribeReservedElasticsearchInstancesPages(*elasticsearchservice.DescribeReservedElasticsearchInstancesInput, func(*elasticsearchservice.DescribeReservedElasticsearchInstancesOutput, bool) bool) error
+	DescribeReservedElasticsearchInstancesPagesWithContext(aws.Context, *elasticsearchservice.DescribeReservedElasticsearchInstancesInput, func(*elasticsearchservice.DescribeReservedElasticsearchInstancesOutput, bool) bool, ...request.Option) error
+
 	ListDomainNames(*elasticsearchservice.ListDomainNamesInput) (*elasticsearchservice.ListDomainNamesOutput, error)
 	ListDomainNamesWithContext(aws.Context, *elasticsearchservice.ListDomainNamesInput, ...request.Option) (*elasticsearchservice.ListDomainNamesOutput, error)
 	ListDomainNamesRequest(*elasticsearchservice.ListDomainNamesInput) (*request.Request, *elasticsearchservice.ListDomainNamesOutput)
@@ -113,6 +127,10 @@ type ElasticsearchServiceAPI interface {
 	ListTags(*elasticsearchservice.ListTagsInput) (*elasticsearchservice.ListTagsOutput, error)
 	ListTagsWithContext(aws.Context, *elasticsearchservice.ListTagsInput, ...request.Option) (*elasticsearchservice.ListTagsOutput, error)
 	ListTagsRequest(*elasticsearchservice.ListTagsInput) (*request.Request, *elasticsearchservice.ListTagsOutput)
+
+	PurchaseReservedElasticsearchInstanceOffering(*elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingInput) (*elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingOutput, error)
+	PurchaseReservedElasticsearchInstanceOfferingWithContext(aws.Context, *elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingInput, ...request.Option) (*elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingOutput, error)
+	PurchaseReservedElasticsearchInstanceOfferingRequest(*elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingInput) (*request.Request, *elasticsearchservice.PurchaseReservedElasticsearchInstanceOfferingOutput)
 
 	RemoveTags(*elasticsearchservice.RemoveTagsInput) (*elasticsearchservice.RemoveTagsOutput, error)
 	RemoveTagsWithContext(aws.Context, *elasticsearchservice.RemoveTagsInput, ...request.Option) (*elasticsearchservice.RemoveTagsOutput, error)


### PR DESCRIPTION
Release v1.13.43 (2018-05-07)
===

### Service Client Updates
* `service/alexaforbusiness`: Updates service API
* `service/budgets`: Updates service API and documentation
  * "With this release, customers can use AWS Budgets to monitor how much of their Amazon EC2, Amazon RDS, Amazon Redshift, and Amazon ElastiCache instance usage is covered by reservations, and receive alerts when their coverage falls below the threshold they define."
* `aws/endpoints`: Updated Regions and Endpoints metadata.
* `service/es`: Updates service API, documentation, and paginators
  * This change brings support for Reserved Instances to AWS Elasticsearch.
* `service/s3`: Updates service API and documentation
  * Added BytesReturned details for Progress and Stats Events for Amazon S3 Select .

