### PR TITLE
private/protocol/rest: Update REST protocol timestamp parse format

### DIFF
--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -481,7 +481,7 @@ func GenerateAssertions(out interface{}, shape *api.Shape, prefix string) string
 		case "timestamp":
 			return fmtAssertEqual(
 				fmt.Sprintf("time.Unix(%#v, 0).UTC().String()", out),
-				fmt.Sprintf("%s.String()", prefix),
+				fmt.Sprintf("%s.UTC().String()", prefix),
 			)
 		case "blob":
 			return fmtAssertEqual(

--- a/private/protocol/jsonrpc/unmarshal_test.go
+++ b/private/protocol/jsonrpc/unmarshal_test.go
@@ -1351,10 +1351,10 @@ func TestOutputService3ProtocolTestTimestampMembersCase1(t *testing.T) {
 	if out == nil {
 		t.Errorf("expect not to be nil")
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.StructMember.Foo.String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.StructMember.Foo.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeMember.String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeMember.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -2534,7 +2534,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	if e, a := "myname", *out.Str; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.String(); e != a {
+	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := true, *out.TrueBool; e != a {

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -20,8 +20,10 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
 
-// RFC822 returns an RFC822 formatted timestamp for AWS protocols
-const RFC822 = "Mon, 2 Jan 2006 15:04:05 GMT"
+// RFC1123GMT is a RFC1123 (RFC822) formated timestame. This format is not
+// using the standard library's time.RFC1123 due to the desire to always use
+// GMT as the timezone.
+const RFC1123GMT = "Mon, 2 Jan 2006 15:04:05 GMT"
 
 // Whether the byte value can be sent without escaping in AWS URLs
 var noEscape [256]bool
@@ -270,7 +272,7 @@ func convertType(v reflect.Value, tag reflect.StructTag) (str string, err error)
 	case float64:
 		str = strconv.FormatFloat(value, 'f', -1, 64)
 	case time.Time:
-		str = value.UTC().Format(RFC822)
+		str = value.UTC().Format(RFC1123GMT)
 	case aws.JSONValue:
 		if len(value) == 0 {
 			return "", errValueNotSet

--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -198,7 +198,7 @@ func unmarshalHeader(v reflect.Value, header string, tag reflect.StructTag) erro
 		}
 		v.Set(reflect.ValueOf(&f))
 	case *time.Time:
-		t, err := time.Parse(RFC822, header)
+		t, err := time.Parse(time.RFC1123, header)
 		if err != nil {
 			return err
 		}

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -2442,10 +2442,10 @@ func TestOutputService3ProtocolTestTimestampMembersCase1(t *testing.T) {
 	if out == nil {
 		t.Errorf("expect not to be nil")
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.StructMember.Foo.String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.StructMember.Foo.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeMember.String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeMember.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 
@@ -2564,10 +2564,10 @@ func TestOutputService7ProtocolTestComplexMapValuesCase1(t *testing.T) {
 	if out == nil {
 		t.Errorf("expect not to be nil")
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.MapMember["a"].String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.MapMember["a"].UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.MapMember["b"].String(); e != a {
+	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.MapMember["b"].UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -2587,7 +2587,7 @@ func TestOutputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 	if e, a := "myname", *out.Str; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.String(); e != a {
+	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := true, *out.TrueBool; e != a {
@@ -2645,7 +2645,7 @@ func TestOutputService1ProtocolTestScalarMembersCase2(t *testing.T) {
 	if e, a := "", *out.Str; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.String(); e != a {
+	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := true, *out.TrueBool; e != a {
@@ -2680,10 +2680,10 @@ func TestOutputService1ProtocolTestScalarMembersCase3(t *testing.T) {
 	if e, a := "value2", string(out.Blobs[1]); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamps[0].String(); e != a {
+	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamps[0].UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.422172801e+09, 0).UTC().String(), out.Timestamps[1].String(); e != a {
+	if e, a := time.Unix(1.422172801e+09, 0).UTC().String(), out.Timestamps[1].UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 
@@ -2995,7 +2995,7 @@ func TestOutputService11ProtocolTestScalarMembersInHeadersCase1(t *testing.T) {
 	if e, a := "string", *out.Str; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.String(); e != a {
+	if e, a := time.Unix(1.4221728e+09, 0).UTC().String(), out.Timestamp.UTC().String(); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := true, *out.TrueBool; e != a {


### PR DESCRIPTION
Updates the REST protocol's timestamp format to not require GMT as the
timezone value parsed. Switching to MST in the parse format string
allows the SDK to parse other timezones.

The SDK will continue to format the timezone as GMT when serialzing out
the timestamp value for REST protocol.

Related to aws/aws-sdk-go-v2#178

Fix #1937