### PR TITLE
aws/request: fixing pagination with cloudwatchlogs

### DIFF
--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -37,6 +37,7 @@ type Pagination struct {
 	NewRequest func() (*Request, error)
 
 	started    bool
+	prevTokens []interface{}
 	nextTokens []interface{}
 
 	err     error
@@ -49,7 +50,7 @@ type Pagination struct {
 //
 // Will always return true if Next has not been called yet.
 func (p *Pagination) HasNextPage() bool {
-	return !(p.started && len(p.nextTokens) == 0)
+	return !(p.started && (len(p.nextTokens) == 0 || awsutil.DeepEqual(p.nextTokens, p.prevTokens)))
 }
 
 // Err returns the error Pagination encountered when retrieving the next page.
@@ -96,6 +97,7 @@ func (p *Pagination) Next() bool {
 		return false
 	}
 
+	p.prevTokens = p.nextTokens
 	p.nextTokens = req.nextPageTokens()
 	p.curPage = req.Data
 

--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -35,6 +35,9 @@ type Pagination struct {
 	// NewRequest should always be built from the same API operations. It is
 	// undefined if different API operations are returned on subsequent calls.
 	NewRequest func() (*Request, error)
+	// EndPageOnSameToken, when enabled, will allow the paginator to stop on
+	// token that are the same as its previous tokens.
+	EndPageOnSameToken bool
 
 	started    bool
 	prevTokens []interface{}
@@ -50,7 +53,15 @@ type Pagination struct {
 //
 // Will always return true if Next has not been called yet.
 func (p *Pagination) HasNextPage() bool {
-	return !(p.started && (len(p.nextTokens) == 0 || awsutil.DeepEqual(p.nextTokens, p.prevTokens)))
+	if !p.started {
+		return true
+	}
+
+	hasNextPage := len(p.nextTokens) != 0
+	if p.EndPageOnSameToken {
+		return hasNextPage && !awsutil.DeepEqual(p.nextTokens, p.prevTokens)
+	}
+	return hasNextPage
 }
 
 // Err returns the error Pagination encountered when retrieving the next page.

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -466,25 +466,40 @@ func TestPagination_Standalone(t *testing.T) {
 		Value, PrevToken, NextToken *string
 	}
 
-	cases := [][]testCase{
+	type testCaseList struct {
+		StopOnSameToken bool
+		Cases           []testCase
+	}
+
+	cases := []testCaseList{
 		{
-			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
-			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
-			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), nil},
+			Cases: []testCase{
+				testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+				testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+				testCase{aws.String("ThirdValue"), aws.String("SecondToken"), nil},
+			},
+			StopOnSameToken: false,
 		},
 		{
-			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
-			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
-			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), aws.String("")},
+			Cases: []testCase{
+				testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+				testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+				testCase{aws.String("ThirdValue"), aws.String("SecondToken"), aws.String("")},
+			},
+			StopOnSameToken: false,
 		},
 		{
-			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
-			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
-			testCase{nil, aws.String("SecondToken"), aws.String("SecondToken")},
+			Cases: []testCase{
+				testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+				testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+				testCase{nil, aws.String("SecondToken"), aws.String("SecondToken")},
+			},
+			StopOnSameToken: true,
 		},
 	}
 
-	for _, c := range cases {
+	for _, testcase := range cases {
+		c := testcase.Cases
 		input := testPageInput{
 			NextToken: c[0].PrevToken,
 		}
@@ -492,6 +507,7 @@ func TestPagination_Standalone(t *testing.T) {
 		svc := awstesting.NewClient()
 		i := 0
 		p := request.Pagination{
+			EndPageOnSameToken: testcase.StopOnSameToken,
 			NewRequest: func() (*request.Request, error) {
 				r := svc.NewRequest(
 					&request.Operation{

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -496,6 +496,14 @@ func TestPagination_Standalone(t *testing.T) {
 			},
 			StopOnSameToken: true,
 		},
+		{
+			Cases: []testCase{
+				testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+				testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+				testCase{aws.String("SecondValue"), aws.String("SecondToken"), aws.String("SecondToken")},
+			},
+			StopOnSameToken: true,
+		},
 	}
 
 	for _, testcase := range cases {

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -477,6 +477,11 @@ func TestPagination_Standalone(t *testing.T) {
 			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
 			testCase{aws.String("ThirdValue"), aws.String("SecondToken"), aws.String("")},
 		},
+		{
+			testCase{aws.String("FirstValue"), aws.String("InitalToken"), aws.String("FirstToken")},
+			testCase{aws.String("SecondValue"), aws.String("FirstToken"), aws.String("SecondToken")},
+			testCase{nil, aws.String("SecondToken"), aws.String("SecondToken")},
+		},
 	}
 
 	for _, c := range cases {

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -66,7 +66,8 @@ func (o *Operation) GetSigner() string {
 
 // tplOperation defines a template for rendering an API Operation
 var tplOperation = template.Must(template.New("operation").Funcs(template.FuncMap{
-	"GetCrosslinkURL": GetCrosslinkURL,
+	"GetCrosslinkURL":       GetCrosslinkURL,
+	"EnableStopOnSameToken": enableStopOnSameToken,
 }).Parse(`
 const op{{ .ExportedName }} = "{{ .Name }}"
 
@@ -214,6 +215,8 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}PagesWithContext(` +
 	`fn func({{ .OutputRef.GoType }}, bool) bool, ` +
 	`opts ...request.Option) error {
 	p := request.Pagination {
+		{{ if EnableStopOnSameToken .API.PackageName -}}EndPageOnSameToken: true,
+		{{ end -}}
 		NewRequest: func() (*request.Request, error) {
 			var inCpy {{ .InputRef.GoType }}
 			if input != nil  {

--- a/private/model/api/pagination.go
+++ b/private/model/api/pagination.go
@@ -89,3 +89,12 @@ func (p *paginationDefinitions) setup() {
 		}
 	}
 }
+
+func enableStopOnSameToken(service string) bool {
+	switch service {
+	case "cloudwatchlogs":
+		return true
+	default:
+		return false
+	}
+}

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -1281,6 +1281,7 @@ func (c *CloudWatchLogs) DescribeDestinationsPages(input *DescribeDestinationsIn
 // for more information on using Contexts.
 func (c *CloudWatchLogs) DescribeDestinationsPagesWithContext(ctx aws.Context, input *DescribeDestinationsInput, fn func(*DescribeDestinationsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *DescribeDestinationsInput
 			if input != nil {
@@ -1503,6 +1504,7 @@ func (c *CloudWatchLogs) DescribeLogGroupsPages(input *DescribeLogGroupsInput, f
 // for more information on using Contexts.
 func (c *CloudWatchLogs) DescribeLogGroupsPagesWithContext(ctx aws.Context, input *DescribeLogGroupsInput, fn func(*DescribeLogGroupsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *DescribeLogGroupsInput
 			if input != nil {
@@ -1649,6 +1651,7 @@ func (c *CloudWatchLogs) DescribeLogStreamsPages(input *DescribeLogStreamsInput,
 // for more information on using Contexts.
 func (c *CloudWatchLogs) DescribeLogStreamsPagesWithContext(ctx aws.Context, input *DescribeLogStreamsInput, fn func(*DescribeLogStreamsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *DescribeLogStreamsInput
 			if input != nil {
@@ -1792,6 +1795,7 @@ func (c *CloudWatchLogs) DescribeMetricFiltersPages(input *DescribeMetricFilters
 // for more information on using Contexts.
 func (c *CloudWatchLogs) DescribeMetricFiltersPagesWithContext(ctx aws.Context, input *DescribeMetricFiltersInput, fn func(*DescribeMetricFiltersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *DescribeMetricFiltersInput
 			if input != nil {
@@ -2017,6 +2021,7 @@ func (c *CloudWatchLogs) DescribeSubscriptionFiltersPages(input *DescribeSubscri
 // for more information on using Contexts.
 func (c *CloudWatchLogs) DescribeSubscriptionFiltersPagesWithContext(ctx aws.Context, input *DescribeSubscriptionFiltersInput, fn func(*DescribeSubscriptionFiltersOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *DescribeSubscriptionFiltersInput
 			if input != nil {
@@ -2264,6 +2269,7 @@ func (c *CloudWatchLogs) FilterLogEventsPages(input *FilterLogEventsInput, fn fu
 // for more information on using Contexts.
 func (c *CloudWatchLogs) FilterLogEventsPagesWithContext(ctx aws.Context, input *FilterLogEventsInput, fn func(*FilterLogEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *FilterLogEventsInput
 			if input != nil {
@@ -2410,6 +2416,7 @@ func (c *CloudWatchLogs) GetLogEventsPages(input *GetLogEventsInput, fn func(*Ge
 // for more information on using Contexts.
 func (c *CloudWatchLogs) GetLogEventsPagesWithContext(ctx aws.Context, input *GetLogEventsInput, fn func(*GetLogEventsOutput, bool) bool, opts ...request.Option) error {
 	p := request.Pagination{
+		EndPageOnSameToken: true,
 		NewRequest: func() (*request.Request, error) {
 			var inCpy *GetLogEventsInput
 			if input != nil {

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -468,7 +468,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("1"),
 				},
 			},
-			NextMarker:  aws.String("1stMarker"),
+			NextMarker:  aws.String("marker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{
@@ -477,7 +477,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("2"),
 				},
 			},
-			NextMarker:  aws.String("2ndMarker"),
+			NextMarker:  aws.String("marker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -468,7 +468,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("1"),
 				},
 			},
-			NextMarker:  aws.String("marker"),
+			NextMarker:  aws.String("1stMarker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{
@@ -477,7 +477,7 @@ func TestBatchDeleteList(t *testing.T) {
 					Key: aws.String("2"),
 				},
 			},
-			NextMarker:  aws.String("marker"),
+			NextMarker:  aws.String("2ndMarker"),
 			IsTruncated: aws.Bool(true),
 		},
 		{


### PR DESCRIPTION
This PR expands on #1908 allowing for a boolean to specify whether or not a paginator needs to stop in the case where two tokens are the same.

To use this in the general paginator simply set the `EndPageOnSameToken` to true.

cc @johanneswuerbach
