### PR TITLE
service/dynamodb/expression: Return nil when expression dose not exists

### DIFF
--- a/service/dynamodb/expression/expression.go
+++ b/service/dynamodb/expression/expression.go
@@ -488,7 +488,10 @@ func (e Expression) returnExpression(expressionType expressionType) *string {
 	if e.expressionMap == nil {
 		return nil
 	}
-	return aws.String(e.expressionMap[expressionType])
+	if s, exists := e.expressionMap[expressionType]; exists {
+		return &s
+	}
+	return nil
 }
 
 // exprNode are the generic nodes that represents both Operands and

--- a/service/dynamodb/expression/expression_test.go
+++ b/service/dynamodb/expression/expression_test.go
@@ -978,6 +978,39 @@ func TestBuildExpressionString(t *testing.T) {
 	}
 }
 
+func TestReturnExpression(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    Expression
+		expected *string
+	}{
+		{
+			name: "projection exists",
+			input: Expression{
+				expressionMap: map[expressionType]string{
+					projection: "#0, #1, #2",
+				},
+			},
+			expected: aws.String("#0, #1, #2"),
+		},
+		{
+			name: "projection not exists",
+			input: Expression{
+				expressionMap: map[expressionType]string{},
+			},
+			expected: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.input.returnExpression(projection)
+			if e, a := c.expected, actual; !reflect.DeepEqual(a, e) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
+	}
+}
+
 func TestAliasValue(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Fix method according to the comment.
https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/expression/expression.go#L486