### PR TITLE
v1.13.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Release v1.13.56 (2018-05-25)
+===
+
+### Service Client Updates
+* `service/appstream`: Updates service API and documentation
+  * This API update enables customers to control whether users can transfer data between their local devices and their streaming applications through file uploads and downloads, clipboard operations, or printing to local devices
+* `service/config`: Updates service API and documentation
+* `service/glue`: Updates service API and documentation
+  * AWS Glue now sends a delay notification to Amazon CloudWatch Events when an ETL job runs longer than the specified delay notification threshold.
+* `service/iot`: Updates service API
+  * We are exposing DELETION_IN_PROGRESS as a new job status in regards to the release of DeleteJob API.
+
 Release v1.13.55 (2018-05-24)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.13.55"
+const SDKVersion = "1.13.56"

--- a/models/apis/appstream/2016-12-01/api-2.json
+++ b/models/apis/appstream/2016-12-01/api-2.json
@@ -493,6 +493,16 @@
       "min":1,
       "sensitive":true
     },
+    "Action":{
+      "type":"string",
+      "enum":[
+        "CLIPBOARD_COPY_FROM_LOCAL_DEVICE",
+        "CLIPBOARD_COPY_TO_LOCAL_DEVICE",
+        "FILE_UPLOAD",
+        "FILE_DOWNLOAD",
+        "PRINTING_TO_LOCAL_DEVICE"
+      ]
+    },
     "Application":{
       "type":"structure",
       "members":{
@@ -685,7 +695,8 @@
         "DisplayName":{"shape":"DisplayName"},
         "StorageConnectors":{"shape":"StorageConnectorList"},
         "RedirectURL":{"shape":"RedirectURL"},
-        "FeedbackURL":{"shape":"FeedbackURL"}
+        "FeedbackURL":{"shape":"FeedbackURL"},
+        "UserSettings":{"shape":"UserSettingList"}
       }
     },
     "CreateStackResult":{
@@ -1247,6 +1258,13 @@
       "type":"list",
       "member":{"shape":"OrganizationalUnitDistinguishedName"}
     },
+    "Permission":{
+      "type":"string",
+      "enum":[
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
     "PlatformType":{
       "type":"string",
       "enum":["WINDOWS"]
@@ -1362,7 +1380,8 @@
         "StorageConnectors":{"shape":"StorageConnectorList"},
         "RedirectURL":{"shape":"RedirectURL"},
         "FeedbackURL":{"shape":"FeedbackURL"},
-        "StackErrors":{"shape":"StackErrors"}
+        "StackErrors":{"shape":"StackErrors"},
+        "UserSettings":{"shape":"UserSettingList"}
       }
     },
     "StackAttribute":{
@@ -1371,7 +1390,8 @@
         "STORAGE_CONNECTORS",
         "REDIRECT_URL",
         "FEEDBACK_URL",
-        "THEME_NAME"
+        "THEME_NAME",
+        "USER_SETTINGS"
       ]
     },
     "StackAttributes":{
@@ -1600,7 +1620,8 @@
         },
         "RedirectURL":{"shape":"RedirectURL"},
         "FeedbackURL":{"shape":"FeedbackURL"},
-        "AttributesToDelete":{"shape":"StackAttributes"}
+        "AttributesToDelete":{"shape":"StackAttributes"},
+        "UserSettings":{"shape":"UserSettingList"}
       }
     },
     "UpdateStackResult":{
@@ -1613,6 +1634,22 @@
       "type":"string",
       "max":32,
       "min":2
+    },
+    "UserSetting":{
+      "type":"structure",
+      "required":[
+        "Action",
+        "Permission"
+      ],
+      "members":{
+        "Action":{"shape":"Action"},
+        "Permission":{"shape":"Permission"}
+      }
+    },
+    "UserSettingList":{
+      "type":"list",
+      "member":{"shape":"UserSetting"},
+      "min":1
     },
     "VisibilityType":{
       "type":"string",

--- a/models/apis/appstream/2016-12-01/docs-2.json
+++ b/models/apis/appstream/2016-12-01/docs-2.json
@@ -49,6 +49,12 @@
         "ServiceAccountCredentials$AccountPassword": "<p>The password for the account.</p>"
       }
     },
+    "Action": {
+      "base": null,
+      "refs": {
+        "UserSetting$Action": "<p>The action that is enabled or disabled.</p>"
+      }
+    },
     "Application": {
       "base": "<p>Describes an application in the application catalog.</p>",
       "refs": {
@@ -666,6 +672,12 @@
         "UpdateDirectoryConfigRequest$OrganizationalUnitDistinguishedNames": "<p>The distinguished names of the organizational units for computer accounts.</p>"
       }
     },
+    "Permission": {
+      "base": null,
+      "refs": {
+        "UserSetting$Permission": "<p>Indicates whether the action is enabled or disabled.</p>"
+      }
+    },
     "PlatformType": {
       "base": null,
       "refs": {
@@ -1062,6 +1074,20 @@
       "refs": {
         "DescribeSessionsRequest$UserId": "<p>The user ID.</p>",
         "Session$UserId": "<p>The identifier of the user for whom the session was created.</p>"
+      }
+    },
+    "UserSetting": {
+      "base": "<p>Describes an action and whether the action is enabled or disabled for users during their streaming sessions.</p>",
+      "refs": {
+        "UserSettingList$member": null
+      }
+    },
+    "UserSettingList": {
+      "base": null,
+      "refs": {
+        "CreateStackRequest$UserSettings": "<p>The actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled. </p>",
+        "Stack$UserSettings": "<p>The actions that are enabled or disabled for users during their streaming sessions. By default these actions are enabled.</p>",
+        "UpdateStackRequest$UserSettings": "<p>The actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled.</p>"
       }
     },
     "VisibilityType": {

--- a/models/apis/config/2014-11-12/api-2.json
+++ b/models/apis/config/2014-11-12/api-2.json
@@ -107,6 +107,18 @@
         {"shape":"InvalidParameterValueException"}
       ]
     },
+    "DeleteRetentionConfiguration":{
+      "name":"DeleteRetentionConfiguration",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteRetentionConfigurationRequest"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"NoSuchRetentionConfigurationException"}
+      ]
+    },
     "DeliverConfigSnapshot":{
       "name":"DeliverConfigSnapshot",
       "http":{
@@ -294,6 +306,20 @@
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidNextTokenException"},
         {"shape":"InvalidLimitException"}
+      ]
+    },
+    "DescribeRetentionConfigurations":{
+      "name":"DescribeRetentionConfigurations",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeRetentionConfigurationsRequest"},
+      "output":{"shape":"DescribeRetentionConfigurationsResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"NoSuchRetentionConfigurationException"},
+        {"shape":"InvalidNextTokenException"}
       ]
     },
     "GetAggregateComplianceDetailsByConfigRule":{
@@ -505,6 +531,19 @@
         {"shape":"InvalidParameterValueException"},
         {"shape":"InvalidResultTokenException"},
         {"shape":"NoSuchConfigRuleException"}
+      ]
+    },
+    "PutRetentionConfiguration":{
+      "name":"PutRetentionConfiguration",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"PutRetentionConfigurationRequest"},
+      "output":{"shape":"PutRetentionConfigurationResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"MaxNumberOfRetentionConfigurationsExceededException"}
       ]
     },
     "StartConfigRulesEvaluation":{
@@ -1081,6 +1120,13 @@
         "RequesterAwsRegion":{"shape":"AwsRegion"}
       }
     },
+    "DeleteRetentionConfigurationRequest":{
+      "type":"structure",
+      "required":["RetentionConfigurationName"],
+      "members":{
+        "RetentionConfigurationName":{"shape":"RetentionConfigurationName"}
+      }
+    },
     "DeliverConfigSnapshotRequest":{
       "type":"structure",
       "required":["deliveryChannelName"],
@@ -1322,6 +1368,20 @@
       "members":{
         "PendingAggregationRequests":{"shape":"PendingAggregationRequestList"},
         "NextToken":{"shape":"String"}
+      }
+    },
+    "DescribeRetentionConfigurationsRequest":{
+      "type":"structure",
+      "members":{
+        "RetentionConfigurationNames":{"shape":"RetentionConfigurationNameList"},
+        "NextToken":{"shape":"NextToken"}
+      }
+    },
+    "DescribeRetentionConfigurationsResponse":{
+      "type":"structure",
+      "members":{
+        "RetentionConfigurations":{"shape":"RetentionConfigurationList"},
+        "NextToken":{"shape":"NextToken"}
       }
     },
     "EarlierTime":{"type":"timestamp"},
@@ -1665,6 +1725,12 @@
       },
       "exception":true
     },
+    "MaxNumberOfRetentionConfigurationsExceededException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
     "MaximumExecutionFrequency":{
       "type":"string",
       "enum":[
@@ -1735,6 +1801,12 @@
       "exception":true
     },
     "NoSuchDeliveryChannelException":{
+      "type":"structure",
+      "members":{
+      },
+      "exception":true
+    },
+    "NoSuchRetentionConfigurationException":{
       "type":"structure",
       "members":{
       },
@@ -1846,6 +1918,19 @@
       "type":"structure",
       "members":{
         "FailedEvaluations":{"shape":"Evaluations"}
+      }
+    },
+    "PutRetentionConfigurationRequest":{
+      "type":"structure",
+      "required":["RetentionPeriodInDays"],
+      "members":{
+        "RetentionPeriodInDays":{"shape":"RetentionPeriodInDays"}
+      }
+    },
+    "PutRetentionConfigurationResponse":{
+      "type":"structure",
+      "members":{
+        "RetentionConfiguration":{"shape":"RetentionConfiguration"}
       }
     },
     "RecorderName":{
@@ -2027,6 +2112,38 @@
       "member":{"shape":"StringWithCharLimit256"},
       "max":20,
       "min":0
+    },
+    "RetentionConfiguration":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "RetentionPeriodInDays"
+      ],
+      "members":{
+        "Name":{"shape":"RetentionConfigurationName"},
+        "RetentionPeriodInDays":{"shape":"RetentionPeriodInDays"}
+      }
+    },
+    "RetentionConfigurationList":{
+      "type":"list",
+      "member":{"shape":"RetentionConfiguration"}
+    },
+    "RetentionConfigurationName":{
+      "type":"string",
+      "max":256,
+      "min":1,
+      "pattern":"[\\w\\-]+"
+    },
+    "RetentionConfigurationNameList":{
+      "type":"list",
+      "member":{"shape":"RetentionConfigurationName"},
+      "max":1,
+      "min":0
+    },
+    "RetentionPeriodInDays":{
+      "type":"integer",
+      "max":2557,
+      "min":30
     },
     "RuleLimit":{
       "type":"integer",

--- a/models/apis/config/2014-11-12/docs-2.json
+++ b/models/apis/config/2014-11-12/docs-2.json
@@ -10,6 +10,7 @@
     "DeleteDeliveryChannel": "<p>Deletes the delivery channel.</p> <p>Before you can delete the delivery channel, you must stop the configuration recorder by using the <a>StopConfigurationRecorder</a> action.</p>",
     "DeleteEvaluationResults": "<p>Deletes the evaluation results for the specified AWS Config rule. You can specify one AWS Config rule per request. After you delete the evaluation results, you can call the <a>StartConfigRulesEvaluation</a> API to start evaluating your AWS resources against the rule.</p>",
     "DeletePendingAggregationRequest": "<p>Deletes pending authorization requests for a specified aggregator account in a specified region.</p>",
+    "DeleteRetentionConfiguration": "<p>Deletes the retention configuration.</p>",
     "DeliverConfigSnapshot": "<p>Schedules delivery of a configuration snapshot to the Amazon S3 bucket in the specified delivery channel. After the delivery has started, AWS Config sends the following notifications using an Amazon SNS topic that you have specified.</p> <ul> <li> <p>Notification of the start of the delivery.</p> </li> <li> <p>Notification of the completion of the delivery, if the delivery was successfully completed.</p> </li> <li> <p>Notification of delivery failure, if the delivery failed.</p> </li> </ul>",
     "DescribeAggregateComplianceByConfigRules": "<p>Returns a list of compliant and noncompliant rules with the number of resources for compliant and noncompliant rules. </p> <note> <p>The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.</p> </note>",
     "DescribeAggregationAuthorizations": "<p>Returns a list of authorizations granted to various aggregator accounts and regions.</p>",
@@ -24,6 +25,7 @@
     "DescribeDeliveryChannelStatus": "<p>Returns the current status of the specified delivery channel. If a delivery channel is not specified, this action returns the current status of all delivery channels associated with the account.</p> <note> <p>Currently, you can specify only one delivery channel per region in your account.</p> </note>",
     "DescribeDeliveryChannels": "<p>Returns details about the specified delivery channel. If a delivery channel is not specified, this action returns the details of all delivery channels associated with the account.</p> <note> <p>Currently, you can specify only one delivery channel per region in your account.</p> </note>",
     "DescribePendingAggregationRequests": "<p>Returns a list of all pending aggregation requests.</p>",
+    "DescribeRetentionConfigurations": "<p>Returns the details of one or more retention configurations. If the retention configuration name is not specified, this action returns the details for all the retention configurations for that account.</p> <note> <p>Currently, AWS Config supports only one retention configuration per region in your account.</p> </note>",
     "GetAggregateComplianceDetailsByConfigRule": "<p>Returns the evaluation results for the specified AWS Config rule for a specific resource in a rule. The results indicate which AWS resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule. </p> <note> <p>The results can return an empty result page. But if you have a nextToken, the results are displayed on the next page.</p> </note>",
     "GetAggregateConfigRuleComplianceSummary": "<p>Returns the number of compliant and noncompliant rules for one or more accounts and regions in an aggregator.</p> <note> <p>The results can return an empty result page, but if you have a nextToken, the results are displayed on the next page.</p> </note>",
     "GetComplianceDetailsByConfigRule": "<p>Returns the evaluation results for the specified AWS Config rule. The results indicate which AWS resources were evaluated by the rule, when each resource was last evaluated, and whether each resource complies with the rule.</p>",
@@ -31,7 +33,7 @@
     "GetComplianceSummaryByConfigRule": "<p>Returns the number of AWS Config rules that are compliant and noncompliant, up to a maximum of 25 for each.</p>",
     "GetComplianceSummaryByResourceType": "<p>Returns the number of resources that are compliant and the number that are noncompliant. You can specify one or more resource types to get these numbers for each resource type. The maximum number returned is 100.</p>",
     "GetDiscoveredResourceCounts": "<p>Returns the resource types, the number of each resource type, and the total number of resources that AWS Config is recording in this region for your AWS account. </p> <p class=\"title\"> <b>Example</b> </p> <ol> <li> <p>AWS Config is recording three resource types in the US East (Ohio) Region for your account: 25 EC2 instances, 20 IAM users, and 15 S3 buckets.</p> </li> <li> <p>You make a call to the <code>GetDiscoveredResourceCounts</code> action and specify that you want all resource types. </p> </li> <li> <p>AWS Config returns the following:</p> <ul> <li> <p>The resource types (EC2 instances, IAM users, and S3 buckets).</p> </li> <li> <p>The number of each resource type (25, 20, and 15).</p> </li> <li> <p>The total number of all resources (60).</p> </li> </ul> </li> </ol> <p>The response is paginated. By default, AWS Config lists 100 <a>ResourceCount</a> objects on each page. You can customize this number with the <code>limit</code> parameter. The response includes a <code>nextToken</code> string. To get the next page of results, run the request again and specify the string for the <code>nextToken</code> parameter.</p> <note> <p>If you make a call to the <a>GetDiscoveredResourceCounts</a> action, you might not immediately receive resource counts in the following situations:</p> <ul> <li> <p>You are a new AWS Config customer.</p> </li> <li> <p>You just enabled resource recording.</p> </li> </ul> <p>It might take a few minutes for AWS Config to record and count your resources. Wait a few minutes and then retry the <a>GetDiscoveredResourceCounts</a> action. </p> </note>",
-    "GetResourceConfigHistory": "<p>Returns a list of configuration items for the specified resource. The list contains details about each state of the resource during the specified time interval.</p> <p>The response is paginated. By default, AWS Config returns a limit of 10 configuration items per page. You can customize this number with the <code>limit</code> parameter. The response includes a <code>nextToken</code> string. To get the next page of results, run the request again and specify the string for the <code>nextToken</code> parameter.</p> <note> <p>Each call to the API is limited to span a duration of seven days. It is likely that the number of records returned is smaller than the specified <code>limit</code>. In such cases, you can make another call, using the <code>nextToken</code>.</p> </note>",
+    "GetResourceConfigHistory": "<p>Returns a list of configuration items for the specified resource. The list contains details about each state of the resource during the specified time interval. If you specified a retention period to retain your <code>ConfigurationItems</code> between a minimum of 30 days and a maximum of 7 years (2557 days), AWS Config returns the <code>ConfigurationItems</code> for the specified retention period. </p> <p>The response is paginated. By default, AWS Config returns a limit of 10 configuration items per page. You can customize this number with the <code>limit</code> parameter. The response includes a <code>nextToken</code> string. To get the next page of results, run the request again and specify the string for the <code>nextToken</code> parameter.</p> <note> <p>Each call to the API is limited to span a duration of seven days. It is likely that the number of records returned is smaller than the specified <code>limit</code>. In such cases, you can make another call, using the <code>nextToken</code>.</p> </note>",
     "ListDiscoveredResources": "<p>Accepts a resource type and returns a list of resource identifiers for the resources of that type. A resource identifier includes the resource type, ID, and (if available) the custom resource name. The results consist of resources that AWS Config has discovered, including those that AWS Config is not currently recording. You can narrow the results to include only resources that have specific resource IDs or a resource name.</p> <note> <p>You can specify either resource IDs or a resource name, but not both, in the same request.</p> </note> <p>The response is paginated. By default, AWS Config lists 100 resource identifiers on each page. You can customize this number with the <code>limit</code> parameter. The response includes a <code>nextToken</code> string. To get the next page of results, run the request again and specify the string for the <code>nextToken</code> parameter.</p>",
     "PutAggregationAuthorization": "<p>Authorizes the aggregator account and region to collect data from the source account and region. </p>",
     "PutConfigRule": "<p>Adds or updates an AWS Config rule for evaluating whether your AWS resources comply with your desired configurations.</p> <p>You can use this action for custom AWS Config rules and AWS managed Config rules. A custom AWS Config rule is a rule that you develop and maintain. An AWS managed Config rule is a customizable, predefined rule that AWS Config provides.</p> <p>If you are adding a new custom AWS Config rule, you must first create the AWS Lambda function that the rule invokes to evaluate your resources. When you use the <code>PutConfigRule</code> action to add the rule to AWS Config, you must specify the Amazon Resource Name (ARN) that AWS Lambda assigns to the function. Specify the ARN for the <code>SourceIdentifier</code> key. This key is part of the <code>Source</code> object, which is part of the <code>ConfigRule</code> object. </p> <p>If you are adding an AWS managed Config rule, specify the rule's identifier for the <code>SourceIdentifier</code> key. To reference AWS managed Config rule identifiers, see <a href=\"http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html\">About AWS Managed Config Rules</a>.</p> <p>For any new rule that you add, specify the <code>ConfigRuleName</code> in the <code>ConfigRule</code> object. Do not specify the <code>ConfigRuleArn</code> or the <code>ConfigRuleId</code>. These values are generated by AWS Config for new rules.</p> <p>If you are updating a rule that you added previously, you can specify the rule by <code>ConfigRuleName</code>, <code>ConfigRuleId</code>, or <code>ConfigRuleArn</code> in the <code>ConfigRule</code> data type that you use in this request.</p> <p>The maximum number of rules that AWS Config supports is 50.</p> <p>For information about requesting a rule limit increase, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_config\">AWS Config Limits</a> in the <i>AWS General Reference Guide</i>.</p> <p>For more information about developing and using AWS Config rules, see <a href=\"http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html\">Evaluating AWS Resource Configurations with AWS Config</a> in the <i>AWS Config Developer Guide</i>.</p>",
@@ -39,6 +41,7 @@
     "PutConfigurationRecorder": "<p>Creates a new configuration recorder to record the selected resource configurations.</p> <p>You can use this action to change the role <code>roleARN</code> or the <code>recordingGroup</code> of an existing recorder. To change the role, call the action on the existing configuration recorder and specify a role.</p> <note> <p>Currently, you can specify only one configuration recorder per region in your account.</p> <p>If <code>ConfigurationRecorder</code> does not have the <b>recordingGroup</b> parameter specified, the default is to record all supported resource types.</p> </note>",
     "PutDeliveryChannel": "<p>Creates a delivery channel object to deliver configuration information to an Amazon S3 bucket and Amazon SNS topic.</p> <p>Before you can create a delivery channel, you must create a configuration recorder.</p> <p>You can use this action to change the Amazon S3 bucket or an Amazon SNS topic of the existing delivery channel. To change the Amazon S3 bucket or an Amazon SNS topic, call this action and specify the changed values for the S3 bucket and the SNS topic. If you specify a different value for either the S3 bucket or the SNS topic, this action will keep the existing value for the parameter that is not changed.</p> <note> <p>You can have only one delivery channel per region in your account.</p> </note>",
     "PutEvaluations": "<p>Used by an AWS Lambda function to deliver evaluation results to AWS Config. This action is required in every AWS Lambda function that is invoked by an AWS Config rule.</p>",
+    "PutRetentionConfiguration": "<p>Creates and updates the retention configuration with details about retention period (number of days) that AWS Config stores your historical information. The API creates the <code>RetentionConfiguration</code> object and names the object as <b>default</b>. When you have a <code>RetentionConfiguration</code> object named <b>default</b>, calling the API modifies the default object. </p> <note> <p>Currently, AWS Config supports only one retention configuration per region in your account.</p> </note>",
     "StartConfigRulesEvaluation": "<p>Runs an on-demand evaluation for the specified AWS Config rules against the last known configuration state of the resources. Use <code>StartConfigRulesEvaluation</code> when you want to test that a rule you updated is working as expected. <code>StartConfigRulesEvaluation</code> does not re-record the latest configuration state for your resources. It re-runs an evaluation against the last known state of your resources. </p> <p>You can specify up to 25 AWS Config rules per request. </p> <p>An existing <code>StartConfigRulesEvaluation</code> call for the specified rules must complete before you can call the API again. If you chose to have AWS Config stream to an Amazon SNS topic, you will receive a <code>ConfigRuleEvaluationStarted</code> notification when the evaluation starts.</p> <note> <p>You don't need to call the <code>StartConfigRulesEvaluation</code> API to run an evaluation for a new rule. When you create a rule, AWS Config evaluates your resources against the rule automatically. </p> </note> <p>The <code>StartConfigRulesEvaluation</code> API is useful if you want to run on-demand evaluations, such as the following example:</p> <ol> <li> <p>You have a custom rule that evaluates your IAM resources every 24 hours.</p> </li> <li> <p>You update your Lambda function to add additional conditions to your rule.</p> </li> <li> <p>Instead of waiting for the next periodic evaluation, you call the <code>StartConfigRulesEvaluation</code> API.</p> </li> <li> <p>AWS Config invokes your Lambda function and evaluates your IAM resources.</p> </li> <li> <p>Your custom rule will still run periodic evaluations every 24 hours.</p> </li> </ol>",
     "StartConfigurationRecorder": "<p>Starts recording configurations of the AWS resources you have selected to record in your AWS account.</p> <p>You must have created at least one delivery channel to successfully start the configuration recorder.</p>",
     "StopConfigurationRecorder": "<p>Stops recording configurations of the AWS resources you have selected to record in your AWS account.</p>"
@@ -133,7 +136,7 @@
     "AggregatedSourceStatusList": {
       "base": null,
       "refs": {
-        "DescribeConfigurationAggregatorSourcesStatusResponse$AggregatedSourceStatusList": "<p>Retuns an AggregatedSourceStatus object. </p>"
+        "DescribeConfigurationAggregatorSourcesStatusResponse$AggregatedSourceStatusList": "<p>Returns an AggregatedSourceStatus object. </p>"
       }
     },
     "AggregatedSourceStatusType": {
@@ -242,12 +245,12 @@
     "Boolean": {
       "base": null,
       "refs": {
-        "AccountAggregationSource$AllAwsRegions": "<p>If true, aggreagate existing AWS Config regions and future regions.</p>",
+        "AccountAggregationSource$AllAwsRegions": "<p>If true, aggregate existing AWS Config regions and future regions.</p>",
         "ComplianceContributorCount$CapExceeded": "<p>Indicates whether the maximum count is reached.</p>",
         "ConfigRuleEvaluationStatus$FirstEvaluationStarted": "<p>Indicates whether AWS Config has evaluated your resources against the rule at least once.</p> <ul> <li> <p> <code>true</code> - AWS Config has evaluated your AWS resources against the rule at least once.</p> </li> <li> <p> <code>false</code> - AWS Config has not once finished evaluating your AWS resources against the rule.</p> </li> </ul>",
         "ConfigurationRecorderStatus$recording": "<p>Specifies whether or not the recorder is currently recording.</p>",
         "ListDiscoveredResourcesRequest$includeDeletedResources": "<p>Specifies whether AWS Config includes deleted resources in the results. By default, deleted resources are not included.</p>",
-        "OrganizationAggregationSource$AllAwsRegions": "<p>If true, aggreagate existing AWS Config regions and future regions.</p>",
+        "OrganizationAggregationSource$AllAwsRegions": "<p>If true, aggregate existing AWS Config regions and future regions.</p>",
         "PutEvaluationsRequest$TestMode": "<p>Use this parameter to specify a test run for <code>PutEvaluations</code>. You can verify whether your AWS Lambda function will deliver evaluation results to AWS Config. No updates occur to your existing evaluations, and evaluation results are not sent to AWS Config.</p> <note> <p>When <code>TestMode</code> is <code>true</code>, <code>PutEvaluations</code> doesn't require a valid value for the <code>ResultToken</code> parameter, but the value cannot be null.</p> </note>"
       }
     },
@@ -620,6 +623,11 @@
       "refs": {
       }
     },
+    "DeleteRetentionConfigurationRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DeliverConfigSnapshotRequest": {
       "base": "<p>The input for the <a>DeliverConfigSnapshot</a> action.</p>",
       "refs": {
@@ -801,6 +809,16 @@
       }
     },
     "DescribePendingAggregationRequestsResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeRetentionConfigurationsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeRetentionConfigurationsResponse": {
       "base": null,
       "refs": {
       }
@@ -1083,6 +1101,11 @@
       "refs": {
       }
     },
+    "MaxNumberOfRetentionConfigurationsExceededException": {
+      "base": "<p>Failed to add the retention configuration because a retention configuration with that name already exists.</p>",
+      "refs": {
+      }
+    },
     "MaximumExecutionFrequency": {
       "base": null,
       "refs": {
@@ -1110,6 +1133,8 @@
         "DescribeAggregateComplianceByConfigRulesResponse$NextToken": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>",
         "DescribeComplianceByResourceRequest$NextToken": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response.</p>",
         "DescribeComplianceByResourceResponse$NextToken": "<p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>",
+        "DescribeRetentionConfigurationsRequest$NextToken": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>",
+        "DescribeRetentionConfigurationsResponse$NextToken": "<p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>",
         "GetAggregateComplianceDetailsByConfigRuleRequest$NextToken": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>",
         "GetAggregateComplianceDetailsByConfigRuleResponse$NextToken": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>",
         "GetAggregateConfigRuleComplianceSummaryRequest$NextToken": "<p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>",
@@ -1166,6 +1191,11 @@
     },
     "NoSuchDeliveryChannelException": {
       "base": "<p>You have specified a delivery channel that does not exist.</p>",
+      "refs": {
+      }
+    },
+    "NoSuchRetentionConfigurationException": {
+      "base": "<p>You have specified a retention configuration that does not exist.</p>",
       "refs": {
       }
     },
@@ -1252,6 +1282,16 @@
     },
     "PutEvaluationsResponse": {
       "base": "<p/>",
+      "refs": {
+      }
+    },
+    "PutRetentionConfigurationRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "PutRetentionConfigurationResponse": {
+      "base": null,
       "refs": {
       }
     },
@@ -1426,6 +1466,40 @@
       "refs": {
         "GetComplianceSummaryByResourceTypeRequest$ResourceTypes": "<p>Specify one or more resource types to get the number of resources that are compliant and the number that are noncompliant for each resource type.</p> <p>For this request, you can specify an AWS resource type such as <code>AWS::EC2::Instance</code>. You can specify that the resource type is an AWS account by specifying <code>AWS::::Account</code>.</p>",
         "GetDiscoveredResourceCountsRequest$resourceTypes": "<p>The comma-separated list that specifies the resource types that you want AWS Config to return (for example, <code>\"AWS::EC2::Instance\"</code>, <code>\"AWS::IAM::User\"</code>).</p> <p>If a value for <code>resourceTypes</code> is not specified, AWS Config returns all resource types that AWS Config is recording in the region for your account.</p> <note> <p>If the configuration recorder is turned off, AWS Config returns an empty list of <a>ResourceCount</a> objects. If the configuration recorder is not recording a specific resource type (for example, S3 buckets), that resource type is not returned in the list of <a>ResourceCount</a> objects.</p> </note>"
+      }
+    },
+    "RetentionConfiguration": {
+      "base": "<p>An object with the name of the retention configuration and the retention period in days. The object stores the configuration for data retention in AWS Config.</p>",
+      "refs": {
+        "PutRetentionConfigurationResponse$RetentionConfiguration": "<p>Returns a retention configuration object.</p>",
+        "RetentionConfigurationList$member": null
+      }
+    },
+    "RetentionConfigurationList": {
+      "base": null,
+      "refs": {
+        "DescribeRetentionConfigurationsResponse$RetentionConfigurations": "<p>Returns a retention configuration object.</p>"
+      }
+    },
+    "RetentionConfigurationName": {
+      "base": null,
+      "refs": {
+        "DeleteRetentionConfigurationRequest$RetentionConfigurationName": "<p>The name of the retention configuration to delete.</p>",
+        "RetentionConfiguration$Name": "<p>The name of the retention configuration object.</p>",
+        "RetentionConfigurationNameList$member": null
+      }
+    },
+    "RetentionConfigurationNameList": {
+      "base": null,
+      "refs": {
+        "DescribeRetentionConfigurationsRequest$RetentionConfigurationNames": "<p>A list of names of retention configurations for which you want details. If you do not specify a name, AWS Config returns details for all the retention configurations for that account.</p> <note> <p>Currently, AWS Config supports only one retention configuration per region in your account.</p> </note>"
+      }
+    },
+    "RetentionPeriodInDays": {
+      "base": null,
+      "refs": {
+        "PutRetentionConfigurationRequest$RetentionPeriodInDays": "<p>Number of days AWS Config stores your historical information.</p> <note> <p>Currently, only applicable to the configuration item history.</p> </note>",
+        "RetentionConfiguration$RetentionPeriodInDays": "<p>Number of days AWS Config stores your historical information.</p> <note> <p>Currently, only applicable to the configuration item history.</p> </note>"
       }
     },
     "RuleLimit": {

--- a/models/apis/glue/2017-03-31/api-2.json
+++ b/models/apis/glue/2017-03-31/api-2.json
@@ -1191,7 +1191,8 @@
       "members":{
         "JobName":{"shape":"NameString"},
         "Arguments":{"shape":"GenericMap"},
-        "Timeout":{"shape":"Timeout"}
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "ActionList":{
@@ -1844,7 +1845,8 @@
         "Connections":{"shape":"ConnectionsList"},
         "MaxRetries":{"shape":"MaxRetries"},
         "AllocatedCapacity":{"shape":"IntegerValue"},
-        "Timeout":{"shape":"Timeout"}
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "CreateJobResponse":{
@@ -2255,6 +2257,7 @@
         "MaxConcurrentRuns":{"shape":"MaxConcurrentRuns"}
       }
     },
+    "ExecutionTime":{"type":"integer"},
     "FieldType":{"type":"string"},
     "FilterString":{
       "type":"string",
@@ -2845,7 +2848,8 @@
         "Connections":{"shape":"ConnectionsList"},
         "MaxRetries":{"shape":"MaxRetries"},
         "AllocatedCapacity":{"shape":"IntegerValue"},
-        "Timeout":{"shape":"Timeout"}
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "JobBookmarkEntry":{
@@ -2886,8 +2890,9 @@
         "ErrorMessage":{"shape":"ErrorString"},
         "PredecessorRuns":{"shape":"PredecessorList"},
         "AllocatedCapacity":{"shape":"IntegerValue"},
-        "ExecutionTime":{"shape":"IntegerValue"},
-        "Timeout":{"shape":"Timeout"}
+        "ExecutionTime":{"shape":"ExecutionTime"},
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "JobRunList":{
@@ -2918,7 +2923,8 @@
         "Connections":{"shape":"ConnectionsList"},
         "MaxRetries":{"shape":"MaxRetries"},
         "AllocatedCapacity":{"shape":"IntegerValue"},
-        "Timeout":{"shape":"Timeout"}
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "JsonClassifier":{
@@ -3064,6 +3070,17 @@
     "NonNegativeInteger":{
       "type":"integer",
       "min":0
+    },
+    "NotificationProperty":{
+      "type":"structure",
+      "members":{
+        "NotifyDelayAfter":{"shape":"NotifyDelayAfter"}
+      }
+    },
+    "NotifyDelayAfter":{
+      "type":"integer",
+      "box":true,
+      "min":1
     },
     "OperationTimeoutException":{
       "type":"structure",
@@ -3369,7 +3386,8 @@
         "JobRunId":{"shape":"IdString"},
         "Arguments":{"shape":"GenericMap"},
         "AllocatedCapacity":{"shape":"IntegerValue"},
-        "Timeout":{"shape":"Timeout"}
+        "Timeout":{"shape":"Timeout"},
+        "NotificationProperty":{"shape":"NotificationProperty"}
       }
     },
     "StartJobRunResponse":{

--- a/models/apis/glue/2017-03-31/docs-2.json
+++ b/models/apis/glue/2017-03-31/docs-2.json
@@ -989,6 +989,12 @@
         "JobUpdate$ExecutionProperty": "<p>An ExecutionProperty specifying the maximum number of concurrent runs allowed for this job.</p>"
       }
     },
+    "ExecutionTime": {
+      "base": null,
+      "refs": {
+        "JobRun$ExecutionTime": "<p>The amount of time (in seconds) that the job run consumed resources.</p>"
+      }
+    },
     "FieldType": {
       "base": null,
       "refs": {
@@ -1446,7 +1452,6 @@
         "JobBookmarkEntry$Run": "<p>The run ID number.</p>",
         "JobBookmarkEntry$Attempt": "<p>The attempt ID number.</p>",
         "JobRun$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
-        "JobRun$ExecutionTime": "<p>The amount of time (in seconds) that the job run consumed resources.</p>",
         "JobUpdate$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>",
         "StartJobRunRequest$AllocatedCapacity": "<p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href=\"https://aws.amazon.com/glue/pricing/\">AWS Glue pricing page</a>.</p>"
       }
@@ -1867,6 +1872,23 @@
         "Segment$SegmentNumber": "<p>The zero-based index number of the this segment. For example, if the total number of segments is 4, SegmentNumber values will range from zero through three.</p>",
         "Table$Retention": "<p>Retention time for this table.</p>",
         "TableInput$Retention": "<p>Retention time for this table.</p>"
+      }
+    },
+    "NotificationProperty": {
+      "base": "<p>Specifies configuration properties of a notification.</p>",
+      "refs": {
+        "Action$NotificationProperty": "<p>Specifies configuration properties of a job run notification.</p>",
+        "CreateJobRequest$NotificationProperty": "<p>Specifies configuration properties of a job notification.</p>",
+        "Job$NotificationProperty": "<p>Specifies configuration properties of a job notification.</p>",
+        "JobRun$NotificationProperty": "<p>Specifies configuration properties of a job run notification.</p>",
+        "JobUpdate$NotificationProperty": "<p>Specifies configuration properties of a job notification.</p>",
+        "StartJobRunRequest$NotificationProperty": "<p>Specifies configuration properties of a job run notification.</p>"
+      }
+    },
+    "NotifyDelayAfter": {
+      "base": null,
+      "refs": {
+        "NotificationProperty$NotifyDelayAfter": "<p>After a job run starts, the number of minutes to wait before sending a job run delay notification.</p>"
       }
     },
     "OperationTimeoutException": {

--- a/models/apis/iot/2015-05-28/api-2.json
+++ b/models/apis/iot/2015-05-28/api-2.json
@@ -4164,7 +4164,8 @@
       "enum":[
         "IN_PROGRESS",
         "CANCELED",
-        "COMPLETED"
+        "COMPLETED",
+        "DELETION_IN_PROGRESS"
       ]
     },
     "JobSummary":{

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -3827,6 +3827,10 @@ type CreateStackInput struct {
 
 	// The storage connectors to enable.
 	StorageConnectors []*StorageConnector `type:"list"`
+
+	// The actions that are enabled or disabled for users during their streaming
+	// sessions. By default, these actions are enabled.
+	UserSettings []*UserSetting `min:"1" type:"list"`
 }
 
 // String returns the string representation
@@ -3848,6 +3852,9 @@ func (s *CreateStackInput) Validate() error {
 	if s.Name != nil && len(*s.Name) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
+	if s.UserSettings != nil && len(s.UserSettings) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserSettings", 1))
+	}
 	if s.StorageConnectors != nil {
 		for i, v := range s.StorageConnectors {
 			if v == nil {
@@ -3855,6 +3862,16 @@ func (s *CreateStackInput) Validate() error {
 			}
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "StorageConnectors", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.UserSettings != nil {
+		for i, v := range s.UserSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserSettings", i), err.(request.ErrInvalidParams))
 			}
 		}
 	}
@@ -3898,6 +3915,12 @@ func (s *CreateStackInput) SetRedirectURL(v string) *CreateStackInput {
 // SetStorageConnectors sets the StorageConnectors field's value.
 func (s *CreateStackInput) SetStorageConnectors(v []*StorageConnector) *CreateStackInput {
 	s.StorageConnectors = v
+	return s
+}
+
+// SetUserSettings sets the UserSettings field's value.
+func (s *CreateStackInput) SetUserSettings(v []*UserSetting) *CreateStackInput {
+	s.UserSettings = v
 	return s
 }
 
@@ -6118,6 +6141,10 @@ type Stack struct {
 
 	// The storage connectors to enable.
 	StorageConnectors []*StorageConnector `type:"list"`
+
+	// The actions that are enabled or disabled for users during their streaming
+	// sessions. By default these actions are enabled.
+	UserSettings []*UserSetting `min:"1" type:"list"`
 }
 
 // String returns the string representation
@@ -6181,6 +6208,12 @@ func (s *Stack) SetStackErrors(v []*StackError) *Stack {
 // SetStorageConnectors sets the StorageConnectors field's value.
 func (s *Stack) SetStorageConnectors(v []*StorageConnector) *Stack {
 	s.StorageConnectors = v
+	return s
+}
+
+// SetUserSettings sets the UserSettings field's value.
+func (s *Stack) SetUserSettings(v []*UserSetting) *Stack {
+	s.UserSettings = v
 	return s
 }
 
@@ -7002,6 +7035,10 @@ type UpdateStackInput struct {
 
 	// The storage connectors to enable.
 	StorageConnectors []*StorageConnector `type:"list"`
+
+	// The actions that are enabled or disabled for users during their streaming
+	// sessions. By default, these actions are enabled.
+	UserSettings []*UserSetting `min:"1" type:"list"`
 }
 
 // String returns the string representation
@@ -7023,6 +7060,9 @@ func (s *UpdateStackInput) Validate() error {
 	if s.Name != nil && len(*s.Name) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
+	if s.UserSettings != nil && len(s.UserSettings) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserSettings", 1))
+	}
 	if s.StorageConnectors != nil {
 		for i, v := range s.StorageConnectors {
 			if v == nil {
@@ -7030,6 +7070,16 @@ func (s *UpdateStackInput) Validate() error {
 			}
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "StorageConnectors", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.UserSettings != nil {
+		for i, v := range s.UserSettings {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "UserSettings", i), err.(request.ErrInvalidParams))
 			}
 		}
 	}
@@ -7088,6 +7138,12 @@ func (s *UpdateStackInput) SetStorageConnectors(v []*StorageConnector) *UpdateSt
 	return s
 }
 
+// SetUserSettings sets the UserSettings field's value.
+func (s *UpdateStackInput) SetUserSettings(v []*UserSetting) *UpdateStackInput {
+	s.UserSettings = v
+	return s
+}
+
 type UpdateStackOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -7108,6 +7164,60 @@ func (s UpdateStackOutput) GoString() string {
 // SetStack sets the Stack field's value.
 func (s *UpdateStackOutput) SetStack(v *Stack) *UpdateStackOutput {
 	s.Stack = v
+	return s
+}
+
+// Describes an action and whether the action is enabled or disabled for users
+// during their streaming sessions.
+type UserSetting struct {
+	_ struct{} `type:"structure"`
+
+	// The action that is enabled or disabled.
+	//
+	// Action is a required field
+	Action *string `type:"string" required:"true" enum:"Action"`
+
+	// Indicates whether the action is enabled or disabled.
+	//
+	// Permission is a required field
+	Permission *string `type:"string" required:"true" enum:"Permission"`
+}
+
+// String returns the string representation
+func (s UserSetting) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UserSetting) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UserSetting) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UserSetting"}
+	if s.Action == nil {
+		invalidParams.Add(request.NewErrParamRequired("Action"))
+	}
+	if s.Permission == nil {
+		invalidParams.Add(request.NewErrParamRequired("Permission"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAction sets the Action field's value.
+func (s *UserSetting) SetAction(v string) *UserSetting {
+	s.Action = &v
+	return s
+}
+
+// SetPermission sets the Permission field's value.
+func (s *UserSetting) SetPermission(v string) *UserSetting {
+	s.Permission = &v
 	return s
 }
 
@@ -7143,6 +7253,23 @@ func (s *VpcConfig) SetSubnetIds(v []*string) *VpcConfig {
 	s.SubnetIds = v
 	return s
 }
+
+const (
+	// ActionClipboardCopyFromLocalDevice is a Action enum value
+	ActionClipboardCopyFromLocalDevice = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
+
+	// ActionClipboardCopyToLocalDevice is a Action enum value
+	ActionClipboardCopyToLocalDevice = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
+
+	// ActionFileUpload is a Action enum value
+	ActionFileUpload = "FILE_UPLOAD"
+
+	// ActionFileDownload is a Action enum value
+	ActionFileDownload = "FILE_DOWNLOAD"
+
+	// ActionPrintingToLocalDevice is a Action enum value
+	ActionPrintingToLocalDevice = "PRINTING_TO_LOCAL_DEVICE"
+)
 
 const (
 	// AuthenticationTypeApi is a AuthenticationType enum value
@@ -7335,6 +7462,14 @@ const (
 )
 
 const (
+	// PermissionEnabled is a Permission enum value
+	PermissionEnabled = "ENABLED"
+
+	// PermissionDisabled is a Permission enum value
+	PermissionDisabled = "DISABLED"
+)
+
+const (
 	// PlatformTypeWindows is a PlatformType enum value
 	PlatformTypeWindows = "WINDOWS"
 )
@@ -7363,6 +7498,9 @@ const (
 
 	// StackAttributeThemeName is a StackAttribute enum value
 	StackAttributeThemeName = "THEME_NAME"
+
+	// StackAttributeUserSettings is a StackAttribute enum value
+	StackAttributeUserSettings = "USER_SETTINGS"
 )
 
 const (

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -709,6 +709,91 @@ func (c *ConfigService) DeletePendingAggregationRequestWithContext(ctx aws.Conte
 	return out, req.Send()
 }
 
+const opDeleteRetentionConfiguration = "DeleteRetentionConfiguration"
+
+// DeleteRetentionConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteRetentionConfiguration operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteRetentionConfiguration for more information on using the DeleteRetentionConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteRetentionConfigurationRequest method.
+//    req, resp := client.DeleteRetentionConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/DeleteRetentionConfiguration
+func (c *ConfigService) DeleteRetentionConfigurationRequest(input *DeleteRetentionConfigurationInput) (req *request.Request, output *DeleteRetentionConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteRetentionConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteRetentionConfigurationInput{}
+	}
+
+	output = &DeleteRetentionConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteRetentionConfiguration API operation for AWS Config.
+//
+// Deletes the retention configuration.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Config's
+// API operation DeleteRetentionConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   One or more of the specified parameters are invalid. Verify that your parameters
+//   are valid and try again.
+//
+//   * ErrCodeNoSuchRetentionConfigurationException "NoSuchRetentionConfigurationException"
+//   You have specified a retention configuration that does not exist.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/DeleteRetentionConfiguration
+func (c *ConfigService) DeleteRetentionConfiguration(input *DeleteRetentionConfigurationInput) (*DeleteRetentionConfigurationOutput, error) {
+	req, out := c.DeleteRetentionConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// DeleteRetentionConfigurationWithContext is the same as DeleteRetentionConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteRetentionConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ConfigService) DeleteRetentionConfigurationWithContext(ctx aws.Context, input *DeleteRetentionConfigurationInput, opts ...request.Option) (*DeleteRetentionConfigurationOutput, error) {
+	req, out := c.DeleteRetentionConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeliverConfigSnapshot = "DeliverConfigSnapshot"
 
 // DeliverConfigSnapshotRequest generates a "aws/request.Request" representing the
@@ -1985,6 +2070,98 @@ func (c *ConfigService) DescribePendingAggregationRequestsWithContext(ctx aws.Co
 	return out, req.Send()
 }
 
+const opDescribeRetentionConfigurations = "DescribeRetentionConfigurations"
+
+// DescribeRetentionConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeRetentionConfigurations operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeRetentionConfigurations for more information on using the DescribeRetentionConfigurations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeRetentionConfigurationsRequest method.
+//    req, resp := client.DescribeRetentionConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/DescribeRetentionConfigurations
+func (c *ConfigService) DescribeRetentionConfigurationsRequest(input *DescribeRetentionConfigurationsInput) (req *request.Request, output *DescribeRetentionConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeRetentionConfigurations,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeRetentionConfigurationsInput{}
+	}
+
+	output = &DescribeRetentionConfigurationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeRetentionConfigurations API operation for AWS Config.
+//
+// Returns the details of one or more retention configurations. If the retention
+// configuration name is not specified, this action returns the details for
+// all the retention configurations for that account.
+//
+// Currently, AWS Config supports only one retention configuration per region
+// in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Config's
+// API operation DescribeRetentionConfigurations for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   One or more of the specified parameters are invalid. Verify that your parameters
+//   are valid and try again.
+//
+//   * ErrCodeNoSuchRetentionConfigurationException "NoSuchRetentionConfigurationException"
+//   You have specified a retention configuration that does not exist.
+//
+//   * ErrCodeInvalidNextTokenException "InvalidNextTokenException"
+//   The specified next token is invalid. Specify the nextToken string that was
+//   returned in the previous response to get the next page of results.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/DescribeRetentionConfigurations
+func (c *ConfigService) DescribeRetentionConfigurations(input *DescribeRetentionConfigurationsInput) (*DescribeRetentionConfigurationsOutput, error) {
+	req, out := c.DescribeRetentionConfigurationsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeRetentionConfigurationsWithContext is the same as DescribeRetentionConfigurations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeRetentionConfigurations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ConfigService) DescribeRetentionConfigurationsWithContext(ctx aws.Context, input *DescribeRetentionConfigurationsInput, opts ...request.Option) (*DescribeRetentionConfigurationsOutput, error) {
+	req, out := c.DescribeRetentionConfigurationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetAggregateComplianceDetailsByConfigRule = "GetAggregateComplianceDetailsByConfigRule"
 
 // GetAggregateComplianceDetailsByConfigRuleRequest generates a "aws/request.Request" representing the
@@ -2673,7 +2850,9 @@ func (c *ConfigService) GetResourceConfigHistoryRequest(input *GetResourceConfig
 //
 // Returns a list of configuration items for the specified resource. The list
 // contains details about each state of the resource during the specified time
-// interval.
+// interval. If you specified a retention period to retain your ConfigurationItems
+// between a minimum of 30 days and a maximum of 7 years (2557 days), AWS Config
+// returns the ConfigurationItems for the specified retention period.
 //
 // The response is paginated. By default, AWS Config returns a limit of 10 configuration
 // items per page. You can customize this number with the limit parameter. The
@@ -3517,6 +3696,97 @@ func (c *ConfigService) PutEvaluationsWithContext(ctx aws.Context, input *PutEva
 	return out, req.Send()
 }
 
+const opPutRetentionConfiguration = "PutRetentionConfiguration"
+
+// PutRetentionConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutRetentionConfiguration operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutRetentionConfiguration for more information on using the PutRetentionConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutRetentionConfigurationRequest method.
+//    req, resp := client.PutRetentionConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/PutRetentionConfiguration
+func (c *ConfigService) PutRetentionConfigurationRequest(input *PutRetentionConfigurationInput) (req *request.Request, output *PutRetentionConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutRetentionConfiguration,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutRetentionConfigurationInput{}
+	}
+
+	output = &PutRetentionConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutRetentionConfiguration API operation for AWS Config.
+//
+// Creates and updates the retention configuration with details about retention
+// period (number of days) that AWS Config stores your historical information.
+// The API creates the RetentionConfiguration object and names the object as
+// default. When you have a RetentionConfiguration object named default, calling
+// the API modifies the default object.
+//
+// Currently, AWS Config supports only one retention configuration per region
+// in your account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Config's
+// API operation PutRetentionConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   One or more of the specified parameters are invalid. Verify that your parameters
+//   are valid and try again.
+//
+//   * ErrCodeMaxNumberOfRetentionConfigurationsExceededException "MaxNumberOfRetentionConfigurationsExceededException"
+//   Failed to add the retention configuration because a retention configuration
+//   with that name already exists.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/config-2014-11-12/PutRetentionConfiguration
+func (c *ConfigService) PutRetentionConfiguration(input *PutRetentionConfigurationInput) (*PutRetentionConfigurationOutput, error) {
+	req, out := c.PutRetentionConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// PutRetentionConfigurationWithContext is the same as PutRetentionConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutRetentionConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ConfigService) PutRetentionConfigurationWithContext(ctx aws.Context, input *PutRetentionConfigurationInput, opts ...request.Option) (*PutRetentionConfigurationOutput, error) {
+	req, out := c.PutRetentionConfigurationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opStartConfigRulesEvaluation = "StartConfigRulesEvaluation"
 
 // StartConfigRulesEvaluationRequest generates a "aws/request.Request" representing the
@@ -3817,7 +4087,7 @@ type AccountAggregationSource struct {
 	// AccountIds is a required field
 	AccountIds []*string `min:"1" type:"list" required:"true"`
 
-	// If true, aggreagate existing AWS Config regions and future regions.
+	// If true, aggregate existing AWS Config regions and future regions.
 	AllAwsRegions *bool `type:"boolean"`
 
 	// The source regions being aggregated.
@@ -6094,6 +6364,61 @@ func (s DeletePendingAggregationRequestOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteRetentionConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the retention configuration to delete.
+	//
+	// RetentionConfigurationName is a required field
+	RetentionConfigurationName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteRetentionConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRetentionConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteRetentionConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteRetentionConfigurationInput"}
+	if s.RetentionConfigurationName == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionConfigurationName"))
+	}
+	if s.RetentionConfigurationName != nil && len(*s.RetentionConfigurationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RetentionConfigurationName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRetentionConfigurationName sets the RetentionConfigurationName field's value.
+func (s *DeleteRetentionConfigurationInput) SetRetentionConfigurationName(v string) *DeleteRetentionConfigurationInput {
+	s.RetentionConfigurationName = &v
+	return s
+}
+
+type DeleteRetentionConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRetentionConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRetentionConfigurationOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the DeliverConfigSnapshot action.
 type DeliverConfigSnapshotInput struct {
 	_ struct{} `type:"structure"`
@@ -6911,7 +7236,7 @@ func (s *DescribeConfigurationAggregatorSourcesStatusInput) SetUpdateStatus(v []
 type DescribeConfigurationAggregatorSourcesStatusOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Retuns an AggregatedSourceStatus object.
+	// Returns an AggregatedSourceStatus object.
 	AggregatedSourceStatusList []*AggregatedSourceStatus `type:"list"`
 
 	// The nextToken string returned on a previous page that you use to get the
@@ -7275,6 +7600,77 @@ func (s *DescribePendingAggregationRequestsOutput) SetNextToken(v string) *Descr
 // SetPendingAggregationRequests sets the PendingAggregationRequests field's value.
 func (s *DescribePendingAggregationRequestsOutput) SetPendingAggregationRequests(v []*PendingAggregationRequest) *DescribePendingAggregationRequestsOutput {
 	s.PendingAggregationRequests = v
+	return s
+}
+
+type DescribeRetentionConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The nextToken string returned on a previous page that you use to get the
+	// next page of results in a paginated response.
+	NextToken *string `type:"string"`
+
+	// A list of names of retention configurations for which you want details. If
+	// you do not specify a name, AWS Config returns details for all the retention
+	// configurations for that account.
+	//
+	// Currently, AWS Config supports only one retention configuration per region
+	// in your account.
+	RetentionConfigurationNames []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeRetentionConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRetentionConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeRetentionConfigurationsInput) SetNextToken(v string) *DescribeRetentionConfigurationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRetentionConfigurationNames sets the RetentionConfigurationNames field's value.
+func (s *DescribeRetentionConfigurationsInput) SetRetentionConfigurationNames(v []*string) *DescribeRetentionConfigurationsInput {
+	s.RetentionConfigurationNames = v
+	return s
+}
+
+type DescribeRetentionConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The nextToken string returned on a previous page that you use to get the
+	// next page of results in a paginated response.
+	NextToken *string `type:"string"`
+
+	// Returns a retention configuration object.
+	RetentionConfigurations []*RetentionConfiguration `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeRetentionConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRetentionConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeRetentionConfigurationsOutput) SetNextToken(v string) *DescribeRetentionConfigurationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetRetentionConfigurations sets the RetentionConfigurations field's value.
+func (s *DescribeRetentionConfigurationsOutput) SetRetentionConfigurations(v []*RetentionConfiguration) *DescribeRetentionConfigurationsOutput {
+	s.RetentionConfigurations = v
 	return s
 }
 
@@ -8520,7 +8916,7 @@ func (s *ListDiscoveredResourcesOutput) SetResourceIdentifiers(v []*ResourceIden
 type OrganizationAggregationSource struct {
 	_ struct{} `type:"structure"`
 
-	// If true, aggreagate existing AWS Config regions and future regions.
+	// If true, aggregate existing AWS Config regions and future regions.
 	AllAwsRegions *bool `type:"boolean"`
 
 	// The source regions being aggregated.
@@ -9059,6 +9455,72 @@ func (s *PutEvaluationsOutput) SetFailedEvaluations(v []*Evaluation) *PutEvaluat
 	return s
 }
 
+type PutRetentionConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// Number of days AWS Config stores your historical information.
+	//
+	// Currently, only applicable to the configuration item history.
+	//
+	// RetentionPeriodInDays is a required field
+	RetentionPeriodInDays *int64 `min:"30" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s PutRetentionConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutRetentionConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutRetentionConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutRetentionConfigurationInput"}
+	if s.RetentionPeriodInDays == nil {
+		invalidParams.Add(request.NewErrParamRequired("RetentionPeriodInDays"))
+	}
+	if s.RetentionPeriodInDays != nil && *s.RetentionPeriodInDays < 30 {
+		invalidParams.Add(request.NewErrParamMinValue("RetentionPeriodInDays", 30))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRetentionPeriodInDays sets the RetentionPeriodInDays field's value.
+func (s *PutRetentionConfigurationInput) SetRetentionPeriodInDays(v int64) *PutRetentionConfigurationInput {
+	s.RetentionPeriodInDays = &v
+	return s
+}
+
+type PutRetentionConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Returns a retention configuration object.
+	RetentionConfiguration *RetentionConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRetentionConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutRetentionConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetRetentionConfiguration sets the RetentionConfiguration field's value.
+func (s *PutRetentionConfigurationOutput) SetRetentionConfiguration(v *RetentionConfiguration) *PutRetentionConfigurationOutput {
+	s.RetentionConfiguration = v
+	return s
+}
+
 // Specifies the types of AWS resource for which AWS Config records configuration
 // changes.
 //
@@ -9346,6 +9808,47 @@ func (s *ResourceKey) SetResourceId(v string) *ResourceKey {
 // SetResourceType sets the ResourceType field's value.
 func (s *ResourceKey) SetResourceType(v string) *ResourceKey {
 	s.ResourceType = &v
+	return s
+}
+
+// An object with the name of the retention configuration and the retention
+// period in days. The object stores the configuration for data retention in
+// AWS Config.
+type RetentionConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the retention configuration object.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// Number of days AWS Config stores your historical information.
+	//
+	// Currently, only applicable to the configuration item history.
+	//
+	// RetentionPeriodInDays is a required field
+	RetentionPeriodInDays *int64 `min:"30" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s RetentionConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RetentionConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *RetentionConfiguration) SetName(v string) *RetentionConfiguration {
+	s.Name = &v
+	return s
+}
+
+// SetRetentionPeriodInDays sets the RetentionPeriodInDays field's value.
+func (s *RetentionConfiguration) SetRetentionPeriodInDays(v int64) *RetentionConfiguration {
+	s.RetentionPeriodInDays = &v
 	return s
 }
 

--- a/service/configservice/configserviceiface/interface.go
+++ b/service/configservice/configserviceiface/interface.go
@@ -92,6 +92,10 @@ type ConfigServiceAPI interface {
 	DeletePendingAggregationRequestWithContext(aws.Context, *configservice.DeletePendingAggregationRequestInput, ...request.Option) (*configservice.DeletePendingAggregationRequestOutput, error)
 	DeletePendingAggregationRequestRequest(*configservice.DeletePendingAggregationRequestInput) (*request.Request, *configservice.DeletePendingAggregationRequestOutput)
 
+	DeleteRetentionConfiguration(*configservice.DeleteRetentionConfigurationInput) (*configservice.DeleteRetentionConfigurationOutput, error)
+	DeleteRetentionConfigurationWithContext(aws.Context, *configservice.DeleteRetentionConfigurationInput, ...request.Option) (*configservice.DeleteRetentionConfigurationOutput, error)
+	DeleteRetentionConfigurationRequest(*configservice.DeleteRetentionConfigurationInput) (*request.Request, *configservice.DeleteRetentionConfigurationOutput)
+
 	DeliverConfigSnapshot(*configservice.DeliverConfigSnapshotInput) (*configservice.DeliverConfigSnapshotOutput, error)
 	DeliverConfigSnapshotWithContext(aws.Context, *configservice.DeliverConfigSnapshotInput, ...request.Option) (*configservice.DeliverConfigSnapshotOutput, error)
 	DeliverConfigSnapshotRequest(*configservice.DeliverConfigSnapshotInput) (*request.Request, *configservice.DeliverConfigSnapshotOutput)
@@ -147,6 +151,10 @@ type ConfigServiceAPI interface {
 	DescribePendingAggregationRequests(*configservice.DescribePendingAggregationRequestsInput) (*configservice.DescribePendingAggregationRequestsOutput, error)
 	DescribePendingAggregationRequestsWithContext(aws.Context, *configservice.DescribePendingAggregationRequestsInput, ...request.Option) (*configservice.DescribePendingAggregationRequestsOutput, error)
 	DescribePendingAggregationRequestsRequest(*configservice.DescribePendingAggregationRequestsInput) (*request.Request, *configservice.DescribePendingAggregationRequestsOutput)
+
+	DescribeRetentionConfigurations(*configservice.DescribeRetentionConfigurationsInput) (*configservice.DescribeRetentionConfigurationsOutput, error)
+	DescribeRetentionConfigurationsWithContext(aws.Context, *configservice.DescribeRetentionConfigurationsInput, ...request.Option) (*configservice.DescribeRetentionConfigurationsOutput, error)
+	DescribeRetentionConfigurationsRequest(*configservice.DescribeRetentionConfigurationsInput) (*request.Request, *configservice.DescribeRetentionConfigurationsOutput)
 
 	GetAggregateComplianceDetailsByConfigRule(*configservice.GetAggregateComplianceDetailsByConfigRuleInput) (*configservice.GetAggregateComplianceDetailsByConfigRuleOutput, error)
 	GetAggregateComplianceDetailsByConfigRuleWithContext(aws.Context, *configservice.GetAggregateComplianceDetailsByConfigRuleInput, ...request.Option) (*configservice.GetAggregateComplianceDetailsByConfigRuleOutput, error)
@@ -210,6 +218,10 @@ type ConfigServiceAPI interface {
 	PutEvaluations(*configservice.PutEvaluationsInput) (*configservice.PutEvaluationsOutput, error)
 	PutEvaluationsWithContext(aws.Context, *configservice.PutEvaluationsInput, ...request.Option) (*configservice.PutEvaluationsOutput, error)
 	PutEvaluationsRequest(*configservice.PutEvaluationsInput) (*request.Request, *configservice.PutEvaluationsOutput)
+
+	PutRetentionConfiguration(*configservice.PutRetentionConfigurationInput) (*configservice.PutRetentionConfigurationOutput, error)
+	PutRetentionConfigurationWithContext(aws.Context, *configservice.PutRetentionConfigurationInput, ...request.Option) (*configservice.PutRetentionConfigurationOutput, error)
+	PutRetentionConfigurationRequest(*configservice.PutRetentionConfigurationInput) (*request.Request, *configservice.PutRetentionConfigurationOutput)
 
 	StartConfigRulesEvaluation(*configservice.StartConfigRulesEvaluationInput) (*configservice.StartConfigRulesEvaluationOutput, error)
 	StartConfigRulesEvaluationWithContext(aws.Context, *configservice.StartConfigRulesEvaluationInput, ...request.Option) (*configservice.StartConfigRulesEvaluationOutput, error)

--- a/service/configservice/errors.go
+++ b/service/configservice/errors.go
@@ -126,6 +126,13 @@ const (
 	// You have reached the limit of the number of delivery channels you can create.
 	ErrCodeMaxNumberOfDeliveryChannelsExceededException = "MaxNumberOfDeliveryChannelsExceededException"
 
+	// ErrCodeMaxNumberOfRetentionConfigurationsExceededException for service response error code
+	// "MaxNumberOfRetentionConfigurationsExceededException".
+	//
+	// Failed to add the retention configuration because a retention configuration
+	// with that name already exists.
+	ErrCodeMaxNumberOfRetentionConfigurationsExceededException = "MaxNumberOfRetentionConfigurationsExceededException"
+
 	// ErrCodeNoAvailableConfigurationRecorderException for service response error code
 	// "NoAvailableConfigurationRecorderException".
 	//
@@ -181,6 +188,12 @@ const (
 	//
 	// You have specified a delivery channel that does not exist.
 	ErrCodeNoSuchDeliveryChannelException = "NoSuchDeliveryChannelException"
+
+	// ErrCodeNoSuchRetentionConfigurationException for service response error code
+	// "NoSuchRetentionConfigurationException".
+	//
+	// You have specified a retention configuration that does not exist.
+	ErrCodeNoSuchRetentionConfigurationException = "NoSuchRetentionConfigurationException"
 
 	// ErrCodeOrganizationAccessDeniedException for service response error code
 	// "OrganizationAccessDeniedException".

--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -7626,6 +7626,9 @@ type Action struct {
 	// The name of a job to be executed.
 	JobName *string `min:"1" type:"string"`
 
+	// Specifies configuration properties of a job run notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// The job run timeout in minutes. It overrides the timeout value of the job.
 	Timeout *int64 `min:"1" type:"integer"`
 }
@@ -7649,6 +7652,11 @@ func (s *Action) Validate() error {
 	if s.Timeout != nil && *s.Timeout < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
 	}
+	if s.NotificationProperty != nil {
+		if err := s.NotificationProperty.Validate(); err != nil {
+			invalidParams.AddNested("NotificationProperty", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7665,6 +7673,12 @@ func (s *Action) SetArguments(v map[string]*string) *Action {
 // SetJobName sets the JobName field's value.
 func (s *Action) SetJobName(v string) *Action {
 	s.JobName = &v
+	return s
+}
+
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *Action) SetNotificationProperty(v *NotificationProperty) *Action {
+	s.NotificationProperty = v
 	return s
 }
 
@@ -10269,6 +10283,9 @@ type CreateJobInput struct {
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
+	// Specifies configuration properties of a job notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// The name or ARN of the IAM role associated with this job.
 	//
 	// Role is a required field
@@ -10305,6 +10322,11 @@ func (s *CreateJobInput) Validate() error {
 	}
 	if s.Timeout != nil && *s.Timeout < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
+	}
+	if s.NotificationProperty != nil {
+		if err := s.NotificationProperty.Validate(); err != nil {
+			invalidParams.AddNested("NotificationProperty", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10364,6 +10386,12 @@ func (s *CreateJobInput) SetMaxRetries(v int64) *CreateJobInput {
 // SetName sets the Name field's value.
 func (s *CreateJobInput) SetName(v string) *CreateJobInput {
 	s.Name = &v
+	return s
+}
+
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *CreateJobInput) SetNotificationProperty(v *NotificationProperty) *CreateJobInput {
+	s.NotificationProperty = v
 	return s
 }
 
@@ -15173,6 +15201,9 @@ type Job struct {
 	// The name you assign to this job definition.
 	Name *string `min:"1" type:"string"`
 
+	// Specifies configuration properties of a job notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// The name or ARN of the IAM role associated with this job.
 	Role *string `type:"string"`
 
@@ -15253,6 +15284,12 @@ func (s *Job) SetMaxRetries(v int64) *Job {
 // SetName sets the Name field's value.
 func (s *Job) SetName(v string) *Job {
 	s.Name = &v
+	return s
+}
+
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *Job) SetNotificationProperty(v *NotificationProperty) *Job {
+	s.NotificationProperty = v
 	return s
 }
 
@@ -15411,6 +15448,9 @@ type JobRun struct {
 	// The last time this job run was modified.
 	LastModifiedOn *time.Time `type:"timestamp" timestampFormat:"unix"`
 
+	// Specifies configuration properties of a job run notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// A list of predecessors to this job run.
 	PredecessorRuns []*Predecessor `type:"list"`
 
@@ -15498,6 +15538,12 @@ func (s *JobRun) SetLastModifiedOn(v time.Time) *JobRun {
 	return s
 }
 
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *JobRun) SetNotificationProperty(v *NotificationProperty) *JobRun {
+	s.NotificationProperty = v
+	return s
+}
+
 // SetPredecessorRuns sets the PredecessorRuns field's value.
 func (s *JobRun) SetPredecessorRuns(v []*Predecessor) *JobRun {
 	s.PredecessorRuns = v
@@ -15573,6 +15619,9 @@ type JobUpdate struct {
 	// The maximum number of times to retry this job if it fails.
 	MaxRetries *int64 `type:"integer"`
 
+	// Specifies configuration properties of a job notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// The name or ARN of the IAM role associated with this job (required).
 	Role *string `type:"string"`
 
@@ -15595,6 +15644,11 @@ func (s *JobUpdate) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "JobUpdate"}
 	if s.Timeout != nil && *s.Timeout < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
+	}
+	if s.NotificationProperty != nil {
+		if err := s.NotificationProperty.Validate(); err != nil {
+			invalidParams.AddNested("NotificationProperty", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15648,6 +15702,12 @@ func (s *JobUpdate) SetLogUri(v string) *JobUpdate {
 // SetMaxRetries sets the MaxRetries field's value.
 func (s *JobUpdate) SetMaxRetries(v int64) *JobUpdate {
 	s.MaxRetries = &v
+	return s
+}
+
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *JobUpdate) SetNotificationProperty(v *NotificationProperty) *JobUpdate {
+	s.NotificationProperty = v
 	return s
 }
 
@@ -15927,6 +15987,44 @@ func (s *MappingEntry) SetTargetTable(v string) *MappingEntry {
 // SetTargetType sets the TargetType field's value.
 func (s *MappingEntry) SetTargetType(v string) *MappingEntry {
 	s.TargetType = &v
+	return s
+}
+
+// Specifies configuration properties of a notification.
+type NotificationProperty struct {
+	_ struct{} `type:"structure"`
+
+	// After a job run starts, the number of minutes to wait before sending a job
+	// run delay notification.
+	NotifyDelayAfter *int64 `min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s NotificationProperty) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NotificationProperty) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *NotificationProperty) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "NotificationProperty"}
+	if s.NotifyDelayAfter != nil && *s.NotifyDelayAfter < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("NotifyDelayAfter", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetNotifyDelayAfter sets the NotifyDelayAfter field's value.
+func (s *NotificationProperty) SetNotifyDelayAfter(v int64) *NotificationProperty {
+	s.NotifyDelayAfter = &v
 	return s
 }
 
@@ -16881,6 +16979,9 @@ type StartJobRunInput struct {
 	// The ID of a previous JobRun to retry.
 	JobRunId *string `min:"1" type:"string"`
 
+	// Specifies configuration properties of a job run notification.
+	NotificationProperty *NotificationProperty `type:"structure"`
+
 	// The job run timeout in minutes. It overrides the timeout value of the job.
 	Timeout *int64 `min:"1" type:"integer"`
 }
@@ -16910,6 +17011,11 @@ func (s *StartJobRunInput) Validate() error {
 	if s.Timeout != nil && *s.Timeout < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Timeout", 1))
 	}
+	if s.NotificationProperty != nil {
+		if err := s.NotificationProperty.Validate(); err != nil {
+			invalidParams.AddNested("NotificationProperty", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -16938,6 +17044,12 @@ func (s *StartJobRunInput) SetJobName(v string) *StartJobRunInput {
 // SetJobRunId sets the JobRunId field's value.
 func (s *StartJobRunInput) SetJobRunId(v string) *StartJobRunInput {
 	s.JobRunId = &v
+	return s
+}
+
+// SetNotificationProperty sets the NotificationProperty field's value.
+func (s *StartJobRunInput) SetNotificationProperty(v *NotificationProperty) *StartJobRunInput {
+	s.NotificationProperty = v
 	return s
 }
 

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -26899,6 +26899,9 @@ const (
 
 	// JobStatusCompleted is a JobStatus enum value
 	JobStatusCompleted = "COMPLETED"
+
+	// JobStatusDeletionInProgress is a JobStatus enum value
+	JobStatusDeletionInProgress = "DELETION_IN_PROGRESS"
 )
 
 const (


### PR DESCRIPTION
Release v1.13.56 (2018-05-25)
===

### Service Client Updates
* `service/appstream`: Updates service API and documentation
  * This API update enables customers to control whether users can transfer data between their local devices and their streaming applications through file uploads and downloads, clipboard operations, or printing to local devices
* `service/config`: Updates service API and documentation
* `service/glue`: Updates service API and documentation
  * AWS Glue now sends a delay notification to Amazon CloudWatch Events when an ETL job runs longer than the specified delay notification threshold.
* `service/iot`: Updates service API
  * We are exposing DELETION_IN_PROGRESS as a new job status in regards to the release of DeleteJob API.

