### PR TITLE
 private/model/api: Update protocol test codgen for ServiceID duplication

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -466,6 +466,13 @@ var tplService = template.Must(template.New("service").Funcs(template.FuncMap{
 
 		return "EndpointsID"
 	},
+	"ServiceIDVar": func(a *API) string {
+		if a.NoConstServiceNames {
+			return fmt.Sprintf("%q", ServiceID(a))
+		}
+
+		return "ServiceID"
+	},
 	"ServiceID": ServiceID,
 }).Parse(`
 // {{ .StructName }} provides the API operation methods for making requests to
@@ -491,11 +498,6 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "{{ .Metadata.EndpointPrefix }}" // Service endpoint prefix API calls made to.
 	EndpointsID = {{ EndpointsIDConstValue . }} // Service ID for Regions and Endpoints metadata.
-	ServiceID = "{{ ServiceID . }}" // ServiceID is a unique identifer of a specific service
-)
-{{ else }}
-// Service information constants
-const (
 	ServiceID = "{{ ServiceID . }}" // ServiceID is a unique identifer of a specific service
 )
 {{- end }}
@@ -537,7 +539,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
     		cfg,
     		metadata.ClientInfo{
 			ServiceName: {{ ServiceNameValue . }},
-			ServiceID : ServiceID,
+			ServiceID : {{ ServiceIDVar . }},
 			SigningName: signingName,
 			SigningRegion: signingRegion,
 			Endpoint:     endpoint,

--- a/service/mediatailor/service.go
+++ b/service/mediatailor/service.go
@@ -31,6 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "api.mediatailor" // Service endpoint prefix API calls made to.
 	EndpointsID = ServiceName       // Service ID for Regions and Endpoints metadata.
+	ServiceID   = "MediaTailor"     // ServiceID is a unique identifer of a specific service
 )
 
 // New creates a new instance of the MediaTailor client with a session.
@@ -58,6 +59,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			cfg,
 			metadata.ClientInfo{
 				ServiceName:   ServiceName,
+				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,

--- a/service/neptune/service.go
+++ b/service/neptune/service.go
@@ -31,6 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "rds"       // Service endpoint prefix API calls made to.
 	EndpointsID = ServiceName // Service ID for Regions and Endpoints metadata.
+	ServiceID   = "Neptune"   // ServiceID is a unique identifer of a specific service
 )
 
 // New creates a new instance of the Neptune client with a session.
@@ -58,6 +59,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			cfg,
 			metadata.ClientInfo{
 				ServiceName:   ServiceName,
+				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,

--- a/service/pi/service.go
+++ b/service/pi/service.go
@@ -31,6 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "pi"        // Service endpoint prefix API calls made to.
 	EndpointsID = ServiceName // Service ID for Regions and Endpoints metadata.
+	ServiceID   = "PI"        // ServiceID is a unique identifer of a specific service
 )
 
 // New creates a new instance of the PI client with a session.
@@ -58,6 +59,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			cfg,
 			metadata.ClientInfo{
 				ServiceName:   ServiceName,
+				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,


### PR DESCRIPTION
Updates the protocol test code generation to not duplicate the ServiceID const for each protocol tests within the same package.