### PR TITLE
Update Travis tests to ensure all codegen changes are accounted for in PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,8 @@ matrix:
         - os: osx
           go: tip
 
-install:
-  - make get-deps
-
 script:
-  - make unit-with-race-cover
+  - make ci-test
 
 branches:
   only:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       - mkdir -p /go/src/github.com/aws
       - ln -s $SDK_CB_ROOT $SDK_GO_ROOT
       - cd $SDK_GO_ROOT
-      - make unit
+      - make ci-test
       - cd $SDK_CB_ROOT
       - #echo Compiling the Go code...
   post_build:


### PR DESCRIPTION
Updates the Travis tests to ensure that any code generation changes are accounted for in the PR, and that there were no mistaken changes made without also running code generation. This change should also help ensure that code generation order is stable, and there are no ordering issues with the SDK's codegen.