### PR TITLE
doc-src/aws-godoc/templates: fixing iOS scrolling issue

### DIFF
--- a/doc-src/aws-godoc/templates/style.css
+++ b/doc-src/aws-godoc/templates/style.css
@@ -186,7 +186,11 @@ div#mobile_only {
 div#fixed {
 	position: fixed;
 	width: 100%;
+	max-width: 100%;
 	height: 100%;
+	overflow-y: scroll;
+	overflow-x: hidden;
+	-webkit-overflow-scrolling: touch;
 }
 
 div .top_link {


### PR DESCRIPTION
iPhone devices were unable to scroll the service package menu in the doc website. This fixes the CSS to allow for all devices to be able to scroll.