### PR TITLE
service/s3: Move SelectObjectContent doc example to API

### DIFF
--- a/service/s3/eventstream_test.go
+++ b/service/s3/eventstream_test.go
@@ -175,7 +175,7 @@ func TestSelectObjectContentEventStream_Close(t *testing.T) {
 	}
 }
 
-func ExampleSelectObjectContentEventStream() {
+func ExampleS3_SelectObjectContent() {
 	sess := session.Must(session.NewSession())
 	svc := New(sess)
 


### PR DESCRIPTION
Moves the SelectObjectContent doc example to the SelectObjectContent API instead of under the nested EventStream shape.