### PR TITLE
aws/client: Fix HTTP debug log EventStream payloads

### DIFF
--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -91,6 +91,6 @@ func (c *Client) AddDebugHandlers() {
 		return
 	}
 
-	c.Handlers.Send.PushFrontNamed(request.NamedHandler{Name: "awssdk.client.LogRequest", Fn: logRequest})
-	c.Handlers.Send.PushBackNamed(request.NamedHandler{Name: "awssdk.client.LogResponse", Fn: logResponse})
+	c.Handlers.Send.PushFrontNamed(LogHTTPRequestHandler)
+	c.Handlers.Send.PushBackNamed(LogHTTPResponseHandler)
 }

--- a/aws/client/logger_test.go
+++ b/aws/client/logger_test.go
@@ -182,11 +182,16 @@ func TestLogResponse(t *testing.T) {
 		}
 
 		logResponse(req)
+		req.Handlers.Unmarshal.Run(req)
 
 		if c.ReadBody {
 			if e, a := len(c.ExpectBody), c.Body.Len(); e != a {
 				t.Errorf("%d, expect orginal body not to of been read", i)
 			}
+		}
+
+		if logW.Len() == 0 {
+			t.Errorf("%d, expect HTTP Response headers to be logged", i)
 		}
 
 		b, err := ioutil.ReadAll(req.HTTPResponse.Body)

--- a/aws/client/logger_test.go
+++ b/aws/client/logger_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -122,6 +123,78 @@ func TestLogRequest(t *testing.T) {
 		}
 
 		if e, a := c.ExpectBody, b; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %v body, got %v", i, e, a)
+		}
+	}
+}
+
+func TestLogResponse(t *testing.T) {
+	cases := []struct {
+		Body       *bytes.Buffer
+		ExpectBody []byte
+		ReadBody   bool
+		LogLevel   aws.LogLevelType
+	}{
+		{
+			Body:       bytes.NewBuffer([]byte("body content")),
+			ExpectBody: []byte("body content"),
+		},
+		{
+			Body:       bytes.NewBuffer([]byte("body content")),
+			LogLevel:   aws.LogDebug,
+			ExpectBody: []byte("body content"),
+		},
+		{
+			Body:       bytes.NewBuffer([]byte("body content")),
+			LogLevel:   aws.LogDebugWithHTTPBody,
+			ReadBody:   true,
+			ExpectBody: []byte("body content"),
+		},
+	}
+
+	for i, c := range cases {
+		var logW bytes.Buffer
+		req := request.New(
+			aws.Config{
+				Credentials: credentials.AnonymousCredentials,
+				Logger:      &bufLogger{w: &logW},
+				LogLevel:    aws.LogLevel(c.LogLevel),
+			},
+			metadata.ClientInfo{
+				Endpoint: "https://mock-service.mock-region.amazonaws.com",
+			},
+			testHandlers(),
+			nil,
+			&request.Operation{
+				Name:       "APIName",
+				HTTPMethod: "POST",
+				HTTPPath:   "/",
+			},
+			struct{}{}, nil,
+		)
+		req.HTTPResponse = &http.Response{
+			StatusCode: 200,
+			Status:     "OK",
+			Header: http.Header{
+				"ABC": []string{"123"},
+			},
+			Body: ioutil.NopCloser(c.Body),
+		}
+
+		logResponse(req)
+
+		if c.ReadBody {
+			if e, a := len(c.ExpectBody), c.Body.Len(); e != a {
+				t.Errorf("%d, expect orginal body not to of been read", i)
+			}
+		}
+
+		b, err := ioutil.ReadAll(req.HTTPResponse.Body)
+		if err != nil {
+			t.Fatalf("%d, expect to read SDK request Body", i)
+		}
+
+		if e, a := c.ExpectBody, b; !bytes.Equal(e, a) {
 			t.Errorf("%d, expect %v body, got %v", i, e, a)
 		}
 	}

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -129,6 +129,7 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 	{{ end -}}
 	{{ if ne .AuthType "" }}{{ .GetSigner }}{{ end -}}
 	{{ if .OutputRef.Shape.EventStreamsMemberName -}}
+		req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
 		req.Handlers.Unmarshal.Swap({{ .API.ProtocolPackage }}.UnmarshalHandler.Name, rest.UnmarshalHandler)
 		req.Handlers.Unmarshal.PushBack(output.runEventStreamLoop)
 	{{ end -}}
@@ -252,6 +253,7 @@ func (o *Operation) GoCode() string {
 
 	if len(o.OutputRef.Shape.EventStreamsMemberName) != 0 {
 		// TODO need better was of updating protocol unmarshalers
+		o.API.imports["github.com/aws/aws-sdk-go/aws/client"] = true
 		o.API.imports["github.com/aws/aws-sdk-go/private/protocol/rest"] = true
 	}
 

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
@@ -6062,6 +6063,7 @@ func (c *S3) SelectObjectContentRequest(input *SelectObjectContentInput) (req *r
 
 	output = &SelectObjectContentOutput{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, rest.UnmarshalHandler)
 	req.Handlers.Unmarshal.PushBack(output.runEventStreamLoop)
 	return


### PR DESCRIPTION
Fixes the SDK's HTTP client debug logging to not log the HTTP response
body for EventStreams. This prevents the SDK from buffering a very large
amount of data to be logged at once. The aws.LogDebugWithEventStreamBody
should be used to log the event stream events.

Also fixes a bug in the SDK's response logger which will buffer the
response body's content if LogDebug is enabled but LogDebugWithHTTPBody
is not.
