### PR TITLE
v1.14.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+Release v1.14.10 (2018-06-20)
+===
+
+### Service Client Updates
+* `service/acm-pca`: Updates service API, documentation, paginators, and examples
+* `service/medialive`: Updates service API, documentation, and paginators
+  * AWS Elemental MediaLive now makes Reserved Outputs and Inputs available through the AWS Management Console and API. You can reserve outputs and inputs with a 12 month commitment in exchange for discounted hourly rates. Pricing is available at https://aws.amazon.com/medialive/pricing/
+* `service/rds`: Updates service API, documentation, and examples
+  * This release adds a new parameter to specify the retention period for Performance Insights data for RDS instances. You can either choose 7 days (default) or 731 days. For more information, see Amazon RDS Documentation.
+
+### SDK Enhancements
+* `service/s3`: Update SelectObjectContent doc example to be on the API not nested type. ([#1991](https://github.com/aws/aws-sdk-go/pull/1991))
+
+### SDK Bugs
+* `aws/client`: Fix HTTP debug log EventStream payloads ([#2000](https://github.com/aws/aws-sdk-go/pull/2000))
+  * Fixes the SDK's HTTP client debug logging to not log the HTTP response body for EventStreams. This prevents the SDK from buffering a very large amount of data to be logged at once. The aws.LogDebugWithEventStreamBody should be used to log the event stream events.
+  * Fixes a bug in the SDK's response logger which will buffer the response body's content if LogDebug is enabled but LogDebugWithHTTPBody is not.
 Release v1.14.9 (2018-06-19)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,9 +1,5 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `service/s3`: Update SelectObjectContent doc example to be on the API not nested type. ([#1991](https://github.com/aws/aws-sdk-go/pull/1991))
 
 ### SDK Bugs
-* `aws/client`: Fix HTTP debug log EventStream payloads ([#2000](https://github.com/aws/aws-sdk-go/pull/2000))
-  * Fixes the SDK's HTTP client debug logging to not log the HTTP response body for EventStreams. This prevents the SDK from buffering a very large amount of data to be logged at once. The aws.LogDebugWithEventStreamBody should be used to log the event stream events.
-  * Fixes a bug in the SDK's response logger which will buffer the response body's content if LogDebug is enabled but LogDebugWithHTTPBody is not.

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.9"
+const SDKVersion = "1.14.10"

--- a/models/apis/acm-pca/2017-08-22/api-2.json
+++ b/models/apis/acm-pca/2017-08-22/api-2.json
@@ -83,6 +83,7 @@
       "output":{"shape":"DescribeCertificateAuthorityAuditReportResponse"},
       "errors":[
         {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidArnException"},
         {"shape":"InvalidArgsException"}
       ]
     },
@@ -128,7 +129,8 @@
         {"shape":"RequestInProgressException"},
         {"shape":"RequestFailedException"},
         {"shape":"ResourceNotFoundException"},
-        {"shape":"InvalidArnException"}
+        {"shape":"InvalidArnException"},
+        {"shape":"InvalidStateException"}
       ]
     },
     "ImportCertificateAuthorityCertificate":{
@@ -144,6 +146,7 @@
         {"shape":"RequestFailedException"},
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidArnException"},
+        {"shape":"InvalidStateException"},
         {"shape":"MalformedCertificateException"},
         {"shape":"CertificateMismatchException"}
       ]
@@ -191,6 +194,19 @@
         {"shape":"InvalidArnException"}
       ]
     },
+    "RestoreCertificateAuthority":{
+      "name":"RestoreCertificateAuthority",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"RestoreCertificateAuthorityRequest"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidStateException"},
+        {"shape":"InvalidArnException"}
+      ]
+    },
     "RevokeCertificate":{
       "name":"RevokeCertificate",
       "http":{
@@ -218,6 +234,7 @@
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidArnException"},
+        {"shape":"InvalidStateException"},
         {"shape":"InvalidTagException"},
         {"shape":"TooManyTagsException"}
       ]
@@ -232,6 +249,7 @@
       "errors":[
         {"shape":"ResourceNotFoundException"},
         {"shape":"InvalidArnException"},
+        {"shape":"InvalidStateException"},
         {"shape":"InvalidTagException"}
       ]
     },
@@ -317,7 +335,8 @@
         "NotAfter":{"shape":"TStamp"},
         "FailureReason":{"shape":"FailureReason"},
         "CertificateAuthorityConfiguration":{"shape":"CertificateAuthorityConfiguration"},
-        "RevocationConfiguration":{"shape":"RevocationConfiguration"}
+        "RevocationConfiguration":{"shape":"RevocationConfiguration"},
+        "RestorableUntil":{"shape":"TStamp"}
       }
     },
     "CertificateAuthorityConfiguration":{
@@ -339,6 +358,7 @@
         "CREATING",
         "PENDING_CERTIFICATE",
         "ACTIVE",
+        "DELETED",
         "DISABLED",
         "EXPIRED",
         "FAILED"
@@ -443,7 +463,8 @@
       "type":"structure",
       "required":["CertificateAuthorityArn"],
       "members":{
-        "CertificateAuthorityArn":{"shape":"Arn"}
+        "CertificateAuthorityArn":{"shape":"Arn"},
+        "PermanentDeletionTimeInDays":{"shape":"PermanentDeletionTimeInDays"}
       }
     },
     "DescribeCertificateAuthorityAuditReportRequest":{
@@ -696,6 +717,11 @@
       "max":500,
       "min":1
     },
+    "PermanentDeletionTimeInDays":{
+      "type":"integer",
+      "max":30,
+      "min":7
+    },
     "PositiveLong":{
       "type":"long",
       "min":1
@@ -727,6 +753,13 @@
         "message":{"shape":"String"}
       },
       "exception":true
+    },
+    "RestoreCertificateAuthorityRequest":{
+      "type":"structure",
+      "required":["CertificateAuthorityArn"],
+      "members":{
+        "CertificateAuthorityArn":{"shape":"Arn"}
+      }
     },
     "RevocationConfiguration":{
       "type":"structure",

--- a/models/apis/acm-pca/2017-08-22/docs-2.json
+++ b/models/apis/acm-pca/2017-08-22/docs-2.json
@@ -1,574 +1,588 @@
 {
-  "version": "2.0",
-  "service": "<p>You can use the ACM PCA API to create a private certificate authority (CA). You must first call the <a>CreateCertificateAuthority</a> function. If successful, the function returns an Amazon Resource Name (ARN) for your private CA. Use this ARN as input to the <a>GetCertificateAuthorityCsr</a> function to retrieve the certificate signing request (CSR) for your private CA certificate. Sign the CSR using the root or an intermediate CA in your on-premises PKI hierarchy, and call the <a>ImportCertificateAuthorityCertificate</a> to import your signed private CA certificate into ACM PCA. </p> <p>Use your private CA to issue and revoke certificates. These are private certificates that identify and secure client computers, servers, applications, services, devices, and users over SSLS/TLS connections within your organization. Call the <a>IssueCertificate</a> function to issue a certificate. Call the <a>RevokeCertificate</a> function to revoke a certificate. </p> <note> <p>Certificates issued by your private CA can be trusted only within your organization, not publicly.</p> </note> <p>Your private CA can optionally create a certificate revocation list (CRL) to track the certificates you revoke. To create a CRL, you must specify a <a>RevocationConfiguration</a> object when you call the <a>CreateCertificateAuthority</a> function. ACM PCA writes the CRL to an S3 bucket that you specify. You must specify a bucket policy that grants ACM PCA write permission. </p> <p>You can also call the <a>CreateCertificateAuthorityAuditReport</a> to create an optional audit report that lists every time the CA private key is used. The private key is used for signing when the <b>IssueCertificate</b> or <b>RevokeCertificate</b> function is called. </p>",
-  "operations": {
-    "CreateCertificateAuthority": "<p>Creates a private subordinate certificate authority (CA). You must specify the CA configuration, the revocation configuration, the CA type, and an optional idempotency token. The CA configuration specifies the name of the algorithm and key size to be used to create the CA private key, the type of signing algorithm that the CA uses to sign, and X.500 subject information. The CRL (certificate revocation list) configuration specifies the CRL expiration period in days (the validity period of the CRL), the Amazon S3 bucket that will contain the CRL, and a CNAME alias for the S3 bucket that is included in certificates issued by the CA. If successful, this function returns the Amazon Resource Name (ARN) of the CA.</p>",
-    "CreateCertificateAuthorityAuditReport": "<p>Creates an audit report that lists every time that the your CA private key is used. The report is saved in the Amazon S3 bucket that you specify on input. The <a>IssueCertificate</a> and <a>RevokeCertificate</a> functions use the private key. You can generate a new report every 30 minutes.</p>",
-    "DeleteCertificateAuthority": "<p>Deletes the private certificate authority (CA) that you created or started to create by calling the <a>CreateCertificateAuthority</a> function. This action requires that you enter an ARN (Amazon Resource Name) for the private CA that you want to delete. You can find the ARN by calling the <a>ListCertificateAuthorities</a> function. You can delete the CA if you are waiting for it to be created (the <b>Status</b> field of the <a>CertificateAuthority</a> is <code>CREATING</code>) or if the CA has been created but you haven't yet imported the signed certificate (the <b>Status</b> is <code>PENDING_CERTIFICATE</code>) into ACM PCA. If you've already imported the certificate, you cannot delete the CA unless it has been disabled for more than 30 days. To disable a CA, call the <a>UpdateCertificateAuthority</a> function and set the <b>CertificateAuthorityStatus</b> argument to <code>DISABLED</code>. </p>",
-    "DescribeCertificateAuthority": "<p>Lists information about your private certificate authority (CA). You specify the private CA on input by its ARN (Amazon Resource Name). The output contains the status of your CA. This can be any of the following: </p> <ul> <li> <p> <b>CREATING:</b> ACM PCA is creating your private certificate authority.</p> </li> <li> <p> <b>PENDING_CERTIFICATE:</b> The certificate is pending. You must use your on-premises root or subordinate CA to sign your private CA CSR and then import it into PCA. </p> </li> <li> <p> <b>ACTIVE:</b> Your private CA is active.</p> </li> <li> <p> <b>DISABLED:</b> Your private CA has been disabled.</p> </li> <li> <p> <b>EXPIRED:</b> Your private CA certificate has expired.</p> </li> <li> <p> <b>FAILED:</b> Your private CA has failed. Your CA can fail for problems such a network outage or backend AWS failure or other errors. A failed CA can never return to the pending state. You must create a new CA. </p> </li> </ul>",
-    "DescribeCertificateAuthorityAuditReport": "<p>Lists information about a specific audit report created by calling the <a>CreateCertificateAuthorityAuditReport</a> function. Audit information is created every time the certificate authority (CA) private key is used. The private key is used when you call the <a>IssueCertificate</a> function or the <a>RevokeCertificate</a> function. </p>",
-    "GetCertificate": "<p>Retrieves a certificate from your private CA. The ARN of the certificate is returned when you call the <a>IssueCertificate</a> function. You must specify both the ARN of your private CA and the ARN of the issued certificate when calling the <b>GetCertificate</b> function. You can retrieve the certificate if it is in the <b>ISSUED</b> state. You can call the <a>CreateCertificateAuthorityAuditReport</a> function to create a report that contains information about all of the certificates issued and revoked by your private CA. </p>",
-    "GetCertificateAuthorityCertificate": "<p>Retrieves the certificate and certificate chain for your private certificate authority (CA). Both the certificate and the chain are base64 PEM-encoded. The chain does not include the CA certificate. Each certificate in the chain signs the one before it. </p>",
-    "GetCertificateAuthorityCsr": "<p>Retrieves the certificate signing request (CSR) for your private certificate authority (CA). The CSR is created when you call the <a>CreateCertificateAuthority</a> function. Take the CSR to your on-premises X.509 infrastructure and sign it by using your root or a subordinate CA. Then import the signed certificate back into ACM PCA by calling the <a>ImportCertificateAuthorityCertificate</a> function. The CSR is returned as a base64 PEM-encoded string. </p>",
-    "ImportCertificateAuthorityCertificate": "<p>Imports your signed private CA certificate into ACM PCA. Before you can call this function, you must create the private certificate authority by calling the <a>CreateCertificateAuthority</a> function. You must then generate a certificate signing request (CSR) by calling the <a>GetCertificateAuthorityCsr</a> function. Take the CSR to your on-premises CA and use the root certificate or a subordinate certificate to sign it. Create a certificate chain and copy the signed certificate and the certificate chain to your working directory. </p> <note> <p>Your certificate chain must not include the private CA certificate that you are importing.</p> </note> <note> <p>Your on-premises CA certificate must be the last certificate in your chain. The subordinate certificate, if any, that your root CA signed must be next to last. The subordinate certificate signed by the preceding subordinate CA must come next, and so on until your chain is built. </p> </note> <note> <p>The chain must be PEM-encoded.</p> </note>",
-    "IssueCertificate": "<p>Uses your private certificate authority (CA) to issue a client certificate. This function returns the Amazon Resource Name (ARN) of the certificate. You can retrieve the certificate by calling the <a>GetCertificate</a> function and specifying the ARN. </p> <note> <p>You cannot use the ACM <b>ListCertificateAuthorities</b> function to retrieve the ARNs of the certificates that you issue by using ACM PCA.</p> </note>",
-    "ListCertificateAuthorities": "<p>Lists the private certificate authorities that you created by using the <a>CreateCertificateAuthority</a> function.</p>",
-    "ListTags": "<p>Lists the tags, if any, that are associated with your private CA. Tags are labels that you can use to identify and organize your CAs. Each tag consists of a key and an optional value. Call the <a>TagCertificateAuthority</a> function to add one or more tags to your CA. Call the <a>UntagCertificateAuthority</a> function to remove tags. </p>",
-    "RevokeCertificate": "<p>Revokes a certificate that you issued by calling the <a>IssueCertificate</a> function. If you enable a certificate revocation list (CRL) when you create or update your private CA, information about the revoked certificates will be included in the CRL. ACM PCA writes the CRL to an S3 bucket that you specify. For more information about revocation, see the <a>CrlConfiguration</a> structure. ACM PCA also writes revocation information to the audit report. For more information, see <a>CreateCertificateAuthorityAuditReport</a>. </p>",
-    "TagCertificateAuthority": "<p>Adds one or more tags to your private CA. Tags are labels that you can use to identify and organize your AWS resources. Each tag consists of a key and an optional value. You specify the private CA on input by its Amazon Resource Name (ARN). You specify the tag by using a key-value pair. You can apply a tag to just one private CA if you want to identify a specific characteristic of that CA, or you can apply the same tag to multiple private CAs if you want to filter for a common relationship among those CAs. To remove one or more tags, use the <a>UntagCertificateAuthority</a> function. Call the <a>ListTags</a> function to see what tags are associated with your CA. </p>",
-    "UntagCertificateAuthority": "<p>Remove one or more tags from your private CA. A tag consists of a key-value pair. If you do not specify the value portion of the tag when calling this function, the tag will be removed regardless of value. If you specify a value, the tag is removed only if it is associated with the specified value. To add tags to a private CA, use the <a>TagCertificateAuthority</a>. Call the <a>ListTags</a> function to see what tags are associated with your CA. </p>",
-    "UpdateCertificateAuthority": "<p>Updates the status or configuration of a private certificate authority (CA). Your private CA must be in the <b> <code>ACTIVE</code> </b> or <b> <code>DISABLED</code> </b> state before you can update it. You can disable a private CA that is in the <b> <code>ACTIVE</code> </b> state or make a CA that is in the <b> <code>DISABLED</code> </b> state active again.</p>"
+  "version":"2.0",
+  "service":"<p>You can use the ACM PCA API to create a private certificate authority (CA). You must first call the <a>CreateCertificateAuthority</a> operation. If successful, the operation returns an Amazon Resource Name (ARN) for your private CA. Use this ARN as input to the <a>GetCertificateAuthorityCsr</a> operation to retrieve the certificate signing request (CSR) for your private CA certificate. Sign the CSR using the root or an intermediate CA in your on-premises PKI hierarchy, and call the <a>ImportCertificateAuthorityCertificate</a> to import your signed private CA certificate into ACM PCA. </p> <p>Use your private CA to issue and revoke certificates. These are private certificates that identify and secure client computers, servers, applications, services, devices, and users over SSLS/TLS connections within your organization. Call the <a>IssueCertificate</a> operation to issue a certificate. Call the <a>RevokeCertificate</a> operation to revoke a certificate. </p> <note> <p>Certificates issued by your private CA can be trusted only within your organization, not publicly.</p> </note> <p>Your private CA can optionally create a certificate revocation list (CRL) to track the certificates you revoke. To create a CRL, you must specify a <a>RevocationConfiguration</a> object when you call the <a>CreateCertificateAuthority</a> operation. ACM PCA writes the CRL to an S3 bucket that you specify. You must specify a bucket policy that grants ACM PCA write permission. </p> <p>You can also call the <a>CreateCertificateAuthorityAuditReport</a> to create an optional audit report that lists every time the CA private key is used. The private key is used for signing when the <b>IssueCertificate</b> or <b>RevokeCertificate</b> operation is called. </p>",
+  "operations":{
+    "CreateCertificateAuthority":"<p>Creates a private subordinate certificate authority (CA). You must specify the CA configuration, the revocation configuration, the CA type, and an optional idempotency token. The CA configuration specifies the name of the algorithm and key size to be used to create the CA private key, the type of signing algorithm that the CA uses to sign, and X.500 subject information. The CRL (certificate revocation list) configuration specifies the CRL expiration period in days (the validity period of the CRL), the Amazon S3 bucket that will contain the CRL, and a CNAME alias for the S3 bucket that is included in certificates issued by the CA. If successful, this operation returns the Amazon Resource Name (ARN) of the CA.</p>",
+    "CreateCertificateAuthorityAuditReport":"<p>Creates an audit report that lists every time that the your CA private key is used. The report is saved in the Amazon S3 bucket that you specify on input. The <a>IssueCertificate</a> and <a>RevokeCertificate</a> operations use the private key. You can generate a new report every 30 minutes.</p>",
+    "DeleteCertificateAuthority":"<p>Deletes a private certificate authority (CA). You must provide the ARN (Amazon Resource Name) of the private CA that you want to delete. You can find the ARN by calling the <a>ListCertificateAuthorities</a> operation. Before you can delete a CA, you must disable it. Call the <a>UpdateCertificateAuthority</a> operation and set the <b>CertificateAuthorityStatus</b> parameter to <code>DISABLED</code>. </p> <p>Additionally, you can delete a CA if you are waiting for it to be created (the <b>Status</b> field of the <a>CertificateAuthority</a> is <code>CREATING</code>). You can also delete it if the CA has been created but you haven't yet imported the signed certificate (the <b>Status</b> is <code>PENDING_CERTIFICATE</code>) into ACM PCA. </p> <p>If the CA is in one of the aforementioned states and you call <a>DeleteCertificateAuthority</a>, the CA's status changes to <code>DELETED</code>. However, the CA won't be permentantly deleted until the restoration period has passed. By default, if you do not set the <code>PermanentDeletionTimeInDays</code> parameter, the CA remains restorable for 30 days. You can set the parameter from 7 to 30 days. The <a>DescribeCertificateAuthority</a> operation returns the time remaining in the restoration window of a Private CA in the <code>DELETED</code> state. To restore an eligable CA, call the <a>RestoreCertificateAuthority</a> operation.</p>",
+    "DescribeCertificateAuthority":"<p>Lists information about your private certificate authority (CA). You specify the private CA on input by its ARN (Amazon Resource Name). The output contains the status of your CA. This can be any of the following: </p> <ul> <li> <p> <code>CREATING</code> - ACM PCA is creating your private certificate authority.</p> </li> <li> <p> <code>PENDING_CERTIFICATE</code> - The certificate is pending. You must use your on-premises root or subordinate CA to sign your private CA CSR and then import it into PCA. </p> </li> <li> <p> <code>ACTIVE</code> - Your private CA is active.</p> </li> <li> <p> <code>DISABLED</code> - Your private CA has been disabled.</p> </li> <li> <p> <code>EXPIRED</code> - Your private CA certificate has expired.</p> </li> <li> <p> <code>FAILED</code> - Your private CA has failed. Your CA can fail because of problems such a network outage or backend AWS failure or other errors. A failed CA can never return to the pending state. You must create a new CA. </p> </li> <li> <p> <code>DELETED</code> - Your private CA is within the restoration period, after which it will be permanently deleted. The length of time remaining in the CA's restoration period will also be included in this operation's output.</p> </li> </ul>",
+    "DescribeCertificateAuthorityAuditReport":"<p>Lists information about a specific audit report created by calling the <a>CreateCertificateAuthorityAuditReport</a> operation. Audit information is created every time the certificate authority (CA) private key is used. The private key is used when you call the <a>IssueCertificate</a> operation or the <a>RevokeCertificate</a> operation. </p>",
+    "GetCertificate":"<p>Retrieves a certificate from your private CA. The ARN of the certificate is returned when you call the <a>IssueCertificate</a> operation. You must specify both the ARN of your private CA and the ARN of the issued certificate when calling the <b>GetCertificate</b> operation. You can retrieve the certificate if it is in the <b>ISSUED</b> state. You can call the <a>CreateCertificateAuthorityAuditReport</a> operation to create a report that contains information about all of the certificates issued and revoked by your private CA. </p>",
+    "GetCertificateAuthorityCertificate":"<p>Retrieves the certificate and certificate chain for your private certificate authority (CA). Both the certificate and the chain are base64 PEM-encoded. The chain does not include the CA certificate. Each certificate in the chain signs the one before it. </p>",
+    "GetCertificateAuthorityCsr":"<p>Retrieves the certificate signing request (CSR) for your private certificate authority (CA). The CSR is created when you call the <a>CreateCertificateAuthority</a> operation. Take the CSR to your on-premises X.509 infrastructure and sign it by using your root or a subordinate CA. Then import the signed certificate back into ACM PCA by calling the <a>ImportCertificateAuthorityCertificate</a> operation. The CSR is returned as a base64 PEM-encoded string. </p>",
+    "ImportCertificateAuthorityCertificate":"<p>Imports your signed private CA certificate into ACM PCA. Before you can call this operation, you must create the private certificate authority by calling the <a>CreateCertificateAuthority</a> operation. You must then generate a certificate signing request (CSR) by calling the <a>GetCertificateAuthorityCsr</a> operation. Take the CSR to your on-premises CA and use the root certificate or a subordinate certificate to sign it. Create a certificate chain and copy the signed certificate and the certificate chain to your working directory. </p> <note> <p>Your certificate chain must not include the private CA certificate that you are importing.</p> </note> <note> <p>Your on-premises CA certificate must be the last certificate in your chain. The subordinate certificate, if any, that your root CA signed must be next to last. The subordinate certificate signed by the preceding subordinate CA must come next, and so on until your chain is built. </p> </note> <note> <p>The chain must be PEM-encoded.</p> </note>",
+    "IssueCertificate":"<p>Uses your private certificate authority (CA) to issue a client certificate. This operation returns the Amazon Resource Name (ARN) of the certificate. You can retrieve the certificate by calling the <a>GetCertificate</a> operation and specifying the ARN. </p> <note> <p>You cannot use the ACM <b>ListCertificateAuthorities</b> operation to retrieve the ARNs of the certificates that you issue by using ACM PCA.</p> </note>",
+    "ListCertificateAuthorities":"<p>Lists the private certificate authorities that you created by using the <a>CreateCertificateAuthority</a> operation.</p>",
+    "ListTags":"<p>Lists the tags, if any, that are associated with your private CA. Tags are labels that you can use to identify and organize your CAs. Each tag consists of a key and an optional value. Call the <a>TagCertificateAuthority</a> operation to add one or more tags to your CA. Call the <a>UntagCertificateAuthority</a> operation to remove tags. </p>",
+    "RestoreCertificateAuthority":"<p>Restores a certificate authority (CA) that is in the <code>DELETED</code> state. You can restore a CA during the period that you defined in the <b>PermanentDeletionTimeInDays</b> parameter of the <a>DeleteCertificateAuthority</a> operation. Currently, you can specify 7 to 30 days. If you did not specify a <b>PermanentDeletionTimeInDays</b> value, by default you can restore the CA at any time in a 30 day period. You can check the time remaining in the restoration period of a private CA in the <code>DELETED</code> state by calling the <a>DescribeCertificateAuthority</a> or <a>ListCertificateAuthorities</a> operations. The status of a restored CA is set to its pre-deletion status when the <b>RestoreCertificateAuthority</b> operation returns. To change its status to <code>ACTIVE</code>, call the <a>UpdateCertificateAuthority</a> operation. If the private CA was in the <code>PENDING_CERTIFICATE</code> state at deletion, you must use the <a>ImportCertificateAuthorityCertificate</a> operation to import a certificate authority into the private CA before it can be activated. You cannot restore a CA after the restoration period has ended.</p>",
+    "RevokeCertificate":"<p>Revokes a certificate that you issued by calling the <a>IssueCertificate</a> operation. If you enable a certificate revocation list (CRL) when you create or update your private CA, information about the revoked certificates will be included in the CRL. ACM PCA writes the CRL to an S3 bucket that you specify. For more information about revocation, see the <a>CrlConfiguration</a> structure. ACM PCA also writes revocation information to the audit report. For more information, see <a>CreateCertificateAuthorityAuditReport</a>. </p>",
+    "TagCertificateAuthority":"<p>Adds one or more tags to your private CA. Tags are labels that you can use to identify and organize your AWS resources. Each tag consists of a key and an optional value. You specify the private CA on input by its Amazon Resource Name (ARN). You specify the tag by using a key-value pair. You can apply a tag to just one private CA if you want to identify a specific characteristic of that CA, or you can apply the same tag to multiple private CAs if you want to filter for a common relationship among those CAs. To remove one or more tags, use the <a>UntagCertificateAuthority</a> operation. Call the <a>ListTags</a> operation to see what tags are associated with your CA. </p>",
+    "UntagCertificateAuthority":"<p>Remove one or more tags from your private CA. A tag consists of a key-value pair. If you do not specify the value portion of the tag when calling this operation, the tag will be removed regardless of value. If you specify a value, the tag is removed only if it is associated with the specified value. To add tags to a private CA, use the <a>TagCertificateAuthority</a>. Call the <a>ListTags</a> operation to see what tags are associated with your CA. </p>",
+    "UpdateCertificateAuthority":"<p>Updates the status or configuration of a private certificate authority (CA). Your private CA must be in the <code>ACTIVE</code> or <code>DISABLED</code> state before you can update it. You can disable a private CA that is in the <code>ACTIVE</code> state or make a CA that is in the <code>DISABLED</code> state active again.</p>"
   },
-  "shapes": {
-    "ASN1Subject": {
-      "base": "<p>Contains information about the certificate subject. The certificate can be one issued by your private certificate authority (CA) or it can be your private CA certificate. The <b>Subject</b> field in the certificate identifies the entity that owns or controls the public key in the certificate. The entity can be a user, computer, device, or service. The <b>Subject</b> must contain an X.500 distinguished name (DN). A DN is a sequence of relative distinguished names (RDNs). The RDNs are separated by commas in the certificate. The DN must be unique for each for each entity, but your private CA can issue more than one certificate with the same DN to the same entity. </p>",
-      "refs": {
-        "CertificateAuthorityConfiguration$Subject": "<p>Structure that contains X.500 distinguished name information for your private CA.</p>"
-      }
-    },
-    "Arn": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$Arn": "<p>Amazon Resource Name (ARN) for your private certificate authority (CA). The format is <code> <i>12345678-1234-1234-1234-123456789012</i> </code>.</p>",
-        "CreateCertificateAuthorityAuditReportRequest$CertificateAuthorityArn": "<p>Amazon Resource Name (ARN) of the CA to be audited. This is of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>.</p>",
-        "CreateCertificateAuthorityResponse$CertificateAuthorityArn": "<p>If successful, the Amazon Resource Name (ARN) of the certificate authority (CA). This is of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "DeleteCertificateAuthorityRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "DescribeCertificateAuthorityAuditReportRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) of the private CA. This must be of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "DescribeCertificateAuthorityRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "GetCertificateAuthorityCertificateRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) of your private CA. This is of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "GetCertificateAuthorityCsrRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called the <a>CreateCertificateAuthority</a> function. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "GetCertificateRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
-        "GetCertificateRequest$CertificateArn": "<p>The ARN of the issued certificate. The ARN contains the certificate serial number and must be in the following form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i>/certificate/<i>286535153982981100925020015808220737245</i> </code> </p>",
-        "ImportCertificateAuthorityCertificateRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "IssueCertificateRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "IssueCertificateResponse$CertificateArn": "<p>The Amazon Resource Name (ARN) of the issued certificate and the certificate serial number. This is of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i>/certificate/<i>286535153982981100925020015808220737245</i> </code> </p>",
-        "ListTagsRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called the <a>CreateCertificateAuthority</a> function. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "RevokeCertificateRequest$CertificateAuthorityArn": "<p>Amazon Resource Name (ARN) of the private CA that issued the certificate to be revoked. This must be of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "TagCertificateAuthorityRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "UntagCertificateAuthorityRequest$CertificateAuthorityArn": "<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
-        "UpdateCertificateAuthorityRequest$CertificateAuthorityArn": "<p>Amazon Resource Name (ARN) of the private CA that issued the certificate to be revoked. This must be of the form:</p> <p> <code>arn:aws:acm:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>"
+  "shapes":{
+    "ASN1Subject":{
+      "base":"<p>Contains information about the certificate subject. The certificate can be one issued by your private certificate authority (CA) or it can be your private CA certificate. The <b>Subject</b> field in the certificate identifies the entity that owns or controls the public key in the certificate. The entity can be a user, computer, device, or service. The <b>Subject</b> must contain an X.500 distinguished name (DN). A DN is a sequence of relative distinguished names (RDNs). The RDNs are separated by commas in the certificate. The DN must be unique for each entity, but your private CA can issue more than one certificate with the same DN to the same entity. </p>",
+      "refs":{
+        "CertificateAuthorityConfiguration$Subject":"<p>Structure that contains X.500 distinguished name information for your private CA.</p>"
+      }
+    },
+    "Arn":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$Arn":"<p>Amazon Resource Name (ARN) for your private certificate authority (CA). The format is <code> <i>12345678-1234-1234-1234-123456789012</i> </code>.</p>",
+        "CreateCertificateAuthorityAuditReportRequest$CertificateAuthorityArn":"<p>Amazon Resource Name (ARN) of the CA to be audited. This is of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>.</p>",
+        "CreateCertificateAuthorityResponse$CertificateAuthorityArn":"<p>If successful, the Amazon Resource Name (ARN) of the certificate authority (CA). This is of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "DeleteCertificateAuthorityRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must have the following form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "DescribeCertificateAuthorityAuditReportRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) of the private CA. This must be of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "DescribeCertificateAuthorityRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "GetCertificateAuthorityCertificateRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) of your private CA. This is of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "GetCertificateAuthorityCsrRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called the <a>CreateCertificateAuthority</a> operation. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "GetCertificateRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>",
+        "GetCertificateRequest$CertificateArn":"<p>The ARN of the issued certificate. The ARN contains the certificate serial number and must be in the following form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i>/certificate/<i>286535153982981100925020015808220737245</i> </code> </p>",
+        "ImportCertificateAuthorityCertificateRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "IssueCertificateRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "IssueCertificateResponse$CertificateArn":"<p>The Amazon Resource Name (ARN) of the issued certificate and the certificate serial number. This is of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i>/certificate/<i>286535153982981100925020015808220737245</i> </code> </p>",
+        "ListTagsRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called the <a>CreateCertificateAuthority</a> operation. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "RestoreCertificateAuthorityRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called the <a>CreateCertificateAuthority</a> operation. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "RevokeCertificateRequest$CertificateAuthorityArn":"<p>Amazon Resource Name (ARN) of the private CA that issued the certificate to be revoked. This must be of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "TagCertificateAuthorityRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "UntagCertificateAuthorityRequest$CertificateAuthorityArn":"<p>The Amazon Resource Name (ARN) that was returned when you called <a>CreateCertificateAuthority</a>. This must be of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>",
+        "UpdateCertificateAuthorityRequest$CertificateAuthorityArn":"<p>Amazon Resource Name (ARN) of the private CA that issued the certificate to be revoked. This must be of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code> </p>"
       }
     },
-    "AuditReportId": {
-      "base": null,
-      "refs": {
-        "CreateCertificateAuthorityAuditReportResponse$AuditReportId": "<p>An alphanumeric string that contains a report identifier.</p>",
-        "DescribeCertificateAuthorityAuditReportRequest$AuditReportId": "<p>The report ID returned by calling the <a>CreateCertificateAuthorityAuditReport</a> function.</p>"
+    "AuditReportId":{
+      "base":null,
+      "refs":{
+        "CreateCertificateAuthorityAuditReportResponse$AuditReportId":"<p>An alphanumeric string that contains a report identifier.</p>",
+        "DescribeCertificateAuthorityAuditReportRequest$AuditReportId":"<p>The report ID returned by calling the <a>CreateCertificateAuthorityAuditReport</a> operation.</p>"
       }
     },
-    "AuditReportResponseFormat": {
-      "base": null,
-      "refs": {
-        "CreateCertificateAuthorityAuditReportRequest$AuditReportResponseFormat": "<p>Format in which to create the report. This can be either <b>JSON</b> or <b>CSV</b>.</p>"
+    "AuditReportResponseFormat":{
+      "base":null,
+      "refs":{
+        "CreateCertificateAuthorityAuditReportRequest$AuditReportResponseFormat":"<p>Format in which to create the report. This can be either <b>JSON</b> or <b>CSV</b>.</p>"
       }
     },
-    "AuditReportStatus": {
-      "base": null,
-      "refs": {
-        "DescribeCertificateAuthorityAuditReportResponse$AuditReportStatus": "<p>Specifies whether report creation is in progress, has succeeded, or has failed.</p>"
+    "AuditReportStatus":{
+      "base":null,
+      "refs":{
+        "DescribeCertificateAuthorityAuditReportResponse$AuditReportStatus":"<p>Specifies whether report creation is in progress, has succeeded, or has failed.</p>"
       }
     },
-    "Boolean": {
-      "base": null,
-      "refs": {
-        "CrlConfiguration$Enabled": "<p>Boolean value that specifies whether certificate revocation lists (CRLs) are enabled. You can use this value to enable certificate revocation for a new CA when you call the <a>CreateCertificateAuthority</a> function or for an existing CA when you call the <a>UpdateCertificateAuthority</a> function. </p>"
+    "Boolean":{
+      "base":null,
+      "refs":{
+        "CrlConfiguration$Enabled":"<p>Boolean value that specifies whether certificate revocation lists (CRLs) are enabled. You can use this value to enable certificate revocation for a new CA when you call the <a>CreateCertificateAuthority</a> operation or for an existing CA when you call the <a>UpdateCertificateAuthority</a> operation. </p>"
       }
     },
-    "CertificateAuthorities": {
-      "base": null,
-      "refs": {
-        "ListCertificateAuthoritiesResponse$CertificateAuthorities": "<p>Summary information about each certificate authority you have created.</p>"
+    "CertificateAuthorities":{
+      "base":null,
+      "refs":{
+        "ListCertificateAuthoritiesResponse$CertificateAuthorities":"<p>Summary information about each certificate authority you have created.</p>"
       }
     },
-    "CertificateAuthority": {
-      "base": "<p>Contains information about your private certificate authority (CA). Your private CA can issue and revoke X.509 digital certificates. Digital certificates verify that the entity named in the certificate <b>Subject</b> field owns or controls the public key contained in the <b>Subject Public Key Info</b> field. Call the <a>CreateCertificateAuthority</a> function to create your private CA. You must then call the <a>GetCertificateAuthorityCertificate</a> function to retrieve a private CA certificate signing request (CSR). Take the CSR to your on-premises CA and sign it with the root CA certificate or a subordinate certificate. Call the <a>ImportCertificateAuthorityCertificate</a> function to import the signed certificate into AWS Certificate Manager (ACM). </p>",
-      "refs": {
-        "CertificateAuthorities$member": null,
-        "DescribeCertificateAuthorityResponse$CertificateAuthority": "<p>A <a>CertificateAuthority</a> structure that contains information about your private CA.</p>"
+    "CertificateAuthority":{
+      "base":"<p>Contains information about your private certificate authority (CA). Your private CA can issue and revoke X.509 digital certificates. Digital certificates verify that the entity named in the certificate <b>Subject</b> field owns or controls the public key contained in the <b>Subject Public Key Info</b> field. Call the <a>CreateCertificateAuthority</a> operation to create your private CA. You must then call the <a>GetCertificateAuthorityCertificate</a> operation to retrieve a private CA certificate signing request (CSR). Take the CSR to your on-premises CA and sign it with the root CA certificate or a subordinate certificate. Call the <a>ImportCertificateAuthorityCertificate</a> operation to import the signed certificate into AWS Certificate Manager (ACM). </p>",
+      "refs":{
+        "CertificateAuthorities$member":null,
+        "DescribeCertificateAuthorityResponse$CertificateAuthority":"<p>A <a>CertificateAuthority</a> structure that contains information about your private CA.</p>"
       }
     },
-    "CertificateAuthorityConfiguration": {
-      "base": "<p>Contains configuration information for your private certificate authority (CA). This includes information about the class of public key algorithm and the key pair that your private CA creates when it issues a certificate, the signature algorithm it uses used when issuing certificates, and its X.500 distinguished name. You must specify this information when you call the <a>CreateCertificateAuthority</a> function. </p>",
-      "refs": {
-        "CertificateAuthority$CertificateAuthorityConfiguration": "<p>Your private CA configuration.</p>",
-        "CreateCertificateAuthorityRequest$CertificateAuthorityConfiguration": "<p>Name and bit size of the private key algorithm, the name of the signing algorithm, and X.500 certificate subject information.</p>"
+    "CertificateAuthorityConfiguration":{
+      "base":"<p>Contains configuration information for your private certificate authority (CA). This includes information about the class of public key algorithm and the key pair that your private CA creates when it issues a certificate, the signature algorithm it uses used when issuing certificates, and its X.500 distinguished name. You must specify this information when you call the <a>CreateCertificateAuthority</a> operation. </p>",
+      "refs":{
+        "CertificateAuthority$CertificateAuthorityConfiguration":"<p>Your private CA configuration.</p>",
+        "CreateCertificateAuthorityRequest$CertificateAuthorityConfiguration":"<p>Name and bit size of the private key algorithm, the name of the signing algorithm, and X.500 certificate subject information.</p>"
       }
     },
-    "CertificateAuthorityStatus": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$Status": "<p>Status of your private CA.</p>",
-        "UpdateCertificateAuthorityRequest$Status": "<p>Status of your private CA.</p>"
+    "CertificateAuthorityStatus":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$Status":"<p>Status of your private CA.</p>",
+        "UpdateCertificateAuthorityRequest$Status":"<p>Status of your private CA.</p>"
       }
     },
-    "CertificateAuthorityType": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$Type": "<p>Type of your private CA.</p>",
-        "CreateCertificateAuthorityRequest$CertificateAuthorityType": "<p>The type of the certificate authority. Currently, this must be <b>SUBORDINATE</b>.</p>"
+    "CertificateAuthorityType":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$Type":"<p>Type of your private CA.</p>",
+        "CreateCertificateAuthorityRequest$CertificateAuthorityType":"<p>The type of the certificate authority. Currently, this must be <b>SUBORDINATE</b>.</p>"
       }
     },
-    "CertificateBody": {
-      "base": null,
-      "refs": {
-        "GetCertificateAuthorityCertificateResponse$Certificate": "<p>Base64-encoded certificate authority (CA) certificate.</p>",
-        "GetCertificateResponse$Certificate": "<p>The base64 PEM-encoded certificate specified by the <code>CertificateArn</code> parameter.</p>"
+    "CertificateBody":{
+      "base":null,
+      "refs":{
+        "GetCertificateAuthorityCertificateResponse$Certificate":"<p>Base64-encoded certificate authority (CA) certificate.</p>",
+        "GetCertificateResponse$Certificate":"<p>The base64 PEM-encoded certificate specified by the <code>CertificateArn</code> parameter.</p>"
       }
     },
-    "CertificateBodyBlob": {
-      "base": null,
-      "refs": {
-        "ImportCertificateAuthorityCertificateRequest$Certificate": "<p>The PEM-encoded certificate for your private CA. This must be signed by using your on-premises CA.</p>"
+    "CertificateBodyBlob":{
+      "base":null,
+      "refs":{
+        "ImportCertificateAuthorityCertificateRequest$Certificate":"<p>The PEM-encoded certificate for your private CA. This must be signed by using your on-premises CA.</p>"
       }
     },
-    "CertificateChain": {
-      "base": null,
-      "refs": {
-        "GetCertificateAuthorityCertificateResponse$CertificateChain": "<p>Base64-encoded certificate chain that includes any intermediate certificates and chains up to root on-premises certificate that you used to sign your private CA certificate. The chain does not include your private CA certificate. </p>",
-        "GetCertificateResponse$CertificateChain": "<p>The base64 PEM-encoded certificate chain that chains up to the on-premises root CA certificate that you used to sign your private CA certificate. </p>"
+    "CertificateChain":{
+      "base":null,
+      "refs":{
+        "GetCertificateAuthorityCertificateResponse$CertificateChain":"<p>Base64-encoded certificate chain that includes any intermediate certificates and chains up to root on-premises certificate that you used to sign your private CA certificate. The chain does not include your private CA certificate. </p>",
+        "GetCertificateResponse$CertificateChain":"<p>The base64 PEM-encoded certificate chain that chains up to the on-premises root CA certificate that you used to sign your private CA certificate. </p>"
       }
     },
-    "CertificateChainBlob": {
-      "base": null,
-      "refs": {
-        "ImportCertificateAuthorityCertificateRequest$CertificateChain": "<p>A PEM-encoded file that contains all of your certificates, other than the certificate you're importing, chaining up to your root CA. Your on-premises root certificate is the last in the chain, and each certificate in the chain signs the one preceding. </p>"
+    "CertificateChainBlob":{
+      "base":null,
+      "refs":{
+        "ImportCertificateAuthorityCertificateRequest$CertificateChain":"<p>A PEM-encoded file that contains all of your certificates, other than the certificate you're importing, chaining up to your root CA. Your on-premises root certificate is the last in the chain, and each certificate in the chain signs the one preceding. </p>"
       }
     },
-    "CertificateMismatchException": {
-      "base": "<p>The certificate authority certificate you are importing does not comply with conditions specified in the certificate that signed it.</p>",
-      "refs": {
+    "CertificateMismatchException":{
+      "base":"<p>The certificate authority certificate you are importing does not comply with conditions specified in the certificate that signed it.</p>",
+      "refs":{
       }
     },
-    "ConcurrentModificationException": {
-      "base": "<p>A previous update to your private CA is still ongoing.</p>",
-      "refs": {
+    "ConcurrentModificationException":{
+      "base":"<p>A previous update to your private CA is still ongoing.</p>",
+      "refs":{
       }
     },
-    "CountryCodeString": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$Country": "<p>Two digit code that specifies the country in which the certificate subject located.</p>"
+    "CountryCodeString":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$Country":"<p>Two-digit code that specifies the country in which the certificate subject located.</p>"
       }
     },
-    "CreateCertificateAuthorityAuditReportRequest": {
-      "base": null,
-      "refs": {
+    "CreateCertificateAuthorityAuditReportRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateCertificateAuthorityAuditReportResponse": {
-      "base": null,
-      "refs": {
+    "CreateCertificateAuthorityAuditReportResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "CreateCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateCertificateAuthorityResponse": {
-      "base": null,
-      "refs": {
+    "CreateCertificateAuthorityResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "CrlConfiguration": {
-      "base": "<p>Contains configuration information for a certificate revocation list (CRL). Your private certificate authority (CA) creates base CRLs. Delta CRLs are not supported. You can enable CRLs for your new or an existing private CA by setting the <b>Enabled</b> parameter to <code>true</code>. Your private CA writes CRLs to an S3 bucket that you specify in the <b>S3BucketName</b> parameter. You can hide the name of your bucket by specifying a value for the <b>CustomCname</b> parameter. Your private CA copies the CNAME or the S3 bucket name to the <b>CRL Distribution Points</b> extension of each certificate it issues. Your S3 bucket policy must give write permission to ACM PCA. </p> <p>Your private CA uses the value in the <b>ExpirationInDays</b> parameter to calculate the <b>nextUpdate</b> field in the CRL. The CRL is refreshed at 1/2 the age of next update or when a certificate is revoked. When a certificate is revoked, it is recorded in the next CRL that is generated and in the next audit report. Only time valid certificates are listed in the CRL. Expired certificates are not included. </p> <p>CRLs contain the following fields:</p> <ul> <li> <p> <b>Version</b>: The current version number defined in RFC 5280 is V2. The integer value is 0x1. </p> </li> <li> <p> <b>Signature Algorithm</b>: The name of the algorithm used to sign the CRL.</p> </li> <li> <p> <b>Issuer</b>: The X.500 distinguished name of your private CA that issued the CRL.</p> </li> <li> <p> <b>Last Update</b>: The issue date and time of this CRL.</p> </li> <li> <p> <b>Next Update</b>: The day and time by which the next CRL will be issued.</p> </li> <li> <p> <b>Revoked Certificates</b>: List of revoked certificates. Each list item contains the following information.</p> <ul> <li> <p> <b>Serial Number</b>: The serial number, in hexadecimal format, of the revoked certificate.</p> </li> <li> <p> <b>Revocation Date</b>: Date and time the certificate was revoked.</p> </li> <li> <p> <b>CRL Entry Extensions</b>: Optional extensions for the CRL entry.</p> <ul> <li> <p> <b>X509v3 CRL Reason Code</b>: Reason the certificate was revoked.</p> </li> </ul> </li> </ul> </li> <li> <p> <b>CRL Extensions</b>: Optional extensions for the CRL.</p> <ul> <li> <p> <b>X509v3 Authority Key Identifier</b>: Identifies the public key associated with the private key used to sign the certificate.</p> </li> <li> <p> <b>X509v3 CRL Number:</b>: Decimal sequence number for the CRL.</p> </li> </ul> </li> <li> <p> <b>Signature Algorithm</b>: Algorithm used by your private CA to sign the CRL.</p> </li> <li> <p> <b>Signature Value</b>: Signature computed over the CRL.</p> </li> </ul> <p>Certificate revocation lists created by ACM PCA are DER-encoded. You can use the following OpenSSL command to list a CRL.</p> <p> <code>openssl crl -inform DER -text -in <i>crl_path</i> -noout</code> </p>",
-      "refs": {
-        "RevocationConfiguration$CrlConfiguration": "<p>Configuration of the certificate revocation list (CRL), if any, maintained by your private CA.</p>"
+    "CrlConfiguration":{
+      "base":"<p>Contains configuration information for a certificate revocation list (CRL). Your private certificate authority (CA) creates base CRLs. Delta CRLs are not supported. You can enable CRLs for your new or an existing private CA by setting the <b>Enabled</b> parameter to <code>true</code>. Your private CA writes CRLs to an S3 bucket that you specify in the <b>S3BucketName</b> parameter. You can hide the name of your bucket by specifying a value for the <b>CustomCname</b> parameter. Your private CA copies the CNAME or the S3 bucket name to the <b>CRL Distribution Points</b> extension of each certificate it issues. Your S3 bucket policy must give write permission to ACM PCA. </p> <p>Your private CA uses the value in the <b>ExpirationInDays</b> parameter to calculate the <b>nextUpdate</b> field in the CRL. The CRL is refreshed at 1/2 the age of next update or when a certificate is revoked. When a certificate is revoked, it is recorded in the next CRL that is generated and in the next audit report. Only time valid certificates are listed in the CRL. Expired certificates are not included. </p> <p>CRLs contain the following fields:</p> <ul> <li> <p> <b>Version</b>: The current version number defined in RFC 5280 is V2. The integer value is 0x1. </p> </li> <li> <p> <b>Signature Algorithm</b>: The name of the algorithm used to sign the CRL.</p> </li> <li> <p> <b>Issuer</b>: The X.500 distinguished name of your private CA that issued the CRL.</p> </li> <li> <p> <b>Last Update</b>: The issue date and time of this CRL.</p> </li> <li> <p> <b>Next Update</b>: The day and time by which the next CRL will be issued.</p> </li> <li> <p> <b>Revoked Certificates</b>: List of revoked certificates. Each list item contains the following information.</p> <ul> <li> <p> <b>Serial Number</b>: The serial number, in hexadecimal format, of the revoked certificate.</p> </li> <li> <p> <b>Revocation Date</b>: Date and time the certificate was revoked.</p> </li> <li> <p> <b>CRL Entry Extensions</b>: Optional extensions for the CRL entry.</p> <ul> <li> <p> <b>X509v3 CRL Reason Code</b>: Reason the certificate was revoked.</p> </li> </ul> </li> </ul> </li> <li> <p> <b>CRL Extensions</b>: Optional extensions for the CRL.</p> <ul> <li> <p> <b>X509v3 Authority Key Identifier</b>: Identifies the public key associated with the private key used to sign the certificate.</p> </li> <li> <p> <b>X509v3 CRL Number:</b>: Decimal sequence number for the CRL.</p> </li> </ul> </li> <li> <p> <b>Signature Algorithm</b>: Algorithm used by your private CA to sign the CRL.</p> </li> <li> <p> <b>Signature Value</b>: Signature computed over the CRL.</p> </li> </ul> <p>Certificate revocation lists created by ACM PCA are DER-encoded. You can use the following OpenSSL command to list a CRL.</p> <p> <code>openssl crl -inform DER -text -in <i>crl_path</i> -noout</code> </p>",
+      "refs":{
+        "RevocationConfiguration$CrlConfiguration":"<p>Configuration of the certificate revocation list (CRL), if any, maintained by your private CA.</p>"
       }
     },
-    "CsrBlob": {
-      "base": null,
-      "refs": {
-        "IssueCertificateRequest$Csr": "<p>The certificate signing request (CSR) for the certificate you want to issue. You can use the following OpenSSL command to create the CSR and a 2048 bit RSA private key. </p> <p> <code>openssl req -new -newkey rsa:2048 -days 365 -keyout private/test_cert_priv_key.pem -out csr/test_cert_.csr</code> </p> <p>If you have a configuration file, you can use the following OpenSSL command. The <code>usr_cert</code> block in the configuration file contains your X509 version 3 extensions. </p> <p> <code>openssl req -new -config openssl_rsa.cnf -extensions usr_cert -newkey rsa:2048 -days -365 -keyout private/test_cert_priv_key.pem -out csr/test_cert_.csr</code> </p>"
+    "CsrBlob":{
+      "base":null,
+      "refs":{
+        "IssueCertificateRequest$Csr":"<p>The certificate signing request (CSR) for the certificate you want to issue. You can use the following OpenSSL command to create the CSR and a 2048 bit RSA private key. </p> <p> <code>openssl req -new -newkey rsa:2048 -days 365 -keyout private/test_cert_priv_key.pem -out csr/test_cert_.csr</code> </p> <p>If you have a configuration file, you can use the following OpenSSL command. The <code>usr_cert</code> block in the configuration file contains your X509 version 3 extensions. </p> <p> <code>openssl req -new -config openssl_rsa.cnf -extensions usr_cert -newkey rsa:2048 -days -365 -keyout private/test_cert_priv_key.pem -out csr/test_cert_.csr</code> </p>"
       }
     },
-    "CsrBody": {
-      "base": null,
-      "refs": {
-        "GetCertificateAuthorityCsrResponse$Csr": "<p>The base64 PEM-encoded certificate signing request (CSR) for your private CA certificate.</p>"
+    "CsrBody":{
+      "base":null,
+      "refs":{
+        "GetCertificateAuthorityCsrResponse$Csr":"<p>The base64 PEM-encoded certificate signing request (CSR) for your private CA certificate.</p>"
       }
     },
-    "DeleteCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "DeleteCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeCertificateAuthorityAuditReportRequest": {
-      "base": null,
-      "refs": {
+    "DescribeCertificateAuthorityAuditReportRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeCertificateAuthorityAuditReportResponse": {
-      "base": null,
-      "refs": {
+    "DescribeCertificateAuthorityAuditReportResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "DescribeCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeCertificateAuthorityResponse": {
-      "base": null,
-      "refs": {
+    "DescribeCertificateAuthorityResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "DistinguishedNameQualifierString": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$DistinguishedNameQualifier": "<p>Disambiguating information for the certificate subject.</p>"
+    "DistinguishedNameQualifierString":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$DistinguishedNameQualifier":"<p>Disambiguating information for the certificate subject.</p>"
       }
     },
-    "FailureReason": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$FailureReason": "<p>Reason the request to create your private CA failed.</p>"
+    "FailureReason":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$FailureReason":"<p>Reason the request to create your private CA failed.</p>"
       }
     },
-    "GetCertificateAuthorityCertificateRequest": {
-      "base": null,
-      "refs": {
+    "GetCertificateAuthorityCertificateRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "GetCertificateAuthorityCertificateResponse": {
-      "base": null,
-      "refs": {
+    "GetCertificateAuthorityCertificateResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "GetCertificateAuthorityCsrRequest": {
-      "base": null,
-      "refs": {
+    "GetCertificateAuthorityCsrRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "GetCertificateAuthorityCsrResponse": {
-      "base": null,
-      "refs": {
+    "GetCertificateAuthorityCsrResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "GetCertificateRequest": {
-      "base": null,
-      "refs": {
+    "GetCertificateRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "GetCertificateResponse": {
-      "base": null,
-      "refs": {
+    "GetCertificateResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "IdempotencyToken": {
-      "base": null,
-      "refs": {
-        "CreateCertificateAuthorityRequest$IdempotencyToken": "<p>Alphanumeric string that can be used to distinguish between calls to <b>CreateCertificateAuthority</b>. Idempotency tokens time out after five minutes. Therefore, if you call <b>CreateCertificateAuthority</b> multiple times with the same idempotency token within a five minute period, ACM PCA recognizes that you are requesting only one certificate and will issue only one. If you change the idempotency token for each call, however, ACM PCA recognizes that you are requesting multiple certificates.</p>",
-        "IssueCertificateRequest$IdempotencyToken": "<p>Custom string that can be used to distinguish between calls to the <b>IssueCertificate</b> function. Idempotency tokens time out after one hour. Therefore, if you call <b>IssueCertificate</b> multiple times with the same idempotency token within 5 minutes, ACM PCA recognizes that you are requesting only one certificate and will issue only one. If you change the idempotency token for each call, PCA recognizes that you are requesting multiple certificates.</p>"
+    "IdempotencyToken":{
+      "base":null,
+      "refs":{
+        "CreateCertificateAuthorityRequest$IdempotencyToken":"<p>Alphanumeric string that can be used to distinguish between calls to <b>CreateCertificateAuthority</b>. Idempotency tokens time out after five minutes. Therefore, if you call <b>CreateCertificateAuthority</b> multiple times with the same idempotency token within a five minute period, ACM PCA recognizes that you are requesting only one certificate. As a result, ACM PCA issues only one. If you change the idempotency token for each call, however, ACM PCA recognizes that you are requesting multiple certificates.</p>",
+        "IssueCertificateRequest$IdempotencyToken":"<p>Custom string that can be used to distinguish between calls to the <b>IssueCertificate</b> operation. Idempotency tokens time out after one hour. Therefore, if you call <b>IssueCertificate</b> multiple times with the same idempotency token within 5 minutes, ACM PCA recognizes that you are requesting only one certificate and will issue only one. If you change the idempotency token for each call, PCA recognizes that you are requesting multiple certificates.</p>"
       }
     },
-    "ImportCertificateAuthorityCertificateRequest": {
-      "base": null,
-      "refs": {
+    "ImportCertificateAuthorityCertificateRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "Integer1To5000": {
-      "base": null,
-      "refs": {
-        "CrlConfiguration$ExpirationInDays": "<p>Number of days until a certificate expires.</p>"
+    "Integer1To5000":{
+      "base":null,
+      "refs":{
+        "CrlConfiguration$ExpirationInDays":"<p>Number of days until a certificate expires.</p>"
       }
     },
-    "InvalidArgsException": {
-      "base": "<p>One or more of the specified arguments was not valid.</p>",
-      "refs": {
+    "InvalidArgsException":{
+      "base":"<p>One or more of the specified arguments was not valid.</p>",
+      "refs":{
       }
     },
-    "InvalidArnException": {
-      "base": "<p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>",
-      "refs": {
+    "InvalidArnException":{
+      "base":"<p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>",
+      "refs":{
       }
     },
-    "InvalidNextTokenException": {
-      "base": "<p>The token specified in the <code>NextToken</code> argument is not valid. Use the token returned from your previous call to <a>ListCertificateAuthorities</a>.</p>",
-      "refs": {
+    "InvalidNextTokenException":{
+      "base":"<p>The token specified in the <code>NextToken</code> argument is not valid. Use the token returned from your previous call to <a>ListCertificateAuthorities</a>.</p>",
+      "refs":{
       }
     },
-    "InvalidPolicyException": {
-      "base": "<p>The S3 bucket policy is not valid. The policy must give ACM PCA rights to read from and write to the bucket and find the bucket location.</p>",
-      "refs": {
+    "InvalidPolicyException":{
+      "base":"<p>The S3 bucket policy is not valid. The policy must give ACM PCA rights to read from and write to the bucket and find the bucket location.</p>",
+      "refs":{
       }
     },
-    "InvalidStateException": {
-      "base": "<p>The private CA is in a state during which a report cannot be generated.</p>",
-      "refs": {
+    "InvalidStateException":{
+      "base":"<p>The private CA is in a state during which a report cannot be generated.</p>",
+      "refs":{
       }
     },
-    "InvalidTagException": {
-      "base": "<p>The tag associated with the CA is not valid. The invalid argument is contained in the message field.</p>",
-      "refs": {
+    "InvalidTagException":{
+      "base":"<p>The tag associated with the CA is not valid. The invalid argument is contained in the message field.</p>",
+      "refs":{
       }
     },
-    "IssueCertificateRequest": {
-      "base": null,
-      "refs": {
+    "IssueCertificateRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "IssueCertificateResponse": {
-      "base": null,
-      "refs": {
+    "IssueCertificateResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "KeyAlgorithm": {
-      "base": null,
-      "refs": {
-        "CertificateAuthorityConfiguration$KeyAlgorithm": "<p>Type of the public key algorithm and size, in bits, of the key pair that your key pair creates when it issues a certificate.</p>"
+    "KeyAlgorithm":{
+      "base":null,
+      "refs":{
+        "CertificateAuthorityConfiguration$KeyAlgorithm":"<p>Type of the public key algorithm and size, in bits, of the key pair that your key pair creates when it issues a certificate.</p>"
       }
     },
-    "LimitExceededException": {
-      "base": "<p>An ACM PCA limit has been exceeded. See the exception message returned to determine the limit that was exceeded.</p>",
-      "refs": {
+    "LimitExceededException":{
+      "base":"<p>An ACM PCA limit has been exceeded. See the exception message returned to determine the limit that was exceeded.</p>",
+      "refs":{
       }
     },
-    "ListCertificateAuthoritiesRequest": {
-      "base": null,
-      "refs": {
+    "ListCertificateAuthoritiesRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "ListCertificateAuthoritiesResponse": {
-      "base": null,
-      "refs": {
+    "ListCertificateAuthoritiesResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "ListTagsRequest": {
-      "base": null,
-      "refs": {
+    "ListTagsRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "ListTagsResponse": {
-      "base": null,
-      "refs": {
+    "ListTagsResponse":{
+      "base":null,
+      "refs":{
       }
     },
-    "MalformedCSRException": {
-      "base": "<p>The certificate signing request is invalid.</p>",
-      "refs": {
+    "MalformedCSRException":{
+      "base":"<p>The certificate signing request is invalid.</p>",
+      "refs":{
       }
     },
-    "MalformedCertificateException": {
-      "base": "<p>One or more fields in the certificate are invalid.</p>",
-      "refs": {
+    "MalformedCertificateException":{
+      "base":"<p>One or more fields in the certificate are invalid.</p>",
+      "refs":{
       }
     },
-    "MaxResults": {
-      "base": null,
-      "refs": {
-        "ListCertificateAuthoritiesRequest$MaxResults": "<p>Use this parameter when paginating results to specify the maximum number of items to return in the response on each page. If additional items exist beyond the number you specify, the <code>NextToken</code> element is sent in the response. Use this <code>NextToken</code> value in a subsequent request to retrieve additional items.</p>",
-        "ListTagsRequest$MaxResults": "<p>Use this parameter when paginating results to specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <b>NextToken</b> element is sent in the response. Use this <b>NextToken</b> value in a subsequent request to retrieve additional items.</p>"
+    "MaxResults":{
+      "base":null,
+      "refs":{
+        "ListCertificateAuthoritiesRequest$MaxResults":"<p>Use this parameter when paginating results to specify the maximum number of items to return in the response on each page. If additional items exist beyond the number you specify, the <code>NextToken</code> element is sent in the response. Use this <code>NextToken</code> value in a subsequent request to retrieve additional items.</p>",
+        "ListTagsRequest$MaxResults":"<p>Use this parameter when paginating results to specify the maximum number of items to return in the response. If additional items exist beyond the number you specify, the <b>NextToken</b> element is sent in the response. Use this <b>NextToken</b> value in a subsequent request to retrieve additional items.</p>"
       }
     },
-    "NextToken": {
-      "base": null,
-      "refs": {
-        "ListCertificateAuthoritiesRequest$NextToken": "<p>Use this parameter when paginating results in a subsequent request after you receive a response with truncated results. Set it to the value of the <code>NextToken</code> parameter from the response you just received.</p>",
-        "ListCertificateAuthoritiesResponse$NextToken": "<p>When the list is truncated, this value is present and should be used for the <code>NextToken</code> parameter in a subsequent pagination request.</p>",
-        "ListTagsRequest$NextToken": "<p>Use this parameter when paginating results in a subsequent request after you receive a response with truncated results. Set it to the value of <b>NextToken</b> from the response you just received.</p>",
-        "ListTagsResponse$NextToken": "<p>When the list is truncated, this value is present and should be used for the <b>NextToken</b> parameter in a subsequent pagination request. </p>"
+    "NextToken":{
+      "base":null,
+      "refs":{
+        "ListCertificateAuthoritiesRequest$NextToken":"<p>Use this parameter when paginating results in a subsequent request after you receive a response with truncated results. Set it to the value of the <code>NextToken</code> parameter from the response you just received.</p>",
+        "ListCertificateAuthoritiesResponse$NextToken":"<p>When the list is truncated, this value is present and should be used for the <code>NextToken</code> parameter in a subsequent pagination request.</p>",
+        "ListTagsRequest$NextToken":"<p>Use this parameter when paginating results in a subsequent request after you receive a response with truncated results. Set it to the value of <b>NextToken</b> from the response you just received.</p>",
+        "ListTagsResponse$NextToken":"<p>When the list is truncated, this value is present and should be used for the <b>NextToken</b> parameter in a subsequent pagination request. </p>"
       }
     },
-    "PositiveLong": {
-      "base": null,
-      "refs": {
-        "Validity$Value": "<p>Time period.</p>"
+    "PermanentDeletionTimeInDays":{
+      "base":null,
+      "refs":{
+        "DeleteCertificateAuthorityRequest$PermanentDeletionTimeInDays":"<p>The number of days to make a CA restorable after it has been deleted. This can be anywhere from 7 to 30 days, with 30 being the default.</p>"
       }
     },
-    "RequestAlreadyProcessedException": {
-      "base": "<p>Your request has already been completed.</p>",
-      "refs": {
+    "PositiveLong":{
+      "base":null,
+      "refs":{
+        "Validity$Value":"<p>Time period.</p>"
       }
     },
-    "RequestFailedException": {
-      "base": "<p>The request has failed for an unspecified reason.</p>",
-      "refs": {
+    "RequestAlreadyProcessedException":{
+      "base":"<p>Your request has already been completed.</p>",
+      "refs":{
       }
     },
-    "RequestInProgressException": {
-      "base": "<p>Your request is already in progress.</p>",
-      "refs": {
+    "RequestFailedException":{
+      "base":"<p>The request has failed for an unspecified reason.</p>",
+      "refs":{
       }
     },
-    "ResourceNotFoundException": {
-      "base": "<p>A resource such as a private CA, S3 bucket, certificate, or audit report cannot be found.</p>",
-      "refs": {
+    "RequestInProgressException":{
+      "base":"<p>Your request is already in progress.</p>",
+      "refs":{
       }
     },
-    "RevocationConfiguration": {
-      "base": "<p>Certificate revocation information used by the <a>CreateCertificateAuthority</a> and <a>UpdateCertificateAuthority</a> functions. Your private certificate authority (CA) can create and maintain a certificate revocation list (CRL). A CRL contains information about certificates revoked by your CA. For more information, see <a>RevokeCertificate</a>.</p>",
-      "refs": {
-        "CertificateAuthority$RevocationConfiguration": "<p>Information about the certificate revocation list (CRL) created and maintained by your private CA. </p>",
-        "CreateCertificateAuthorityRequest$RevocationConfiguration": "<p>Contains a Boolean value that you can use to enable a certification revocation list (CRL) for the CA, the name of the S3 bucket to which ACM PCA will write the CRL, and an optional CNAME alias that you can use to hide the name of your bucket in the <b>CRL Distribution Points</b> extension of your CA certificate. For more information, see the <a>CrlConfiguration</a> structure. </p>",
-        "UpdateCertificateAuthorityRequest$RevocationConfiguration": "<p>Revocation information for your private CA.</p>"
+    "ResourceNotFoundException":{
+      "base":"<p>A resource such as a private CA, S3 bucket, certificate, or audit report cannot be found.</p>",
+      "refs":{
       }
     },
-    "RevocationReason": {
-      "base": null,
-      "refs": {
-        "RevokeCertificateRequest$RevocationReason": "<p>Specifies why you revoked the certificate.</p>"
+    "RestoreCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "RevokeCertificateRequest": {
-      "base": null,
-      "refs": {
+    "RevocationConfiguration":{
+      "base":"<p>Certificate revocation information used by the <a>CreateCertificateAuthority</a> and <a>UpdateCertificateAuthority</a> operations. Your private certificate authority (CA) can create and maintain a certificate revocation list (CRL). A CRL contains information about certificates revoked by your CA. For more information, see <a>RevokeCertificate</a>.</p>",
+      "refs":{
+        "CertificateAuthority$RevocationConfiguration":"<p>Information about the certificate revocation list (CRL) created and maintained by your private CA. </p>",
+        "CreateCertificateAuthorityRequest$RevocationConfiguration":"<p>Contains a Boolean value that you can use to enable a certification revocation list (CRL) for the CA, the name of the S3 bucket to which ACM PCA will write the CRL, and an optional CNAME alias that you can use to hide the name of your bucket in the <b>CRL Distribution Points</b> extension of your CA certificate. For more information, see the <a>CrlConfiguration</a> structure. </p>",
+        "UpdateCertificateAuthorityRequest$RevocationConfiguration":"<p>Revocation information for your private CA.</p>"
       }
     },
-    "SigningAlgorithm": {
-      "base": null,
-      "refs": {
-        "CertificateAuthorityConfiguration$SigningAlgorithm": "<p>Name of the algorithm your private CA uses to sign certificate requests.</p>",
-        "IssueCertificateRequest$SigningAlgorithm": "<p>The name of the algorithm that will be used to sign the certificate to be issued.</p>"
+    "RevocationReason":{
+      "base":null,
+      "refs":{
+        "RevokeCertificateRequest$RevocationReason":"<p>Specifies why you revoked the certificate.</p>"
       }
     },
-    "String": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$Serial": "<p>Serial number of your private CA.</p>",
-        "CertificateMismatchException$message": null,
-        "ConcurrentModificationException$message": null,
-        "CreateCertificateAuthorityAuditReportRequest$S3BucketName": "<p>Name of the S3 bucket that will contain the audit report.</p>",
-        "CreateCertificateAuthorityAuditReportResponse$S3Key": "<p>The <b>key</b> that uniquely identifies the report file in your S3 bucket.</p>",
-        "DescribeCertificateAuthorityAuditReportResponse$S3BucketName": "<p>Name of the S3 bucket that contains the report.</p>",
-        "DescribeCertificateAuthorityAuditReportResponse$S3Key": "<p>S3 <b>key</b> that uniquely identifies the report file in your S3 bucket.</p>",
-        "InvalidArgsException$message": null,
-        "InvalidArnException$message": null,
-        "InvalidNextTokenException$message": null,
-        "InvalidPolicyException$message": null,
-        "InvalidStateException$message": null,
-        "InvalidTagException$message": null,
-        "LimitExceededException$message": null,
-        "MalformedCSRException$message": null,
-        "MalformedCertificateException$message": null,
-        "RequestAlreadyProcessedException$message": null,
-        "RequestFailedException$message": null,
-        "RequestInProgressException$message": null,
-        "ResourceNotFoundException$message": null,
-        "TooManyTagsException$message": null
+    "RevokeCertificateRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "String128": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$State": "<p>State in which the subject of the certificate is located.</p>",
-        "ASN1Subject$Locality": "<p>The locality (such as a city or town) in which the certificate subject is located.</p>",
-        "ASN1Subject$Pseudonym": "<p>Typically a shortened version of a longer <b>GivenName</b>. For example, Jonathan is often shortened to John. Elizabeth is often shortened to Beth, Liz, or Eliza.</p>",
-        "RevokeCertificateRequest$CertificateSerial": "<p>Serial number of the certificate to be revoked. This must be in hexadecimal format. You can retrieve the serial number by calling <a>GetCertificate</a> with the Amazon Resource Name (ARN) of the certificate you want and the ARN of your private CA. The <b>GetCertificate</b> function retrieves the certificate in the PEM format. You can use the following OpenSSL command to list the certificate in text format and copy the hexadecimal serial number. </p> <p> <code>openssl x509 -in <i>file_path</i> -text -noout</code> </p> <p>You can also copy the serial number from the console or use the <a href=\"http://docs.aws.amazon.comacm/latest/APIReferenceAPI_DescribeCertificate.html\">DescribeCertificate</a> function in the <i>AWS Certificate Manager API Reference</i>. </p>"
+    "SigningAlgorithm":{
+      "base":null,
+      "refs":{
+        "CertificateAuthorityConfiguration$SigningAlgorithm":"<p>Name of the algorithm your private CA uses to sign certificate requests.</p>",
+        "IssueCertificateRequest$SigningAlgorithm":"<p>The name of the algorithm that will be used to sign the certificate to be issued.</p>"
       }
     },
-    "String16": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$GivenName": "<p>First name.</p>"
+    "String":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$Serial":"<p>Serial number of your private CA.</p>",
+        "CertificateMismatchException$message":null,
+        "ConcurrentModificationException$message":null,
+        "CreateCertificateAuthorityAuditReportRequest$S3BucketName":"<p>Name of the S3 bucket that will contain the audit report.</p>",
+        "CreateCertificateAuthorityAuditReportResponse$S3Key":"<p>The <b>key</b> that uniquely identifies the report file in your S3 bucket.</p>",
+        "DescribeCertificateAuthorityAuditReportResponse$S3BucketName":"<p>Name of the S3 bucket that contains the report.</p>",
+        "DescribeCertificateAuthorityAuditReportResponse$S3Key":"<p>S3 <b>key</b> that uniquely identifies the report file in your S3 bucket.</p>",
+        "InvalidArgsException$message":null,
+        "InvalidArnException$message":null,
+        "InvalidNextTokenException$message":null,
+        "InvalidPolicyException$message":null,
+        "InvalidStateException$message":null,
+        "InvalidTagException$message":null,
+        "LimitExceededException$message":null,
+        "MalformedCSRException$message":null,
+        "MalformedCertificateException$message":null,
+        "RequestAlreadyProcessedException$message":null,
+        "RequestFailedException$message":null,
+        "RequestInProgressException$message":null,
+        "ResourceNotFoundException$message":null,
+        "TooManyTagsException$message":null
       }
     },
-    "String253": {
-      "base": null,
-      "refs": {
-        "CrlConfiguration$CustomCname": "<p>Name inserted into the certificate <b>CRL Distribution Points</b> extension that enables the use of an alias for the CRL distribution point. Use this value if you don't want the name of your S3 bucket to be public.</p>"
+    "String128":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$State":"<p>State in which the subject of the certificate is located.</p>",
+        "ASN1Subject$Locality":"<p>The locality (such as a city or town) in which the certificate subject is located.</p>",
+        "ASN1Subject$Pseudonym":"<p>Typically a shortened version of a longer <b>GivenName</b>. For example, Jonathan is often shortened to John. Elizabeth is often shortened to Beth, Liz, or Eliza.</p>",
+        "RevokeCertificateRequest$CertificateSerial":"<p>Serial number of the certificate to be revoked. This must be in hexadecimal format. You can retrieve the serial number by calling <a>GetCertificate</a> with the Amazon Resource Name (ARN) of the certificate you want and the ARN of your private CA. The <b>GetCertificate</b> operation retrieves the certificate in the PEM format. You can use the following OpenSSL command to list the certificate in text format and copy the hexadecimal serial number. </p> <p> <code>openssl x509 -in <i>file_path</i> -text -noout</code> </p> <p>You can also copy the serial number from the console or use the <a href=\"https://docs.aws.amazon.com/acm/latest/APIReference/API_DescribeCertificate.html\">DescribeCertificate</a> operation in the <i>AWS Certificate Manager API Reference</i>. </p>"
       }
     },
-    "String3": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$GenerationQualifier": "<p>Typically a qualifier appended to the name of an individual. Examples include Jr. for junior, Sr. for senior, and III for third.</p>"
+    "String16":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$GivenName":"<p>First name.</p>"
       }
     },
-    "String3To255": {
-      "base": null,
-      "refs": {
-        "CrlConfiguration$S3BucketName": "<p>Name of the S3 bucket that contains the CRL. If you do not provide a value for the <b>CustomCname</b> argument, the name of your S3 bucket is placed into the <b>CRL Distribution Points</b> extension of the issued certificate. You can change the name of your bucket by calling the <a>UpdateCertificateAuthority</a> function. You must specify a bucket policy that allows ACM PCA to write the CRL to your bucket.</p>"
+    "String253":{
+      "base":null,
+      "refs":{
+        "CrlConfiguration$CustomCname":"<p>Name inserted into the certificate <b>CRL Distribution Points</b> extension that enables the use of an alias for the CRL distribution point. Use this value if you don't want the name of your S3 bucket to be public.</p>"
       }
     },
-    "String40": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$Surname": "<p>Family name. In the US and the UK for example, the surname of an individual is ordered last. In Asian cultures the surname is typically ordered first.</p>"
+    "String3":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$GenerationQualifier":"<p>Typically a qualifier appended to the name of an individual. Examples include Jr. for junior, Sr. for senior, and III for third.</p>"
       }
     },
-    "String5": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$Initials": "<p>Concatenation that typically contains the first letter of the <b>GivenName</b>, the first letter of the middle name if one exists, and the first letter of the <b>SurName</b>.</p>"
+    "String3To255":{
+      "base":null,
+      "refs":{
+        "CrlConfiguration$S3BucketName":"<p>Name of the S3 bucket that contains the CRL. If you do not provide a value for the <b>CustomCname</b> argument, the name of your S3 bucket is placed into the <b>CRL Distribution Points</b> extension of the issued certificate. You can change the name of your bucket by calling the <a>UpdateCertificateAuthority</a> operation. You must specify a bucket policy that allows ACM PCA to write the CRL to your bucket.</p>"
       }
     },
-    "String64": {
-      "base": null,
-      "refs": {
-        "ASN1Subject$Organization": "<p>Legal name of the organization with which the certificate subject is affiliated. </p>",
-        "ASN1Subject$OrganizationalUnit": "<p>A subdivision or unit of the organization (such as sales or finance) with which the certificate subject is affiliated.</p>",
-        "ASN1Subject$CommonName": "<p>Fully qualified domain name (FQDN) associated with the certificate subject.</p>",
-        "ASN1Subject$SerialNumber": "<p>The certificate serial number.</p>",
-        "ASN1Subject$Title": "<p>A title such as Mr. or Ms. which is pre-pended to the name to refer formally to the certificate subject.</p>"
+    "String40":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$Surname":"<p>Family name. In the US and the UK, for example, the surname of an individual is ordered last. In Asian cultures the surname is typically ordered first.</p>"
       }
     },
-    "TStamp": {
-      "base": null,
-      "refs": {
-        "CertificateAuthority$CreatedAt": "<p>Date and time at which your private CA was created.</p>",
-        "CertificateAuthority$LastStateChangeAt": "<p>Date and time at which your private CA was last updated.</p>",
-        "CertificateAuthority$NotBefore": "<p>Date and time before which your private CA certificate is not valid.</p>",
-        "CertificateAuthority$NotAfter": "<p>Date and time after which your private CA certificate is not valid.</p>",
-        "DescribeCertificateAuthorityAuditReportResponse$CreatedAt": "<p>The date and time at which the report was created.</p>"
+    "String5":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$Initials":"<p>Concatenation that typically contains the first letter of the <b>GivenName</b>, the first letter of the middle name if one exists, and the first letter of the <b>SurName</b>.</p>"
       }
     },
-    "Tag": {
-      "base": "<p>Tags are labels that you can use to identify and organize your private CAs. Each tag consists of a key and an optional value. You can associate up to 50 tags with a private CA. To add one or more tags to a private CA, call the <a>TagCertificateAuthority</a> function. To remove a tag, call the <a>UntagCertificateAuthority</a> function. </p>",
-      "refs": {
-        "TagList$member": null
+    "String64":{
+      "base":null,
+      "refs":{
+        "ASN1Subject$Organization":"<p>Legal name of the organization with which the certificate subject is affiliated. </p>",
+        "ASN1Subject$OrganizationalUnit":"<p>A subdivision or unit of the organization (such as sales or finance) with which the certificate subject is affiliated.</p>",
+        "ASN1Subject$CommonName":"<p>Fully qualified domain name (FQDN) associated with the certificate subject.</p>",
+        "ASN1Subject$SerialNumber":"<p>The certificate serial number.</p>",
+        "ASN1Subject$Title":"<p>A title such as Mr. or Ms., which is pre-pended to the name to refer formally to the certificate subject.</p>"
       }
     },
-    "TagCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "TStamp":{
+      "base":null,
+      "refs":{
+        "CertificateAuthority$CreatedAt":"<p>Date and time at which your private CA was created.</p>",
+        "CertificateAuthority$LastStateChangeAt":"<p>Date and time at which your private CA was last updated.</p>",
+        "CertificateAuthority$NotBefore":"<p>Date and time before which your private CA certificate is not valid.</p>",
+        "CertificateAuthority$NotAfter":"<p>Date and time after which your private CA certificate is not valid.</p>",
+        "CertificateAuthority$RestorableUntil":"<p>The period during which a deleted CA can be restored. For more information, see the <code>PermanentDeletionTimeInDays</code> parameter of the <a>DeleteCertificateAuthorityRequest</a> operation. </p>",
+        "DescribeCertificateAuthorityAuditReportResponse$CreatedAt":"<p>The date and time at which the report was created.</p>"
       }
     },
-    "TagKey": {
-      "base": null,
-      "refs": {
-        "Tag$Key": "<p>Key (name) of the tag.</p>"
+    "Tag":{
+      "base":"<p>Tags are labels that you can use to identify and organize your private CAs. Each tag consists of a key and an optional value. You can associate up to 50 tags with a private CA. To add one or more tags to a private CA, call the <a>TagCertificateAuthority</a> operation. To remove a tag, call the <a>UntagCertificateAuthority</a> operation. </p>",
+      "refs":{
+        "TagList$member":null
       }
     },
-    "TagList": {
-      "base": null,
-      "refs": {
-        "ListTagsResponse$Tags": "<p>The tags associated with your private CA.</p>",
-        "TagCertificateAuthorityRequest$Tags": "<p>List of tags to be associated with the CA.</p>",
-        "UntagCertificateAuthorityRequest$Tags": "<p>List of tags to be removed from the CA.</p>"
+    "TagCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "TagValue": {
-      "base": null,
-      "refs": {
-        "Tag$Value": "<p>Value of the tag.</p>"
+    "TagKey":{
+      "base":null,
+      "refs":{
+        "Tag$Key":"<p>Key (name) of the tag.</p>"
       }
     },
-    "TooManyTagsException": {
-      "base": "<p>You can associate up to 50 tags with a private CA. Exception information is contained in the exception message field.</p>",
-      "refs": {
+    "TagList":{
+      "base":null,
+      "refs":{
+        "ListTagsResponse$Tags":"<p>The tags associated with your private CA.</p>",
+        "TagCertificateAuthorityRequest$Tags":"<p>List of tags to be associated with the CA.</p>",
+        "UntagCertificateAuthorityRequest$Tags":"<p>List of tags to be removed from the CA.</p>"
       }
     },
-    "UntagCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "TagValue":{
+      "base":null,
+      "refs":{
+        "Tag$Value":"<p>Value of the tag.</p>"
       }
     },
-    "UpdateCertificateAuthorityRequest": {
-      "base": null,
-      "refs": {
+    "TooManyTagsException":{
+      "base":"<p>You can associate up to 50 tags with a private CA. Exception information is contained in the exception message field.</p>",
+      "refs":{
       }
     },
-    "Validity": {
-      "base": "<p>Length of time for which the certificate issued by your private certificate authority (CA), or by the private CA itself, is valid in days, months, or years. You can issue a certificate by calling the <a>IssueCertificate</a> function.</p>",
-      "refs": {
-        "IssueCertificateRequest$Validity": "<p>The type of the validity period.</p>"
+    "UntagCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
       }
     },
-    "ValidityPeriodType": {
-      "base": null,
-      "refs": {
-        "Validity$Type": "<p>Specifies whether the <code>Value</code> parameter represents days, months, or years.</p>"
+    "UpdateCertificateAuthorityRequest":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "Validity":{
+      "base":"<p>Length of time for which the certificate issued by your private certificate authority (CA), or by the private CA itself, is valid in days, months, or years. You can issue a certificate by calling the <a>IssueCertificate</a> operation.</p>",
+      "refs":{
+        "IssueCertificateRequest$Validity":"<p>The type of the validity period.</p>"
+      }
+    },
+    "ValidityPeriodType":{
+      "base":null,
+      "refs":{
+        "Validity$Type":"<p>Specifies whether the <code>Value</code> parameter represents days, months, or years.</p>"
       }
     }
   }

--- a/models/apis/acm-pca/2017-08-22/examples-1.json
+++ b/models/apis/acm-pca/2017-08-22/examples-1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
-  "examples": {
+  "version":"1.0",
+  "examples":{
   }
 }

--- a/models/apis/acm-pca/2017-08-22/paginators-1.json
+++ b/models/apis/acm-pca/2017-08-22/paginators-1.json
@@ -1,4 +1,4 @@
 {
-  "pagination": {
+  "pagination":{
   }
 }

--- a/models/apis/medialive/2017-10-14/api-2.json
+++ b/models/apis/medialive/2017-10-14/api-2.json
@@ -237,6 +237,46 @@
         }
       ]
     },
+    "DeleteReservation": {
+      "name": "DeleteReservation",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/prod/reservations/{reservationId}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteReservationRequest"
+      },
+      "output": {
+        "shape": "DeleteReservationResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "ConflictException"
+        }
+      ]
+    },
     "DescribeChannel": {
       "name": "DescribeChannel",
       "http": {
@@ -323,6 +363,80 @@
       },
       "output": {
         "shape": "DescribeInputSecurityGroupResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeOffering": {
+      "name": "DescribeOffering",
+      "http": {
+        "method": "GET",
+        "requestUri": "/prod/offerings/{offeringId}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeOfferingRequest"
+      },
+      "output": {
+        "shape": "DescribeOfferingResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeReservation": {
+      "name": "DescribeReservation",
+      "http": {
+        "method": "GET",
+        "requestUri": "/prod/reservations/{reservationId}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeReservationRequest"
+      },
+      "output": {
+        "shape": "DescribeReservationResponse"
       },
       "errors": [
         {
@@ -447,6 +561,114 @@
         },
         {
           "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListOfferings": {
+      "name": "ListOfferings",
+      "http": {
+        "method": "GET",
+        "requestUri": "/prod/offerings",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListOfferingsRequest"
+      },
+      "output": {
+        "shape": "ListOfferingsResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListReservations": {
+      "name": "ListReservations",
+      "http": {
+        "method": "GET",
+        "requestUri": "/prod/reservations",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListReservationsRequest"
+      },
+      "output": {
+        "shape": "ListReservationsResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "PurchaseOffering": {
+      "name": "PurchaseOffering",
+      "http": {
+        "method": "POST",
+        "requestUri": "/prod/offerings/{offeringId}/purchase",
+        "responseCode": 201
+      },
+      "input": {
+        "shape": "PurchaseOfferingRequest"
+      },
+      "output": {
+        "shape": "PurchaseOfferingResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "BadGatewayException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "GatewayTimeoutException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "ConflictException"
         }
       ]
     },
@@ -1976,6 +2198,92 @@
       "members": {
       }
     },
+    "DeleteReservationRequest": {
+      "type": "structure",
+      "members": {
+        "ReservationId": {
+          "shape": "__string",
+          "location": "uri",
+          "locationName": "reservationId"
+        }
+      },
+      "required": [
+        "ReservationId"
+      ]
+    },
+    "DeleteReservationResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "Count": {
+          "shape": "__integer",
+          "locationName": "count"
+        },
+        "CurrencyCode": {
+          "shape": "__string",
+          "locationName": "currencyCode"
+        },
+        "Duration": {
+          "shape": "__integer",
+          "locationName": "duration"
+        },
+        "DurationUnits": {
+          "shape": "OfferingDurationUnits",
+          "locationName": "durationUnits"
+        },
+        "End": {
+          "shape": "__string",
+          "locationName": "end"
+        },
+        "FixedPrice": {
+          "shape": "__double",
+          "locationName": "fixedPrice"
+        },
+        "Name": {
+          "shape": "__string",
+          "locationName": "name"
+        },
+        "OfferingDescription": {
+          "shape": "__string",
+          "locationName": "offeringDescription"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "locationName": "offeringId"
+        },
+        "OfferingType": {
+          "shape": "OfferingType",
+          "locationName": "offeringType"
+        },
+        "Region": {
+          "shape": "__string",
+          "locationName": "region"
+        },
+        "ReservationId": {
+          "shape": "__string",
+          "locationName": "reservationId"
+        },
+        "ResourceSpecification": {
+          "shape": "ReservationResourceSpecification",
+          "locationName": "resourceSpecification"
+        },
+        "Start": {
+          "shape": "__string",
+          "locationName": "start"
+        },
+        "State": {
+          "shape": "ReservationState",
+          "locationName": "state"
+        },
+        "UsagePrice": {
+          "shape": "__double",
+          "locationName": "usagePrice"
+        }
+      }
+    },
     "DescribeChannelRequest": {
       "type": "structure",
       "members": {
@@ -2131,6 +2439,154 @@
         "WhitelistRules": {
           "shape": "__listOfInputWhitelistRule",
           "locationName": "whitelistRules"
+        }
+      }
+    },
+    "DescribeOfferingRequest": {
+      "type": "structure",
+      "members": {
+        "OfferingId": {
+          "shape": "__string",
+          "location": "uri",
+          "locationName": "offeringId"
+        }
+      },
+      "required": [
+        "OfferingId"
+      ]
+    },
+    "DescribeOfferingResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "CurrencyCode": {
+          "shape": "__string",
+          "locationName": "currencyCode"
+        },
+        "Duration": {
+          "shape": "__integer",
+          "locationName": "duration"
+        },
+        "DurationUnits": {
+          "shape": "OfferingDurationUnits",
+          "locationName": "durationUnits"
+        },
+        "FixedPrice": {
+          "shape": "__double",
+          "locationName": "fixedPrice"
+        },
+        "OfferingDescription": {
+          "shape": "__string",
+          "locationName": "offeringDescription"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "locationName": "offeringId"
+        },
+        "OfferingType": {
+          "shape": "OfferingType",
+          "locationName": "offeringType"
+        },
+        "Region": {
+          "shape": "__string",
+          "locationName": "region"
+        },
+        "ResourceSpecification": {
+          "shape": "ReservationResourceSpecification",
+          "locationName": "resourceSpecification"
+        },
+        "UsagePrice": {
+          "shape": "__double",
+          "locationName": "usagePrice"
+        }
+      }
+    },
+    "DescribeReservationRequest": {
+      "type": "structure",
+      "members": {
+        "ReservationId": {
+          "shape": "__string",
+          "location": "uri",
+          "locationName": "reservationId"
+        }
+      },
+      "required": [
+        "ReservationId"
+      ]
+    },
+    "DescribeReservationResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "Count": {
+          "shape": "__integer",
+          "locationName": "count"
+        },
+        "CurrencyCode": {
+          "shape": "__string",
+          "locationName": "currencyCode"
+        },
+        "Duration": {
+          "shape": "__integer",
+          "locationName": "duration"
+        },
+        "DurationUnits": {
+          "shape": "OfferingDurationUnits",
+          "locationName": "durationUnits"
+        },
+        "End": {
+          "shape": "__string",
+          "locationName": "end"
+        },
+        "FixedPrice": {
+          "shape": "__double",
+          "locationName": "fixedPrice"
+        },
+        "Name": {
+          "shape": "__string",
+          "locationName": "name"
+        },
+        "OfferingDescription": {
+          "shape": "__string",
+          "locationName": "offeringDescription"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "locationName": "offeringId"
+        },
+        "OfferingType": {
+          "shape": "OfferingType",
+          "locationName": "offeringType"
+        },
+        "Region": {
+          "shape": "__string",
+          "locationName": "region"
+        },
+        "ReservationId": {
+          "shape": "__string",
+          "locationName": "reservationId"
+        },
+        "ResourceSpecification": {
+          "shape": "ReservationResourceSpecification",
+          "locationName": "resourceSpecification"
+        },
+        "Start": {
+          "shape": "__string",
+          "locationName": "start"
+        },
+        "State": {
+          "shape": "ReservationState",
+          "locationName": "state"
+        },
+        "UsagePrice": {
+          "shape": "__double",
+          "locationName": "usagePrice"
         }
       }
     },
@@ -4070,6 +4526,163 @@
         }
       }
     },
+    "ListOfferingsRequest": {
+      "type": "structure",
+      "members": {
+        "ChannelConfiguration": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "channelConfiguration"
+        },
+        "Codec": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "codec"
+        },
+        "MaxResults": {
+          "shape": "MaxResults",
+          "location": "querystring",
+          "locationName": "maxResults"
+        },
+        "MaximumBitrate": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "maximumBitrate"
+        },
+        "MaximumFramerate": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "maximumFramerate"
+        },
+        "NextToken": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "Resolution": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "resolution"
+        },
+        "ResourceType": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "resourceType"
+        },
+        "SpecialFeature": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "specialFeature"
+        },
+        "VideoQuality": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "videoQuality"
+        }
+      }
+    },
+    "ListOfferingsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "__string",
+          "locationName": "nextToken"
+        },
+        "Offerings": {
+          "shape": "__listOfOffering",
+          "locationName": "offerings"
+        }
+      }
+    },
+    "ListOfferingsResultModel": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "__string",
+          "locationName": "nextToken"
+        },
+        "Offerings": {
+          "shape": "__listOfOffering",
+          "locationName": "offerings"
+        }
+      }
+    },
+    "ListReservationsRequest": {
+      "type": "structure",
+      "members": {
+        "Codec": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "codec"
+        },
+        "MaxResults": {
+          "shape": "MaxResults",
+          "location": "querystring",
+          "locationName": "maxResults"
+        },
+        "MaximumBitrate": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "maximumBitrate"
+        },
+        "MaximumFramerate": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "maximumFramerate"
+        },
+        "NextToken": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "Resolution": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "resolution"
+        },
+        "ResourceType": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "resourceType"
+        },
+        "SpecialFeature": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "specialFeature"
+        },
+        "VideoQuality": {
+          "shape": "__string",
+          "location": "querystring",
+          "locationName": "videoQuality"
+        }
+      }
+    },
+    "ListReservationsResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "__string",
+          "locationName": "nextToken"
+        },
+        "Reservations": {
+          "shape": "__listOfReservation",
+          "locationName": "reservations"
+        }
+      }
+    },
+    "ListReservationsResultModel": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "shape": "__string",
+          "locationName": "nextToken"
+        },
+        "Reservations": {
+          "shape": "__listOfReservation",
+          "locationName": "reservations"
+        }
+      }
+    },
     "LogLevel": {
       "type": "string",
       "enum": [
@@ -4644,6 +5257,67 @@
         "httpStatusCode": 404
       }
     },
+    "Offering": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "CurrencyCode": {
+          "shape": "__string",
+          "locationName": "currencyCode"
+        },
+        "Duration": {
+          "shape": "__integer",
+          "locationName": "duration"
+        },
+        "DurationUnits": {
+          "shape": "OfferingDurationUnits",
+          "locationName": "durationUnits"
+        },
+        "FixedPrice": {
+          "shape": "__double",
+          "locationName": "fixedPrice"
+        },
+        "OfferingDescription": {
+          "shape": "__string",
+          "locationName": "offeringDescription"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "locationName": "offeringId"
+        },
+        "OfferingType": {
+          "shape": "OfferingType",
+          "locationName": "offeringType"
+        },
+        "Region": {
+          "shape": "__string",
+          "locationName": "region"
+        },
+        "ResourceSpecification": {
+          "shape": "ReservationResourceSpecification",
+          "locationName": "resourceSpecification"
+        },
+        "UsagePrice": {
+          "shape": "__double",
+          "locationName": "usagePrice"
+        }
+      }
+    },
+    "OfferingDurationUnits": {
+      "type": "string",
+      "enum": [
+        "MONTHS"
+      ]
+    },
+    "OfferingType": {
+      "type": "string",
+      "enum": [
+        "NO_UPFRONT"
+      ]
+    },
     "Output": {
       "type": "structure",
       "members": {
@@ -4791,6 +5465,68 @@
       "members": {
       }
     },
+    "PurchaseOffering": {
+      "type": "structure",
+      "members": {
+        "Count": {
+          "shape": "__integerMin1",
+          "locationName": "count"
+        },
+        "Name": {
+          "shape": "__string",
+          "locationName": "name"
+        },
+        "RequestId": {
+          "shape": "__string",
+          "locationName": "requestId",
+          "idempotencyToken": true
+        }
+      }
+    },
+    "PurchaseOfferingRequest": {
+      "type": "structure",
+      "members": {
+        "Count": {
+          "shape": "__integerMin1",
+          "locationName": "count"
+        },
+        "Name": {
+          "shape": "__string",
+          "locationName": "name"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "location": "uri",
+          "locationName": "offeringId"
+        },
+        "RequestId": {
+          "shape": "__string",
+          "locationName": "requestId",
+          "idempotencyToken": true
+        }
+      },
+      "required": [
+        "OfferingId"
+      ]
+    },
+    "PurchaseOfferingResponse": {
+      "type": "structure",
+      "members": {
+        "Reservation": {
+          "shape": "Reservation",
+          "locationName": "reservation"
+        }
+      }
+    },
+    "PurchaseOfferingResultModel": {
+      "type": "structure",
+      "members": {
+        "Reservation": {
+          "shape": "Reservation",
+          "locationName": "reservation"
+        }
+      }
+    },
     "RemixSettings": {
       "type": "structure",
       "members": {
@@ -4809,6 +5545,176 @@
       },
       "required": [
         "ChannelMappings"
+      ]
+    },
+    "Reservation": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "Count": {
+          "shape": "__integer",
+          "locationName": "count"
+        },
+        "CurrencyCode": {
+          "shape": "__string",
+          "locationName": "currencyCode"
+        },
+        "Duration": {
+          "shape": "__integer",
+          "locationName": "duration"
+        },
+        "DurationUnits": {
+          "shape": "OfferingDurationUnits",
+          "locationName": "durationUnits"
+        },
+        "End": {
+          "shape": "__string",
+          "locationName": "end"
+        },
+        "FixedPrice": {
+          "shape": "__double",
+          "locationName": "fixedPrice"
+        },
+        "Name": {
+          "shape": "__string",
+          "locationName": "name"
+        },
+        "OfferingDescription": {
+          "shape": "__string",
+          "locationName": "offeringDescription"
+        },
+        "OfferingId": {
+          "shape": "__string",
+          "locationName": "offeringId"
+        },
+        "OfferingType": {
+          "shape": "OfferingType",
+          "locationName": "offeringType"
+        },
+        "Region": {
+          "shape": "__string",
+          "locationName": "region"
+        },
+        "ReservationId": {
+          "shape": "__string",
+          "locationName": "reservationId"
+        },
+        "ResourceSpecification": {
+          "shape": "ReservationResourceSpecification",
+          "locationName": "resourceSpecification"
+        },
+        "Start": {
+          "shape": "__string",
+          "locationName": "start"
+        },
+        "State": {
+          "shape": "ReservationState",
+          "locationName": "state"
+        },
+        "UsagePrice": {
+          "shape": "__double",
+          "locationName": "usagePrice"
+        }
+      }
+    },
+    "ReservationCodec": {
+      "type": "string",
+      "enum": [
+        "MPEG2",
+        "AVC",
+        "HEVC",
+        "AUDIO"
+      ]
+    },
+    "ReservationMaximumBitrate": {
+      "type": "string",
+      "enum": [
+        "MAX_10_MBPS",
+        "MAX_20_MBPS",
+        "MAX_50_MBPS"
+      ]
+    },
+    "ReservationMaximumFramerate": {
+      "type": "string",
+      "enum": [
+        "MAX_30_FPS",
+        "MAX_60_FPS"
+      ]
+    },
+    "ReservationResolution": {
+      "type": "string",
+      "enum": [
+        "SD",
+        "HD",
+        "UHD"
+      ]
+    },
+    "ReservationResourceSpecification": {
+      "type": "structure",
+      "members": {
+        "Codec": {
+          "shape": "ReservationCodec",
+          "locationName": "codec"
+        },
+        "MaximumBitrate": {
+          "shape": "ReservationMaximumBitrate",
+          "locationName": "maximumBitrate"
+        },
+        "MaximumFramerate": {
+          "shape": "ReservationMaximumFramerate",
+          "locationName": "maximumFramerate"
+        },
+        "Resolution": {
+          "shape": "ReservationResolution",
+          "locationName": "resolution"
+        },
+        "ResourceType": {
+          "shape": "ReservationResourceType",
+          "locationName": "resourceType"
+        },
+        "SpecialFeature": {
+          "shape": "ReservationSpecialFeature",
+          "locationName": "specialFeature"
+        },
+        "VideoQuality": {
+          "shape": "ReservationVideoQuality",
+          "locationName": "videoQuality"
+        }
+      }
+    },
+    "ReservationResourceType": {
+      "type": "string",
+      "enum": [
+        "INPUT",
+        "OUTPUT",
+        "CHANNEL"
+      ]
+    },
+    "ReservationSpecialFeature": {
+      "type": "string",
+      "enum": [
+        "ADVANCED_AUDIO",
+        "AUDIO_NORMALIZATION"
+      ]
+    },
+    "ReservationState": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "EXPIRED",
+        "CANCELED",
+        "DELETED"
+      ]
+    },
+    "ReservationVideoQuality": {
+      "type": "string",
+      "enum": [
+        "STANDARD",
+        "ENHANCED",
+        "PREMIUM"
       ]
     },
     "ResourceConflict": {
@@ -6029,6 +6935,12 @@
         "shape": "InputWhitelistRuleCidr"
       }
     },
+    "__listOfOffering": {
+      "type": "list",
+      "member": {
+        "shape": "Offering"
+      }
+    },
     "__listOfOutput": {
       "type": "list",
       "member": {
@@ -6051,6 +6963,12 @@
       "type": "list",
       "member": {
         "shape": "OutputGroup"
+      }
+    },
+    "__listOfReservation": {
+      "type": "list",
+      "member": {
+        "shape": "Reservation"
       }
     },
     "__listOfValidationError": {

--- a/models/apis/medialive/2017-10-14/docs-2.json
+++ b/models/apis/medialive/2017-10-14/docs-2.json
@@ -8,12 +8,18 @@
     "DeleteChannel": "Starts deletion of channel. The associated outputs are also deleted.",
     "DeleteInput": "Deletes the input end point",
     "DeleteInputSecurityGroup": "Deletes an Input Security Group",
+    "DeleteReservation": "Delete an expired reservation.",
     "DescribeChannel": "Gets details about a channel",
     "DescribeInput": "Produces details about an input",
     "DescribeInputSecurityGroup": "Produces a summary of an Input Security Group",
+    "DescribeOffering": "Get details for an offering.",
+    "DescribeReservation": "Get details for a reservation.",
     "ListChannels": "Produces list of channels that have been created",
     "ListInputSecurityGroups": "Produces a list of Input Security Groups for an account",
     "ListInputs": "Produces list of inputs that have been created",
+    "ListOfferings": "List offerings available for purchase.",
+    "ListReservations": "List purchased reservations.",
+    "PurchaseOffering": "Purchase an offering and create a reservation.",
     "StartChannel": "Starts an existing channel",
     "StopChannel": "Stops a running channel",
     "UpdateChannel": "Updates a channel.",
@@ -1207,6 +1213,16 @@
       "refs": {
       }
     },
+    "ListOfferingsResultModel": {
+      "base": "ListOfferings response",
+      "refs": {
+      }
+    },
+    "ListReservationsResultModel": {
+      "base": "ListReservations response",
+      "refs": {
+      }
+    },
     "LogLevel": {
       "base": null,
       "refs": {
@@ -1396,6 +1412,26 @@
       "refs": {
       }
     },
+    "Offering": {
+      "base": "Reserved resources available for purchase",
+      "refs": {
+        "__listOfOffering$member": null
+      }
+    },
+    "OfferingDurationUnits": {
+      "base": "Units for duration, e.g. 'MONTHS'",
+      "refs": {
+        "Offering$DurationUnits": "Units for duration, e.g. 'MONTHS'",
+        "Reservation$DurationUnits": "Units for duration, e.g. 'MONTHS'"
+      }
+    },
+    "OfferingType": {
+      "base": "Offering type, e.g. 'NO_UPFRONT'",
+      "refs": {
+        "Offering$OfferingType": "Offering type, e.g. 'NO_UPFRONT'",
+        "Reservation$OfferingType": "Offering type, e.g. 'NO_UPFRONT'"
+      }
+    },
     "Output": {
       "base": "Output settings. There can be multiple outputs within a group.",
       "refs": {
@@ -1448,10 +1484,82 @@
         "AudioCodecSettings$PassThroughSettings": null
       }
     },
+    "PurchaseOffering": {
+      "base": "PurchaseOffering request",
+      "refs": {
+      }
+    },
+    "PurchaseOfferingResultModel": {
+      "base": "PurchaseOffering response",
+      "refs": {
+      }
+    },
     "RemixSettings": {
       "base": null,
       "refs": {
         "AudioDescription$RemixSettings": "Settings that control how input audio channels are remixed into the output audio channels."
+      }
+    },
+    "Reservation": {
+      "base": "Reserved resources available to use",
+      "refs": {
+        "PurchaseOfferingResultModel$Reservation": null,
+        "__listOfReservation$member": null
+      }
+    },
+    "ReservationCodec": {
+      "base": "Codec, 'MPEG2', 'AVC', 'HEVC', or 'AUDIO'",
+      "refs": {
+        "ReservationResourceSpecification$Codec": "Codec, e.g. 'AVC'"
+      }
+    },
+    "ReservationMaximumBitrate": {
+      "base": "Maximum bitrate in megabits per second",
+      "refs": {
+        "ReservationResourceSpecification$MaximumBitrate": "Maximum bitrate, e.g. 'MAX_20_MBPS'"
+      }
+    },
+    "ReservationMaximumFramerate": {
+      "base": "Maximum framerate in frames per second (Outputs only)",
+      "refs": {
+        "ReservationResourceSpecification$MaximumFramerate": "Maximum framerate, e.g. 'MAX_30_FPS' (Outputs only)"
+      }
+    },
+    "ReservationResolution": {
+      "base": "Resolution based on lines of vertical resolution; SD is less than 720 lines, HD is 720 to 1080 lines, UHD is greater than 1080 lines\n",
+      "refs": {
+        "ReservationResourceSpecification$Resolution": "Resolution, e.g. 'HD'"
+      }
+    },
+    "ReservationResourceSpecification": {
+      "base": "Resource configuration (codec, resolution, bitrate, ...)",
+      "refs": {
+        "Offering$ResourceSpecification": "Resource configuration details",
+        "Reservation$ResourceSpecification": "Resource configuration details"
+      }
+    },
+    "ReservationResourceType": {
+      "base": "Resource type, 'INPUT', 'OUTPUT', or 'CHANNEL'",
+      "refs": {
+        "ReservationResourceSpecification$ResourceType": "Resource type, 'INPUT', 'OUTPUT', or 'CHANNEL'"
+      }
+    },
+    "ReservationSpecialFeature": {
+      "base": "Special features, 'ADVANCED_AUDIO' or 'AUDIO_NORMALIZATION'",
+      "refs": {
+        "ReservationResourceSpecification$SpecialFeature": "Special feature, e.g. 'AUDIO_NORMALIZATION' (Channels only)"
+      }
+    },
+    "ReservationState": {
+      "base": "Current reservation state",
+      "refs": {
+        "Reservation$State": "Current state of reservation, e.g. 'ACTIVE'"
+      }
+    },
+    "ReservationVideoQuality": {
+      "base": "Video quality, e.g. 'STANDARD' (Outputs only)",
+      "refs": {
+        "ReservationResourceSpecification$VideoQuality": "Video quality, e.g. 'STANDARD' (Outputs only)"
       }
     },
     "ResourceConflict": {
@@ -1811,7 +1919,11 @@
         "Eac3Settings$LtRtCenterMixLevel": "Left total/Right total center mix level. Only used for 3/2 coding mode.",
         "Eac3Settings$LtRtSurroundMixLevel": "Left total/Right total surround mix level. Only used for 3/2 coding mode.",
         "Mp2Settings$Bitrate": "Average bitrate in bits/second.",
-        "Mp2Settings$SampleRate": "Sample rate in Hz."
+        "Mp2Settings$SampleRate": "Sample rate in Hz.",
+        "Offering$FixedPrice": "One-time charge for each reserved resource, e.g. '0.0' for a NO_UPFRONT offering",
+        "Offering$UsagePrice": "Recurring usage charge for each reserved resource, e.g. '157.0'",
+        "Reservation$FixedPrice": "One-time charge for each reserved resource, e.g. '0.0' for a NO_UPFRONT offering",
+        "Reservation$UsagePrice": "Recurring usage charge for each reserved resource, e.g. '157.0'"
       }
     },
     "__doubleMin0": {
@@ -1846,6 +1958,9 @@
         "H264Settings$FramerateDenominator": "Framerate denominator.",
         "H264Settings$FramerateNumerator": "Framerate numerator - framerate is a fraction, e.g. 24000 / 1001 = 23.976 fps.",
         "H264Settings$ParNumerator": "Pixel Aspect Ratio numerator.",
+        "Offering$Duration": "Lease duration, e.g. '12'",
+        "Reservation$Count": "Number of reserved resources",
+        "Reservation$Duration": "Lease duration, e.g. '12'",
         "VideoDescription$Height": "Output video height (in pixels). Leave blank to use source video height. If left blank, width must also be unspecified.",
         "VideoDescription$Width": "Output video width (in pixels). Leave out to use source video width.  If left out, height must also be left out. Display aspect ratio is always preserved by letterboxing or pillarboxing when necessary."
       }
@@ -2019,6 +2134,7 @@
         "HlsGroupSettings$SegmentLength": "Length of MPEG-2 Transport Stream segments to create (in seconds). Note that segments will end on the next keyframe after this number of seconds, so actual segment length may be longer.",
         "HlsGroupSettings$SegmentsPerSubdirectory": "Number of segments to write to a subdirectory before starting a new one. directoryStructure must be subdirectoryPerStream for this setting to have an effect.",
         "MsSmoothGroupSettings$FragmentLength": "Length of mp4 fragments to generate (in seconds). Fragment length must be compatible with GOP size and framerate.",
+        "PurchaseOffering$Count": "Number of resources",
         "RtmpOutputSettings$ConnectionRetryInterval": "Number of seconds to wait before retrying a connection to the Flash Media server if the connection is lost.",
         "Scte27SourceSettings$Pid": "The pid field is used in conjunction with the caption selector languageCode field as follows:\n  - Specify PID and Language: Extracts captions from that PID; the language is \"informational\".\n  - Specify PID and omit Language: Extracts the specified PID.\n  - Omit PID and specify Language: Extracts the specified language, whichever PID that happens to be.\n  - Omit PID and omit Language: Valid only if source is DVB-Sub that is being passed through; all languages will be passed through."
       }
@@ -2270,6 +2386,12 @@
         "InputSecurityGroupWhitelistRequest$WhitelistRules": "List of IPv4 CIDR addresses to whitelist"
       }
     },
+    "__listOfOffering": {
+      "base": null,
+      "refs": {
+        "ListOfferingsResultModel$Offerings": "List of offerings"
+      }
+    },
     "__listOfOutput": {
       "base": null,
       "refs": {
@@ -2295,6 +2417,12 @@
       "base": null,
       "refs": {
         "EncoderSettings$OutputGroups": null
+      }
+    },
+    "__listOfReservation": {
+      "base": null,
+      "refs": {
+        "ListReservationsResultModel$Reservations": "List of reservations"
       }
     },
     "__listOfValidationError": {
@@ -2393,6 +2521,8 @@
         "ListChannelsResultModel$NextToken": null,
         "ListInputSecurityGroupsResultModel$NextToken": null,
         "ListInputsResultModel$NextToken": null,
+        "ListOfferingsResultModel$NextToken": "Token to retrieve the next page of results",
+        "ListReservationsResultModel$NextToken": "Token to retrieve the next page of results",
         "M2tsSettings$AribCaptionsPid": "Packet Identifier (PID) for ARIB Captions in the transport stream. Can be entered as a decimal or hexadecimal value.  Valid values are 32 (or 0x20)..8182 (or 0x1ff6).",
         "M2tsSettings$AudioPids": "Packet Identifier (PID) of the elementary audio stream(s) in the transport stream. Multiple values are accepted, and can be entered in ranges and/or by comma separation. Can be entered as decimal or hexadecimal values. Each PID specified must be in the range of 32 (or 0x20)..8182 (or 0x1ff6).",
         "M2tsSettings$DvbSubPids": "Packet Identifier (PID) for input source DVB Subtitle data to this output. Multiple values are accepted, and can be entered in ranges and/or by comma separation. Can be entered as decimal or hexadecimal values.  Each PID specified must be in the range of 32 (or 0x20)..8182 (or 0x1ff6).",
@@ -2418,6 +2548,11 @@
         "MsSmoothGroupSettings$EventId": "MS Smooth event ID to be sent to the IIS server.\n\nShould only be specified if eventIdMode is set to useConfigured.",
         "MsSmoothGroupSettings$TimestampOffset": "Timestamp offset for the event.  Only used if timestampOffsetMode is set to useConfiguredOffset.",
         "MsSmoothOutputSettings$NameModifier": "String concatenated to the end of the destination filename.  Required for multiple outputs of the same type.",
+        "Offering$Arn": "Unique offering ARN, e.g. 'arn:aws:medialive:us-west-2:123456789012:offering:87654321'",
+        "Offering$CurrencyCode": "Currency code for usagePrice and fixedPrice in ISO-4217 format, e.g. 'USD'",
+        "Offering$OfferingDescription": "Offering description, e.g. 'HD AVC output at 10-20 Mbps, 30 fps, and standard VQ in US West (Oregon)'",
+        "Offering$OfferingId": "Unique offering ID, e.g. '87654321'",
+        "Offering$Region": "AWS region, e.g. 'us-west-2'",
         "Output$VideoDescriptionName": "The name of the VideoDescription used as the source for this output.",
         "OutputDestination$Id": "User-specified id. This is used in an output group or an output.",
         "OutputDestinationSettings$PasswordParam": "key used to extract the password from EC2 Parameter store",
@@ -2425,6 +2560,17 @@
         "OutputDestinationSettings$Url": "A URL specifying a destination",
         "OutputDestinationSettings$Username": "username for destination",
         "OutputLocationRef$DestinationRefId": null,
+        "PurchaseOffering$Name": "Name for the new reservation",
+        "PurchaseOffering$RequestId": "Unique request ID to be specified. This is needed to prevent retries from creating multiple resources.",
+        "Reservation$Arn": "Unique reservation ARN, e.g. 'arn:aws:medialive:us-west-2:123456789012:reservation:1234567'",
+        "Reservation$CurrencyCode": "Currency code for usagePrice and fixedPrice in ISO-4217 format, e.g. 'USD'",
+        "Reservation$End": "Reservation UTC end date and time in ISO-8601 format, e.g. '2019-03-01T00:00:00'",
+        "Reservation$Name": "User specified reservation name",
+        "Reservation$OfferingDescription": "Offering description, e.g. 'HD AVC output at 10-20 Mbps, 30 fps, and standard VQ in US West (Oregon)'",
+        "Reservation$OfferingId": "Unique offering ID, e.g. '87654321'",
+        "Reservation$Region": "AWS region, e.g. 'us-west-2'",
+        "Reservation$ReservationId": "Unique reservation ID, e.g. '1234567'",
+        "Reservation$Start": "Reservation UTC start date and time in ISO-8601 format, e.g. '2018-03-01T00:00:00'",
         "ResourceConflict$Message": null,
         "ResourceNotFound$Message": null,
         "StandardHlsSettings$AudioRenditionSets": "List all the audio groups that are used with the video output stream. Input all the audio GROUP-IDs that are associated to the video, separate by ','.",

--- a/models/apis/medialive/2017-10-14/paginators-1.json
+++ b/models/apis/medialive/2017-10-14/paginators-1.json
@@ -1,5 +1,11 @@
 {
   "pagination": {
+    "ListInputs": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Inputs"
+    },
     "ListChannels": {
       "input_token": "NextToken",
       "output_token": "NextToken",
@@ -12,11 +18,17 @@
       "limit_key": "MaxResults",
       "result_key": "InputSecurityGroups"
     },
-    "ListInputs": {
+    "ListOfferings": {
       "input_token": "NextToken",
       "output_token": "NextToken",
       "limit_key": "MaxResults",
-      "result_key": "Inputs"
+      "result_key": "Offerings"
+    },
+    "ListReservations": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults",
+      "result_key": "Reservations"
     }
   }
 }

--- a/models/apis/rds/2014-10-31/api-2.json
+++ b/models/apis/rds/2014-10-31/api-2.json
@@ -1436,7 +1436,8 @@
         {"shape":"DBSubnetGroupNotFoundFault"},
         {"shape":"InvalidSubnet"},
         {"shape":"OptionGroupNotFoundFault"},
-        {"shape":"KMSKeyNotAccessibleFault"}
+        {"shape":"KMSKeyNotAccessibleFault"},
+        {"shape":"DBClusterParameterGroupNotFoundFault"}
       ]
     },
     "RestoreDBClusterToPointInTime":{
@@ -1466,7 +1467,8 @@
         {"shape":"InvalidVPCNetworkStateFault"},
         {"shape":"KMSKeyNotAccessibleFault"},
         {"shape":"OptionGroupNotFoundFault"},
-        {"shape":"StorageQuotaExceededFault"}
+        {"shape":"StorageQuotaExceededFault"},
+        {"shape":"DBClusterParameterGroupNotFoundFault"}
       ]
     },
     "RestoreDBInstanceFromDBSnapshot":{
@@ -1498,7 +1500,8 @@
         {"shape":"AuthorizationNotFoundFault"},
         {"shape":"KMSKeyNotAccessibleFault"},
         {"shape":"DBSecurityGroupNotFoundFault"},
-        {"shape":"DomainNotFoundFault"}
+        {"shape":"DomainNotFoundFault"},
+        {"shape":"DBParameterGroupNotFoundFault"}
       ]
     },
     "RestoreDBInstanceFromS3":{
@@ -1561,7 +1564,8 @@
         {"shape":"AuthorizationNotFoundFault"},
         {"shape":"KMSKeyNotAccessibleFault"},
         {"shape":"DBSecurityGroupNotFoundFault"},
-        {"shape":"DomainNotFoundFault"}
+        {"shape":"DomainNotFoundFault"},
+        {"shape":"DBParameterGroupNotFoundFault"}
       ]
     },
     "RevokeDBSecurityGroupIngress":{
@@ -2102,6 +2106,7 @@
         "EnableIAMDatabaseAuthentication":{"shape":"BooleanOptional"},
         "EnablePerformanceInsights":{"shape":"BooleanOptional"},
         "PerformanceInsightsKMSKeyId":{"shape":"String"},
+        "PerformanceInsightsRetentionPeriod":{"shape":"IntegerOptional"},
         "EnableCloudwatchLogsExports":{"shape":"LogTypeList"},
         "ProcessorFeatures":{"shape":"ProcessorFeatureList"}
       }
@@ -2134,6 +2139,7 @@
         "EnableIAMDatabaseAuthentication":{"shape":"BooleanOptional"},
         "EnablePerformanceInsights":{"shape":"BooleanOptional"},
         "PerformanceInsightsKMSKeyId":{"shape":"String"},
+        "PerformanceInsightsRetentionPeriod":{"shape":"IntegerOptional"},
         "EnableCloudwatchLogsExports":{"shape":"LogTypeList"},
         "ProcessorFeatures":{"shape":"ProcessorFeatureList"},
         "UseDefaultProcessorFeatures":{"shape":"BooleanOptional"}
@@ -2694,6 +2700,7 @@
         "IAMDatabaseAuthenticationEnabled":{"shape":"Boolean"},
         "PerformanceInsightsEnabled":{"shape":"BooleanOptional"},
         "PerformanceInsightsKMSKeyId":{"shape":"String"},
+        "PerformanceInsightsRetentionPeriod":{"shape":"IntegerOptional"},
         "EnabledCloudwatchLogsExports":{"shape":"LogTypeList"},
         "ProcessorFeatures":{"shape":"ProcessorFeatureList"}
       },
@@ -4176,6 +4183,7 @@
         "EnableIAMDatabaseAuthentication":{"shape":"BooleanOptional"},
         "EnablePerformanceInsights":{"shape":"BooleanOptional"},
         "PerformanceInsightsKMSKeyId":{"shape":"String"},
+        "PerformanceInsightsRetentionPeriod":{"shape":"IntegerOptional"},
         "CloudwatchLogsExportConfiguration":{"shape":"CloudwatchLogsExportConfiguration"},
         "ProcessorFeatures":{"shape":"ProcessorFeatureList"},
         "UseDefaultProcessorFeatures":{"shape":"BooleanOptional"}
@@ -5161,6 +5169,7 @@
         "S3IngestionRoleArn":{"shape":"String"},
         "EnablePerformanceInsights":{"shape":"BooleanOptional"},
         "PerformanceInsightsKMSKeyId":{"shape":"String"},
+        "PerformanceInsightsRetentionPeriod":{"shape":"IntegerOptional"},
         "EnableCloudwatchLogsExports":{"shape":"LogTypeList"},
         "ProcessorFeatures":{"shape":"ProcessorFeatureList"},
         "UseDefaultProcessorFeatures":{"shape":"BooleanOptional"}

--- a/models/apis/rds/2014-10-31/docs-2.json
+++ b/models/apis/rds/2014-10-31/docs-2.json
@@ -1,3302 +1,3307 @@
 {
-  "version": "2.0",
-  "service": "<fullname>Amazon Relational Database Service</fullname> <p> </p> <p>Amazon Relational Database Service (Amazon RDS) is a web service that makes it easier to set up, operate, and scale a relational database in the cloud. It provides cost-efficient, resizable capacity for an industry-standard relational database and manages common database administration tasks, freeing up developers to focus on what makes their applications and businesses unique.</p> <p>Amazon RDS gives you access to the capabilities of a MySQL, MariaDB, PostgreSQL, Microsoft SQL Server, Oracle, or Amazon Aurora database server. These capabilities mean that the code, applications, and tools you already use today with your existing databases work with Amazon RDS without modification. Amazon RDS automatically backs up your database and maintains the database software that powers your DB instance. Amazon RDS is flexible: you can scale your DB instance's compute resources and storage capacity to meet your application's demand. As with all Amazon Web Services, there are no up-front investments, and you pay only for the resources you use.</p> <p>This interface reference for Amazon RDS contains documentation for a programming or command line interface you can use to manage Amazon RDS. Note that Amazon RDS is asynchronous, which means that some interfaces might require techniques such as polling or callback functions to determine when a command has been applied. In this reference, the parameter descriptions indicate whether a command is applied immediately, on the next instance reboot, or during the maintenance window. The reference structure is as follows, and we list following some related topics from the user guide.</p> <p> <b>Amazon RDS API Reference</b> </p> <ul> <li> <p>For the alphabetical list of API actions, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Operations.html\">API Actions</a>.</p> </li> <li> <p>For the alphabetical list of data types, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Types.html\">Data Types</a>.</p> </li> <li> <p>For a list of common query parameters, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/CommonParameters.html\">Common Parameters</a>.</p> </li> <li> <p>For descriptions of the error codes, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p> </li> </ul> <p> <b>Amazon RDS User Guide</b> </p> <ul> <li> <p>For a summary of the Amazon RDS interfaces, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html#Welcome.Interfaces\">Available RDS Interfaces</a>.</p> </li> <li> <p>For more information about how to use the Query API, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Using_the_Query_API.html\">Using the Query API</a>.</p> </li> </ul>",
-  "operations": {
-    "AddRoleToDBCluster": "<p>Associates an Identity and Access Management (IAM) role from an Aurora DB cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Authorizing.AWSServices.html\">Authorizing Amazon Aurora to Access Other AWS Services On Your Behalf</a>.</p>",
-    "AddSourceIdentifierToSubscription": "<p>Adds a source identifier to an existing RDS event notification subscription.</p>",
-    "AddTagsToResource": "<p>Adds metadata tags to an Amazon RDS resource. These tags can also be used with cost allocation reporting to track cost associated with Amazon RDS resources, or used in a Condition statement in an IAM policy for Amazon RDS.</p> <p>For an overview on tagging Amazon RDS resources, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
-    "ApplyPendingMaintenanceAction": "<p>Applies a pending maintenance action to a resource (for example, to a DB instance).</p>",
-    "AuthorizeDBSecurityGroupIngress": "<p>Enables ingress to a DBSecurityGroup using one of two forms of authorization. First, EC2 or VPC security groups can be added to the DBSecurityGroup if the application using the database is running on EC2 or VPC instances. Second, IP ranges are available if the application accessing your database is running on the Internet. Required parameters for this API are one of CIDR range, EC2SecurityGroupId for VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId for non-VPC).</p> <note> <p>You can't authorize ingress from an EC2 security group in one AWS Region to an Amazon RDS DB instance in another. You can't authorize ingress from a VPC security group in one VPC to an Amazon RDS DB instance in another.</p> </note> <p>For an overview of CIDR ranges, go to the <a href=\"http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Wikipedia Tutorial</a>. </p>",
-    "BacktrackDBCluster": "<p>Backtracks a DB cluster to a specific time, without creating a new DB cluster.</p> <p>For more information on backtracking, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Managing.Backtrack.html\"> Backtracking an Aurora DB Cluster</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CopyDBClusterParameterGroup": "<p>Copies the specified DB cluster parameter group.</p>",
-    "CopyDBClusterSnapshot": "<p>Copies a snapshot of a DB cluster.</p> <p>To copy a DB cluster snapshot from a shared manual DB cluster snapshot, <code>SourceDBClusterSnapshotIdentifier</code> must be the Amazon Resource Name (ARN) of the shared DB cluster snapshot.</p> <p>You can copy an encrypted DB cluster snapshot from another AWS Region. In that case, the AWS Region where you call the <code>CopyDBClusterSnapshot</code> action is the destination AWS Region for the encrypted DB cluster snapshot to be copied to. To copy an encrypted DB cluster snapshot from another AWS Region, you must provide the following values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS Key Management System (AWS KMS) key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region.</p> </li> <li> <p> <code>PreSignedUrl</code> - A URL that contains a Signature Version 4 signed request for the <code>CopyDBClusterSnapshot</code> action to be called in the source AWS Region where the DB cluster snapshot is copied from. The pre-signed URL must be a valid request for the <code>CopyDBClusterSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster snapshot to be copied.</p> <p>The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBClusterSnapshot</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that the DB cluster snapshot will be created in.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster snapshot from the us-west-2 AWS Region, then your <code>SourceDBClusterSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p> </li> <li> <p> <code>TargetDBClusterSnapshotIdentifier</code> - The identifier for the new copy of the DB cluster snapshot in the destination AWS Region.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the ARN format for the source AWS Region and is the same value as the <code>SourceDBClusterSnapshotIdentifier</code> in the pre-signed URL. </p> </li> </ul> <p>To cancel the copy operation once it is in progress, delete the target DB cluster snapshot identified by <code>TargetDBClusterSnapshotIdentifier</code> while that DB cluster snapshot is in \"copying\" status.</p> <p>For more information on copying encrypted DB cluster snapshots from one AWS Region to another, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopyDBClusterSnapshot.CrossRegion\"> Copying a DB Cluster Snapshot in the Same Account, Either in the Same Region or Across Regions</a> in the <i>Amazon RDS User Guide.</i> </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CopyDBParameterGroup": "<p>Copies the specified DB parameter group.</p>",
-    "CopyDBSnapshot": "<p>Copies the specified DB snapshot. The source DB snapshot must be in the \"available\" state.</p> <p>You can copy a snapshot from one AWS Region to another. In that case, the AWS Region where you call the <code>CopyDBSnapshot</code> action is the destination AWS Region for the DB snapshot copy. </p> <p>For more information about copying snapshots, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopyDBSnapshot.html\">Copying a DB Snapshot</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CopyOptionGroup": "<p>Copies the specified option group.</p>",
-    "CreateDBCluster": "<p>Creates a new Amazon Aurora DB cluster.</p> <p>You can use the <code>ReplicationSourceIdentifier</code> parameter to create the DB cluster as a Read Replica of another DB cluster or Amazon RDS MySQL DB instance. For cross-region replication where the DB cluster identified by <code>ReplicationSourceIdentifier</code> is encrypted, you must also specify the <code>PreSignedUrl</code> parameter.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CreateDBClusterParameterGroup": "<p>Creates a new DB cluster parameter group.</p> <p>Parameters in a DB cluster parameter group apply to all of the instances in a DB cluster.</p> <p> A DB cluster parameter group is initially created with the default parameters for the database engine used by instances in the DB cluster. To provide custom values for any of the parameters, you must modify the group after creating it using <a>ModifyDBClusterParameterGroup</a>. Once you've created a DB cluster parameter group, you need to associate it with your DB cluster using <a>ModifyDBCluster</a>. When you associate a new DB cluster parameter group with a running DB cluster, you need to reboot the DB instances in the DB cluster without failover for the new DB cluster parameter group and associated settings to take effect. </p> <important> <p>After you create a DB cluster parameter group, you should wait at least 5 minutes before creating your first DB cluster that uses that DB cluster parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the DB cluster parameter group is used as the default for a new DB cluster. This is especially important for parameters that are critical when creating the default database for a DB cluster, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <a>DescribeDBClusterParameters</a> command to verify that your DB cluster parameter group has been created or modified.</p> </important> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CreateDBClusterSnapshot": "<p>Creates a snapshot of a DB cluster. For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "CreateDBInstance": "<p>Creates a new DB instance.</p>",
-    "CreateDBInstanceReadReplica": "<p>Creates a new DB instance that acts as a Read Replica for an existing source DB instance. You can create a Read Replica for a DB instance running MySQL, MariaDB, or PostgreSQL. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html\">Working with PostgreSQL, MySQL, and MariaDB Read Replicas</a>. </p> <p>Amazon Aurora doesn't support this action. You must call the <code>CreateDBInstance</code> action to create a DB instance for an Aurora DB cluster. </p> <p>All Read Replica DB instances are created with backups disabled. All other DB instance attributes (including DB security groups and DB parameter groups) are inherited from the source DB instance, except as specified following. </p> <important> <p>Your source DB instance must have backup retention enabled. </p> </important>",
-    "CreateDBParameterGroup": "<p>Creates a new DB parameter group.</p> <p> A DB parameter group is initially created with the default parameters for the database engine used by the DB instance. To provide custom values for any of the parameters, you must modify the group after creating it using <i>ModifyDBParameterGroup</i>. Once you've created a DB parameter group, you need to associate it with your DB instance using <i>ModifyDBInstance</i>. When you associate a new DB parameter group with a running DB instance, you need to reboot the DB instance without failover for the new DB parameter group and associated settings to take effect. </p> <important> <p>After you create a DB parameter group, you should wait at least 5 minutes before creating your first DB instance that uses that DB parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the parameter group is used as the default for a new DB instance. This is especially important for parameters that are critical when creating the default database for a DB instance, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <i>DescribeDBParameters</i> command to verify that your DB parameter group has been created or modified.</p> </important>",
-    "CreateDBSecurityGroup": "<p>Creates a new DB security group. DB security groups control access to a DB instance.</p> <note> <p>A DB security group controls access to EC2-Classic DB instances that are not in a VPC.</p> </note>",
-    "CreateDBSnapshot": "<p>Creates a DBSnapshot. The source DBInstance must be in \"available\" state.</p>",
-    "CreateDBSubnetGroup": "<p>Creates a new DB subnet group. DB subnet groups must contain at least one subnet in at least two AZs in the AWS Region.</p>",
-    "CreateEventSubscription": "<p>Creates an RDS event notification subscription. This action requires a topic ARN (Amazon Resource Name) created by either the RDS console, the SNS console, or the SNS API. To obtain an ARN with SNS, you must create a topic in Amazon SNS and subscribe to the topic. The ARN is displayed in the SNS console.</p> <p>You can specify the type of source (SourceType) you want to be notified of, provide a list of RDS sources (SourceIds) that triggers the events, and provide a list of event categories (EventCategories) for events you want to be notified of. For example, you can specify SourceType = db-instance, SourceIds = mydbinstance1, mydbinstance2 and EventCategories = Availability, Backup.</p> <p>If you specify both the SourceType and SourceIds, such as SourceType = db-instance and SourceIdentifier = myDBInstance1, you are notified of all the db-instance events for the specified source. If you specify a SourceType but do not specify a SourceIdentifier, you receive notice of the events for that source type for all your RDS sources. If you do not specify either the SourceType nor the SourceIdentifier, you are notified of events generated from all RDS sources belonging to your customer account.</p>",
-    "CreateOptionGroup": "<p>Creates a new option group. You can create up to 20 option groups.</p>",
-    "DeleteDBCluster": "<p>The DeleteDBCluster action deletes a previously provisioned DB cluster. When you delete a DB cluster, all automated backups for that DB cluster are deleted and can't be recovered. Manual DB cluster snapshots of the specified DB cluster are not deleted.</p> <p/> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DeleteDBClusterParameterGroup": "<p>Deletes a specified DB cluster parameter group. The DB cluster parameter group to be deleted can't be associated with any DB clusters.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DeleteDBClusterSnapshot": "<p>Deletes a DB cluster snapshot. If the snapshot is being copied, the copy operation is terminated.</p> <note> <p>The DB cluster snapshot must be in the <code>available</code> state to be deleted.</p> </note> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DeleteDBInstance": "<p>The DeleteDBInstance action deletes a previously provisioned DB instance. When you delete a DB instance, all automated backups for that instance are deleted and can't be recovered. Manual DB snapshots of the DB instance to be deleted by <code>DeleteDBInstance</code> are not deleted.</p> <p> If you request a final DB snapshot the status of the Amazon RDS DB instance is <code>deleting</code> until the DB snapshot is created. The API action <code>DescribeDBInstance</code> is used to monitor the status of this operation. The action can't be canceled or reverted once submitted. </p> <p>Note that when a DB instance is in a failure state and has a status of <code>failed</code>, <code>incompatible-restore</code>, or <code>incompatible-network</code>, you can only delete it when the <code>SkipFinalSnapshot</code> parameter is set to <code>true</code>.</p> <p>If the specified DB instance is part of an Amazon Aurora DB cluster, you can't delete the DB instance if both of the following conditions are true:</p> <ul> <li> <p>The DB cluster is a Read Replica of another Amazon Aurora DB cluster.</p> </li> <li> <p>The DB instance is the only instance in the DB cluster.</p> </li> </ul> <p>To delete a DB instance in this case, first call the <a>PromoteReadReplicaDBCluster</a> API action to promote the DB cluster so it's no longer a Read Replica. After the promotion completes, then call the <code>DeleteDBInstance</code> API action to delete the final instance in the DB cluster.</p>",
-    "DeleteDBParameterGroup": "<p>Deletes a specified DBParameterGroup. The DBParameterGroup to be deleted can't be associated with any DB instances.</p>",
-    "DeleteDBSecurityGroup": "<p>Deletes a DB security group.</p> <note> <p>The specified DB security group must not be associated with any DB instances.</p> </note>",
-    "DeleteDBSnapshot": "<p>Deletes a DBSnapshot. If the snapshot is being copied, the copy operation is terminated.</p> <note> <p>The DBSnapshot must be in the <code>available</code> state to be deleted.</p> </note>",
-    "DeleteDBSubnetGroup": "<p>Deletes a DB subnet group.</p> <note> <p>The specified database subnet group must not be associated with any DB instances.</p> </note>",
-    "DeleteEventSubscription": "<p>Deletes an RDS event notification subscription.</p>",
-    "DeleteOptionGroup": "<p>Deletes an existing option group.</p>",
-    "DescribeAccountAttributes": "<p>Lists all of the attributes for a customer account. The attributes include Amazon RDS quotas for the account, such as the number of DB instances allowed. The description for a quota includes the quota name, current usage toward that quota, and the quota's maximum value.</p> <p>This command doesn't take any parameters.</p>",
-    "DescribeCertificates": "<p>Lists the set of CA certificates provided by Amazon RDS for this AWS account.</p>",
-    "DescribeDBClusterBacktracks": "<p>Returns information about backtracks for a DB cluster.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeDBClusterParameterGroups": "<p> Returns a list of <code>DBClusterParameterGroup</code> descriptions. If a <code>DBClusterParameterGroupName</code> parameter is specified, the list will contain only the description of the specified DB cluster parameter group. </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeDBClusterParameters": "<p>Returns the detailed parameter list for a particular DB cluster parameter group.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeDBClusterSnapshotAttributes": "<p>Returns a list of DB cluster snapshot attribute names and values for a manual DB cluster snapshot.</p> <p>When sharing snapshots with other AWS accounts, <code>DescribeDBClusterSnapshotAttributes</code> returns the <code>restore</code> attribute and a list of IDs for the AWS accounts that are authorized to copy or restore the manual DB cluster snapshot. If <code>all</code> is included in the list of values for the <code>restore</code> attribute, then the manual DB cluster snapshot is public and can be copied or restored by all AWS accounts.</p> <p>To add or remove access for an AWS account to copy or restore a manual DB cluster snapshot, or to make the manual DB cluster snapshot public or private, use the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-    "DescribeDBClusterSnapshots": "<p>Returns information about DB cluster snapshots. This API action supports pagination.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeDBClusters": "<p>Returns information about provisioned Aurora DB clusters. This API supports pagination.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeDBEngineVersions": "<p>Returns a list of the available DB engines.</p>",
-    "DescribeDBInstances": "<p>Returns information about provisioned RDS instances. This API supports pagination.</p>",
-    "DescribeDBLogFiles": "<p>Returns a list of DB log files for the DB instance.</p>",
-    "DescribeDBParameterGroups": "<p> Returns a list of <code>DBParameterGroup</code> descriptions. If a <code>DBParameterGroupName</code> is specified, the list will contain only the description of the specified DB parameter group. </p>",
-    "DescribeDBParameters": "<p>Returns the detailed parameter list for a particular DB parameter group.</p>",
-    "DescribeDBSecurityGroups": "<p> Returns a list of <code>DBSecurityGroup</code> descriptions. If a <code>DBSecurityGroupName</code> is specified, the list will contain only the descriptions of the specified DB security group. </p>",
-    "DescribeDBSnapshotAttributes": "<p>Returns a list of DB snapshot attribute names and values for a manual DB snapshot.</p> <p>When sharing snapshots with other AWS accounts, <code>DescribeDBSnapshotAttributes</code> returns the <code>restore</code> attribute and a list of IDs for the AWS accounts that are authorized to copy or restore the manual DB snapshot. If <code>all</code> is included in the list of values for the <code>restore</code> attribute, then the manual DB snapshot is public and can be copied or restored by all AWS accounts.</p> <p>To add or remove access for an AWS account to copy or restore a manual DB snapshot, or to make the manual DB snapshot public or private, use the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
-    "DescribeDBSnapshots": "<p>Returns information about DB snapshots. This API action supports pagination.</p>",
-    "DescribeDBSubnetGroups": "<p>Returns a list of DBSubnetGroup descriptions. If a DBSubnetGroupName is specified, the list will contain only the descriptions of the specified DBSubnetGroup.</p> <p>For an overview of CIDR ranges, go to the <a href=\"http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Wikipedia Tutorial</a>. </p>",
-    "DescribeEngineDefaultClusterParameters": "<p>Returns the default engine and system parameter information for the cluster database engine.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeEngineDefaultParameters": "<p>Returns the default engine and system parameter information for the specified database engine.</p>",
-    "DescribeEventCategories": "<p>Displays a list of categories for all event source types, or, if specified, for a specified source type. You can see a list of the event categories and source types in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\"> Events</a> topic in the <i>Amazon RDS User Guide.</i> </p>",
-    "DescribeEventSubscriptions": "<p>Lists all the subscription descriptions for a customer account. The description for a subscription includes SubscriptionName, SNSTopicARN, CustomerID, SourceType, SourceID, CreationTime, and Status.</p> <p>If you specify a SubscriptionName, lists the description for that subscription.</p>",
-    "DescribeEvents": "<p>Returns events related to DB instances, DB security groups, DB snapshots, and DB parameter groups for the past 14 days. Events specific to a particular DB instance, DB security group, database snapshot, or DB parameter group can be obtained by providing the name as a parameter. By default, the past hour of events are returned.</p>",
-    "DescribeOptionGroupOptions": "<p>Describes all available options.</p>",
-    "DescribeOptionGroups": "<p>Describes the available option groups.</p>",
-    "DescribeOrderableDBInstanceOptions": "<p>Returns a list of orderable DB instance options for the specified engine.</p>",
-    "DescribePendingMaintenanceActions": "<p>Returns a list of resources (for example, DB instances) that have at least one pending maintenance action.</p>",
-    "DescribeReservedDBInstances": "<p>Returns information about reserved DB instances for this account, or about a specified reserved DB instance.</p>",
-    "DescribeReservedDBInstancesOfferings": "<p>Lists available reserved DB instance offerings.</p>",
-    "DescribeSourceRegions": "<p>Returns a list of the source AWS Regions where the current AWS Region can create a Read Replica or copy a DB snapshot from. This API action supports pagination.</p>",
-    "DescribeValidDBInstanceModifications": "<p>You can call <a>DescribeValidDBInstanceModifications</a> to learn what modifications you can make to your DB instance. You can use this information when you call <a>ModifyDBInstance</a>. </p>",
-    "DownloadDBLogFilePortion": "<p>Downloads all or a portion of the specified log file, up to 1 MB in size.</p>",
-    "FailoverDBCluster": "<p>Forces a failover for a DB cluster.</p> <p>A failover for a DB cluster promotes one of the Aurora Replicas (read-only instances) in the DB cluster to be the primary instance (the cluster writer).</p> <p>Amazon Aurora will automatically fail over to an Aurora Replica, if one exists, when the primary instance fails. You can force a failover when you want to simulate a failure of a primary instance for testing. Because each instance in a DB cluster has its own endpoint address, you will need to clean up and re-establish any existing connections that use those endpoint addresses when the failover is complete.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "ListTagsForResource": "<p>Lists all tags on an Amazon RDS resource.</p> <p>For an overview on tagging an Amazon RDS resource, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
-    "ModifyDBCluster": "<p>Modify a setting for an Amazon Aurora DB cluster. You can change one or more database configuration parameters by specifying these parameters and the new values in the request. For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "ModifyDBClusterParameterGroup": "<p> Modifies the parameters of a DB cluster parameter group. To modify more than one parameter, submit a list of the following: <code>ParameterName</code>, <code>ParameterValue</code>, and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request. </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p> <note> <p>Changes to dynamic parameters are applied immediately. Changes to static parameters require a reboot without failover to the DB cluster associated with the parameter group before the change can take effect.</p> </note> <important> <p>After you create a DB cluster parameter group, you should wait at least 5 minutes before creating your first DB cluster that uses that DB cluster parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the parameter group is used as the default for a new DB cluster. This is especially important for parameters that are critical when creating the default database for a DB cluster, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <a>DescribeDBClusterParameters</a> command to verify that your DB cluster parameter group has been created or modified.</p> </important>",
-    "ModifyDBClusterSnapshotAttribute": "<p>Adds an attribute and values to, or removes an attribute and values from, a manual DB cluster snapshot.</p> <p>To share a manual DB cluster snapshot with other AWS accounts, specify <code>restore</code> as the <code>AttributeName</code> and use the <code>ValuesToAdd</code> parameter to add a list of IDs of the AWS accounts that are authorized to restore the manual DB cluster snapshot. Use the value <code>all</code> to make the manual DB cluster snapshot public, which means that it can be copied or restored by all AWS accounts. Do not add the <code>all</code> value for any manual DB cluster snapshots that contain private information that you don't want available to all AWS accounts. If a manual DB cluster snapshot is encrypted, it can be shared, but only by specifying a list of authorized AWS account IDs for the <code>ValuesToAdd</code> parameter. You can't use <code>all</code> as a value for that parameter in this case.</p> <p>To view which AWS accounts have access to copy or restore a manual DB cluster snapshot, or whether a manual DB cluster snapshot public or private, use the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p>",
-    "ModifyDBInstance": "<p>Modifies settings for a DB instance. You can change one or more database configuration parameters by specifying these parameters and the new values in the request. To learn what modifications you can make to your DB instance, call <a>DescribeValidDBInstanceModifications</a> before you call <a>ModifyDBInstance</a>. </p>",
-    "ModifyDBParameterGroup": "<p> Modifies the parameters of a DB parameter group. To modify more than one parameter, submit a list of the following: <code>ParameterName</code>, <code>ParameterValue</code>, and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request. </p> <note> <p>Changes to dynamic parameters are applied immediately. Changes to static parameters require a reboot without failover to the DB instance associated with the parameter group before the change can take effect.</p> </note> <important> <p>After you modify a DB parameter group, you should wait at least 5 minutes before creating your first DB instance that uses that DB parameter group as the default parameter group. This allows Amazon RDS to fully complete the modify action before the parameter group is used as the default for a new DB instance. This is especially important for parameters that are critical when creating the default database for a DB instance, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <i>DescribeDBParameters</i> command to verify that your DB parameter group has been created or modified.</p> </important>",
-    "ModifyDBSnapshot": "<p>Updates a manual DB snapshot, which can be encrypted or not encrypted, with a new engine version. </p> <p>Amazon RDS supports upgrading DB snapshots for MySQL and Oracle. </p>",
-    "ModifyDBSnapshotAttribute": "<p>Adds an attribute and values to, or removes an attribute and values from, a manual DB snapshot.</p> <p>To share a manual DB snapshot with other AWS accounts, specify <code>restore</code> as the <code>AttributeName</code> and use the <code>ValuesToAdd</code> parameter to add a list of IDs of the AWS accounts that are authorized to restore the manual DB snapshot. Uses the value <code>all</code> to make the manual DB snapshot public, which means it can be copied or restored by all AWS accounts. Do not add the <code>all</code> value for any manual DB snapshots that contain private information that you don't want available to all AWS accounts. If the manual DB snapshot is encrypted, it can be shared, but only by specifying a list of authorized AWS account IDs for the <code>ValuesToAdd</code> parameter. You can't use <code>all</code> as a value for that parameter in this case.</p> <p>To view which AWS accounts have access to copy or restore a manual DB snapshot, or whether a manual DB snapshot public or private, use the <a>DescribeDBSnapshotAttributes</a> API action.</p>",
-    "ModifyDBSubnetGroup": "<p>Modifies an existing DB subnet group. DB subnet groups must contain at least one subnet in at least two AZs in the AWS Region.</p>",
-    "ModifyEventSubscription": "<p>Modifies an existing RDS event notification subscription. Note that you can't modify the source identifiers using this call; to change source identifiers for a subscription, use the <a>AddSourceIdentifierToSubscription</a> and <a>RemoveSourceIdentifierFromSubscription</a> calls.</p> <p>You can see a list of the event categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action.</p>",
-    "ModifyOptionGroup": "<p>Modifies an existing option group.</p>",
-    "PromoteReadReplica": "<p>Promotes a Read Replica DB instance to a standalone DB instance.</p> <note> <ul> <li> <p>Backup duration is a function of the amount of changes to the database since the previous backup. If you plan to promote a Read Replica to a standalone instance, we recommend that you enable backups and complete at least one backup prior to promotion. In addition, a Read Replica cannot be promoted to a standalone instance when it is in the <code>backing-up</code> status. If you have enabled backups on your Read Replica, configure the automated backup window so that daily backups do not interfere with Read Replica promotion.</p> </li> <li> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </li> </ul> </note>",
-    "PromoteReadReplicaDBCluster": "<p>Promotes a Read Replica DB cluster to a standalone DB cluster.</p>",
-    "PurchaseReservedDBInstancesOffering": "<p>Purchases a reserved DB instance offering.</p>",
-    "RebootDBInstance": "<p>You might need to reboot your DB instance, usually for maintenance reasons. For example, if you make certain modifications, or if you change the DB parameter group associated with the DB instance, you must reboot the instance for the changes to take effect. </p> <p>Rebooting a DB instance restarts the database engine service. Rebooting a DB instance results in a momentary outage, during which the DB instance status is set to rebooting. </p> <p>For more information about rebooting, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html\">Rebooting a DB Instance</a>. </p>",
-    "RemoveRoleFromDBCluster": "<p>Disassociates an Identity and Access Management (IAM) role from an Aurora DB cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Authorizing.AWSServices.html\">Authorizing Amazon Aurora to Access Other AWS Services On Your Behalf</a>.</p>",
-    "RemoveSourceIdentifierFromSubscription": "<p>Removes a source identifier from an existing RDS event notification subscription.</p>",
-    "RemoveTagsFromResource": "<p>Removes metadata tags from an Amazon RDS resource.</p> <p>For an overview on tagging an Amazon RDS resource, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
-    "ResetDBClusterParameterGroup": "<p> Modifies the parameters of a DB cluster parameter group to the default value. To reset specific parameters submit a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. To reset the entire DB cluster parameter group, specify the <code>DBClusterParameterGroupName</code> and <code>ResetAllParameters</code> parameters. </p> <p> When resetting the entire group, dynamic parameters are updated immediately and static parameters are set to <code>pending-reboot</code> to take effect on the next DB instance restart or <a>RebootDBInstance</a> request. You must call <a>RebootDBInstance</a> for every DB instance in your DB cluster that you want the updated static parameter to apply to.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "ResetDBParameterGroup": "<p>Modifies the parameters of a DB parameter group to the engine/system default value. To reset specific parameters, provide a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. To reset the entire DB parameter group, specify the <code>DBParameterGroup</code> name and <code>ResetAllParameters</code> parameters. When resetting the entire group, dynamic parameters are updated immediately and static parameters are set to <code>pending-reboot</code> to take effect on the next DB instance restart or <code>RebootDBInstance</code> request. </p>",
-    "RestoreDBClusterFromS3": "<p>Creates an Amazon Aurora DB cluster from data stored in an Amazon S3 bucket. Amazon RDS must be authorized to access the Amazon S3 bucket and the data must be created using the Percona XtraBackup utility as described in <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Migrate.MySQL.html#Aurora.Migrate.MySQL.S3\">Migrating Data from MySQL by Using an Amazon S3 Bucket</a>.</p>",
-    "RestoreDBClusterFromSnapshot": "<p>Creates a new DB cluster from a DB snapshot or DB cluster snapshot.</p> <p>If a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.</p> <p>If a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "RestoreDBClusterToPointInTime": "<p>Restores a DB cluster to an arbitrary point in time. Users can restore to any point in time before <code>LatestRestorableTime</code> for up to <code>BackupRetentionPeriod</code> days. The target DB cluster is created from the source DB cluster with the same configuration as the original DB cluster, except that the new DB cluster is created with the default DB security group. </p> <note> <p>This action only restores the DB cluster, not the DB instances for that DB cluster. You must invoke the <a>CreateDBInstance</a> action to create DB instances for the restored DB cluster, specifying the identifier of the restored DB cluster in <code>DBClusterIdentifier</code>. You can create DB instances only after the <code>RestoreDBClusterToPointInTime</code> action has completed and the DB cluster is available.</p> </note> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
-    "RestoreDBInstanceFromDBSnapshot": "<p>Creates a new DB instance from a DB snapshot. The target database is created from the source database restore point with the most of original configuration with the default security group and the default DB parameter group. By default, the new DB instance is created as a single-AZ deployment except when the instance is a SQL Server instance that has an option group that is associated with mirroring; in this case, the instance becomes a mirrored AZ deployment and not a single-AZ deployment.</p> <p>If your intent is to replace your original DB instance with the new, restored DB instance, then rename your original DB instance before you call the RestoreDBInstanceFromDBSnapshot action. RDS doesn't allow two DB instances with the same name. Once you have renamed your original DB instance with a different identifier, then you can pass the original name of the DB instance as the DBInstanceIdentifier in the call to the RestoreDBInstanceFromDBSnapshot action. The result is that you will replace the original DB instance with the DB instance created from the snapshot.</p> <p>If you are restoring from a shared manual DB snapshot, the <code>DBSnapshotIdentifier</code> must be the ARN of the shared DB snapshot.</p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For Aurora, use <a>RestoreDBClusterFromSnapshot</a>.</p> </note>",
-    "RestoreDBInstanceFromS3": "<p>Amazon Relational Database Service (Amazon RDS) supports importing MySQL databases by using backup files. You can create a backup of your on-premises database, store it on Amazon Simple Storage Service (Amazon S3), and then restore the backup file onto a new Amazon RDS DB instance running MySQL. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html\">Importing Data into an Amazon RDS MySQL DB Instance</a>. </p>",
-    "RestoreDBInstanceToPointInTime": "<p>Restores a DB instance to an arbitrary point in time. You can restore to any point in time before the time identified by the LatestRestorableTime property. You can restore to a point up to the number of days specified by the BackupRetentionPeriod property.</p> <p>The target database is created with most of the original configuration, but in a system-selected Availability Zone, with the default security group, the default subnet group, and the default DB parameter group. By default, the new DB instance is created as a single-AZ deployment except when the instance is a SQL Server instance that has an option group that is associated with mirroring; in this case, the instance becomes a mirrored deployment and not a single-AZ deployment.</p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For Aurora, use <a>RestoreDBClusterToPointInTime</a>.</p> </note>",
-    "RevokeDBSecurityGroupIngress": "<p>Revokes ingress from a DBSecurityGroup for previously authorized IP ranges or EC2 or VPC Security Groups. Required parameters for this API are one of CIDRIP, EC2SecurityGroupId for VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId).</p>",
-    "StartDBInstance": "<p> Starts a DB instance that was stopped using the AWS console, the stop-db-instance AWS CLI command, or the StopDBInstance action. For more information, see Stopping and Starting a DB instance in the AWS RDS user guide. </p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </note>",
-    "StopDBInstance": "<p> Stops a DB instance. When you stop a DB instance, Amazon RDS retains the DB instance's metadata, including its endpoint, DB parameter group, and option group membership. Amazon RDS also retains the transaction logs so you can do a point-in-time restore if necessary. For more information, see Stopping and Starting a DB instance in the AWS RDS user guide. </p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </note>"
+  "version":"2.0",
+  "service":"<fullname>Amazon Relational Database Service</fullname> <p> </p> <p>Amazon Relational Database Service (Amazon RDS) is a web service that makes it easier to set up, operate, and scale a relational database in the cloud. It provides cost-efficient, resizable capacity for an industry-standard relational database and manages common database administration tasks, freeing up developers to focus on what makes their applications and businesses unique.</p> <p>Amazon RDS gives you access to the capabilities of a MySQL, MariaDB, PostgreSQL, Microsoft SQL Server, Oracle, or Amazon Aurora database server. These capabilities mean that the code, applications, and tools you already use today with your existing databases work with Amazon RDS without modification. Amazon RDS automatically backs up your database and maintains the database software that powers your DB instance. Amazon RDS is flexible: you can scale your DB instance's compute resources and storage capacity to meet your application's demand. As with all Amazon Web Services, there are no up-front investments, and you pay only for the resources you use.</p> <p>This interface reference for Amazon RDS contains documentation for a programming or command line interface you can use to manage Amazon RDS. Note that Amazon RDS is asynchronous, which means that some interfaces might require techniques such as polling or callback functions to determine when a command has been applied. In this reference, the parameter descriptions indicate whether a command is applied immediately, on the next instance reboot, or during the maintenance window. The reference structure is as follows, and we list following some related topics from the user guide.</p> <p> <b>Amazon RDS API Reference</b> </p> <ul> <li> <p>For the alphabetical list of API actions, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Operations.html\">API Actions</a>.</p> </li> <li> <p>For the alphabetical list of data types, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Types.html\">Data Types</a>.</p> </li> <li> <p>For a list of common query parameters, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/CommonParameters.html\">Common Parameters</a>.</p> </li> <li> <p>For descriptions of the error codes, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/CommonErrors.html\">Common Errors</a>.</p> </li> </ul> <p> <b>Amazon RDS User Guide</b> </p> <ul> <li> <p>For a summary of the Amazon RDS interfaces, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html#Welcome.Interfaces\">Available RDS Interfaces</a>.</p> </li> <li> <p>For more information about how to use the Query API, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Using_the_Query_API.html\">Using the Query API</a>.</p> </li> </ul>",
+  "operations":{
+    "AddRoleToDBCluster":"<p>Associates an Identity and Access Management (IAM) role from an Aurora DB cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Authorizing.AWSServices.html\">Authorizing Amazon Aurora to Access Other AWS Services On Your Behalf</a>.</p>",
+    "AddSourceIdentifierToSubscription":"<p>Adds a source identifier to an existing RDS event notification subscription.</p>",
+    "AddTagsToResource":"<p>Adds metadata tags to an Amazon RDS resource. These tags can also be used with cost allocation reporting to track cost associated with Amazon RDS resources, or used in a Condition statement in an IAM policy for Amazon RDS.</p> <p>For an overview on tagging Amazon RDS resources, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
+    "ApplyPendingMaintenanceAction":"<p>Applies a pending maintenance action to a resource (for example, to a DB instance).</p>",
+    "AuthorizeDBSecurityGroupIngress":"<p>Enables ingress to a DBSecurityGroup using one of two forms of authorization. First, EC2 or VPC security groups can be added to the DBSecurityGroup if the application using the database is running on EC2 or VPC instances. Second, IP ranges are available if the application accessing your database is running on the Internet. Required parameters for this API are one of CIDR range, EC2SecurityGroupId for VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId for non-VPC).</p> <note> <p>You can't authorize ingress from an EC2 security group in one AWS Region to an Amazon RDS DB instance in another. You can't authorize ingress from a VPC security group in one VPC to an Amazon RDS DB instance in another.</p> </note> <p>For an overview of CIDR ranges, go to the <a href=\"http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Wikipedia Tutorial</a>. </p>",
+    "BacktrackDBCluster":"<p>Backtracks a DB cluster to a specific time, without creating a new DB cluster.</p> <p>For more information on backtracking, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Managing.Backtrack.html\"> Backtracking an Aurora DB Cluster</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CopyDBClusterParameterGroup":"<p>Copies the specified DB cluster parameter group.</p>",
+    "CopyDBClusterSnapshot":"<p>Copies a snapshot of a DB cluster.</p> <p>To copy a DB cluster snapshot from a shared manual DB cluster snapshot, <code>SourceDBClusterSnapshotIdentifier</code> must be the Amazon Resource Name (ARN) of the shared DB cluster snapshot.</p> <p>You can copy an encrypted DB cluster snapshot from another AWS Region. In that case, the AWS Region where you call the <code>CopyDBClusterSnapshot</code> action is the destination AWS Region for the encrypted DB cluster snapshot to be copied to. To copy an encrypted DB cluster snapshot from another AWS Region, you must provide the following values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS Key Management System (AWS KMS) key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region.</p> </li> <li> <p> <code>PreSignedUrl</code> - A URL that contains a Signature Version 4 signed request for the <code>CopyDBClusterSnapshot</code> action to be called in the source AWS Region where the DB cluster snapshot is copied from. The pre-signed URL must be a valid request for the <code>CopyDBClusterSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster snapshot to be copied.</p> <p>The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The KMS key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBClusterSnapshot</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that the DB cluster snapshot will be created in.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster snapshot from the us-west-2 AWS Region, then your <code>SourceDBClusterSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p> </li> <li> <p> <code>TargetDBClusterSnapshotIdentifier</code> - The identifier for the new copy of the DB cluster snapshot in the destination AWS Region.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the ARN format for the source AWS Region and is the same value as the <code>SourceDBClusterSnapshotIdentifier</code> in the pre-signed URL. </p> </li> </ul> <p>To cancel the copy operation once it is in progress, delete the target DB cluster snapshot identified by <code>TargetDBClusterSnapshotIdentifier</code> while that DB cluster snapshot is in \"copying\" status.</p> <p>For more information on copying encrypted DB cluster snapshots from one AWS Region to another, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopyDBClusterSnapshot.CrossRegion\"> Copying a DB Cluster Snapshot in the Same Account, Either in the Same Region or Across Regions</a> in the <i>Amazon RDS User Guide.</i> </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CopyDBParameterGroup":"<p>Copies the specified DB parameter group.</p>",
+    "CopyDBSnapshot":"<p>Copies the specified DB snapshot. The source DB snapshot must be in the \"available\" state.</p> <p>You can copy a snapshot from one AWS Region to another. In that case, the AWS Region where you call the <code>CopyDBSnapshot</code> action is the destination AWS Region for the DB snapshot copy. </p> <p>For more information about copying snapshots, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopyDBSnapshot.html\">Copying a DB Snapshot</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CopyOptionGroup":"<p>Copies the specified option group.</p>",
+    "CreateDBCluster":"<p>Creates a new Amazon Aurora DB cluster.</p> <p>You can use the <code>ReplicationSourceIdentifier</code> parameter to create the DB cluster as a Read Replica of another DB cluster or Amazon RDS MySQL DB instance. For cross-region replication where the DB cluster identified by <code>ReplicationSourceIdentifier</code> is encrypted, you must also specify the <code>PreSignedUrl</code> parameter.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CreateDBClusterParameterGroup":"<p>Creates a new DB cluster parameter group.</p> <p>Parameters in a DB cluster parameter group apply to all of the instances in a DB cluster.</p> <p> A DB cluster parameter group is initially created with the default parameters for the database engine used by instances in the DB cluster. To provide custom values for any of the parameters, you must modify the group after creating it using <a>ModifyDBClusterParameterGroup</a>. Once you've created a DB cluster parameter group, you need to associate it with your DB cluster using <a>ModifyDBCluster</a>. When you associate a new DB cluster parameter group with a running DB cluster, you need to reboot the DB instances in the DB cluster without failover for the new DB cluster parameter group and associated settings to take effect. </p> <important> <p>After you create a DB cluster parameter group, you should wait at least 5 minutes before creating your first DB cluster that uses that DB cluster parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the DB cluster parameter group is used as the default for a new DB cluster. This is especially important for parameters that are critical when creating the default database for a DB cluster, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <a>DescribeDBClusterParameters</a> command to verify that your DB cluster parameter group has been created or modified.</p> </important> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CreateDBClusterSnapshot":"<p>Creates a snapshot of a DB cluster. For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "CreateDBInstance":"<p>Creates a new DB instance.</p>",
+    "CreateDBInstanceReadReplica":"<p>Creates a new DB instance that acts as a Read Replica for an existing source DB instance. You can create a Read Replica for a DB instance running MySQL, MariaDB, or PostgreSQL. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html\">Working with PostgreSQL, MySQL, and MariaDB Read Replicas</a>. </p> <p>Amazon Aurora doesn't support this action. You must call the <code>CreateDBInstance</code> action to create a DB instance for an Aurora DB cluster. </p> <p>All Read Replica DB instances are created with backups disabled. All other DB instance attributes (including DB security groups and DB parameter groups) are inherited from the source DB instance, except as specified following. </p> <important> <p>Your source DB instance must have backup retention enabled. </p> </important>",
+    "CreateDBParameterGroup":"<p>Creates a new DB parameter group.</p> <p> A DB parameter group is initially created with the default parameters for the database engine used by the DB instance. To provide custom values for any of the parameters, you must modify the group after creating it using <i>ModifyDBParameterGroup</i>. Once you've created a DB parameter group, you need to associate it with your DB instance using <i>ModifyDBInstance</i>. When you associate a new DB parameter group with a running DB instance, you need to reboot the DB instance without failover for the new DB parameter group and associated settings to take effect. </p> <important> <p>After you create a DB parameter group, you should wait at least 5 minutes before creating your first DB instance that uses that DB parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the parameter group is used as the default for a new DB instance. This is especially important for parameters that are critical when creating the default database for a DB instance, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <i>DescribeDBParameters</i> command to verify that your DB parameter group has been created or modified.</p> </important>",
+    "CreateDBSecurityGroup":"<p>Creates a new DB security group. DB security groups control access to a DB instance.</p> <note> <p>A DB security group controls access to EC2-Classic DB instances that are not in a VPC.</p> </note>",
+    "CreateDBSnapshot":"<p>Creates a DBSnapshot. The source DBInstance must be in \"available\" state.</p>",
+    "CreateDBSubnetGroup":"<p>Creates a new DB subnet group. DB subnet groups must contain at least one subnet in at least two AZs in the AWS Region.</p>",
+    "CreateEventSubscription":"<p>Creates an RDS event notification subscription. This action requires a topic ARN (Amazon Resource Name) created by either the RDS console, the SNS console, or the SNS API. To obtain an ARN with SNS, you must create a topic in Amazon SNS and subscribe to the topic. The ARN is displayed in the SNS console.</p> <p>You can specify the type of source (SourceType) you want to be notified of, provide a list of RDS sources (SourceIds) that triggers the events, and provide a list of event categories (EventCategories) for events you want to be notified of. For example, you can specify SourceType = db-instance, SourceIds = mydbinstance1, mydbinstance2 and EventCategories = Availability, Backup.</p> <p>If you specify both the SourceType and SourceIds, such as SourceType = db-instance and SourceIdentifier = myDBInstance1, you are notified of all the db-instance events for the specified source. If you specify a SourceType but do not specify a SourceIdentifier, you receive notice of the events for that source type for all your RDS sources. If you do not specify either the SourceType nor the SourceIdentifier, you are notified of events generated from all RDS sources belonging to your customer account.</p>",
+    "CreateOptionGroup":"<p>Creates a new option group. You can create up to 20 option groups.</p>",
+    "DeleteDBCluster":"<p>The DeleteDBCluster action deletes a previously provisioned DB cluster. When you delete a DB cluster, all automated backups for that DB cluster are deleted and can't be recovered. Manual DB cluster snapshots of the specified DB cluster are not deleted.</p> <p/> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DeleteDBClusterParameterGroup":"<p>Deletes a specified DB cluster parameter group. The DB cluster parameter group to be deleted can't be associated with any DB clusters.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DeleteDBClusterSnapshot":"<p>Deletes a DB cluster snapshot. If the snapshot is being copied, the copy operation is terminated.</p> <note> <p>The DB cluster snapshot must be in the <code>available</code> state to be deleted.</p> </note> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DeleteDBInstance":"<p>The DeleteDBInstance action deletes a previously provisioned DB instance. When you delete a DB instance, all automated backups for that instance are deleted and can't be recovered. Manual DB snapshots of the DB instance to be deleted by <code>DeleteDBInstance</code> are not deleted.</p> <p> If you request a final DB snapshot the status of the Amazon RDS DB instance is <code>deleting</code> until the DB snapshot is created. The API action <code>DescribeDBInstance</code> is used to monitor the status of this operation. The action can't be canceled or reverted once submitted. </p> <p>Note that when a DB instance is in a failure state and has a status of <code>failed</code>, <code>incompatible-restore</code>, or <code>incompatible-network</code>, you can only delete it when the <code>SkipFinalSnapshot</code> parameter is set to <code>true</code>.</p> <p>If the specified DB instance is part of an Amazon Aurora DB cluster, you can't delete the DB instance if both of the following conditions are true:</p> <ul> <li> <p>The DB cluster is a Read Replica of another Amazon Aurora DB cluster.</p> </li> <li> <p>The DB instance is the only instance in the DB cluster.</p> </li> </ul> <p>To delete a DB instance in this case, first call the <a>PromoteReadReplicaDBCluster</a> API action to promote the DB cluster so it's no longer a Read Replica. After the promotion completes, then call the <code>DeleteDBInstance</code> API action to delete the final instance in the DB cluster.</p>",
+    "DeleteDBParameterGroup":"<p>Deletes a specified DBParameterGroup. The DBParameterGroup to be deleted can't be associated with any DB instances.</p>",
+    "DeleteDBSecurityGroup":"<p>Deletes a DB security group.</p> <note> <p>The specified DB security group must not be associated with any DB instances.</p> </note>",
+    "DeleteDBSnapshot":"<p>Deletes a DBSnapshot. If the snapshot is being copied, the copy operation is terminated.</p> <note> <p>The DBSnapshot must be in the <code>available</code> state to be deleted.</p> </note>",
+    "DeleteDBSubnetGroup":"<p>Deletes a DB subnet group.</p> <note> <p>The specified database subnet group must not be associated with any DB instances.</p> </note>",
+    "DeleteEventSubscription":"<p>Deletes an RDS event notification subscription.</p>",
+    "DeleteOptionGroup":"<p>Deletes an existing option group.</p>",
+    "DescribeAccountAttributes":"<p>Lists all of the attributes for a customer account. The attributes include Amazon RDS quotas for the account, such as the number of DB instances allowed. The description for a quota includes the quota name, current usage toward that quota, and the quota's maximum value.</p> <p>This command doesn't take any parameters.</p>",
+    "DescribeCertificates":"<p>Lists the set of CA certificates provided by Amazon RDS for this AWS account.</p>",
+    "DescribeDBClusterBacktracks":"<p>Returns information about backtracks for a DB cluster.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeDBClusterParameterGroups":"<p> Returns a list of <code>DBClusterParameterGroup</code> descriptions. If a <code>DBClusterParameterGroupName</code> parameter is specified, the list will contain only the description of the specified DB cluster parameter group. </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeDBClusterParameters":"<p>Returns the detailed parameter list for a particular DB cluster parameter group.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeDBClusterSnapshotAttributes":"<p>Returns a list of DB cluster snapshot attribute names and values for a manual DB cluster snapshot.</p> <p>When sharing snapshots with other AWS accounts, <code>DescribeDBClusterSnapshotAttributes</code> returns the <code>restore</code> attribute and a list of IDs for the AWS accounts that are authorized to copy or restore the manual DB cluster snapshot. If <code>all</code> is included in the list of values for the <code>restore</code> attribute, then the manual DB cluster snapshot is public and can be copied or restored by all AWS accounts.</p> <p>To add or remove access for an AWS account to copy or restore a manual DB cluster snapshot, or to make the manual DB cluster snapshot public or private, use the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+    "DescribeDBClusterSnapshots":"<p>Returns information about DB cluster snapshots. This API action supports pagination.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeDBClusters":"<p>Returns information about provisioned Aurora DB clusters. This API supports pagination.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeDBEngineVersions":"<p>Returns a list of the available DB engines.</p>",
+    "DescribeDBInstances":"<p>Returns information about provisioned RDS instances. This API supports pagination.</p>",
+    "DescribeDBLogFiles":"<p>Returns a list of DB log files for the DB instance.</p>",
+    "DescribeDBParameterGroups":"<p> Returns a list of <code>DBParameterGroup</code> descriptions. If a <code>DBParameterGroupName</code> is specified, the list will contain only the description of the specified DB parameter group. </p>",
+    "DescribeDBParameters":"<p>Returns the detailed parameter list for a particular DB parameter group.</p>",
+    "DescribeDBSecurityGroups":"<p> Returns a list of <code>DBSecurityGroup</code> descriptions. If a <code>DBSecurityGroupName</code> is specified, the list will contain only the descriptions of the specified DB security group. </p>",
+    "DescribeDBSnapshotAttributes":"<p>Returns a list of DB snapshot attribute names and values for a manual DB snapshot.</p> <p>When sharing snapshots with other AWS accounts, <code>DescribeDBSnapshotAttributes</code> returns the <code>restore</code> attribute and a list of IDs for the AWS accounts that are authorized to copy or restore the manual DB snapshot. If <code>all</code> is included in the list of values for the <code>restore</code> attribute, then the manual DB snapshot is public and can be copied or restored by all AWS accounts.</p> <p>To add or remove access for an AWS account to copy or restore a manual DB snapshot, or to make the manual DB snapshot public or private, use the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
+    "DescribeDBSnapshots":"<p>Returns information about DB snapshots. This API action supports pagination.</p>",
+    "DescribeDBSubnetGroups":"<p>Returns a list of DBSubnetGroup descriptions. If a DBSubnetGroupName is specified, the list will contain only the descriptions of the specified DBSubnetGroup.</p> <p>For an overview of CIDR ranges, go to the <a href=\"http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing\">Wikipedia Tutorial</a>. </p>",
+    "DescribeEngineDefaultClusterParameters":"<p>Returns the default engine and system parameter information for the cluster database engine.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeEngineDefaultParameters":"<p>Returns the default engine and system parameter information for the specified database engine.</p>",
+    "DescribeEventCategories":"<p>Displays a list of categories for all event source types, or, if specified, for a specified source type. You can see a list of the event categories and source types in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\"> Events</a> topic in the <i>Amazon RDS User Guide.</i> </p>",
+    "DescribeEventSubscriptions":"<p>Lists all the subscription descriptions for a customer account. The description for a subscription includes SubscriptionName, SNSTopicARN, CustomerID, SourceType, SourceID, CreationTime, and Status.</p> <p>If you specify a SubscriptionName, lists the description for that subscription.</p>",
+    "DescribeEvents":"<p>Returns events related to DB instances, DB security groups, DB snapshots, and DB parameter groups for the past 14 days. Events specific to a particular DB instance, DB security group, database snapshot, or DB parameter group can be obtained by providing the name as a parameter. By default, the past hour of events are returned.</p>",
+    "DescribeOptionGroupOptions":"<p>Describes all available options.</p>",
+    "DescribeOptionGroups":"<p>Describes the available option groups.</p>",
+    "DescribeOrderableDBInstanceOptions":"<p>Returns a list of orderable DB instance options for the specified engine.</p>",
+    "DescribePendingMaintenanceActions":"<p>Returns a list of resources (for example, DB instances) that have at least one pending maintenance action.</p>",
+    "DescribeReservedDBInstances":"<p>Returns information about reserved DB instances for this account, or about a specified reserved DB instance.</p>",
+    "DescribeReservedDBInstancesOfferings":"<p>Lists available reserved DB instance offerings.</p>",
+    "DescribeSourceRegions":"<p>Returns a list of the source AWS Regions where the current AWS Region can create a Read Replica or copy a DB snapshot from. This API action supports pagination.</p>",
+    "DescribeValidDBInstanceModifications":"<p>You can call <a>DescribeValidDBInstanceModifications</a> to learn what modifications you can make to your DB instance. You can use this information when you call <a>ModifyDBInstance</a>. </p>",
+    "DownloadDBLogFilePortion":"<p>Downloads all or a portion of the specified log file, up to 1 MB in size.</p>",
+    "FailoverDBCluster":"<p>Forces a failover for a DB cluster.</p> <p>A failover for a DB cluster promotes one of the Aurora Replicas (read-only instances) in the DB cluster to be the primary instance (the cluster writer).</p> <p>Amazon Aurora will automatically fail over to an Aurora Replica, if one exists, when the primary instance fails. You can force a failover when you want to simulate a failure of a primary instance for testing. Because each instance in a DB cluster has its own endpoint address, you will need to clean up and re-establish any existing connections that use those endpoint addresses when the failover is complete.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "ListTagsForResource":"<p>Lists all tags on an Amazon RDS resource.</p> <p>For an overview on tagging an Amazon RDS resource, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
+    "ModifyDBCluster":"<p>Modify a setting for an Amazon Aurora DB cluster. You can change one or more database configuration parameters by specifying these parameters and the new values in the request. For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "ModifyDBClusterParameterGroup":"<p> Modifies the parameters of a DB cluster parameter group. To modify more than one parameter, submit a list of the following: <code>ParameterName</code>, <code>ParameterValue</code>, and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request. </p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p> <note> <p>Changes to dynamic parameters are applied immediately. Changes to static parameters require a reboot without failover to the DB cluster associated with the parameter group before the change can take effect.</p> </note> <important> <p>After you create a DB cluster parameter group, you should wait at least 5 minutes before creating your first DB cluster that uses that DB cluster parameter group as the default parameter group. This allows Amazon RDS to fully complete the create action before the parameter group is used as the default for a new DB cluster. This is especially important for parameters that are critical when creating the default database for a DB cluster, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <a>DescribeDBClusterParameters</a> command to verify that your DB cluster parameter group has been created or modified.</p> </important>",
+    "ModifyDBClusterSnapshotAttribute":"<p>Adds an attribute and values to, or removes an attribute and values from, a manual DB cluster snapshot.</p> <p>To share a manual DB cluster snapshot with other AWS accounts, specify <code>restore</code> as the <code>AttributeName</code> and use the <code>ValuesToAdd</code> parameter to add a list of IDs of the AWS accounts that are authorized to restore the manual DB cluster snapshot. Use the value <code>all</code> to make the manual DB cluster snapshot public, which means that it can be copied or restored by all AWS accounts. Do not add the <code>all</code> value for any manual DB cluster snapshots that contain private information that you don't want available to all AWS accounts. If a manual DB cluster snapshot is encrypted, it can be shared, but only by specifying a list of authorized AWS account IDs for the <code>ValuesToAdd</code> parameter. You can't use <code>all</code> as a value for that parameter in this case.</p> <p>To view which AWS accounts have access to copy or restore a manual DB cluster snapshot, or whether a manual DB cluster snapshot public or private, use the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p>",
+    "ModifyDBInstance":"<p>Modifies settings for a DB instance. You can change one or more database configuration parameters by specifying these parameters and the new values in the request. To learn what modifications you can make to your DB instance, call <a>DescribeValidDBInstanceModifications</a> before you call <a>ModifyDBInstance</a>. </p>",
+    "ModifyDBParameterGroup":"<p> Modifies the parameters of a DB parameter group. To modify more than one parameter, submit a list of the following: <code>ParameterName</code>, <code>ParameterValue</code>, and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request. </p> <note> <p>Changes to dynamic parameters are applied immediately. Changes to static parameters require a reboot without failover to the DB instance associated with the parameter group before the change can take effect.</p> </note> <important> <p>After you modify a DB parameter group, you should wait at least 5 minutes before creating your first DB instance that uses that DB parameter group as the default parameter group. This allows Amazon RDS to fully complete the modify action before the parameter group is used as the default for a new DB instance. This is especially important for parameters that are critical when creating the default database for a DB instance, such as the character set for the default database defined by the <code>character_set_database</code> parameter. You can use the <i>Parameter Groups</i> option of the <a href=\"https://console.aws.amazon.com/rds/\">Amazon RDS console</a> or the <i>DescribeDBParameters</i> command to verify that your DB parameter group has been created or modified.</p> </important>",
+    "ModifyDBSnapshot":"<p>Updates a manual DB snapshot, which can be encrypted or not encrypted, with a new engine version. </p> <p>Amazon RDS supports upgrading DB snapshots for MySQL and Oracle. </p>",
+    "ModifyDBSnapshotAttribute":"<p>Adds an attribute and values to, or removes an attribute and values from, a manual DB snapshot.</p> <p>To share a manual DB snapshot with other AWS accounts, specify <code>restore</code> as the <code>AttributeName</code> and use the <code>ValuesToAdd</code> parameter to add a list of IDs of the AWS accounts that are authorized to restore the manual DB snapshot. Uses the value <code>all</code> to make the manual DB snapshot public, which means it can be copied or restored by all AWS accounts. Do not add the <code>all</code> value for any manual DB snapshots that contain private information that you don't want available to all AWS accounts. If the manual DB snapshot is encrypted, it can be shared, but only by specifying a list of authorized AWS account IDs for the <code>ValuesToAdd</code> parameter. You can't use <code>all</code> as a value for that parameter in this case.</p> <p>To view which AWS accounts have access to copy or restore a manual DB snapshot, or whether a manual DB snapshot public or private, use the <a>DescribeDBSnapshotAttributes</a> API action.</p>",
+    "ModifyDBSubnetGroup":"<p>Modifies an existing DB subnet group. DB subnet groups must contain at least one subnet in at least two AZs in the AWS Region.</p>",
+    "ModifyEventSubscription":"<p>Modifies an existing RDS event notification subscription. Note that you can't modify the source identifiers using this call; to change source identifiers for a subscription, use the <a>AddSourceIdentifierToSubscription</a> and <a>RemoveSourceIdentifierFromSubscription</a> calls.</p> <p>You can see a list of the event categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action.</p>",
+    "ModifyOptionGroup":"<p>Modifies an existing option group.</p>",
+    "PromoteReadReplica":"<p>Promotes a Read Replica DB instance to a standalone DB instance.</p> <note> <ul> <li> <p>Backup duration is a function of the amount of changes to the database since the previous backup. If you plan to promote a Read Replica to a standalone instance, we recommend that you enable backups and complete at least one backup prior to promotion. In addition, a Read Replica cannot be promoted to a standalone instance when it is in the <code>backing-up</code> status. If you have enabled backups on your Read Replica, configure the automated backup window so that daily backups do not interfere with Read Replica promotion.</p> </li> <li> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </li> </ul> </note>",
+    "PromoteReadReplicaDBCluster":"<p>Promotes a Read Replica DB cluster to a standalone DB cluster.</p>",
+    "PurchaseReservedDBInstancesOffering":"<p>Purchases a reserved DB instance offering.</p>",
+    "RebootDBInstance":"<p>You might need to reboot your DB instance, usually for maintenance reasons. For example, if you make certain modifications, or if you change the DB parameter group associated with the DB instance, you must reboot the instance for the changes to take effect. </p> <p>Rebooting a DB instance restarts the database engine service. Rebooting a DB instance results in a momentary outage, during which the DB instance status is set to rebooting. </p> <p>For more information about rebooting, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_RebootInstance.html\">Rebooting a DB Instance</a>. </p>",
+    "RemoveRoleFromDBCluster":"<p>Disassociates an Identity and Access Management (IAM) role from an Aurora DB cluster. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Authorizing.AWSServices.html\">Authorizing Amazon Aurora to Access Other AWS Services On Your Behalf</a>.</p>",
+    "RemoveSourceIdentifierFromSubscription":"<p>Removes a source identifier from an existing RDS event notification subscription.</p>",
+    "RemoveTagsFromResource":"<p>Removes metadata tags from an Amazon RDS resource.</p> <p>For an overview on tagging an Amazon RDS resource, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Tagging.html\">Tagging Amazon RDS Resources</a>.</p>",
+    "ResetDBClusterParameterGroup":"<p> Modifies the parameters of a DB cluster parameter group to the default value. To reset specific parameters submit a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. To reset the entire DB cluster parameter group, specify the <code>DBClusterParameterGroupName</code> and <code>ResetAllParameters</code> parameters. </p> <p> When resetting the entire group, dynamic parameters are updated immediately and static parameters are set to <code>pending-reboot</code> to take effect on the next DB instance restart or <a>RebootDBInstance</a> request. You must call <a>RebootDBInstance</a> for every DB instance in your DB cluster that you want the updated static parameter to apply to.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "ResetDBParameterGroup":"<p>Modifies the parameters of a DB parameter group to the engine/system default value. To reset specific parameters, provide a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. To reset the entire DB parameter group, specify the <code>DBParameterGroup</code> name and <code>ResetAllParameters</code> parameters. When resetting the entire group, dynamic parameters are updated immediately and static parameters are set to <code>pending-reboot</code> to take effect on the next DB instance restart or <code>RebootDBInstance</code> request. </p>",
+    "RestoreDBClusterFromS3":"<p>Creates an Amazon Aurora DB cluster from data stored in an Amazon S3 bucket. Amazon RDS must be authorized to access the Amazon S3 bucket and the data must be created using the Percona XtraBackup utility as described in <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Migrate.MySQL.html#Aurora.Migrate.MySQL.S3\">Migrating Data from MySQL by Using an Amazon S3 Bucket</a>.</p>",
+    "RestoreDBClusterFromSnapshot":"<p>Creates a new DB cluster from a DB snapshot or DB cluster snapshot.</p> <p>If a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.</p> <p>If a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group.</p> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "RestoreDBClusterToPointInTime":"<p>Restores a DB cluster to an arbitrary point in time. Users can restore to any point in time before <code>LatestRestorableTime</code> for up to <code>BackupRetentionPeriod</code> days. The target DB cluster is created from the source DB cluster with the same configuration as the original DB cluster, except that the new DB cluster is created with the default DB security group. </p> <note> <p>This action only restores the DB cluster, not the DB instances for that DB cluster. You must invoke the <a>CreateDBInstance</a> action to create DB instances for the restored DB cluster, specifying the identifier of the restored DB cluster in <code>DBClusterIdentifier</code>. You can create DB instances only after the <code>RestoreDBClusterToPointInTime</code> action has completed and the DB cluster is available.</p> </note> <p>For more information on Amazon Aurora, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html\">Aurora on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p>",
+    "RestoreDBInstanceFromDBSnapshot":"<p>Creates a new DB instance from a DB snapshot. The target database is created from the source database restore point with the most of original configuration with the default security group and the default DB parameter group. By default, the new DB instance is created as a single-AZ deployment except when the instance is a SQL Server instance that has an option group that is associated with mirroring; in this case, the instance becomes a mirrored AZ deployment and not a single-AZ deployment.</p> <p>If your intent is to replace your original DB instance with the new, restored DB instance, then rename your original DB instance before you call the RestoreDBInstanceFromDBSnapshot action. RDS doesn't allow two DB instances with the same name. Once you have renamed your original DB instance with a different identifier, then you can pass the original name of the DB instance as the DBInstanceIdentifier in the call to the RestoreDBInstanceFromDBSnapshot action. The result is that you will replace the original DB instance with the DB instance created from the snapshot.</p> <p>If you are restoring from a shared manual DB snapshot, the <code>DBSnapshotIdentifier</code> must be the ARN of the shared DB snapshot.</p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For Aurora, use <a>RestoreDBClusterFromSnapshot</a>.</p> </note>",
+    "RestoreDBInstanceFromS3":"<p>Amazon Relational Database Service (Amazon RDS) supports importing MySQL databases by using backup files. You can create a backup of your on-premises database, store it on Amazon Simple Storage Service (Amazon S3), and then restore the backup file onto a new Amazon RDS DB instance running MySQL. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html\">Importing Data into an Amazon RDS MySQL DB Instance</a>. </p>",
+    "RestoreDBInstanceToPointInTime":"<p>Restores a DB instance to an arbitrary point in time. You can restore to any point in time before the time identified by the LatestRestorableTime property. You can restore to a point up to the number of days specified by the BackupRetentionPeriod property.</p> <p>The target database is created with most of the original configuration, but in a system-selected Availability Zone, with the default security group, the default subnet group, and the default DB parameter group. By default, the new DB instance is created as a single-AZ deployment except when the instance is a SQL Server instance that has an option group that is associated with mirroring; in this case, the instance becomes a mirrored deployment and not a single-AZ deployment.</p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL. For Aurora, use <a>RestoreDBClusterToPointInTime</a>.</p> </note>",
+    "RevokeDBSecurityGroupIngress":"<p>Revokes ingress from a DBSecurityGroup for previously authorized IP ranges or EC2 or VPC Security Groups. Required parameters for this API are one of CIDRIP, EC2SecurityGroupId for VPC, or (EC2SecurityGroupOwnerId and either EC2SecurityGroupName or EC2SecurityGroupId).</p>",
+    "StartDBInstance":"<p> Starts a DB instance that was stopped using the AWS console, the stop-db-instance AWS CLI command, or the StopDBInstance action. For more information, see Stopping and Starting a DB instance in the AWS RDS user guide. </p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </note>",
+    "StopDBInstance":"<p> Stops a DB instance. When you stop a DB instance, Amazon RDS retains the DB instance's metadata, including its endpoint, DB parameter group, and option group membership. Amazon RDS also retains the transaction logs so you can do a point-in-time restore if necessary. For more information, see Stopping and Starting a DB instance in the AWS RDS user guide. </p> <note> <p>This command doesn't apply to Aurora MySQL and Aurora PostgreSQL.</p> </note>"
   },
-  "shapes": {
-    "AccountAttributesMessage": {
-      "base": "<p>Data returned by the <b>DescribeAccountAttributes</b> action.</p>",
-      "refs": {
+  "shapes":{
+    "AccountAttributesMessage":{
+      "base":"<p>Data returned by the <b>DescribeAccountAttributes</b> action.</p>",
+      "refs":{
       }
     },
-    "AccountQuota": {
-      "base": "<p>Describes a quota for an AWS account, for example, the number of DB instances allowed.</p>",
-      "refs": {
-        "AccountQuotaList$member": null
+    "AccountQuota":{
+      "base":"<p>Describes a quota for an AWS account, for example, the number of DB instances allowed.</p>",
+      "refs":{
+        "AccountQuotaList$member":null
       }
     },
-    "AccountQuotaList": {
-      "base": null,
-      "refs": {
-        "AccountAttributesMessage$AccountQuotas": "<p>A list of <a>AccountQuota</a> objects. Within this list, each quota has a name, a count of usage toward the quota maximum, and a maximum value for the quota.</p>"
+    "AccountQuotaList":{
+      "base":null,
+      "refs":{
+        "AccountAttributesMessage$AccountQuotas":"<p>A list of <a>AccountQuota</a> objects. Within this list, each quota has a name, a count of usage toward the quota maximum, and a maximum value for the quota.</p>"
       }
     },
-    "AddRoleToDBClusterMessage": {
-      "base": null,
-      "refs": {
+    "AddRoleToDBClusterMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "AddSourceIdentifierToSubscriptionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "AddSourceIdentifierToSubscriptionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "AddSourceIdentifierToSubscriptionResult": {
-      "base": null,
-      "refs": {
+    "AddSourceIdentifierToSubscriptionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "AddTagsToResourceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "AddTagsToResourceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ApplyMethod": {
-      "base": null,
-      "refs": {
-        "Parameter$ApplyMethod": "<p>Indicates when to apply parameter updates.</p>"
+    "ApplyMethod":{
+      "base":null,
+      "refs":{
+        "Parameter$ApplyMethod":"<p>Indicates when to apply parameter updates.</p>"
       }
     },
-    "ApplyPendingMaintenanceActionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ApplyPendingMaintenanceActionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ApplyPendingMaintenanceActionResult": {
-      "base": null,
-      "refs": {
+    "ApplyPendingMaintenanceActionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "AttributeValueList": {
-      "base": null,
-      "refs": {
-        "DBClusterSnapshotAttribute$AttributeValues": "<p>The value(s) for the manual DB cluster snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB cluster snapshot. If a value of <code>all</code> is in the list, then the manual DB cluster snapshot is public and available for any AWS account to copy or restore.</p>",
-        "DBSnapshotAttribute$AttributeValues": "<p>The value or values for the manual DB snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB snapshot. If a value of <code>all</code> is in the list, then the manual DB snapshot is public and available for any AWS account to copy or restore.</p>",
-        "ModifyDBClusterSnapshotAttributeMessage$ValuesToAdd": "<p>A list of DB cluster snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB cluster snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB cluster snapshots that contain private information that you don't want available to all AWS accounts.</p>",
-        "ModifyDBClusterSnapshotAttributeMessage$ValuesToRemove": "<p>A list of DB cluster snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB cluster snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore a manual DB cluster snapshot.</p>",
-        "ModifyDBSnapshotAttributeMessage$ValuesToAdd": "<p>A list of DB snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB snapshots that contain private information that you don't want available to all AWS accounts.</p>",
-        "ModifyDBSnapshotAttributeMessage$ValuesToRemove": "<p>A list of DB snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore the manual DB snapshot.</p>"
+    "AttributeValueList":{
+      "base":null,
+      "refs":{
+        "DBClusterSnapshotAttribute$AttributeValues":"<p>The value(s) for the manual DB cluster snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB cluster snapshot. If a value of <code>all</code> is in the list, then the manual DB cluster snapshot is public and available for any AWS account to copy or restore.</p>",
+        "DBSnapshotAttribute$AttributeValues":"<p>The value or values for the manual DB snapshot attribute.</p> <p>If the <code>AttributeName</code> field is set to <code>restore</code>, then this element returns a list of IDs of the AWS accounts that are authorized to copy or restore the manual DB snapshot. If a value of <code>all</code> is in the list, then the manual DB snapshot is public and available for any AWS account to copy or restore.</p>",
+        "ModifyDBClusterSnapshotAttributeMessage$ValuesToAdd":"<p>A list of DB cluster snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB cluster snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB cluster snapshots that contain private information that you don't want available to all AWS accounts.</p>",
+        "ModifyDBClusterSnapshotAttributeMessage$ValuesToRemove":"<p>A list of DB cluster snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB cluster snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore a manual DB cluster snapshot.</p>",
+        "ModifyDBSnapshotAttributeMessage$ValuesToAdd":"<p>A list of DB snapshot attributes to add to the attribute specified by <code>AttributeName</code>.</p> <p>To authorize other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account IDs, or <code>all</code> to make the manual DB snapshot restorable by any AWS account. Do not add the <code>all</code> value for any manual DB snapshots that contain private information that you don't want available to all AWS accounts.</p>",
+        "ModifyDBSnapshotAttributeMessage$ValuesToRemove":"<p>A list of DB snapshot attributes to remove from the attribute specified by <code>AttributeName</code>.</p> <p>To remove authorization for other AWS accounts to copy or restore a manual snapshot, set this list to include one or more AWS account identifiers, or <code>all</code> to remove authorization for any AWS account to copy or restore the DB snapshot. If you specify <code>all</code>, an AWS account whose account ID is explicitly added to the <code>restore</code> attribute can still copy or restore the manual DB snapshot.</p>"
       }
     },
-    "AuthorizationAlreadyExistsFault": {
-      "base": "<p>The specified CIDRIP or Amazon EC2 security group is already authorized for the specified DB security group.</p>",
-      "refs": {
+    "AuthorizationAlreadyExistsFault":{
+      "base":"<p>The specified CIDRIP or Amazon EC2 security group is already authorized for the specified DB security group.</p>",
+      "refs":{
       }
     },
-    "AuthorizationNotFoundFault": {
-      "base": "<p>The specified CIDRIP or Amazon EC2 security group isn't authorized for the specified DB security group.</p> <p>RDS also may not be authorized by using IAM to perform necessary actions on your behalf.</p>",
-      "refs": {
+    "AuthorizationNotFoundFault":{
+      "base":"<p>The specified CIDRIP or Amazon EC2 security group isn't authorized for the specified DB security group.</p> <p>RDS also may not be authorized by using IAM to perform necessary actions on your behalf.</p>",
+      "refs":{
       }
     },
-    "AuthorizationQuotaExceededFault": {
-      "base": "<p>The DB security group authorization quota has been reached.</p>",
-      "refs": {
-      }
-    },
-    "AuthorizeDBSecurityGroupIngressMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "AuthorizeDBSecurityGroupIngressResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "AvailabilityZone": {
-      "base": "<p>Contains Availability Zone information.</p> <p> This data type is used as an element in the following data type:</p> <ul> <li> <p> <a>OrderableDBInstanceOption</a> </p> </li> </ul>",
-      "refs": {
-        "AvailabilityZoneList$member": null,
-        "Subnet$SubnetAvailabilityZone": null
-      }
-    },
-    "AvailabilityZoneList": {
-      "base": null,
-      "refs": {
-        "OrderableDBInstanceOption$AvailabilityZones": "<p>A list of Availability Zones for a DB instance.</p>"
-      }
-    },
-    "AvailabilityZones": {
-      "base": null,
-      "refs": {
-        "CreateDBClusterMessage$AvailabilityZones": "<p>A list of EC2 Availability Zones that instances in the DB cluster can be created in. For information on AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p>",
-        "DBCluster$AvailabilityZones": "<p>Provides the list of EC2 Availability Zones that instances in the DB cluster can be created in.</p>",
-        "DBClusterSnapshot$AvailabilityZones": "<p>Provides the list of EC2 Availability Zones that instances in the DB cluster snapshot can be restored in.</p>",
-        "RestoreDBClusterFromS3Message$AvailabilityZones": "<p>A list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>",
-        "RestoreDBClusterFromSnapshotMessage$AvailabilityZones": "<p>Provides the list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>"
-      }
-    },
-    "AvailableProcessorFeature": {
-      "base": "<p>Contains the available processor feature information for the DB instance class of a DB instance.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#USER_ConfigureProcessor\">Configuring the Processor of the DB Instance Class</a> in the <i>Amazon RDS User Guide. </i> </p>",
-      "refs": {
-        "AvailableProcessorFeatureList$member": null
-      }
-    },
-    "AvailableProcessorFeatureList": {
-      "base": null,
-      "refs": {
-        "OrderableDBInstanceOption$AvailableProcessorFeatures": "<p>A list of the available processor features for the DB instance class of a DB instance.</p>",
-        "ValidDBInstanceModificationsMessage$ValidProcessorFeatures": "<p>Valid processor features for your DB instance. </p>"
-      }
-    },
-    "BacktrackDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "Boolean": {
-      "base": null,
-      "refs": {
-        "DBCluster$MultiAZ": "<p>Specifies whether the DB cluster has instances in multiple Availability Zones.</p>",
-        "DBCluster$StorageEncrypted": "<p>Specifies whether the DB cluster is encrypted.</p>",
-        "DBCluster$IAMDatabaseAuthenticationEnabled": "<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
-        "DBClusterMember$IsClusterWriter": "<p>Value that is <code>true</code> if the cluster member is the primary instance for the DB cluster and <code>false</code> otherwise.</p>",
-        "DBClusterSnapshot$StorageEncrypted": "<p>Specifies whether the DB cluster snapshot is encrypted.</p>",
-        "DBClusterSnapshot$IAMDatabaseAuthenticationEnabled": "<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
-        "DBEngineVersion$SupportsLogExportsToCloudwatchLogs": "<p>A value that indicates whether the engine version supports exporting the log types specified by ExportableLogTypes to CloudWatch Logs.</p>",
-        "DBEngineVersion$SupportsReadReplica": "<p>Indicates whether the database engine version supports read replicas.</p>",
-        "DBInstance$MultiAZ": "<p>Specifies if the DB instance is a Multi-AZ deployment.</p>",
-        "DBInstance$AutoMinorVersionUpgrade": "<p>Indicates that minor version patches are applied automatically.</p>",
-        "DBInstance$PubliclyAccessible": "<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
-        "DBInstance$StorageEncrypted": "<p>Specifies whether the DB instance is encrypted.</p>",
-        "DBInstance$CopyTagsToSnapshot": "<p>Specifies whether tags are copied from the DB instance to snapshots of the DB instance.</p>",
-        "DBInstance$IAMDatabaseAuthenticationEnabled": "<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p> <p>IAM database authentication can be enabled for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher. To enable IAM database authentication for Aurora, see DBCluster Type.</p> </li> </ul>",
-        "DBInstanceStatusInfo$Normal": "<p>Boolean value that is true if the instance is operating normally, or false if the instance is in an error state.</p>",
-        "DBSnapshot$Encrypted": "<p>Specifies whether the DB snapshot is encrypted.</p>",
-        "DBSnapshot$IAMDatabaseAuthenticationEnabled": "<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
-        "DeleteDBClusterMessage$SkipFinalSnapshot": "<p> Determines whether a final DB cluster snapshot is created before the DB cluster is deleted. If <code>true</code> is specified, no DB cluster snapshot is created. If <code>false</code> is specified, a DB cluster snapshot is created before the DB cluster is deleted. </p> <note> <p>You must specify a <code>FinalDBSnapshotIdentifier</code> parameter if <code>SkipFinalSnapshot</code> is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>",
-        "DeleteDBInstanceMessage$SkipFinalSnapshot": "<p> Determines whether a final DB snapshot is created before the DB instance is deleted. If <code>true</code> is specified, no DBSnapshot is created. If <code>false</code> is specified, a DB snapshot is created before the DB instance is deleted. </p> <p>Note that when a DB instance is in a failure state and has a status of 'failed', 'incompatible-restore', or 'incompatible-network', it can only be deleted when the SkipFinalSnapshot parameter is set to \"true\".</p> <p>Specify <code>true</code> when deleting a Read Replica.</p> <note> <p>The FinalDBSnapshotIdentifier parameter must be specified if SkipFinalSnapshot is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>",
-        "DescribeDBClusterSnapshotsMessage$IncludeShared": "<p>True to include shared manual DB cluster snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, and otherwise false. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB cluster snapshot from another AWS account by the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-        "DescribeDBClusterSnapshotsMessage$IncludePublic": "<p>True to include manual DB cluster snapshots that are public and can be copied or restored by any AWS account, and otherwise false. The default is <code>false</code>. The default is false.</p> <p>You can share a manual DB cluster snapshot as public by using the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-        "DescribeDBEngineVersionsMessage$DefaultOnly": "<p>Indicates that only the default version of the specified engine or engine and major version combination is returned.</p>",
-        "DescribeDBSnapshotsMessage$IncludeShared": "<p>True to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, and otherwise false. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB snapshot from another AWS account by using the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
-        "DescribeDBSnapshotsMessage$IncludePublic": "<p>True to include manual DB snapshots that are public and can be copied or restored by any AWS account, and otherwise false. The default is false.</p> <p>You can share a manual DB snapshot as public by using the <a>ModifyDBSnapshotAttribute</a> API.</p>",
-        "DownloadDBLogFilePortionDetails$AdditionalDataPending": "<p>Boolean value that if true, indicates there is more data to be downloaded.</p>",
-        "EventSubscription$Enabled": "<p>A Boolean value indicating if the subscription is enabled. True indicates the subscription is enabled.</p>",
-        "ModifyDBClusterMessage$ApplyImmediately": "<p>A value that specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB cluster. If this parameter is set to <code>false</code>, changes to the DB cluster are applied during the next maintenance window.</p> <p>The <code>ApplyImmediately</code> parameter only affects the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values. If you set the <code>ApplyImmediately</code> parameter value to false, then changes to the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values are applied during the next maintenance window. All other changes are applied immediately, regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: <code>false</code> </p>",
-        "ModifyDBInstanceMessage$ApplyImmediately": "<p>Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB instance. </p> <p> If this parameter is set to <code>false</code>, changes to the DB instance are applied during the next maintenance window. Some parameter changes can cause an outage and are applied on the next call to <a>RebootDBInstance</a>, or the next failure reboot. Review the table of parameters in <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html\">Modifying a DB Instance and Using the Apply Immediately Parameter</a> to see the impact that setting <code>ApplyImmediately</code> to <code>true</code> or <code>false</code> has for each modified parameter and to determine when the changes are applied. </p> <p>Default: <code>false</code> </p>",
-        "ModifyDBInstanceMessage$AllowMajorVersionUpgrade": "<p>Indicates that major version upgrades are allowed. Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints: This parameter must be set to true when specifying a value for the EngineVersion parameter that is a different major version than the DB instance's current version.</p>",
-        "ModifyOptionGroupMessage$ApplyImmediately": "<p>Indicates whether the changes should be applied immediately, or during the next maintenance window for each instance associated with the option group.</p>",
-        "Option$Persistent": "<p>Indicate if this option is persistent.</p>",
-        "Option$Permanent": "<p>Indicate if this option is permanent.</p>",
-        "OptionGroup$AllowsVpcAndNonVpcInstanceMemberships": "<p>Indicates whether this option group can be applied to both VPC and non-VPC instances. The value <code>true</code> indicates the option group can be applied to both VPC and non-VPC instances. </p>",
-        "OptionGroupOption$PortRequired": "<p>Specifies whether the option requires a port.</p>",
-        "OptionGroupOption$Persistent": "<p>Persistent options can't be removed from an option group while DB instances are associated with the option group. If you disassociate all DB instances from the option group, your can remove the persistent option from the option group.</p>",
-        "OptionGroupOption$Permanent": "<p>Permanent options can never be removed from an option group. An option group containing a permanent option can't be removed from a DB instance.</p>",
-        "OptionGroupOption$RequiresAutoMinorEngineVersionUpgrade": "<p>If true, you must enable the Auto Minor Version Upgrade setting for your DB instance before you can use this option. You can enable Auto Minor Version Upgrade when you first create your DB instance, or by modifying your DB instance later. </p>",
-        "OptionGroupOption$VpcOnly": "<p>If true, you can only use this option with a DB instance that is in a VPC. </p>",
-        "OptionGroupOptionSetting$IsModifiable": "<p>Boolean value where true indicates that this option group option can be changed from the default value.</p>",
-        "OptionSetting$IsModifiable": "<p>A Boolean value that, when true, indicates the option setting can be modified from the default.</p>",
-        "OptionSetting$IsCollection": "<p>Indicates if the option setting is part of a collection.</p>",
-        "OptionVersion$IsDefault": "<p>True if the version is the default version of the option, and otherwise false.</p>",
-        "OrderableDBInstanceOption$MultiAZCapable": "<p>Indicates whether a DB instance is Multi-AZ capable.</p>",
-        "OrderableDBInstanceOption$ReadReplicaCapable": "<p>Indicates whether a DB instance can have a Read Replica.</p>",
-        "OrderableDBInstanceOption$Vpc": "<p>Indicates whether a DB instance is in a VPC.</p>",
-        "OrderableDBInstanceOption$SupportsStorageEncryption": "<p>Indicates whether a DB instance supports encrypted storage.</p>",
-        "OrderableDBInstanceOption$SupportsIops": "<p>Indicates whether a DB instance supports provisioned IOPS.</p>",
-        "OrderableDBInstanceOption$SupportsEnhancedMonitoring": "<p>Indicates whether a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.</p>",
-        "OrderableDBInstanceOption$SupportsIAMDatabaseAuthentication": "<p>Indicates whether a DB instance supports IAM database authentication.</p>",
-        "OrderableDBInstanceOption$SupportsPerformanceInsights": "<p>True if a DB instance supports Performance Insights, otherwise false.</p>",
-        "Parameter$IsModifiable": "<p> Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed. </p>",
-        "ReservedDBInstance$MultiAZ": "<p>Indicates if the reservation applies to Multi-AZ deployments.</p>",
-        "ReservedDBInstancesOffering$MultiAZ": "<p>Indicates if the offering applies to Multi-AZ deployments.</p>",
-        "ResetDBClusterParameterGroupMessage$ResetAllParameters": "<p>A value that is set to <code>true</code> to reset all parameters in the DB cluster parameter group to their default values, and <code>false</code> otherwise. You can't use this parameter if there is a list of parameter names specified for the <code>Parameters</code> parameter.</p>",
-        "ResetDBParameterGroupMessage$ResetAllParameters": "<p> Specifies whether (<code>true</code>) or not (<code>false</code>) to reset all parameters in the DB parameter group to default values. </p> <p>Default: <code>true</code> </p>",
-        "RestoreDBClusterToPointInTimeMessage$UseLatestRestorableTime": "<p>A value that is set to <code>true</code> to restore the DB cluster to the latest restorable backup time, and <code>false</code> otherwise. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if <code>RestoreToTime</code> parameter is provided.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$UseLatestRestorableTime": "<p> Specifies whether (<code>true</code>) or not (<code>false</code>) the DB instance is restored from the latest backup time. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if RestoreTime parameter is provided.</p>",
-        "UpgradeTarget$AutoUpgrade": "<p>A value that indicates whether the target version is applied to any source DB instances that have AutoMinorVersionUpgrade set to true.</p>",
-        "UpgradeTarget$IsMajorVersionUpgrade": "<p>A value that indicates whether a database engine is upgraded to a major version.</p>"
-      }
-    },
-    "BooleanOptional": {
-      "base": null,
-      "refs": {
-        "BacktrackDBClusterMessage$Force": "<p>A value that, if specified, forces the DB cluster to backtrack when binary logging is enabled. Otherwise, an error occurs when binary logging is enabled.</p>",
-        "BacktrackDBClusterMessage$UseEarliestTimeOnPointInTimeUnavailable": "<p>If <i>BacktrackTo</i> is set to a timestamp earlier than the earliest backtrack time, this value backtracks the DB cluster to the earliest possible backtrack time. Otherwise, an error occurs.</p>",
-        "CopyDBClusterSnapshotMessage$CopyTags": "<p>True to copy all tags from the source DB cluster snapshot to the target DB cluster snapshot, and otherwise false. The default is false.</p>",
-        "CopyDBSnapshotMessage$CopyTags": "<p>True to copy all tags from the source DB snapshot to the target DB snapshot, and otherwise false. The default is false.</p>",
-        "CreateDBClusterMessage$StorageEncrypted": "<p>Specifies whether the DB cluster is encrypted.</p>",
-        "CreateDBClusterMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
-        "CreateDBInstanceMessage$MultiAZ": "<p>Specifies if the DB instance is a Multi-AZ deployment. You can't set the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p>",
-        "CreateDBInstanceMessage$AutoMinorVersionUpgrade": "<p>Indicates that minor engine upgrades are applied automatically to the DB instance during the maintenance window.</p> <p>Default: <code>true</code> </p>",
-        "CreateDBInstanceMessage$PubliclyAccessible": "<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
-        "CreateDBInstanceMessage$StorageEncrypted": "<p>Specifies whether the DB instance is encrypted.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The encryption for DB instances is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: false</p>",
-        "CreateDBInstanceMessage$CopyTagsToSnapshot": "<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
-        "CreateDBInstanceMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false. </p> <p>You can enable IAM database authentication for the following database engines:</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
-        "CreateDBInstanceMessage$EnablePerformanceInsights": "<p>True to enable Performance Insights for the DB instance, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
-        "CreateDBInstanceReadReplicaMessage$MultiAZ": "<p>Specifies whether the Read Replica is in a Multi-AZ deployment. </p> <p>You can create a Read Replica as a Multi-AZ DB instance. RDS creates a standby of your replica in another Availability Zone for failover support for the replica. Creating your Read Replica as a Multi-AZ DB instance is independent of whether the source database is a Multi-AZ DB instance. </p>",
-        "CreateDBInstanceReadReplicaMessage$AutoMinorVersionUpgrade": "<p>Indicates that minor engine upgrades are applied automatically to the Read Replica during the maintenance window.</p> <p>Default: Inherits from the source DB instance</p>",
-        "CreateDBInstanceReadReplicaMessage$PubliclyAccessible": "<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
-        "CreateDBInstanceReadReplicaMessage$CopyTagsToSnapshot": "<p>True to copy all tags from the Read Replica to snapshots of the Read Replica, and otherwise false. The default is false.</p>",
-        "CreateDBInstanceReadReplicaMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher.</p> </li> </ul> <p>Default: <code>false</code> </p>",
-        "CreateDBInstanceReadReplicaMessage$EnablePerformanceInsights": "<p>True to enable Performance Insights for the read replica, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
-        "CreateDBInstanceReadReplicaMessage$UseDefaultProcessorFeatures": "<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
-        "CreateEventSubscriptionMessage$Enabled": "<p> A Boolean value; set to <b>true</b> to activate the subscription, set to <b>false</b> to create the subscription but not active it. </p>",
-        "DBInstance$PerformanceInsightsEnabled": "<p>True if Performance Insights is enabled for the DB instance, and otherwise false.</p>",
-        "DescribeDBEngineVersionsMessage$ListSupportedCharacterSets": "<p>If this parameter is specified and the requested engine supports the <code>CharacterSetName</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported character sets for each engine version. </p>",
-        "DescribeDBEngineVersionsMessage$ListSupportedTimezones": "<p>If this parameter is specified and the requested engine supports the <code>TimeZone</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported time zones for each engine version. </p>",
-        "DescribeOrderableDBInstanceOptionsMessage$Vpc": "<p>The VPC filter value. Specify this parameter to show only the available VPC or non-VPC offerings.</p>",
-        "DescribeReservedDBInstancesMessage$MultiAZ": "<p>The Multi-AZ filter value. Specify this parameter to show only those reservations matching the specified Multi-AZ parameter.</p>",
-        "DescribeReservedDBInstancesOfferingsMessage$MultiAZ": "<p>The Multi-AZ filter value. Specify this parameter to show only the available offerings matching the specified Multi-AZ parameter.</p>",
-        "ModifyDBClusterMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
-        "ModifyDBInstanceMessage$MultiAZ": "<p>Specifies if the DB instance is a Multi-AZ deployment. Changing this parameter doesn't result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p>",
-        "ModifyDBInstanceMessage$AutoMinorVersionUpgrade": "<p> Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window. Changing this parameter doesn't result in an outage except in the following case and the change is asynchronously applied as soon as possible. An outage will result if this parameter is set to <code>true</code> during the maintenance window, and a newer minor version is available, and RDS has enabled auto patching for that engine version. </p>",
-        "ModifyDBInstanceMessage$CopyTagsToSnapshot": "<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
-        "ModifyDBInstanceMessage$PubliclyAccessible": "<p>Boolean value that indicates if the DB instance has a publicly resolvable DNS name. Set to <code>True</code> to make the DB instance Internet-facing with a publicly resolvable DNS name, which resolves to a public IP address. Set to <code>False</code> to make the DB instance internal with a DNS name that resolves to a private IP address. </p> <p> <code>PubliclyAccessible</code> only applies to DB instances in a VPC. The DB instance must be part of a public subnet and <code>PubliclyAccessible</code> must be true in order for it to be publicly accessible. </p> <p>Changes to the <code>PubliclyAccessible</code> parameter are applied immediately regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: false</p>",
-        "ModifyDBInstanceMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
-        "ModifyDBInstanceMessage$EnablePerformanceInsights": "<p>True to enable Performance Insights for the DB instance, and otherwise false.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
-        "ModifyDBInstanceMessage$UseDefaultProcessorFeatures": "<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
-        "ModifyEventSubscriptionMessage$Enabled": "<p> A Boolean value; set to <b>true</b> to activate the subscription. </p>",
-        "OptionGroupOption$SupportsOptionVersionDowngrade": "<p>If true, you can change the option to an earlier version of the option. This only applies to options that have different versions available. </p>",
-        "PendingModifiedValues$MultiAZ": "<p>Indicates that the Single-AZ DB instance is to change to a Multi-AZ deployment.</p>",
-        "RebootDBInstanceMessage$ForceFailover": "<p> When <code>true</code>, the reboot is conducted through a MultiAZ failover. </p> <p>Constraint: You can't specify <code>true</code> if the instance is not configured for MultiAZ.</p>",
-        "RestoreDBClusterFromS3Message$StorageEncrypted": "<p>Specifies whether the restored DB cluster is encrypted.</p>",
-        "RestoreDBClusterFromS3Message$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
-        "RestoreDBClusterFromSnapshotMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
-        "RestoreDBClusterToPointInTimeMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$MultiAZ": "<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$PubliclyAccessible": "<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$AutoMinorVersionUpgrade": "<p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$CopyTagsToSnapshot": "<p>True to copy all tags from the restored DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$UseDefaultProcessorFeatures": "<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
-        "RestoreDBInstanceFromS3Message$MultiAZ": "<p>Specifies whether the DB instance is a Multi-AZ deployment. If MultiAZ is set to <code>true</code>, you can't set the AvailabilityZone parameter. </p>",
-        "RestoreDBInstanceFromS3Message$AutoMinorVersionUpgrade": "<p>True to indicate that minor engine upgrades are applied automatically to the DB instance during the maintenance window, and otherwise false. </p> <p>Default: <code>true</code> </p>",
-        "RestoreDBInstanceFromS3Message$PubliclyAccessible": "<p>Specifies whether the DB instance is publicly accessible or not. For more information, see <a>CreateDBInstance</a>. </p>",
-        "RestoreDBInstanceFromS3Message$StorageEncrypted": "<p>Specifies whether the new DB instance is encrypted or not. </p>",
-        "RestoreDBInstanceFromS3Message$CopyTagsToSnapshot": "<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. </p> <p>Default: false. </p>",
-        "RestoreDBInstanceFromS3Message$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false. </p> <p>Default: <code>false</code> </p>",
-        "RestoreDBInstanceFromS3Message$EnablePerformanceInsights": "<p>True to enable Performance Insights for the DB instance, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
-        "RestoreDBInstanceFromS3Message$UseDefaultProcessorFeatures": "<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$MultiAZ": "<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$PubliclyAccessible": "<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$AutoMinorVersionUpgrade": "<p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$CopyTagsToSnapshot": "<p>True to copy all tags from the restored DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$EnableIAMDatabaseAuthentication": "<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$UseDefaultProcessorFeatures": "<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>"
-      }
-    },
-    "Certificate": {
-      "base": "<p>A CA certificate for an AWS account.</p>",
-      "refs": {
-        "CertificateList$member": null
-      }
-    },
-    "CertificateList": {
-      "base": null,
-      "refs": {
-        "CertificateMessage$Certificates": "<p>The list of <a>Certificate</a> objects for the AWS account.</p>"
-      }
-    },
-    "CertificateMessage": {
-      "base": "<p>Data returned by the <b>DescribeCertificates</b> action.</p>",
-      "refs": {
-      }
-    },
-    "CertificateNotFoundFault": {
-      "base": "<p> <i>CertificateIdentifier</i> doesn't refer to an existing certificate. </p>",
-      "refs": {
-      }
-    },
-    "CharacterSet": {
-      "base": "<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
-      "refs": {
-        "DBEngineVersion$DefaultCharacterSet": "<p> The default character set for new instances of this engine version, if the <code>CharacterSetName</code> parameter of the CreateDBInstance API is not specified. </p>",
-        "SupportedCharacterSetsList$member": null
-      }
-    },
-    "CloudwatchLogsExportConfiguration": {
-      "base": "<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance or DB cluster.</p>",
-      "refs": {
-        "ModifyDBClusterMessage$CloudwatchLogsExportConfiguration": "<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB cluster.</p>",
-        "ModifyDBInstanceMessage$CloudwatchLogsExportConfiguration": "<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance.</p>"
-      }
-    },
-    "CopyDBClusterParameterGroupMessage": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CopyDBClusterParameterGroupResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CopyDBClusterSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CopyDBClusterSnapshotResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CopyDBParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CopyDBParameterGroupResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CopyDBSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CopyDBSnapshotResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CopyOptionGroupMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CopyOptionGroupResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CreateDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CreateDBClusterParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CreateDBClusterParameterGroupResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CreateDBClusterResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CreateDBClusterSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CreateDBClusterSnapshotResult": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CreateDBInstanceMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "CreateDBInstanceReadReplicaMessage": {
-      "base": null,
-      "refs": {
-      }
-    },
-    "CreateDBInstanceReadReplicaResult": {
-      "base": null,
-      "refs": {
+    "AuthorizationQuotaExceededFault":{
+      "base":"<p>The DB security group authorization quota has been reached.</p>",
+      "refs":{
+      }
+    },
+    "AuthorizeDBSecurityGroupIngressMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "AuthorizeDBSecurityGroupIngressResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "AvailabilityZone":{
+      "base":"<p>Contains Availability Zone information.</p> <p> This data type is used as an element in the following data type:</p> <ul> <li> <p> <a>OrderableDBInstanceOption</a> </p> </li> </ul>",
+      "refs":{
+        "AvailabilityZoneList$member":null,
+        "Subnet$SubnetAvailabilityZone":null
+      }
+    },
+    "AvailabilityZoneList":{
+      "base":null,
+      "refs":{
+        "OrderableDBInstanceOption$AvailabilityZones":"<p>A list of Availability Zones for a DB instance.</p>"
+      }
+    },
+    "AvailabilityZones":{
+      "base":null,
+      "refs":{
+        "CreateDBClusterMessage$AvailabilityZones":"<p>A list of EC2 Availability Zones that instances in the DB cluster can be created in. For information on AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p>",
+        "DBCluster$AvailabilityZones":"<p>Provides the list of EC2 Availability Zones that instances in the DB cluster can be created in.</p>",
+        "DBClusterSnapshot$AvailabilityZones":"<p>Provides the list of EC2 Availability Zones that instances in the DB cluster snapshot can be restored in.</p>",
+        "RestoreDBClusterFromS3Message$AvailabilityZones":"<p>A list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>",
+        "RestoreDBClusterFromSnapshotMessage$AvailabilityZones":"<p>Provides the list of EC2 Availability Zones that instances in the restored DB cluster can be created in.</p>"
+      }
+    },
+    "AvailableProcessorFeature":{
+      "base":"<p>Contains the available processor feature information for the DB instance class of a DB instance.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#USER_ConfigureProcessor\">Configuring the Processor of the DB Instance Class</a> in the <i>Amazon RDS User Guide. </i> </p>",
+      "refs":{
+        "AvailableProcessorFeatureList$member":null
+      }
+    },
+    "AvailableProcessorFeatureList":{
+      "base":null,
+      "refs":{
+        "OrderableDBInstanceOption$AvailableProcessorFeatures":"<p>A list of the available processor features for the DB instance class of a DB instance.</p>",
+        "ValidDBInstanceModificationsMessage$ValidProcessorFeatures":"<p>Valid processor features for your DB instance. </p>"
+      }
+    },
+    "BacktrackDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "Boolean":{
+      "base":null,
+      "refs":{
+        "DBCluster$MultiAZ":"<p>Specifies whether the DB cluster has instances in multiple Availability Zones.</p>",
+        "DBCluster$StorageEncrypted":"<p>Specifies whether the DB cluster is encrypted.</p>",
+        "DBCluster$IAMDatabaseAuthenticationEnabled":"<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
+        "DBClusterMember$IsClusterWriter":"<p>Value that is <code>true</code> if the cluster member is the primary instance for the DB cluster and <code>false</code> otherwise.</p>",
+        "DBClusterSnapshot$StorageEncrypted":"<p>Specifies whether the DB cluster snapshot is encrypted.</p>",
+        "DBClusterSnapshot$IAMDatabaseAuthenticationEnabled":"<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
+        "DBEngineVersion$SupportsLogExportsToCloudwatchLogs":"<p>A value that indicates whether the engine version supports exporting the log types specified by ExportableLogTypes to CloudWatch Logs.</p>",
+        "DBEngineVersion$SupportsReadReplica":"<p>Indicates whether the database engine version supports read replicas.</p>",
+        "DBInstance$MultiAZ":"<p>Specifies if the DB instance is a Multi-AZ deployment.</p>",
+        "DBInstance$AutoMinorVersionUpgrade":"<p>Indicates that minor version patches are applied automatically.</p>",
+        "DBInstance$PubliclyAccessible":"<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
+        "DBInstance$StorageEncrypted":"<p>Specifies whether the DB instance is encrypted.</p>",
+        "DBInstance$CopyTagsToSnapshot":"<p>Specifies whether tags are copied from the DB instance to snapshots of the DB instance.</p>",
+        "DBInstance$IAMDatabaseAuthenticationEnabled":"<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p> <p>IAM database authentication can be enabled for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher. To enable IAM database authentication for Aurora, see DBCluster Type.</p> </li> </ul>",
+        "DBInstanceStatusInfo$Normal":"<p>Boolean value that is true if the instance is operating normally, or false if the instance is in an error state.</p>",
+        "DBSnapshot$Encrypted":"<p>Specifies whether the DB snapshot is encrypted.</p>",
+        "DBSnapshot$IAMDatabaseAuthenticationEnabled":"<p>True if mapping of AWS Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false.</p>",
+        "DeleteDBClusterMessage$SkipFinalSnapshot":"<p> Determines whether a final DB cluster snapshot is created before the DB cluster is deleted. If <code>true</code> is specified, no DB cluster snapshot is created. If <code>false</code> is specified, a DB cluster snapshot is created before the DB cluster is deleted. </p> <note> <p>You must specify a <code>FinalDBSnapshotIdentifier</code> parameter if <code>SkipFinalSnapshot</code> is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>",
+        "DeleteDBInstanceMessage$SkipFinalSnapshot":"<p> Determines whether a final DB snapshot is created before the DB instance is deleted. If <code>true</code> is specified, no DBSnapshot is created. If <code>false</code> is specified, a DB snapshot is created before the DB instance is deleted. </p> <p>Note that when a DB instance is in a failure state and has a status of 'failed', 'incompatible-restore', or 'incompatible-network', it can only be deleted when the SkipFinalSnapshot parameter is set to \"true\".</p> <p>Specify <code>true</code> when deleting a Read Replica.</p> <note> <p>The FinalDBSnapshotIdentifier parameter must be specified if SkipFinalSnapshot is <code>false</code>.</p> </note> <p>Default: <code>false</code> </p>",
+        "DescribeDBClusterSnapshotsMessage$IncludeShared":"<p>True to include shared manual DB cluster snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, and otherwise false. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB cluster snapshot from another AWS account by the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+        "DescribeDBClusterSnapshotsMessage$IncludePublic":"<p>True to include manual DB cluster snapshots that are public and can be copied or restored by any AWS account, and otherwise false. The default is <code>false</code>. The default is false.</p> <p>You can share a manual DB cluster snapshot as public by using the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+        "DescribeDBEngineVersionsMessage$DefaultOnly":"<p>Indicates that only the default version of the specified engine or engine and major version combination is returned.</p>",
+        "DescribeDBSnapshotsMessage$IncludeShared":"<p>True to include shared manual DB snapshots from other AWS accounts that this AWS account has been given permission to copy or restore, and otherwise false. The default is <code>false</code>.</p> <p>You can give an AWS account permission to restore a manual DB snapshot from another AWS account by using the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
+        "DescribeDBSnapshotsMessage$IncludePublic":"<p>True to include manual DB snapshots that are public and can be copied or restored by any AWS account, and otherwise false. The default is false.</p> <p>You can share a manual DB snapshot as public by using the <a>ModifyDBSnapshotAttribute</a> API.</p>",
+        "DownloadDBLogFilePortionDetails$AdditionalDataPending":"<p>Boolean value that if true, indicates there is more data to be downloaded.</p>",
+        "EventSubscription$Enabled":"<p>A Boolean value indicating if the subscription is enabled. True indicates the subscription is enabled.</p>",
+        "ModifyDBClusterMessage$ApplyImmediately":"<p>A value that specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB cluster. If this parameter is set to <code>false</code>, changes to the DB cluster are applied during the next maintenance window.</p> <p>The <code>ApplyImmediately</code> parameter only affects the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values. If you set the <code>ApplyImmediately</code> parameter value to false, then changes to the <code>NewDBClusterIdentifier</code> and <code>MasterUserPassword</code> values are applied during the next maintenance window. All other changes are applied immediately, regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: <code>false</code> </p>",
+        "ModifyDBInstanceMessage$ApplyImmediately":"<p>Specifies whether the modifications in this request and any pending modifications are asynchronously applied as soon as possible, regardless of the <code>PreferredMaintenanceWindow</code> setting for the DB instance. </p> <p> If this parameter is set to <code>false</code>, changes to the DB instance are applied during the next maintenance window. Some parameter changes can cause an outage and are applied on the next call to <a>RebootDBInstance</a>, or the next failure reboot. Review the table of parameters in <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html\">Modifying a DB Instance and Using the Apply Immediately Parameter</a> to see the impact that setting <code>ApplyImmediately</code> to <code>true</code> or <code>false</code> has for each modified parameter and to determine when the changes are applied. </p> <p>Default: <code>false</code> </p>",
+        "ModifyDBInstanceMessage$AllowMajorVersionUpgrade":"<p>Indicates that major version upgrades are allowed. Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints: This parameter must be set to true when specifying a value for the EngineVersion parameter that is a different major version than the DB instance's current version.</p>",
+        "ModifyOptionGroupMessage$ApplyImmediately":"<p>Indicates whether the changes should be applied immediately, or during the next maintenance window for each instance associated with the option group.</p>",
+        "Option$Persistent":"<p>Indicate if this option is persistent.</p>",
+        "Option$Permanent":"<p>Indicate if this option is permanent.</p>",
+        "OptionGroup$AllowsVpcAndNonVpcInstanceMemberships":"<p>Indicates whether this option group can be applied to both VPC and non-VPC instances. The value <code>true</code> indicates the option group can be applied to both VPC and non-VPC instances. </p>",
+        "OptionGroupOption$PortRequired":"<p>Specifies whether the option requires a port.</p>",
+        "OptionGroupOption$Persistent":"<p>Persistent options can't be removed from an option group while DB instances are associated with the option group. If you disassociate all DB instances from the option group, your can remove the persistent option from the option group.</p>",
+        "OptionGroupOption$Permanent":"<p>Permanent options can never be removed from an option group. An option group containing a permanent option can't be removed from a DB instance.</p>",
+        "OptionGroupOption$RequiresAutoMinorEngineVersionUpgrade":"<p>If true, you must enable the Auto Minor Version Upgrade setting for your DB instance before you can use this option. You can enable Auto Minor Version Upgrade when you first create your DB instance, or by modifying your DB instance later. </p>",
+        "OptionGroupOption$VpcOnly":"<p>If true, you can only use this option with a DB instance that is in a VPC. </p>",
+        "OptionGroupOptionSetting$IsModifiable":"<p>Boolean value where true indicates that this option group option can be changed from the default value.</p>",
+        "OptionSetting$IsModifiable":"<p>A Boolean value that, when true, indicates the option setting can be modified from the default.</p>",
+        "OptionSetting$IsCollection":"<p>Indicates if the option setting is part of a collection.</p>",
+        "OptionVersion$IsDefault":"<p>True if the version is the default version of the option, and otherwise false.</p>",
+        "OrderableDBInstanceOption$MultiAZCapable":"<p>Indicates whether a DB instance is Multi-AZ capable.</p>",
+        "OrderableDBInstanceOption$ReadReplicaCapable":"<p>Indicates whether a DB instance can have a Read Replica.</p>",
+        "OrderableDBInstanceOption$Vpc":"<p>Indicates whether a DB instance is in a VPC.</p>",
+        "OrderableDBInstanceOption$SupportsStorageEncryption":"<p>Indicates whether a DB instance supports encrypted storage.</p>",
+        "OrderableDBInstanceOption$SupportsIops":"<p>Indicates whether a DB instance supports provisioned IOPS.</p>",
+        "OrderableDBInstanceOption$SupportsEnhancedMonitoring":"<p>Indicates whether a DB instance supports Enhanced Monitoring at intervals from 1 to 60 seconds.</p>",
+        "OrderableDBInstanceOption$SupportsIAMDatabaseAuthentication":"<p>Indicates whether a DB instance supports IAM database authentication.</p>",
+        "OrderableDBInstanceOption$SupportsPerformanceInsights":"<p>True if a DB instance supports Performance Insights, otherwise false.</p>",
+        "Parameter$IsModifiable":"<p> Indicates whether (<code>true</code>) or not (<code>false</code>) the parameter can be modified. Some parameters have security or operational implications that prevent them from being changed. </p>",
+        "ReservedDBInstance$MultiAZ":"<p>Indicates if the reservation applies to Multi-AZ deployments.</p>",
+        "ReservedDBInstancesOffering$MultiAZ":"<p>Indicates if the offering applies to Multi-AZ deployments.</p>",
+        "ResetDBClusterParameterGroupMessage$ResetAllParameters":"<p>A value that is set to <code>true</code> to reset all parameters in the DB cluster parameter group to their default values, and <code>false</code> otherwise. You can't use this parameter if there is a list of parameter names specified for the <code>Parameters</code> parameter.</p>",
+        "ResetDBParameterGroupMessage$ResetAllParameters":"<p> Specifies whether (<code>true</code>) or not (<code>false</code>) to reset all parameters in the DB parameter group to default values. </p> <p>Default: <code>true</code> </p>",
+        "RestoreDBClusterToPointInTimeMessage$UseLatestRestorableTime":"<p>A value that is set to <code>true</code> to restore the DB cluster to the latest restorable backup time, and <code>false</code> otherwise. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if <code>RestoreToTime</code> parameter is provided.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$UseLatestRestorableTime":"<p> Specifies whether (<code>true</code>) or not (<code>false</code>) the DB instance is restored from the latest backup time. </p> <p>Default: <code>false</code> </p> <p>Constraints: Cannot be specified if RestoreTime parameter is provided.</p>",
+        "UpgradeTarget$AutoUpgrade":"<p>A value that indicates whether the target version is applied to any source DB instances that have AutoMinorVersionUpgrade set to true.</p>",
+        "UpgradeTarget$IsMajorVersionUpgrade":"<p>A value that indicates whether a database engine is upgraded to a major version.</p>"
+      }
+    },
+    "BooleanOptional":{
+      "base":null,
+      "refs":{
+        "BacktrackDBClusterMessage$Force":"<p>A value that, if specified, forces the DB cluster to backtrack when binary logging is enabled. Otherwise, an error occurs when binary logging is enabled.</p>",
+        "BacktrackDBClusterMessage$UseEarliestTimeOnPointInTimeUnavailable":"<p>If <i>BacktrackTo</i> is set to a timestamp earlier than the earliest backtrack time, this value backtracks the DB cluster to the earliest possible backtrack time. Otherwise, an error occurs.</p>",
+        "CopyDBClusterSnapshotMessage$CopyTags":"<p>True to copy all tags from the source DB cluster snapshot to the target DB cluster snapshot, and otherwise false. The default is false.</p>",
+        "CopyDBSnapshotMessage$CopyTags":"<p>True to copy all tags from the source DB snapshot to the target DB snapshot, and otherwise false. The default is false.</p>",
+        "CreateDBClusterMessage$StorageEncrypted":"<p>Specifies whether the DB cluster is encrypted.</p>",
+        "CreateDBClusterMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
+        "CreateDBInstanceMessage$MultiAZ":"<p>Specifies if the DB instance is a Multi-AZ deployment. You can't set the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p>",
+        "CreateDBInstanceMessage$AutoMinorVersionUpgrade":"<p>Indicates that minor engine upgrades are applied automatically to the DB instance during the maintenance window.</p> <p>Default: <code>true</code> </p>",
+        "CreateDBInstanceMessage$PubliclyAccessible":"<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
+        "CreateDBInstanceMessage$StorageEncrypted":"<p>Specifies whether the DB instance is encrypted.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The encryption for DB instances is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: false</p>",
+        "CreateDBInstanceMessage$CopyTagsToSnapshot":"<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
+        "CreateDBInstanceMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false. </p> <p>You can enable IAM database authentication for the following database engines:</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
+        "CreateDBInstanceMessage$EnablePerformanceInsights":"<p>True to enable Performance Insights for the DB instance, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
+        "CreateDBInstanceReadReplicaMessage$MultiAZ":"<p>Specifies whether the Read Replica is in a Multi-AZ deployment. </p> <p>You can create a Read Replica as a Multi-AZ DB instance. RDS creates a standby of your replica in another Availability Zone for failover support for the replica. Creating your Read Replica as a Multi-AZ DB instance is independent of whether the source database is a Multi-AZ DB instance. </p>",
+        "CreateDBInstanceReadReplicaMessage$AutoMinorVersionUpgrade":"<p>Indicates that minor engine upgrades are applied automatically to the Read Replica during the maintenance window.</p> <p>Default: Inherits from the source DB instance</p>",
+        "CreateDBInstanceReadReplicaMessage$PubliclyAccessible":"<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
+        "CreateDBInstanceReadReplicaMessage$CopyTagsToSnapshot":"<p>True to copy all tags from the Read Replica to snapshots of the Read Replica, and otherwise false. The default is false.</p>",
+        "CreateDBInstanceReadReplicaMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> <li> <p>Aurora 5.6 or higher.</p> </li> </ul> <p>Default: <code>false</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$EnablePerformanceInsights":"<p>True to enable Performance Insights for the read replica, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
+        "CreateDBInstanceReadReplicaMessage$UseDefaultProcessorFeatures":"<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
+        "CreateEventSubscriptionMessage$Enabled":"<p> A Boolean value; set to <b>true</b> to activate the subscription, set to <b>false</b> to create the subscription but not active it. </p>",
+        "DBInstance$PerformanceInsightsEnabled":"<p>True if Performance Insights is enabled for the DB instance, and otherwise false.</p>",
+        "DescribeDBEngineVersionsMessage$ListSupportedCharacterSets":"<p>If this parameter is specified and the requested engine supports the <code>CharacterSetName</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported character sets for each engine version. </p>",
+        "DescribeDBEngineVersionsMessage$ListSupportedTimezones":"<p>If this parameter is specified and the requested engine supports the <code>TimeZone</code> parameter for <code>CreateDBInstance</code>, the response includes a list of supported time zones for each engine version. </p>",
+        "DescribeOrderableDBInstanceOptionsMessage$Vpc":"<p>The VPC filter value. Specify this parameter to show only the available VPC or non-VPC offerings.</p>",
+        "DescribeReservedDBInstancesMessage$MultiAZ":"<p>The Multi-AZ filter value. Specify this parameter to show only those reservations matching the specified Multi-AZ parameter.</p>",
+        "DescribeReservedDBInstancesOfferingsMessage$MultiAZ":"<p>The Multi-AZ filter value. Specify this parameter to show only the available offerings matching the specified Multi-AZ parameter.</p>",
+        "ModifyDBClusterMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
+        "ModifyDBInstanceMessage$MultiAZ":"<p>Specifies if the DB instance is a Multi-AZ deployment. Changing this parameter doesn't result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p>",
+        "ModifyDBInstanceMessage$AutoMinorVersionUpgrade":"<p> Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window. Changing this parameter doesn't result in an outage except in the following case and the change is asynchronously applied as soon as possible. An outage will result if this parameter is set to <code>true</code> during the maintenance window, and a newer minor version is available, and RDS has enabled auto patching for that engine version. </p>",
+        "ModifyDBInstanceMessage$CopyTagsToSnapshot":"<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
+        "ModifyDBInstanceMessage$PubliclyAccessible":"<p>Boolean value that indicates if the DB instance has a publicly resolvable DNS name. Set to <code>True</code> to make the DB instance Internet-facing with a publicly resolvable DNS name, which resolves to a public IP address. Set to <code>False</code> to make the DB instance internal with a DNS name that resolves to a private IP address. </p> <p> <code>PubliclyAccessible</code> only applies to DB instances in a VPC. The DB instance must be part of a public subnet and <code>PubliclyAccessible</code> must be true in order for it to be publicly accessible. </p> <p>Changes to the <code>PubliclyAccessible</code> parameter are applied immediately regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p>Default: false</p>",
+        "ModifyDBInstanceMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p> <b>MySQL</b> </p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
+        "ModifyDBInstanceMessage$EnablePerformanceInsights":"<p>True to enable Performance Insights for the DB instance, and otherwise false.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
+        "ModifyDBInstanceMessage$UseDefaultProcessorFeatures":"<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
+        "ModifyEventSubscriptionMessage$Enabled":"<p> A Boolean value; set to <b>true</b> to activate the subscription. </p>",
+        "OptionGroupOption$SupportsOptionVersionDowngrade":"<p>If true, you can change the option to an earlier version of the option. This only applies to options that have different versions available. </p>",
+        "PendingModifiedValues$MultiAZ":"<p>Indicates that the Single-AZ DB instance is to change to a Multi-AZ deployment.</p>",
+        "RebootDBInstanceMessage$ForceFailover":"<p> When <code>true</code>, the reboot is conducted through a MultiAZ failover. </p> <p>Constraint: You can't specify <code>true</code> if the instance is not configured for MultiAZ.</p>",
+        "RestoreDBClusterFromS3Message$StorageEncrypted":"<p>Specifies whether the restored DB cluster is encrypted.</p>",
+        "RestoreDBClusterFromS3Message$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
+        "RestoreDBClusterFromSnapshotMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
+        "RestoreDBClusterToPointInTimeMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>Default: <code>false</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$MultiAZ":"<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$PubliclyAccessible":"<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b> true</p> </li> <li> <p> <b>VPC:</b> false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$AutoMinorVersionUpgrade":"<p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$CopyTagsToSnapshot":"<p>True to copy all tags from the restored DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$UseDefaultProcessorFeatures":"<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
+        "RestoreDBInstanceFromS3Message$MultiAZ":"<p>Specifies whether the DB instance is a Multi-AZ deployment. If MultiAZ is set to <code>true</code>, you can't set the AvailabilityZone parameter. </p>",
+        "RestoreDBInstanceFromS3Message$AutoMinorVersionUpgrade":"<p>True to indicate that minor engine upgrades are applied automatically to the DB instance during the maintenance window, and otherwise false. </p> <p>Default: <code>true</code> </p>",
+        "RestoreDBInstanceFromS3Message$PubliclyAccessible":"<p>Specifies whether the DB instance is publicly accessible or not. For more information, see <a>CreateDBInstance</a>. </p>",
+        "RestoreDBInstanceFromS3Message$StorageEncrypted":"<p>Specifies whether the new DB instance is encrypted or not. </p>",
+        "RestoreDBInstanceFromS3Message$CopyTagsToSnapshot":"<p>True to copy all tags from the DB instance to snapshots of the DB instance, and otherwise false. </p> <p>Default: false. </p>",
+        "RestoreDBInstanceFromS3Message$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false. </p> <p>Default: <code>false</code> </p>",
+        "RestoreDBInstanceFromS3Message$EnablePerformanceInsights":"<p>True to enable Performance Insights for the DB instance, and otherwise false. </p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html\">Using Amazon Performance Insights</a> in the <i>Amazon Relational Database Service User Guide</i>. </p>",
+        "RestoreDBInstanceFromS3Message$UseDefaultProcessorFeatures":"<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$MultiAZ":"<p>Specifies if the DB instance is a Multi-AZ deployment.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$PubliclyAccessible":"<p>Specifies the accessibility options for the DB instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address.</p> <p>Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.</p> <ul> <li> <p> <b>Default VPC:</b>true</p> </li> <li> <p> <b>VPC:</b>false</p> </li> </ul> <p>If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance is private.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$AutoMinorVersionUpgrade":"<p>Indicates that minor version upgrades are applied automatically to the DB instance during the maintenance window.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$CopyTagsToSnapshot":"<p>True to copy all tags from the restored DB instance to snapshots of the DB instance, and otherwise false. The default is false.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$EnableIAMDatabaseAuthentication":"<p>True to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts, and otherwise false.</p> <p>You can enable IAM database authentication for the following database engines</p> <ul> <li> <p>For MySQL 5.6, minor version 5.6.34 or higher</p> </li> <li> <p>For MySQL 5.7, minor version 5.7.16 or higher</p> </li> </ul> <p>Default: <code>false</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$UseDefaultProcessorFeatures":"<p>A value that specifies that the DB instance class of the DB instance uses its default processor features.</p>"
+      }
+    },
+    "Certificate":{
+      "base":"<p>A CA certificate for an AWS account.</p>",
+      "refs":{
+        "CertificateList$member":null
+      }
+    },
+    "CertificateList":{
+      "base":null,
+      "refs":{
+        "CertificateMessage$Certificates":"<p>The list of <a>Certificate</a> objects for the AWS account.</p>"
+      }
+    },
+    "CertificateMessage":{
+      "base":"<p>Data returned by the <b>DescribeCertificates</b> action.</p>",
+      "refs":{
+      }
+    },
+    "CertificateNotFoundFault":{
+      "base":"<p> <i>CertificateIdentifier</i> doesn't refer to an existing certificate. </p>",
+      "refs":{
+      }
+    },
+    "CharacterSet":{
+      "base":"<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
+      "refs":{
+        "DBEngineVersion$DefaultCharacterSet":"<p> The default character set for new instances of this engine version, if the <code>CharacterSetName</code> parameter of the CreateDBInstance API is not specified. </p>",
+        "SupportedCharacterSetsList$member":null
+      }
+    },
+    "CloudwatchLogsExportConfiguration":{
+      "base":"<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance or DB cluster.</p>",
+      "refs":{
+        "ModifyDBClusterMessage$CloudwatchLogsExportConfiguration":"<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB cluster.</p>",
+        "ModifyDBInstanceMessage$CloudwatchLogsExportConfiguration":"<p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance.</p>"
+      }
+    },
+    "CopyDBClusterParameterGroupMessage":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CopyDBClusterParameterGroupResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CopyDBClusterSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CopyDBClusterSnapshotResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CopyDBParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CopyDBParameterGroupResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CopyDBSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CopyDBSnapshotResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CopyOptionGroupMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CopyOptionGroupResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CreateDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CreateDBClusterParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CreateDBClusterParameterGroupResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CreateDBClusterResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CreateDBClusterSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CreateDBClusterSnapshotResult":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CreateDBInstanceMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "CreateDBInstanceReadReplicaMessage":{
+      "base":null,
+      "refs":{
+      }
+    },
+    "CreateDBInstanceReadReplicaResult":{
+      "base":null,
+      "refs":{
       }
-    },
-    "CreateDBInstanceResult": {
-      "base": null,
-      "refs": {
+    },
+    "CreateDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateDBParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateDBParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateDBParameterGroupResult": {
-      "base": null,
-      "refs": {
+    "CreateDBParameterGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateDBSecurityGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateDBSecurityGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateDBSecurityGroupResult": {
-      "base": null,
-      "refs": {
+    "CreateDBSecurityGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateDBSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateDBSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateDBSnapshotResult": {
-      "base": null,
-      "refs": {
+    "CreateDBSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateDBSubnetGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateDBSubnetGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateDBSubnetGroupResult": {
-      "base": null,
-      "refs": {
+    "CreateDBSubnetGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateEventSubscriptionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateEventSubscriptionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateEventSubscriptionResult": {
-      "base": null,
-      "refs": {
+    "CreateEventSubscriptionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "CreateOptionGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "CreateOptionGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "CreateOptionGroupResult": {
-      "base": null,
-      "refs": {
+    "CreateOptionGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DBCluster": {
-      "base": "<p>Contains the details of an Amazon RDS DB cluster. </p> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action. </p>",
-      "refs": {
-        "CreateDBClusterResult$DBCluster": null,
-        "DBClusterList$member": null,
-        "DeleteDBClusterResult$DBCluster": null,
-        "FailoverDBClusterResult$DBCluster": null,
-        "ModifyDBClusterResult$DBCluster": null,
-        "PromoteReadReplicaDBClusterResult$DBCluster": null,
-        "RestoreDBClusterFromS3Result$DBCluster": null,
-        "RestoreDBClusterFromSnapshotResult$DBCluster": null,
-        "RestoreDBClusterToPointInTimeResult$DBCluster": null
+    "DBCluster":{
+      "base":"<p>Contains the details of an Amazon RDS DB cluster. </p> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action. </p>",
+      "refs":{
+        "CreateDBClusterResult$DBCluster":null,
+        "DBClusterList$member":null,
+        "DeleteDBClusterResult$DBCluster":null,
+        "FailoverDBClusterResult$DBCluster":null,
+        "ModifyDBClusterResult$DBCluster":null,
+        "PromoteReadReplicaDBClusterResult$DBCluster":null,
+        "RestoreDBClusterFromS3Result$DBCluster":null,
+        "RestoreDBClusterFromSnapshotResult$DBCluster":null,
+        "RestoreDBClusterToPointInTimeResult$DBCluster":null
       }
     },
-    "DBClusterAlreadyExistsFault": {
-      "base": "<p>The user already has a DB cluster with the given identifier.</p>",
-      "refs": {
+    "DBClusterAlreadyExistsFault":{
+      "base":"<p>The user already has a DB cluster with the given identifier.</p>",
+      "refs":{
       }
     },
-    "DBClusterBacktrack": {
-      "base": "<p>This data type is used as a response element in the <a>DescribeDBClusterBacktracks</a> action.</p>",
-      "refs": {
-        "DBClusterBacktrackList$member": null
+    "DBClusterBacktrack":{
+      "base":"<p>This data type is used as a response element in the <a>DescribeDBClusterBacktracks</a> action.</p>",
+      "refs":{
+        "DBClusterBacktrackList$member":null
       }
     },
-    "DBClusterBacktrackList": {
-      "base": null,
-      "refs": {
-        "DBClusterBacktrackMessage$DBClusterBacktracks": "<p>Contains a list of backtracks for the user.</p>"
+    "DBClusterBacktrackList":{
+      "base":null,
+      "refs":{
+        "DBClusterBacktrackMessage$DBClusterBacktracks":"<p>Contains a list of backtracks for the user.</p>"
       }
     },
-    "DBClusterBacktrackMessage": {
-      "base": "<p>Contains the result of a successful invocation of the <a>DescribeDBClusterBacktracks</a> action.</p>",
-      "refs": {
+    "DBClusterBacktrackMessage":{
+      "base":"<p>Contains the result of a successful invocation of the <a>DescribeDBClusterBacktracks</a> action.</p>",
+      "refs":{
       }
     },
-    "DBClusterBacktrackNotFoundFault": {
-      "base": "<p> <i>BacktrackIdentifier</i> doesn't refer to an existing backtrack. </p>",
-      "refs": {
+    "DBClusterBacktrackNotFoundFault":{
+      "base":"<p> <i>BacktrackIdentifier</i> doesn't refer to an existing backtrack. </p>",
+      "refs":{
       }
     },
-    "DBClusterList": {
-      "base": null,
-      "refs": {
-        "DBClusterMessage$DBClusters": "<p>Contains a list of DB clusters for the user.</p>"
+    "DBClusterList":{
+      "base":null,
+      "refs":{
+        "DBClusterMessage$DBClusters":"<p>Contains a list of DB clusters for the user.</p>"
       }
     },
-    "DBClusterMember": {
-      "base": "<p>Contains information about an instance that is part of a DB cluster.</p>",
-      "refs": {
-        "DBClusterMemberList$member": null
+    "DBClusterMember":{
+      "base":"<p>Contains information about an instance that is part of a DB cluster.</p>",
+      "refs":{
+        "DBClusterMemberList$member":null
       }
     },
-    "DBClusterMemberList": {
-      "base": null,
-      "refs": {
-        "DBCluster$DBClusterMembers": "<p>Provides the list of instances that make up the DB cluster.</p>"
+    "DBClusterMemberList":{
+      "base":null,
+      "refs":{
+        "DBCluster$DBClusterMembers":"<p>Provides the list of instances that make up the DB cluster.</p>"
       }
     },
-    "DBClusterMessage": {
-      "base": "<p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>",
-      "refs": {
+    "DBClusterMessage":{
+      "base":"<p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>",
+      "refs":{
       }
     },
-    "DBClusterNotFoundFault": {
-      "base": "<p> <i>DBClusterIdentifier</i> doesn't refer to an existing DB cluster. </p>",
-      "refs": {
+    "DBClusterNotFoundFault":{
+      "base":"<p> <i>DBClusterIdentifier</i> doesn't refer to an existing DB cluster. </p>",
+      "refs":{
       }
     },
-    "DBClusterOptionGroupMemberships": {
-      "base": null,
-      "refs": {
-        "DBCluster$DBClusterOptionGroupMemberships": "<p>Provides the list of option group memberships for this DB cluster.</p>"
+    "DBClusterOptionGroupMemberships":{
+      "base":null,
+      "refs":{
+        "DBCluster$DBClusterOptionGroupMemberships":"<p>Provides the list of option group memberships for this DB cluster.</p>"
       }
     },
-    "DBClusterOptionGroupStatus": {
-      "base": "<p>Contains status information for a DB cluster option group.</p>",
-      "refs": {
-        "DBClusterOptionGroupMemberships$member": null
+    "DBClusterOptionGroupStatus":{
+      "base":"<p>Contains status information for a DB cluster option group.</p>",
+      "refs":{
+        "DBClusterOptionGroupMemberships$member":null
       }
     },
-    "DBClusterParameterGroup": {
-      "base": "<p>Contains the details of an Amazon RDS DB cluster parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>",
-      "refs": {
-        "CopyDBClusterParameterGroupResult$DBClusterParameterGroup": null,
-        "CreateDBClusterParameterGroupResult$DBClusterParameterGroup": null,
-        "DBClusterParameterGroupList$member": null
+    "DBClusterParameterGroup":{
+      "base":"<p>Contains the details of an Amazon RDS DB cluster parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>",
+      "refs":{
+        "CopyDBClusterParameterGroupResult$DBClusterParameterGroup":null,
+        "CreateDBClusterParameterGroupResult$DBClusterParameterGroup":null,
+        "DBClusterParameterGroupList$member":null
       }
     },
-    "DBClusterParameterGroupDetails": {
-      "base": "<p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>",
-      "refs": {
+    "DBClusterParameterGroupDetails":{
+      "base":"<p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>",
+      "refs":{
       }
     },
-    "DBClusterParameterGroupList": {
-      "base": null,
-      "refs": {
-        "DBClusterParameterGroupsMessage$DBClusterParameterGroups": "<p>A list of DB cluster parameter groups.</p>"
+    "DBClusterParameterGroupList":{
+      "base":null,
+      "refs":{
+        "DBClusterParameterGroupsMessage$DBClusterParameterGroups":"<p>A list of DB cluster parameter groups.</p>"
       }
     },
-    "DBClusterParameterGroupNameMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DBClusterParameterGroupNameMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DBClusterParameterGroupNotFoundFault": {
-      "base": "<p> <i>DBClusterParameterGroupName</i> doesn't refer to an existing DB cluster parameter group. </p>",
-      "refs": {
+    "DBClusterParameterGroupNotFoundFault":{
+      "base":"<p> <i>DBClusterParameterGroupName</i> doesn't refer to an existing DB cluster parameter group. </p>",
+      "refs":{
       }
     },
-    "DBClusterParameterGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DBClusterParameterGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DBClusterQuotaExceededFault": {
-      "base": "<p>The user attempted to create a new DB cluster and the user has already reached the maximum allowed DB cluster quota.</p>",
-      "refs": {
+    "DBClusterQuotaExceededFault":{
+      "base":"<p>The user attempted to create a new DB cluster and the user has already reached the maximum allowed DB cluster quota.</p>",
+      "refs":{
       }
     },
-    "DBClusterRole": {
-      "base": "<p>Describes an AWS Identity and Access Management (IAM) role that is associated with a DB cluster.</p>",
-      "refs": {
-        "DBClusterRoles$member": null
+    "DBClusterRole":{
+      "base":"<p>Describes an AWS Identity and Access Management (IAM) role that is associated with a DB cluster.</p>",
+      "refs":{
+        "DBClusterRoles$member":null
       }
     },
-    "DBClusterRoleAlreadyExistsFault": {
-      "base": "<p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>",
-      "refs": {
+    "DBClusterRoleAlreadyExistsFault":{
+      "base":"<p>The specified IAM role Amazon Resource Name (ARN) is already associated with the specified DB cluster.</p>",
+      "refs":{
       }
     },
-    "DBClusterRoleNotFoundFault": {
-      "base": "<p>The specified IAM role Amazon Resource Name (ARN) isn't associated with the specified DB cluster.</p>",
-      "refs": {
+    "DBClusterRoleNotFoundFault":{
+      "base":"<p>The specified IAM role Amazon Resource Name (ARN) isn't associated with the specified DB cluster.</p>",
+      "refs":{
       }
     },
-    "DBClusterRoleQuotaExceededFault": {
-      "base": "<p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>",
-      "refs": {
+    "DBClusterRoleQuotaExceededFault":{
+      "base":"<p>You have exceeded the maximum number of IAM roles that can be associated with the specified DB cluster.</p>",
+      "refs":{
       }
     },
-    "DBClusterRoles": {
-      "base": null,
-      "refs": {
-        "DBCluster$AssociatedRoles": "<p>Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf.</p>"
+    "DBClusterRoles":{
+      "base":null,
+      "refs":{
+        "DBCluster$AssociatedRoles":"<p>Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf.</p>"
       }
     },
-    "DBClusterSnapshot": {
-      "base": "<p>Contains the details for an Amazon RDS DB cluster snapshot </p> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action. </p>",
-      "refs": {
-        "CopyDBClusterSnapshotResult$DBClusterSnapshot": null,
-        "CreateDBClusterSnapshotResult$DBClusterSnapshot": null,
-        "DBClusterSnapshotList$member": null,
-        "DeleteDBClusterSnapshotResult$DBClusterSnapshot": null
+    "DBClusterSnapshot":{
+      "base":"<p>Contains the details for an Amazon RDS DB cluster snapshot </p> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action. </p>",
+      "refs":{
+        "CopyDBClusterSnapshotResult$DBClusterSnapshot":null,
+        "CreateDBClusterSnapshotResult$DBClusterSnapshot":null,
+        "DBClusterSnapshotList$member":null,
+        "DeleteDBClusterSnapshotResult$DBClusterSnapshot":null
       }
     },
-    "DBClusterSnapshotAlreadyExistsFault": {
-      "base": "<p>The user already has a DB cluster snapshot with the given identifier.</p>",
-      "refs": {
+    "DBClusterSnapshotAlreadyExistsFault":{
+      "base":"<p>The user already has a DB cluster snapshot with the given identifier.</p>",
+      "refs":{
       }
     },
-    "DBClusterSnapshotAttribute": {
-      "base": "<p>Contains the name and values of a manual DB cluster snapshot attribute.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-      "refs": {
-        "DBClusterSnapshotAttributeList$member": null
+    "DBClusterSnapshotAttribute":{
+      "base":"<p>Contains the name and values of a manual DB cluster snapshot attribute.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+      "refs":{
+        "DBClusterSnapshotAttributeList$member":null
       }
     },
-    "DBClusterSnapshotAttributeList": {
-      "base": null,
-      "refs": {
-        "DBClusterSnapshotAttributesResult$DBClusterSnapshotAttributes": "<p>The list of attributes and values for the manual DB cluster snapshot.</p>"
+    "DBClusterSnapshotAttributeList":{
+      "base":null,
+      "refs":{
+        "DBClusterSnapshotAttributesResult$DBClusterSnapshotAttributes":"<p>The list of attributes and values for the manual DB cluster snapshot.</p>"
       }
     },
-    "DBClusterSnapshotAttributesResult": {
-      "base": "<p>Contains the results of a successful call to the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-      "refs": {
-        "DescribeDBClusterSnapshotAttributesResult$DBClusterSnapshotAttributesResult": null,
-        "ModifyDBClusterSnapshotAttributeResult$DBClusterSnapshotAttributesResult": null
+    "DBClusterSnapshotAttributesResult":{
+      "base":"<p>Contains the results of a successful call to the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+      "refs":{
+        "DescribeDBClusterSnapshotAttributesResult$DBClusterSnapshotAttributesResult":null,
+        "ModifyDBClusterSnapshotAttributeResult$DBClusterSnapshotAttributesResult":null
       }
     },
-    "DBClusterSnapshotList": {
-      "base": null,
-      "refs": {
-        "DBClusterSnapshotMessage$DBClusterSnapshots": "<p>Provides a list of DB cluster snapshots for the user.</p>"
+    "DBClusterSnapshotList":{
+      "base":null,
+      "refs":{
+        "DBClusterSnapshotMessage$DBClusterSnapshots":"<p>Provides a list of DB cluster snapshots for the user.</p>"
       }
     },
-    "DBClusterSnapshotMessage": {
-      "base": "<p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>",
-      "refs": {
+    "DBClusterSnapshotMessage":{
+      "base":"<p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>",
+      "refs":{
       }
     },
-    "DBClusterSnapshotNotFoundFault": {
-      "base": "<p> <i>DBClusterSnapshotIdentifier</i> doesn't refer to an existing DB cluster snapshot. </p>",
-      "refs": {
+    "DBClusterSnapshotNotFoundFault":{
+      "base":"<p> <i>DBClusterSnapshotIdentifier</i> doesn't refer to an existing DB cluster snapshot. </p>",
+      "refs":{
       }
     },
-    "DBEngineVersion": {
-      "base": "<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
-      "refs": {
-        "DBEngineVersionList$member": null
+    "DBEngineVersion":{
+      "base":"<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
+      "refs":{
+        "DBEngineVersionList$member":null
       }
     },
-    "DBEngineVersionList": {
-      "base": null,
-      "refs": {
-        "DBEngineVersionMessage$DBEngineVersions": "<p> A list of <code>DBEngineVersion</code> elements. </p>"
+    "DBEngineVersionList":{
+      "base":null,
+      "refs":{
+        "DBEngineVersionMessage$DBEngineVersions":"<p> A list of <code>DBEngineVersion</code> elements. </p>"
       }
     },
-    "DBEngineVersionMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>",
-      "refs": {
+    "DBEngineVersionMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>",
+      "refs":{
       }
     },
-    "DBInstance": {
-      "base": "<p>Contains the details of an Amazon RDS DB instance. </p> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action. </p>",
-      "refs": {
-        "CreateDBInstanceReadReplicaResult$DBInstance": null,
-        "CreateDBInstanceResult$DBInstance": null,
-        "DBInstanceList$member": null,
-        "DeleteDBInstanceResult$DBInstance": null,
-        "ModifyDBInstanceResult$DBInstance": null,
-        "PromoteReadReplicaResult$DBInstance": null,
-        "RebootDBInstanceResult$DBInstance": null,
-        "RestoreDBInstanceFromDBSnapshotResult$DBInstance": null,
-        "RestoreDBInstanceFromS3Result$DBInstance": null,
-        "RestoreDBInstanceToPointInTimeResult$DBInstance": null,
-        "StartDBInstanceResult$DBInstance": null,
-        "StopDBInstanceResult$DBInstance": null
+    "DBInstance":{
+      "base":"<p>Contains the details of an Amazon RDS DB instance. </p> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action. </p>",
+      "refs":{
+        "CreateDBInstanceReadReplicaResult$DBInstance":null,
+        "CreateDBInstanceResult$DBInstance":null,
+        "DBInstanceList$member":null,
+        "DeleteDBInstanceResult$DBInstance":null,
+        "ModifyDBInstanceResult$DBInstance":null,
+        "PromoteReadReplicaResult$DBInstance":null,
+        "RebootDBInstanceResult$DBInstance":null,
+        "RestoreDBInstanceFromDBSnapshotResult$DBInstance":null,
+        "RestoreDBInstanceFromS3Result$DBInstance":null,
+        "RestoreDBInstanceToPointInTimeResult$DBInstance":null,
+        "StartDBInstanceResult$DBInstance":null,
+        "StopDBInstanceResult$DBInstance":null
       }
     },
-    "DBInstanceAlreadyExistsFault": {
-      "base": "<p>The user already has a DB instance with the given identifier.</p>",
-      "refs": {
+    "DBInstanceAlreadyExistsFault":{
+      "base":"<p>The user already has a DB instance with the given identifier.</p>",
+      "refs":{
       }
     },
-    "DBInstanceList": {
-      "base": null,
-      "refs": {
-        "DBInstanceMessage$DBInstances": "<p> A list of <a>DBInstance</a> instances. </p>"
+    "DBInstanceList":{
+      "base":null,
+      "refs":{
+        "DBInstanceMessage$DBInstances":"<p> A list of <a>DBInstance</a> instances. </p>"
       }
     },
-    "DBInstanceMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>",
-      "refs": {
+    "DBInstanceMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>",
+      "refs":{
       }
     },
-    "DBInstanceNotFoundFault": {
-      "base": "<p> <i>DBInstanceIdentifier</i> doesn't refer to an existing DB instance. </p>",
-      "refs": {
+    "DBInstanceNotFoundFault":{
+      "base":"<p> <i>DBInstanceIdentifier</i> doesn't refer to an existing DB instance. </p>",
+      "refs":{
       }
     },
-    "DBInstanceStatusInfo": {
-      "base": "<p>Provides a list of status information for a DB instance.</p>",
-      "refs": {
-        "DBInstanceStatusInfoList$member": null
+    "DBInstanceStatusInfo":{
+      "base":"<p>Provides a list of status information for a DB instance.</p>",
+      "refs":{
+        "DBInstanceStatusInfoList$member":null
       }
     },
-    "DBInstanceStatusInfoList": {
-      "base": null,
-      "refs": {
-        "DBInstance$StatusInfos": "<p>The status of a Read Replica. If the instance is not a Read Replica, this is blank.</p>"
+    "DBInstanceStatusInfoList":{
+      "base":null,
+      "refs":{
+        "DBInstance$StatusInfos":"<p>The status of a Read Replica. If the instance is not a Read Replica, this is blank.</p>"
       }
     },
-    "DBLogFileNotFoundFault": {
-      "base": "<p> <i>LogFileName</i> doesn't refer to an existing DB log file.</p>",
-      "refs": {
+    "DBLogFileNotFoundFault":{
+      "base":"<p> <i>LogFileName</i> doesn't refer to an existing DB log file.</p>",
+      "refs":{
       }
     },
-    "DBParameterGroup": {
-      "base": "<p>Contains the details of an Amazon RDS DB parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBParameterGroups</a> action. </p>",
-      "refs": {
-        "CopyDBParameterGroupResult$DBParameterGroup": null,
-        "CreateDBParameterGroupResult$DBParameterGroup": null,
-        "DBParameterGroupList$member": null
+    "DBParameterGroup":{
+      "base":"<p>Contains the details of an Amazon RDS DB parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBParameterGroups</a> action. </p>",
+      "refs":{
+        "CopyDBParameterGroupResult$DBParameterGroup":null,
+        "CreateDBParameterGroupResult$DBParameterGroup":null,
+        "DBParameterGroupList$member":null
       }
     },
-    "DBParameterGroupAlreadyExistsFault": {
-      "base": "<p>A DB parameter group with the same name exists.</p>",
-      "refs": {
+    "DBParameterGroupAlreadyExistsFault":{
+      "base":"<p>A DB parameter group with the same name exists.</p>",
+      "refs":{
       }
     },
-    "DBParameterGroupDetails": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>",
-      "refs": {
+    "DBParameterGroupDetails":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>",
+      "refs":{
       }
     },
-    "DBParameterGroupList": {
-      "base": null,
-      "refs": {
-        "DBParameterGroupsMessage$DBParameterGroups": "<p> A list of <a>DBParameterGroup</a> instances. </p>"
+    "DBParameterGroupList":{
+      "base":null,
+      "refs":{
+        "DBParameterGroupsMessage$DBParameterGroups":"<p> A list of <a>DBParameterGroup</a> instances. </p>"
       }
     },
-    "DBParameterGroupNameMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>",
-      "refs": {
+    "DBParameterGroupNameMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>",
+      "refs":{
       }
     },
-    "DBParameterGroupNotFoundFault": {
-      "base": "<p> <i>DBParameterGroupName</i> doesn't refer to an existing DB parameter group. </p>",
-      "refs": {
+    "DBParameterGroupNotFoundFault":{
+      "base":"<p> <i>DBParameterGroupName</i> doesn't refer to an existing DB parameter group. </p>",
+      "refs":{
       }
     },
-    "DBParameterGroupQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of DB parameter groups.</p>",
-      "refs": {
+    "DBParameterGroupQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of DB parameter groups.</p>",
+      "refs":{
       }
     },
-    "DBParameterGroupStatus": {
-      "base": "<p>The status of the DB parameter group.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>CreateDBInstanceReadReplica</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> </ul>",
-      "refs": {
-        "DBParameterGroupStatusList$member": null
+    "DBParameterGroupStatus":{
+      "base":"<p>The status of the DB parameter group.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>CreateDBInstanceReadReplica</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> </ul>",
+      "refs":{
+        "DBParameterGroupStatusList$member":null
       }
     },
-    "DBParameterGroupStatusList": {
-      "base": null,
-      "refs": {
-        "DBInstance$DBParameterGroups": "<p>Provides the list of DB parameter groups applied to this DB instance.</p>"
+    "DBParameterGroupStatusList":{
+      "base":null,
+      "refs":{
+        "DBInstance$DBParameterGroups":"<p>Provides the list of DB parameter groups applied to this DB instance.</p>"
       }
     },
-    "DBParameterGroupsMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>",
-      "refs": {
+    "DBParameterGroupsMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>",
+      "refs":{
       }
     },
-    "DBSecurityGroup": {
-      "base": "<p>Contains the details for an Amazon RDS DB security group. </p> <p>This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>",
-      "refs": {
-        "AuthorizeDBSecurityGroupIngressResult$DBSecurityGroup": null,
-        "CreateDBSecurityGroupResult$DBSecurityGroup": null,
-        "DBSecurityGroups$member": null,
-        "RevokeDBSecurityGroupIngressResult$DBSecurityGroup": null
+    "DBSecurityGroup":{
+      "base":"<p>Contains the details for an Amazon RDS DB security group. </p> <p>This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>",
+      "refs":{
+        "AuthorizeDBSecurityGroupIngressResult$DBSecurityGroup":null,
+        "CreateDBSecurityGroupResult$DBSecurityGroup":null,
+        "DBSecurityGroups$member":null,
+        "RevokeDBSecurityGroupIngressResult$DBSecurityGroup":null
       }
     },
-    "DBSecurityGroupAlreadyExistsFault": {
-      "base": "<p> A DB security group with the name specified in <i>DBSecurityGroupName</i> already exists. </p>",
-      "refs": {
+    "DBSecurityGroupAlreadyExistsFault":{
+      "base":"<p> A DB security group with the name specified in <i>DBSecurityGroupName</i> already exists. </p>",
+      "refs":{
       }
     },
-    "DBSecurityGroupMembership": {
-      "base": "<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul>",
-      "refs": {
-        "DBSecurityGroupMembershipList$member": null
+    "DBSecurityGroupMembership":{
+      "base":"<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul>",
+      "refs":{
+        "DBSecurityGroupMembershipList$member":null
       }
     },
-    "DBSecurityGroupMembershipList": {
-      "base": null,
-      "refs": {
-        "DBInstance$DBSecurityGroups": "<p> Provides List of DB security group elements containing only <code>DBSecurityGroup.Name</code> and <code>DBSecurityGroup.Status</code> subelements. </p>",
-        "Option$DBSecurityGroupMemberships": "<p>If the option requires access to a port, then this DB security group allows access to the port.</p>"
+    "DBSecurityGroupMembershipList":{
+      "base":null,
+      "refs":{
+        "DBInstance$DBSecurityGroups":"<p> Provides List of DB security group elements containing only <code>DBSecurityGroup.Name</code> and <code>DBSecurityGroup.Status</code> subelements. </p>",
+        "Option$DBSecurityGroupMemberships":"<p>If the option requires access to a port, then this DB security group allows access to the port.</p>"
       }
     },
-    "DBSecurityGroupMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBSecurityGroups</a> action. </p>",
-      "refs": {
+    "DBSecurityGroupMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBSecurityGroups</a> action. </p>",
+      "refs":{
       }
     },
-    "DBSecurityGroupNameList": {
-      "base": null,
-      "refs": {
-        "CreateDBInstanceMessage$DBSecurityGroups": "<p>A list of DB security groups to associate with this DB instance.</p> <p>Default: The default DB security group for the database engine.</p>",
-        "ModifyDBInstanceMessage$DBSecurityGroups": "<p>A list of DB security groups to authorize on this DB instance. Changing this setting doesn't result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match existing DBSecurityGroups.</p> </li> </ul>",
-        "OptionConfiguration$DBSecurityGroupMemberships": "<p>A list of DBSecurityGroupMemebrship name strings used for this option.</p>",
-        "RestoreDBInstanceFromS3Message$DBSecurityGroups": "<p>A list of DB security groups to associate with this DB instance.</p> <p>Default: The default DB security group for the database engine.</p>"
+    "DBSecurityGroupNameList":{
+      "base":null,
+      "refs":{
+        "CreateDBInstanceMessage$DBSecurityGroups":"<p>A list of DB security groups to associate with this DB instance.</p> <p>Default: The default DB security group for the database engine.</p>",
+        "ModifyDBInstanceMessage$DBSecurityGroups":"<p>A list of DB security groups to authorize on this DB instance. Changing this setting doesn't result in an outage and the change is asynchronously applied as soon as possible.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match existing DBSecurityGroups.</p> </li> </ul>",
+        "OptionConfiguration$DBSecurityGroupMemberships":"<p>A list of DBSecurityGroupMemebrship name strings used for this option.</p>",
+        "RestoreDBInstanceFromS3Message$DBSecurityGroups":"<p>A list of DB security groups to associate with this DB instance.</p> <p>Default: The default DB security group for the database engine.</p>"
       }
     },
-    "DBSecurityGroupNotFoundFault": {
-      "base": "<p> <i>DBSecurityGroupName</i> doesn't refer to an existing DB security group. </p>",
-      "refs": {
+    "DBSecurityGroupNotFoundFault":{
+      "base":"<p> <i>DBSecurityGroupName</i> doesn't refer to an existing DB security group. </p>",
+      "refs":{
       }
     },
-    "DBSecurityGroupNotSupportedFault": {
-      "base": "<p>A DB security group isn't allowed for this action.</p>",
-      "refs": {
+    "DBSecurityGroupNotSupportedFault":{
+      "base":"<p>A DB security group isn't allowed for this action.</p>",
+      "refs":{
       }
     },
-    "DBSecurityGroupQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of DB security groups.</p>",
-      "refs": {
+    "DBSecurityGroupQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of DB security groups.</p>",
+      "refs":{
       }
     },
-    "DBSecurityGroups": {
-      "base": null,
-      "refs": {
-        "DBSecurityGroupMessage$DBSecurityGroups": "<p> A list of <a>DBSecurityGroup</a> instances. </p>"
+    "DBSecurityGroups":{
+      "base":null,
+      "refs":{
+        "DBSecurityGroupMessage$DBSecurityGroups":"<p> A list of <a>DBSecurityGroup</a> instances. </p>"
       }
     },
-    "DBSnapshot": {
-      "base": "<p>Contains the details of an Amazon RDS DB snapshot. </p> <p>This data type is used as a response element in the <a>DescribeDBSnapshots</a> action. </p>",
-      "refs": {
-        "CopyDBSnapshotResult$DBSnapshot": null,
-        "CreateDBSnapshotResult$DBSnapshot": null,
-        "DBSnapshotList$member": null,
-        "DeleteDBSnapshotResult$DBSnapshot": null,
-        "ModifyDBSnapshotResult$DBSnapshot": null
+    "DBSnapshot":{
+      "base":"<p>Contains the details of an Amazon RDS DB snapshot. </p> <p>This data type is used as a response element in the <a>DescribeDBSnapshots</a> action. </p>",
+      "refs":{
+        "CopyDBSnapshotResult$DBSnapshot":null,
+        "CreateDBSnapshotResult$DBSnapshot":null,
+        "DBSnapshotList$member":null,
+        "DeleteDBSnapshotResult$DBSnapshot":null,
+        "ModifyDBSnapshotResult$DBSnapshot":null
       }
     },
-    "DBSnapshotAlreadyExistsFault": {
-      "base": "<p> <i>DBSnapshotIdentifier</i> is already used by an existing snapshot. </p>",
-      "refs": {
+    "DBSnapshotAlreadyExistsFault":{
+      "base":"<p> <i>DBSnapshotIdentifier</i> is already used by an existing snapshot. </p>",
+      "refs":{
       }
     },
-    "DBSnapshotAttribute": {
-      "base": "<p>Contains the name and values of a manual DB snapshot attribute</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API.</p>",
-      "refs": {
-        "DBSnapshotAttributeList$member": null
+    "DBSnapshotAttribute":{
+      "base":"<p>Contains the name and values of a manual DB snapshot attribute</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API.</p>",
+      "refs":{
+        "DBSnapshotAttributeList$member":null
       }
     },
-    "DBSnapshotAttributeList": {
-      "base": null,
-      "refs": {
-        "DBSnapshotAttributesResult$DBSnapshotAttributes": "<p>The list of attributes and values for the manual DB snapshot.</p>"
+    "DBSnapshotAttributeList":{
+      "base":null,
+      "refs":{
+        "DBSnapshotAttributesResult$DBSnapshotAttributes":"<p>The list of attributes and values for the manual DB snapshot.</p>"
       }
     },
-    "DBSnapshotAttributesResult": {
-      "base": "<p>Contains the results of a successful call to the <a>DescribeDBSnapshotAttributes</a> API action.</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
-      "refs": {
-        "DescribeDBSnapshotAttributesResult$DBSnapshotAttributesResult": null,
-        "ModifyDBSnapshotAttributeResult$DBSnapshotAttributesResult": null
+    "DBSnapshotAttributesResult":{
+      "base":"<p>Contains the results of a successful call to the <a>DescribeDBSnapshotAttributes</a> API action.</p> <p>Manual DB snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
+      "refs":{
+        "DescribeDBSnapshotAttributesResult$DBSnapshotAttributesResult":null,
+        "ModifyDBSnapshotAttributeResult$DBSnapshotAttributesResult":null
       }
     },
-    "DBSnapshotList": {
-      "base": null,
-      "refs": {
-        "DBSnapshotMessage$DBSnapshots": "<p> A list of <a>DBSnapshot</a> instances. </p>"
+    "DBSnapshotList":{
+      "base":null,
+      "refs":{
+        "DBSnapshotMessage$DBSnapshots":"<p> A list of <a>DBSnapshot</a> instances. </p>"
       }
     },
-    "DBSnapshotMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBSnapshots</a> action. </p>",
-      "refs": {
+    "DBSnapshotMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBSnapshots</a> action. </p>",
+      "refs":{
       }
     },
-    "DBSnapshotNotFoundFault": {
-      "base": "<p> <i>DBSnapshotIdentifier</i> doesn't refer to an existing DB snapshot. </p>",
-      "refs": {
+    "DBSnapshotNotFoundFault":{
+      "base":"<p> <i>DBSnapshotIdentifier</i> doesn't refer to an existing DB snapshot. </p>",
+      "refs":{
       }
     },
-    "DBSubnetGroup": {
-      "base": "<p>Contains the details of an Amazon RDS DB subnet group. </p> <p>This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>",
-      "refs": {
-        "CreateDBSubnetGroupResult$DBSubnetGroup": null,
-        "DBInstance$DBSubnetGroup": "<p>Specifies information on the subnet group associated with the DB instance, including the name, description, and subnets in the subnet group.</p>",
-        "DBSubnetGroups$member": null,
-        "ModifyDBSubnetGroupResult$DBSubnetGroup": null
+    "DBSubnetGroup":{
+      "base":"<p>Contains the details of an Amazon RDS DB subnet group. </p> <p>This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>",
+      "refs":{
+        "CreateDBSubnetGroupResult$DBSubnetGroup":null,
+        "DBInstance$DBSubnetGroup":"<p>Specifies information on the subnet group associated with the DB instance, including the name, description, and subnets in the subnet group.</p>",
+        "DBSubnetGroups$member":null,
+        "ModifyDBSubnetGroupResult$DBSubnetGroup":null
       }
     },
-    "DBSubnetGroupAlreadyExistsFault": {
-      "base": "<p> <i>DBSubnetGroupName</i> is already used by an existing DB subnet group. </p>",
-      "refs": {
+    "DBSubnetGroupAlreadyExistsFault":{
+      "base":"<p> <i>DBSubnetGroupName</i> is already used by an existing DB subnet group. </p>",
+      "refs":{
       }
     },
-    "DBSubnetGroupDoesNotCoverEnoughAZs": {
-      "base": "<p>Subnets in the DB subnet group should cover at least two Availability Zones unless there is only one Availability Zone.</p>",
-      "refs": {
+    "DBSubnetGroupDoesNotCoverEnoughAZs":{
+      "base":"<p>Subnets in the DB subnet group should cover at least two Availability Zones unless there is only one Availability Zone.</p>",
+      "refs":{
       }
     },
-    "DBSubnetGroupMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>",
-      "refs": {
+    "DBSubnetGroupMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>",
+      "refs":{
       }
     },
-    "DBSubnetGroupNotAllowedFault": {
-      "base": "<p>The DBSubnetGroup shouldn't be specified while creating read replicas that lie in the same region as the source instance.</p>",
-      "refs": {
+    "DBSubnetGroupNotAllowedFault":{
+      "base":"<p>The DBSubnetGroup shouldn't be specified while creating read replicas that lie in the same region as the source instance.</p>",
+      "refs":{
       }
     },
-    "DBSubnetGroupNotFoundFault": {
-      "base": "<p> <i>DBSubnetGroupName</i> doesn't refer to an existing DB subnet group. </p>",
-      "refs": {
+    "DBSubnetGroupNotFoundFault":{
+      "base":"<p> <i>DBSubnetGroupName</i> doesn't refer to an existing DB subnet group. </p>",
+      "refs":{
       }
     },
-    "DBSubnetGroupQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of DB subnet groups.</p>",
-      "refs": {
+    "DBSubnetGroupQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of DB subnet groups.</p>",
+      "refs":{
       }
     },
-    "DBSubnetGroups": {
-      "base": null,
-      "refs": {
-        "DBSubnetGroupMessage$DBSubnetGroups": "<p> A list of <a>DBSubnetGroup</a> instances. </p>"
+    "DBSubnetGroups":{
+      "base":null,
+      "refs":{
+        "DBSubnetGroupMessage$DBSubnetGroups":"<p> A list of <a>DBSubnetGroup</a> instances. </p>"
       }
     },
-    "DBSubnetQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of subnets in a DB subnet groups.</p>",
-      "refs": {
+    "DBSubnetQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of subnets in a DB subnet groups.</p>",
+      "refs":{
       }
     },
-    "DBUpgradeDependencyFailureFault": {
-      "base": "<p>The DB upgrade failed because a resource the DB depends on can't be modified.</p>",
-      "refs": {
+    "DBUpgradeDependencyFailureFault":{
+      "base":"<p>The DB upgrade failed because a resource the DB depends on can't be modified.</p>",
+      "refs":{
       }
     },
-    "DeleteDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBClusterParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBClusterParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBClusterResult": {
-      "base": null,
-      "refs": {
+    "DeleteDBClusterResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DeleteDBClusterSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBClusterSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBClusterSnapshotResult": {
-      "base": null,
-      "refs": {
+    "DeleteDBClusterSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DeleteDBInstanceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBInstanceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBInstanceResult": {
-      "base": null,
-      "refs": {
+    "DeleteDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DeleteDBParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBSecurityGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBSecurityGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteDBSnapshotResult": {
-      "base": null,
-      "refs": {
+    "DeleteDBSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DeleteDBSubnetGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteDBSubnetGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteEventSubscriptionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteEventSubscriptionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DeleteEventSubscriptionResult": {
-      "base": null,
-      "refs": {
+    "DeleteEventSubscriptionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DeleteOptionGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DeleteOptionGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeAccountAttributesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeAccountAttributesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeCertificatesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeCertificatesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClusterBacktracksMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClusterBacktracksMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClusterParameterGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClusterParameterGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClusterParametersMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClusterParametersMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClusterSnapshotAttributesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClusterSnapshotAttributesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClusterSnapshotAttributesResult": {
-      "base": null,
-      "refs": {
+    "DescribeDBClusterSnapshotAttributesResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeDBClusterSnapshotsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClusterSnapshotsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBClustersMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBClustersMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBEngineVersionsMessage": {
-      "base": null,
-      "refs": {
+    "DescribeDBEngineVersionsMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeDBInstancesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBInstancesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBLogFilesDetails": {
-      "base": "<p>This data type is used as a response element to <a>DescribeDBLogFiles</a>.</p>",
-      "refs": {
-        "DescribeDBLogFilesList$member": null
+    "DescribeDBLogFilesDetails":{
+      "base":"<p>This data type is used as a response element to <a>DescribeDBLogFiles</a>.</p>",
+      "refs":{
+        "DescribeDBLogFilesList$member":null
       }
     },
-    "DescribeDBLogFilesList": {
-      "base": null,
-      "refs": {
-        "DescribeDBLogFilesResponse$DescribeDBLogFiles": "<p>The DB log files returned.</p>"
+    "DescribeDBLogFilesList":{
+      "base":null,
+      "refs":{
+        "DescribeDBLogFilesResponse$DescribeDBLogFiles":"<p>The DB log files returned.</p>"
       }
     },
-    "DescribeDBLogFilesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBLogFilesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBLogFilesResponse": {
-      "base": "<p> The response from a call to <a>DescribeDBLogFiles</a>. </p>",
-      "refs": {
+    "DescribeDBLogFilesResponse":{
+      "base":"<p> The response from a call to <a>DescribeDBLogFiles</a>. </p>",
+      "refs":{
       }
     },
-    "DescribeDBParameterGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBParameterGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBParametersMessage": {
-      "base": null,
-      "refs": {
+    "DescribeDBParametersMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeDBSecurityGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBSecurityGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBSnapshotAttributesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBSnapshotAttributesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBSnapshotAttributesResult": {
-      "base": null,
-      "refs": {
+    "DescribeDBSnapshotAttributesResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeDBSnapshotsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBSnapshotsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeDBSubnetGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeDBSubnetGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeEngineDefaultClusterParametersMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeEngineDefaultClusterParametersMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeEngineDefaultClusterParametersResult": {
-      "base": null,
-      "refs": {
+    "DescribeEngineDefaultClusterParametersResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeEngineDefaultParametersMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeEngineDefaultParametersMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeEngineDefaultParametersResult": {
-      "base": null,
-      "refs": {
+    "DescribeEngineDefaultParametersResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DescribeEventCategoriesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeEventCategoriesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeEventSubscriptionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeEventSubscriptionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeEventsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeEventsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeOptionGroupOptionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeOptionGroupOptionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeOptionGroupsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeOptionGroupsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeOrderableDBInstanceOptionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeOrderableDBInstanceOptionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribePendingMaintenanceActionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribePendingMaintenanceActionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeReservedDBInstancesMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeReservedDBInstancesMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeReservedDBInstancesOfferingsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeReservedDBInstancesOfferingsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeSourceRegionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeSourceRegionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeValidDBInstanceModificationsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DescribeValidDBInstanceModificationsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "DescribeValidDBInstanceModificationsResult": {
-      "base": null,
-      "refs": {
+    "DescribeValidDBInstanceModificationsResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "DomainMembership": {
-      "base": "<p>An Active Directory Domain membership record associated with the DB instance.</p>",
-      "refs": {
-        "DomainMembershipList$member": null
+    "DomainMembership":{
+      "base":"<p>An Active Directory Domain membership record associated with the DB instance.</p>",
+      "refs":{
+        "DomainMembershipList$member":null
       }
     },
-    "DomainMembershipList": {
-      "base": "<p>List of Active Directory Domain membership records associated with a DB instance.</p>",
-      "refs": {
-        "DBInstance$DomainMemberships": "<p>The Active Directory Domain membership records associated with the DB instance.</p>"
+    "DomainMembershipList":{
+      "base":"<p>List of Active Directory Domain membership records associated with a DB instance.</p>",
+      "refs":{
+        "DBInstance$DomainMemberships":"<p>The Active Directory Domain membership records associated with the DB instance.</p>"
       }
     },
-    "DomainNotFoundFault": {
-      "base": "<p> <i>Domain</i> doesn't refer to an existing Active Directory domain. </p>",
-      "refs": {
+    "DomainNotFoundFault":{
+      "base":"<p> <i>Domain</i> doesn't refer to an existing Active Directory domain. </p>",
+      "refs":{
       }
     },
-    "Double": {
-      "base": null,
-      "refs": {
-        "DoubleRange$From": "<p>The minimum value in the range.</p>",
-        "DoubleRange$To": "<p>The maximum value in the range.</p>",
-        "RecurringCharge$RecurringChargeAmount": "<p>The amount of the recurring charge.</p>",
-        "ReservedDBInstance$FixedPrice": "<p>The fixed price charged for this reserved DB instance.</p>",
-        "ReservedDBInstance$UsagePrice": "<p>The hourly price charged for this reserved DB instance.</p>",
-        "ReservedDBInstancesOffering$FixedPrice": "<p>The fixed price charged for this offering.</p>",
-        "ReservedDBInstancesOffering$UsagePrice": "<p>The hourly price charged for this offering.</p>"
+    "Double":{
+      "base":null,
+      "refs":{
+        "DoubleRange$From":"<p>The minimum value in the range.</p>",
+        "DoubleRange$To":"<p>The maximum value in the range.</p>",
+        "RecurringCharge$RecurringChargeAmount":"<p>The amount of the recurring charge.</p>",
+        "ReservedDBInstance$FixedPrice":"<p>The fixed price charged for this reserved DB instance.</p>",
+        "ReservedDBInstance$UsagePrice":"<p>The hourly price charged for this reserved DB instance.</p>",
+        "ReservedDBInstancesOffering$FixedPrice":"<p>The fixed price charged for this offering.</p>",
+        "ReservedDBInstancesOffering$UsagePrice":"<p>The hourly price charged for this offering.</p>"
       }
     },
-    "DoubleOptional": {
-      "base": null,
-      "refs": {
-        "OrderableDBInstanceOption$MinIopsPerGib": "<p>Minimum provisioned IOPS per GiB for a DB instance.</p>",
-        "OrderableDBInstanceOption$MaxIopsPerGib": "<p>Maximum provisioned IOPS per GiB for a DB instance.</p>"
+    "DoubleOptional":{
+      "base":null,
+      "refs":{
+        "OrderableDBInstanceOption$MinIopsPerGib":"<p>Minimum provisioned IOPS per GiB for a DB instance.</p>",
+        "OrderableDBInstanceOption$MaxIopsPerGib":"<p>Maximum provisioned IOPS per GiB for a DB instance.</p>"
       }
     },
-    "DoubleRange": {
-      "base": "<p>A range of double values.</p>",
-      "refs": {
-        "DoubleRangeList$member": null
+    "DoubleRange":{
+      "base":"<p>A range of double values.</p>",
+      "refs":{
+        "DoubleRangeList$member":null
       }
     },
-    "DoubleRangeList": {
-      "base": null,
-      "refs": {
-        "ValidStorageOptions$IopsToStorageRatio": "<p>The valid range of Provisioned IOPS to gibibytes of storage multiplier. For example, 3-10, which means that provisioned IOPS can be between 3 and 10 times storage. </p>"
+    "DoubleRangeList":{
+      "base":null,
+      "refs":{
+        "ValidStorageOptions$IopsToStorageRatio":"<p>The valid range of Provisioned IOPS to gibibytes of storage multiplier. For example, 3-10, which means that provisioned IOPS can be between 3 and 10 times storage. </p>"
       }
     },
-    "DownloadDBLogFilePortionDetails": {
-      "base": "<p>This data type is used as a response element to <a>DownloadDBLogFilePortion</a>.</p>",
-      "refs": {
+    "DownloadDBLogFilePortionDetails":{
+      "base":"<p>This data type is used as a response element to <a>DownloadDBLogFilePortion</a>.</p>",
+      "refs":{
       }
     },
-    "DownloadDBLogFilePortionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "DownloadDBLogFilePortionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "EC2SecurityGroup": {
-      "base": "<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>AuthorizeDBSecurityGroupIngress</a> </p> </li> <li> <p> <a>DescribeDBSecurityGroups</a> </p> </li> <li> <p> <a>RevokeDBSecurityGroupIngress</a> </p> </li> </ul>",
-      "refs": {
-        "EC2SecurityGroupList$member": null
+    "EC2SecurityGroup":{
+      "base":"<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>AuthorizeDBSecurityGroupIngress</a> </p> </li> <li> <p> <a>DescribeDBSecurityGroups</a> </p> </li> <li> <p> <a>RevokeDBSecurityGroupIngress</a> </p> </li> </ul>",
+      "refs":{
+        "EC2SecurityGroupList$member":null
       }
     },
-    "EC2SecurityGroupList": {
-      "base": null,
-      "refs": {
-        "DBSecurityGroup$EC2SecurityGroups": "<p> Contains a list of <a>EC2SecurityGroup</a> elements. </p>"
+    "EC2SecurityGroupList":{
+      "base":null,
+      "refs":{
+        "DBSecurityGroup$EC2SecurityGroups":"<p> Contains a list of <a>EC2SecurityGroup</a> elements. </p>"
       }
     },
-    "Endpoint": {
-      "base": "<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> </ul>",
-      "refs": {
-        "DBInstance$Endpoint": "<p>Specifies the connection endpoint.</p>"
+    "Endpoint":{
+      "base":"<p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> </ul>",
+      "refs":{
+        "DBInstance$Endpoint":"<p>Specifies the connection endpoint.</p>"
       }
     },
-    "EngineDefaults": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>",
-      "refs": {
-        "DescribeEngineDefaultClusterParametersResult$EngineDefaults": null,
-        "DescribeEngineDefaultParametersResult$EngineDefaults": null
+    "EngineDefaults":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>",
+      "refs":{
+        "DescribeEngineDefaultClusterParametersResult$EngineDefaults":null,
+        "DescribeEngineDefaultParametersResult$EngineDefaults":null
       }
     },
-    "Event": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>",
-      "refs": {
-        "EventList$member": null
+    "Event":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>",
+      "refs":{
+        "EventList$member":null
       }
     },
-    "EventCategoriesList": {
-      "base": null,
-      "refs": {
-        "CreateEventSubscriptionMessage$EventCategories": "<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>",
-        "DescribeEventsMessage$EventCategories": "<p>A list of event categories that trigger notifications for a event notification subscription.</p>",
-        "Event$EventCategories": "<p>Specifies the category for the event.</p>",
-        "EventCategoriesMap$EventCategories": "<p>The event categories for the specified source type</p>",
-        "EventSubscription$EventCategoriesList": "<p>A list of event categories for the RDS event notification subscription.</p>",
-        "ModifyEventSubscriptionMessage$EventCategories": "<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>"
+    "EventCategoriesList":{
+      "base":null,
+      "refs":{
+        "CreateEventSubscriptionMessage$EventCategories":"<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>",
+        "DescribeEventsMessage$EventCategories":"<p>A list of event categories that trigger notifications for a event notification subscription.</p>",
+        "Event$EventCategories":"<p>Specifies the category for the event.</p>",
+        "EventCategoriesMap$EventCategories":"<p>The event categories for the specified source type</p>",
+        "EventSubscription$EventCategoriesList":"<p>A list of event categories for the RDS event notification subscription.</p>",
+        "ModifyEventSubscriptionMessage$EventCategories":"<p> A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html\">Events</a> topic in the Amazon RDS User Guide or by using the <b>DescribeEventCategories</b> action. </p>"
       }
     },
-    "EventCategoriesMap": {
-      "base": "<p>Contains the results of a successful invocation of the <a>DescribeEventCategories</a> action.</p>",
-      "refs": {
-        "EventCategoriesMapList$member": null
+    "EventCategoriesMap":{
+      "base":"<p>Contains the results of a successful invocation of the <a>DescribeEventCategories</a> action.</p>",
+      "refs":{
+        "EventCategoriesMapList$member":null
       }
     },
-    "EventCategoriesMapList": {
-      "base": null,
-      "refs": {
-        "EventCategoriesMessage$EventCategoriesMapList": "<p>A list of EventCategoriesMap data types.</p>"
+    "EventCategoriesMapList":{
+      "base":null,
+      "refs":{
+        "EventCategoriesMessage$EventCategoriesMapList":"<p>A list of EventCategoriesMap data types.</p>"
       }
     },
-    "EventCategoriesMessage": {
-      "base": "<p>Data returned from the <b>DescribeEventCategories</b> action.</p>",
-      "refs": {
+    "EventCategoriesMessage":{
+      "base":"<p>Data returned from the <b>DescribeEventCategories</b> action.</p>",
+      "refs":{
       }
     },
-    "EventList": {
-      "base": null,
-      "refs": {
-        "EventsMessage$Events": "<p> A list of <a>Event</a> instances. </p>"
+    "EventList":{
+      "base":null,
+      "refs":{
+        "EventsMessage$Events":"<p> A list of <a>Event</a> instances. </p>"
       }
     },
-    "EventSubscription": {
-      "base": "<p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>",
-      "refs": {
-        "AddSourceIdentifierToSubscriptionResult$EventSubscription": null,
-        "CreateEventSubscriptionResult$EventSubscription": null,
-        "DeleteEventSubscriptionResult$EventSubscription": null,
-        "EventSubscriptionsList$member": null,
-        "ModifyEventSubscriptionResult$EventSubscription": null,
-        "RemoveSourceIdentifierFromSubscriptionResult$EventSubscription": null
+    "EventSubscription":{
+      "base":"<p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>",
+      "refs":{
+        "AddSourceIdentifierToSubscriptionResult$EventSubscription":null,
+        "CreateEventSubscriptionResult$EventSubscription":null,
+        "DeleteEventSubscriptionResult$EventSubscription":null,
+        "EventSubscriptionsList$member":null,
+        "ModifyEventSubscriptionResult$EventSubscription":null,
+        "RemoveSourceIdentifierFromSubscriptionResult$EventSubscription":null
       }
     },
-    "EventSubscriptionQuotaExceededFault": {
-      "base": "<p>You have reached the maximum number of event subscriptions.</p>",
-      "refs": {
+    "EventSubscriptionQuotaExceededFault":{
+      "base":"<p>You have reached the maximum number of event subscriptions.</p>",
+      "refs":{
       }
     },
-    "EventSubscriptionsList": {
-      "base": null,
-      "refs": {
-        "EventSubscriptionsMessage$EventSubscriptionsList": "<p>A list of EventSubscriptions data types.</p>"
+    "EventSubscriptionsList":{
+      "base":null,
+      "refs":{
+        "EventSubscriptionsMessage$EventSubscriptionsList":"<p>A list of EventSubscriptions data types.</p>"
       }
     },
-    "EventSubscriptionsMessage": {
-      "base": "<p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>",
-      "refs": {
+    "EventSubscriptionsMessage":{
+      "base":"<p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>",
+      "refs":{
       }
     },
-    "EventsMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>",
-      "refs": {
+    "EventsMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>",
+      "refs":{
       }
     },
-    "FailoverDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
+    "FailoverDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "FailoverDBClusterResult": {
-      "base": null,
-      "refs": {
+    "FailoverDBClusterResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "Filter": {
-      "base": "<p>A filter name and value pair that is used to return a more specific list of results from a describe operation. Filters can be used to match a set of resources by specific criteria, such as IDs. The filters supported by a describe operation are documented with the describe operation.</p> <note> <p>Currently, wildcards are not supported in filters.</p> </note> <p>The following actions can be filtered:</p> <ul> <li> <p> <a>DescribeDBClusterBacktracks</a> </p> </li> <li> <p> <a>DescribeDBClusters</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DescribePendingMaintenanceActions</a> </p> </li> </ul>",
-      "refs": {
-        "FilterList$member": null
+    "Filter":{
+      "base":"<p>A filter name and value pair that is used to return a more specific list of results from a describe operation. Filters can be used to match a set of resources by specific criteria, such as IDs. The filters supported by a describe operation are documented with the describe operation.</p> <note> <p>Currently, wildcards are not supported in filters.</p> </note> <p>The following actions can be filtered:</p> <ul> <li> <p> <a>DescribeDBClusterBacktracks</a> </p> </li> <li> <p> <a>DescribeDBClusters</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DescribePendingMaintenanceActions</a> </p> </li> </ul>",
+      "refs":{
+        "FilterList$member":null
       }
     },
-    "FilterList": {
-      "base": null,
-      "refs": {
-        "DescribeCertificatesMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBClusterBacktracksMessage$Filters": "<p>A filter that specifies one or more DB clusters to describe. Supported filters include the following:</p> <ul> <li> <p> <code>db-cluster-backtrack-id</code> - Accepts backtrack identifiers. The results list includes information about only the backtracks identified by these identifiers.</p> </li> <li> <p> <code>db-cluster-backtrack-status</code> - Accepts any of the following backtrack status values:</p> <ul> <li> <p> <code>applying</code> </p> </li> <li> <p> <code>completed</code> </p> </li> <li> <p> <code>failed</code> </p> </li> <li> <p> <code>pending</code> </p> </li> </ul> <p>The results list includes information about only the backtracks identified by these values. For more information about backtrack status values, see <a>DBClusterBacktrack</a>.</p> </li> </ul>",
-        "DescribeDBClusterParameterGroupsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBClusterParametersMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBClusterSnapshotsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBClustersMessage$Filters": "<p>A filter that specifies one or more DB clusters to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB clusters identified by these ARNs.</p> </li> </ul>",
-        "DescribeDBEngineVersionsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBInstancesMessage$Filters": "<p>A filter that specifies one or more DB instances to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB instances associated with the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance Amazon Resource Names (ARNs). The results list will only include information about the DB instances identified by these ARNs.</p> </li> </ul>",
-        "DescribeDBLogFilesMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBParameterGroupsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBParametersMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBSecurityGroupsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBSnapshotsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeDBSubnetGroupsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeEngineDefaultClusterParametersMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeEngineDefaultParametersMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeEventCategoriesMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeEventSubscriptionsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeEventsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeOptionGroupOptionsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeOptionGroupsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribePendingMaintenanceActionsMessage$Filters": "<p>A filter that specifies one or more resources to return pending maintenance actions for.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include pending maintenance actions for the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance ARNs. The results list will only include pending maintenance actions for the DB instances identified by these ARNs.</p> </li> </ul>",
-        "DescribeReservedDBInstancesMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeReservedDBInstancesOfferingsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "DescribeSourceRegionsMessage$Filters": "<p>This parameter is not currently supported.</p>",
-        "ListTagsForResourceMessage$Filters": "<p>This parameter is not currently supported.</p>"
+    "FilterList":{
+      "base":null,
+      "refs":{
+        "DescribeCertificatesMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBClusterBacktracksMessage$Filters":"<p>A filter that specifies one or more DB clusters to describe. Supported filters include the following:</p> <ul> <li> <p> <code>db-cluster-backtrack-id</code> - Accepts backtrack identifiers. The results list includes information about only the backtracks identified by these identifiers.</p> </li> <li> <p> <code>db-cluster-backtrack-status</code> - Accepts any of the following backtrack status values:</p> <ul> <li> <p> <code>applying</code> </p> </li> <li> <p> <code>completed</code> </p> </li> <li> <p> <code>failed</code> </p> </li> <li> <p> <code>pending</code> </p> </li> </ul> <p>The results list includes information about only the backtracks identified by these values. For more information about backtrack status values, see <a>DBClusterBacktrack</a>.</p> </li> </ul>",
+        "DescribeDBClusterParameterGroupsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBClusterParametersMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBClusterSnapshotsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBClustersMessage$Filters":"<p>A filter that specifies one or more DB clusters to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB clusters identified by these ARNs.</p> </li> </ul>",
+        "DescribeDBEngineVersionsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBInstancesMessage$Filters":"<p>A filter that specifies one or more DB instances to describe.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include information about the DB instances associated with the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance Amazon Resource Names (ARNs). The results list will only include information about the DB instances identified by these ARNs.</p> </li> </ul>",
+        "DescribeDBLogFilesMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBParameterGroupsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBParametersMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBSecurityGroupsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBSnapshotsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeDBSubnetGroupsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeEngineDefaultClusterParametersMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeEngineDefaultParametersMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeEventCategoriesMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeEventSubscriptionsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeEventsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeOptionGroupOptionsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeOptionGroupsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribePendingMaintenanceActionsMessage$Filters":"<p>A filter that specifies one or more resources to return pending maintenance actions for.</p> <p>Supported filters:</p> <ul> <li> <p> <code>db-cluster-id</code> - Accepts DB cluster identifiers and DB cluster Amazon Resource Names (ARNs). The results list will only include pending maintenance actions for the DB clusters identified by these ARNs.</p> </li> <li> <p> <code>db-instance-id</code> - Accepts DB instance identifiers and DB instance ARNs. The results list will only include pending maintenance actions for the DB instances identified by these ARNs.</p> </li> </ul>",
+        "DescribeReservedDBInstancesMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeReservedDBInstancesOfferingsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "DescribeSourceRegionsMessage$Filters":"<p>This parameter is not currently supported.</p>",
+        "ListTagsForResourceMessage$Filters":"<p>This parameter is not currently supported.</p>"
       }
     },
-    "FilterValueList": {
-      "base": null,
-      "refs": {
-        "Filter$Values": "<p>One or more filter values. Filter values are case-sensitive.</p>"
+    "FilterValueList":{
+      "base":null,
+      "refs":{
+        "Filter$Values":"<p>One or more filter values. Filter values are case-sensitive.</p>"
       }
     },
-    "IPRange": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>",
-      "refs": {
-        "IPRangeList$member": null
+    "IPRange":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>",
+      "refs":{
+        "IPRangeList$member":null
       }
     },
-    "IPRangeList": {
-      "base": null,
-      "refs": {
-        "DBSecurityGroup$IPRanges": "<p> Contains a list of <a>IPRange</a> elements. </p>"
+    "IPRangeList":{
+      "base":null,
+      "refs":{
+        "DBSecurityGroup$IPRanges":"<p> Contains a list of <a>IPRange</a> elements. </p>"
       }
     },
-    "InstanceQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of DB instances.</p>",
-      "refs": {
+    "InstanceQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of DB instances.</p>",
+      "refs":{
       }
     },
-    "InsufficientDBClusterCapacityFault": {
-      "base": "<p>The DB cluster doesn't have enough capacity for the current operation.</p>",
-      "refs": {
+    "InsufficientDBClusterCapacityFault":{
+      "base":"<p>The DB cluster doesn't have enough capacity for the current operation.</p>",
+      "refs":{
       }
     },
-    "InsufficientDBInstanceCapacityFault": {
-      "base": "<p>The specified DB instance class isn't available in the specified Availability Zone.</p>",
-      "refs": {
+    "InsufficientDBInstanceCapacityFault":{
+      "base":"<p>The specified DB instance class isn't available in the specified Availability Zone.</p>",
+      "refs":{
       }
     },
-    "InsufficientStorageClusterCapacityFault": {
-      "base": "<p>There is insufficient storage available for the current action. You might be able to resolve this error by updating your subnet group to use different Availability Zones that have more storage available.</p>",
-      "refs": {
+    "InsufficientStorageClusterCapacityFault":{
+      "base":"<p>There is insufficient storage available for the current action. You might be able to resolve this error by updating your subnet group to use different Availability Zones that have more storage available.</p>",
+      "refs":{
       }
     },
-    "Integer": {
-      "base": null,
-      "refs": {
-        "DBClusterSnapshot$AllocatedStorage": "<p>Specifies the allocated storage size in gibibytes (GiB).</p>",
-        "DBClusterSnapshot$Port": "<p>Specifies the port that the DB cluster was listening on at the time of the snapshot.</p>",
-        "DBClusterSnapshot$PercentProgress": "<p>Specifies the percentage of the estimated data that has been transferred.</p>",
-        "DBInstance$AllocatedStorage": "<p>Specifies the allocated storage size specified in gibibytes.</p>",
-        "DBInstance$BackupRetentionPeriod": "<p>Specifies the number of days for which automatic DB snapshots are retained.</p>",
-        "DBInstance$DbInstancePort": "<p>Specifies the port that the DB instance listens on. If the DB instance is part of a DB cluster, this can be a different port than the DB cluster port.</p>",
-        "DBSnapshot$AllocatedStorage": "<p>Specifies the allocated storage size in gibibytes (GiB).</p>",
-        "DBSnapshot$Port": "<p>Specifies the port that the database engine was listening on at the time of the snapshot.</p>",
-        "DBSnapshot$PercentProgress": "<p>The percentage of the estimated data that has been transferred.</p>",
-        "DownloadDBLogFilePortionMessage$NumberOfLines": "<p>The number of lines to download. If the number of lines specified results in a file over 1 MB in size, the file is truncated at 1 MB in size.</p> <p>If the NumberOfLines parameter is specified, then the block of lines returned can be from the beginning or the end of the log file, depending on the value of the Marker parameter.</p> <ul> <li> <p>If neither Marker or NumberOfLines are specified, the entire log file is returned up to a maximum of 10000 lines, starting with the most recent log entries first.</p> </li> <li> <p>If NumberOfLines is specified and Marker is not specified, then the most recent lines from the end of the log file are returned.</p> </li> <li> <p>If Marker is specified as \"0\", then the specified number of lines from the beginning of the log file are returned.</p> </li> <li> <p>You can download the log file in blocks of lines by specifying the size of the block using the NumberOfLines parameter, and by specifying a value of \"0\" for the Marker parameter in your first request. Include the Marker value returned in the response as the Marker value for the next request, continuing until the AdditionalDataPending response element returns false.</p> </li> </ul>",
-        "Endpoint$Port": "<p>Specifies the port that the database engine is listening on.</p>",
-        "Range$From": "<p>The minimum value in the range.</p>",
-        "Range$To": "<p>The maximum value in the range.</p>",
-        "ReservedDBInstance$Duration": "<p>The duration of the reservation in seconds.</p>",
-        "ReservedDBInstance$DBInstanceCount": "<p>The number of reserved DB instances.</p>",
-        "ReservedDBInstancesOffering$Duration": "<p>The duration of the offering in seconds.</p>"
+    "Integer":{
+      "base":null,
+      "refs":{
+        "DBClusterSnapshot$AllocatedStorage":"<p>Specifies the allocated storage size in gibibytes (GiB).</p>",
+        "DBClusterSnapshot$Port":"<p>Specifies the port that the DB cluster was listening on at the time of the snapshot.</p>",
+        "DBClusterSnapshot$PercentProgress":"<p>Specifies the percentage of the estimated data that has been transferred.</p>",
+        "DBInstance$AllocatedStorage":"<p>Specifies the allocated storage size specified in gibibytes.</p>",
+        "DBInstance$BackupRetentionPeriod":"<p>Specifies the number of days for which automatic DB snapshots are retained.</p>",
+        "DBInstance$DbInstancePort":"<p>Specifies the port that the DB instance listens on. If the DB instance is part of a DB cluster, this can be a different port than the DB cluster port.</p>",
+        "DBSnapshot$AllocatedStorage":"<p>Specifies the allocated storage size in gibibytes (GiB).</p>",
+        "DBSnapshot$Port":"<p>Specifies the port that the database engine was listening on at the time of the snapshot.</p>",
+        "DBSnapshot$PercentProgress":"<p>The percentage of the estimated data that has been transferred.</p>",
+        "DownloadDBLogFilePortionMessage$NumberOfLines":"<p>The number of lines to download. If the number of lines specified results in a file over 1 MB in size, the file is truncated at 1 MB in size.</p> <p>If the NumberOfLines parameter is specified, then the block of lines returned can be from the beginning or the end of the log file, depending on the value of the Marker parameter.</p> <ul> <li> <p>If neither Marker or NumberOfLines are specified, the entire log file is returned up to a maximum of 10000 lines, starting with the most recent log entries first.</p> </li> <li> <p>If NumberOfLines is specified and Marker is not specified, then the most recent lines from the end of the log file are returned.</p> </li> <li> <p>If Marker is specified as \"0\", then the specified number of lines from the beginning of the log file are returned.</p> </li> <li> <p>You can download the log file in blocks of lines by specifying the size of the block using the NumberOfLines parameter, and by specifying a value of \"0\" for the Marker parameter in your first request. Include the Marker value returned in the response as the Marker value for the next request, continuing until the AdditionalDataPending response element returns false.</p> </li> </ul>",
+        "Endpoint$Port":"<p>Specifies the port that the database engine is listening on.</p>",
+        "Range$From":"<p>The minimum value in the range.</p>",
+        "Range$To":"<p>The maximum value in the range.</p>",
+        "ReservedDBInstance$Duration":"<p>The duration of the reservation in seconds.</p>",
+        "ReservedDBInstance$DBInstanceCount":"<p>The number of reserved DB instances.</p>",
+        "ReservedDBInstancesOffering$Duration":"<p>The duration of the offering in seconds.</p>"
       }
     },
-    "IntegerOptional": {
-      "base": null,
-      "refs": {
-        "CreateDBClusterMessage$BackupRetentionPeriod": "<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
-        "CreateDBClusterMessage$Port": "<p>The port number on which the instances in the DB cluster accept connections.</p> <p> Default: <code>3306</code> if engine is set as aurora or <code>5432</code> if set to aurora-postgresql. </p>",
-        "CreateDBInstanceMessage$AllocatedStorage": "<p>The amount of storage (in gibibytes) to allocate for the DB instance.</p> <p>Type: Integer</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Aurora cluster volumes automatically grow as the amount of data in your database increases, though you are only charged for the space that you use in an Aurora cluster volume.</p> <p> <b>MySQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 10 to 3072.</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 16384.</p> </li> </ul> </li> <li> <p>Provisioned IOPS storage (io1):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 100 to 16384.</p> </li> </ul> </li> <li> <p>Magnetic storage (standard):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 1024.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 1024.</p> </li> </ul> </li> </ul>",
-        "CreateDBInstanceMessage$BackupRetentionPeriod": "<p>The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>",
-        "CreateDBInstanceMessage$Port": "<p>The port number on which the database accepts connections.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p>",
-        "CreateDBInstanceMessage$Iops": "<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance. For information about valid Iops values, see see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p> <p>Constraints: Must be a multiple between 1 and 50 of the storage amount for the DB instance. Must also be an integer multiple of 1000. For example, if the size of your DB instance is 500 GiB, then your <code>Iops</code> value can be 2000, 3000, 4000, or 5000. </p>",
-        "CreateDBInstanceMessage$MonitoringInterval": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
-        "CreateDBInstanceMessage$PromotionTier": "<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>",
-        "CreateDBInstanceReadReplicaMessage$Port": "<p>The port number that the DB instance uses for connections.</p> <p>Default: Inherits from the source DB instance</p> <p>Valid Values: <code>1150-65535</code> </p>",
-        "CreateDBInstanceReadReplicaMessage$Iops": "<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p>",
-        "CreateDBInstanceReadReplicaMessage$MonitoringInterval": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the Read Replica. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
-        "DBCluster$AllocatedStorage": "<p>For all database engines except Amazon Aurora, <code>AllocatedStorage</code> specifies the allocated storage size in gibibytes (GiB). For Aurora, <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size is not fixed, but instead automatically adjusts as needed.</p>",
-        "DBCluster$BackupRetentionPeriod": "<p>Specifies the number of days for which automatic DB snapshots are retained.</p>",
-        "DBCluster$Port": "<p>Specifies the port that the database engine is listening on.</p>",
-        "DBClusterMember$PromotionTier": "<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>",
-        "DBInstance$Iops": "<p>Specifies the Provisioned IOPS (I/O operations per second) value.</p>",
-        "DBInstance$MonitoringInterval": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance.</p>",
-        "DBInstance$PromotionTier": "<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>",
-        "DBSnapshot$Iops": "<p>Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.</p>",
-        "DescribeCertificatesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBClusterBacktracksMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBClusterParameterGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBClusterParametersMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBClusterSnapshotsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBClustersMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBEngineVersionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBInstancesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBLogFilesMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified MaxRecords value, a pagination token called a marker is included in the response so that the remaining results can be retrieved.</p>",
-        "DescribeDBParameterGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBParametersMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBSecurityGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBSnapshotsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeDBSubnetGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeEngineDefaultClusterParametersMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeEngineDefaultParametersMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeEventSubscriptionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeEventsMessage$Duration": "<p>The number of minutes to retrieve events for.</p> <p>Default: 60</p>",
-        "DescribeEventsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeOptionGroupOptionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeOptionGroupsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribePendingMaintenanceActionsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeReservedDBInstancesMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeReservedDBInstancesOfferingsMessage$MaxRecords": "<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "DescribeSourceRegionsMessage$MaxRecords": "<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
-        "ModifyDBClusterMessage$BackupRetentionPeriod": "<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
-        "ModifyDBClusterMessage$Port": "<p>The port number on which the DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>",
-        "ModifyDBInstanceMessage$AllocatedStorage": "<p>The new amount of storage (in gibibytes) to allocate for the DB instance. </p> <p>For MariaDB, MySQL, Oracle, and PostgreSQL, the value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. </p> <p>For the valid values for allocated storage for each engine, see <a>CreateDBInstance</a>. </p>",
-        "ModifyDBInstanceMessage$BackupRetentionPeriod": "<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Changing this parameter can result in an outage if you change from 0 to a non-zero value or from a non-zero value to 0. These changes are applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If you change the parameter from one non-zero value to another non-zero value, the change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Default: Uses existing setting</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Can be specified for a MySQL Read Replica only if the source is running MySQL 5.6</p> </li> <li> <p>Can be specified for a PostgreSQL Read Replica only if the source is running PostgreSQL 9.3.5</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>",
-        "ModifyDBInstanceMessage$Iops": "<p>The new Provisioned IOPS (I/O operations per second) value for the RDS instance. </p> <p>Changing this setting doesn't result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If you are migrating from Provisioned IOPS to standard storage, set this value to 0. The DB instance will require a reboot for the change in storage type to take effect. </p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance is available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance are suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance. </p> <p>Constraints: For MariaDB, MySQL, Oracle, and PostgreSQL, the value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. </p> <p>Default: Uses existing setting</p>",
-        "ModifyDBInstanceMessage$MonitoringInterval": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
-        "ModifyDBInstanceMessage$DBPortNumber": "<p>The port number on which the database accepts connections.</p> <p>The value of the <code>DBPortNumber</code> parameter must not match any of the port values specified for options in the option group for the DB instance.</p> <p>Your database will restart when you change the <code>DBPortNumber</code> value regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p>",
-        "ModifyDBInstanceMessage$PromotionTier": "<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>",
-        "Option$Port": "<p>If required, the port configured for this option to use.</p>",
-        "OptionConfiguration$Port": "<p>The optional port for the option.</p>",
-        "OptionGroupOption$DefaultPort": "<p>If the option requires a port, specifies the default port for the option.</p>",
-        "OrderableDBInstanceOption$MinStorageSize": "<p>Minimum storage size for a DB instance.</p>",
-        "OrderableDBInstanceOption$MaxStorageSize": "<p>Maximum storage size for a DB instance.</p>",
-        "OrderableDBInstanceOption$MinIopsPerDbInstance": "<p>Minimum total provisioned IOPS for a DB instance.</p>",
-        "OrderableDBInstanceOption$MaxIopsPerDbInstance": "<p>Maximum total provisioned IOPS for a DB instance.</p>",
-        "PendingModifiedValues$AllocatedStorage": "<p> Contains the new <code>AllocatedStorage</code> size for the DB instance that will be applied or is currently being applied. </p>",
-        "PendingModifiedValues$Port": "<p>Specifies the pending port for the DB instance.</p>",
-        "PendingModifiedValues$BackupRetentionPeriod": "<p>Specifies the pending number of days for which automated backups are retained.</p>",
-        "PendingModifiedValues$Iops": "<p>Specifies the new Provisioned IOPS value for the DB instance that will be applied or is currently being applied.</p>",
-        "PromoteReadReplicaMessage$BackupRetentionPeriod": "<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 8</p> </li> </ul>",
-        "PurchaseReservedDBInstancesOfferingMessage$DBInstanceCount": "<p>The number of instances to reserve.</p> <p>Default: <code>1</code> </p>",
-        "Range$Step": "<p>The step value for the range. For example, if you have a range of 5,000 to 10,000, with a step value of 1,000, the valid values start at 5,000 and step up by 1,000. Even though 7,500 is within the range, it isn't a valid value for the range. The valid values are 5,000, 6,000, 7,000, 8,000... </p>",
-        "RestoreDBClusterFromS3Message$BackupRetentionPeriod": "<p>The number of days for which automated backups of the restored DB cluster are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
-        "RestoreDBClusterFromS3Message$Port": "<p>The port number on which the instances in the restored DB cluster accept connections.</p> <p> Default: <code>3306</code> </p>",
-        "RestoreDBClusterFromSnapshotMessage$Port": "<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>",
-        "RestoreDBClusterToPointInTimeMessage$Port": "<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: A value from <code>1150-65535</code>. </p> <p>Default: The default port for the engine.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$Port": "<p>The port number on which the database accepts connections.</p> <p>Default: The same port as the original DB instance</p> <p>Constraints: Value must be <code>1150-65535</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$Iops": "<p>Specifies the amount of provisioned IOPS for the DB instance, expressed in I/O operations per second. If this parameter is not specified, the IOPS value is taken from the backup. If this parameter is set to 0, the new instance is converted to a non-PIOPS instance. The conversion takes additional time, though your DB instance is available for connections before the conversion starts. </p> <p>The provisioned IOPS value must follow the requirements for your database engine. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p> <p>Constraints: Must be an integer greater than 1000.</p>",
-        "RestoreDBInstanceFromS3Message$AllocatedStorage": "<p>The amount of storage (in gigabytes) to allocate initially for the DB instance. Follow the allocation rules specified in <a>CreateDBInstance</a>. </p> <note> <p>Be sure to allocate enough memory for your new DB instance so that the restore operation can succeed. You can also allocate additional memory for future growth. </p> </note>",
-        "RestoreDBInstanceFromS3Message$BackupRetentionPeriod": "<p>The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. For more information, see <a>CreateDBInstance</a>. </p>",
-        "RestoreDBInstanceFromS3Message$Port": "<p>The port number on which the database accepts connections. </p> <p>Type: Integer </p> <p>Valid Values: <code>1150</code>-<code>65535</code> </p> <p>Default: <code>3306</code> </p>",
-        "RestoreDBInstanceFromS3Message$Iops": "<p>The amount of Provisioned IOPS (input/output operations per second) to allocate initially for the DB instance. For information about valid Iops values, see see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p>",
-        "RestoreDBInstanceFromS3Message$MonitoringInterval": "<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. </p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0. </p> <p>Valid Values: 0, 1, 5, 10, 15, 30, 60 </p> <p>Default: <code>0</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$Port": "<p>The port number on which the database accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB instance.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$Iops": "<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p> <p>Constraints: Must be an integer greater than 1000.</p> <p> <b>SQL Server</b> </p> <p>Setting the IOPS value for the SQL Server database engine is not supported.</p>"
+    "IntegerOptional":{
+      "base":null,
+      "refs":{
+        "CreateDBClusterMessage$BackupRetentionPeriod":"<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
+        "CreateDBClusterMessage$Port":"<p>The port number on which the instances in the DB cluster accept connections.</p> <p> Default: <code>3306</code> if engine is set as aurora or <code>5432</code> if set to aurora-postgresql. </p>",
+        "CreateDBInstanceMessage$AllocatedStorage":"<p>The amount of storage (in gibibytes) to allocate for the DB instance.</p> <p>Type: Integer</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. Aurora cluster volumes automatically grow as the amount of data in your database increases, though you are only charged for the space that you use in an Aurora cluster volume.</p> <p> <b>MySQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 5 to 3072.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2): Must be an integer from 20 to 16384.</p> </li> <li> <p>Provisioned IOPS storage (io1): Must be an integer from 100 to 16384.</p> </li> <li> <p>Magnetic storage (standard): Must be an integer from 10 to 3072.</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Constraints to the amount of storage for each storage type are the following: </p> <ul> <li> <p>General Purpose (SSD) storage (gp2):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 16384.</p> </li> </ul> </li> <li> <p>Provisioned IOPS storage (io1):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 16384.</p> </li> <li> <p>Web and Express editions: Must be an integer from 100 to 16384.</p> </li> </ul> </li> <li> <p>Magnetic storage (standard):</p> <ul> <li> <p>Enterprise and Standard editions: Must be an integer from 200 to 1024.</p> </li> <li> <p>Web and Express editions: Must be an integer from 20 to 1024.</p> </li> </ul> </li> </ul>",
+        "CreateDBInstanceMessage$BackupRetentionPeriod":"<p>The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>",
+        "CreateDBInstanceMessage$Port":"<p>The port number on which the database accepts connections.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p>",
+        "CreateDBInstanceMessage$Iops":"<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance. For information about valid Iops values, see see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p> <p>Constraints: Must be a multiple between 1 and 50 of the storage amount for the DB instance. Must also be an integer multiple of 1000. For example, if the size of your DB instance is 500 GiB, then your <code>Iops</code> value can be 2000, 3000, 4000, or 5000. </p>",
+        "CreateDBInstanceMessage$MonitoringInterval":"<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
+        "CreateDBInstanceMessage$PromotionTier":"<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>",
+        "CreateDBInstanceMessage$PerformanceInsightsRetentionPeriod":"<p>The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years). </p>",
+        "CreateDBInstanceReadReplicaMessage$Port":"<p>The port number that the DB instance uses for connections.</p> <p>Default: Inherits from the source DB instance</p> <p>Valid Values: <code>1150-65535</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$Iops":"<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p>",
+        "CreateDBInstanceReadReplicaMessage$MonitoringInterval":"<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the Read Replica. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$PerformanceInsightsRetentionPeriod":"<p>The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years). </p>",
+        "DBCluster$AllocatedStorage":"<p>For all database engines except Amazon Aurora, <code>AllocatedStorage</code> specifies the allocated storage size in gibibytes (GiB). For Aurora, <code>AllocatedStorage</code> always returns 1, because Aurora DB cluster storage size is not fixed, but instead automatically adjusts as needed.</p>",
+        "DBCluster$BackupRetentionPeriod":"<p>Specifies the number of days for which automatic DB snapshots are retained.</p>",
+        "DBCluster$Port":"<p>Specifies the port that the database engine is listening on.</p>",
+        "DBClusterMember$PromotionTier":"<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>",
+        "DBInstance$Iops":"<p>Specifies the Provisioned IOPS (I/O operations per second) value.</p>",
+        "DBInstance$MonitoringInterval":"<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance.</p>",
+        "DBInstance$PromotionTier":"<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p>",
+        "DBInstance$PerformanceInsightsRetentionPeriod":"<p>The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years). </p>",
+        "DBSnapshot$Iops":"<p>Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.</p>",
+        "DescribeCertificatesMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBClusterBacktracksMessage$MaxRecords":"<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBClusterParameterGroupsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBClusterParametersMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBClusterSnapshotsMessage$MaxRecords":"<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBClustersMessage$MaxRecords":"<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBEngineVersionsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBInstancesMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBLogFilesMessage$MaxRecords":"<p>The maximum number of records to include in the response. If more records exist than the specified MaxRecords value, a pagination token called a marker is included in the response so that the remaining results can be retrieved.</p>",
+        "DescribeDBParameterGroupsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBParametersMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBSecurityGroupsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBSnapshotsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeDBSubnetGroupsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEngineDefaultClusterParametersMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEngineDefaultParametersMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEventSubscriptionsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeEventsMessage$Duration":"<p>The number of minutes to retrieve events for.</p> <p>Default: 60</p>",
+        "DescribeEventsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeOptionGroupOptionsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeOptionGroupsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribePendingMaintenanceActionsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeReservedDBInstancesMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeReservedDBInstancesOfferingsMessage$MaxRecords":"<p> The maximum number of records to include in the response. If more than the <code>MaxRecords</code> value is available, a pagination token called a marker is included in the response so that the following results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "DescribeSourceRegionsMessage$MaxRecords":"<p>The maximum number of records to include in the response. If more records exist than the specified <code>MaxRecords</code> value, a pagination token called a marker is included in the response so that the remaining results can be retrieved. </p> <p>Default: 100</p> <p>Constraints: Minimum 20, maximum 100.</p>",
+        "ModifyDBClusterMessage$BackupRetentionPeriod":"<p>The number of days for which automated backups are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
+        "ModifyDBClusterMessage$Port":"<p>The port number on which the DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>",
+        "ModifyDBInstanceMessage$AllocatedStorage":"<p>The new amount of storage (in gibibytes) to allocate for the DB instance. </p> <p>For MariaDB, MySQL, Oracle, and PostgreSQL, the value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. </p> <p>For the valid values for allocated storage for each engine, see <a>CreateDBInstance</a>. </p>",
+        "ModifyDBInstanceMessage$BackupRetentionPeriod":"<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Changing this parameter can result in an outage if you change from 0 to a non-zero value or from a non-zero value to 0. These changes are applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If you change the parameter from one non-zero value to another non-zero value, the change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The retention period for automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Default: Uses existing setting</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 35</p> </li> <li> <p>Can be specified for a MySQL Read Replica only if the source is running MySQL 5.6</p> </li> <li> <p>Can be specified for a PostgreSQL Read Replica only if the source is running PostgreSQL 9.3.5</p> </li> <li> <p>Cannot be set to 0 if the DB instance is a source to Read Replicas</p> </li> </ul>",
+        "ModifyDBInstanceMessage$Iops":"<p>The new Provisioned IOPS (I/O operations per second) value for the RDS instance. </p> <p>Changing this setting doesn't result in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If you are migrating from Provisioned IOPS to standard storage, set this value to 0. The DB instance will require a reboot for the change in storage type to take effect. </p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance is available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance are suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance. </p> <p>Constraints: For MariaDB, MySQL, Oracle, and PostgreSQL, the value supplied must be at least 10% greater than the current value. Values that are not at least 10% greater than the existing value are rounded up so that they are 10% greater than the current value. </p> <p>Default: Uses existing setting</p>",
+        "ModifyDBInstanceMessage$MonitoringInterval":"<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0.</p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0.</p> <p>Valid Values: <code>0, 1, 5, 10, 15, 30, 60</code> </p>",
+        "ModifyDBInstanceMessage$DBPortNumber":"<p>The port number on which the database accepts connections.</p> <p>The value of the <code>DBPortNumber</code> parameter must not match any of the port values specified for options in the option group for the DB instance.</p> <p>Your database will restart when you change the <code>DBPortNumber</code> value regardless of the value of the <code>ApplyImmediately</code> parameter.</p> <p> <b>MySQL</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>MariaDB</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>PostgreSQL</b> </p> <p> Default: <code>5432</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p>Type: Integer</p> <p> <b>Oracle</b> </p> <p> Default: <code>1521</code> </p> <p> Valid Values: <code>1150-65535</code> </p> <p> <b>SQL Server</b> </p> <p> Default: <code>1433</code> </p> <p> Valid Values: <code>1150-65535</code> except for <code>1434</code>, <code>3389</code>, <code>47001</code>, <code>49152</code>, and <code>49152</code> through <code>49156</code>. </p> <p> <b>Amazon Aurora</b> </p> <p> Default: <code>3306</code> </p> <p> Valid Values: <code>1150-65535</code> </p>",
+        "ModifyDBInstanceMessage$PromotionTier":"<p>A value that specifies the order in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.Managing.html#Aurora.Managing.FaultTolerance\"> Fault Tolerance for an Aurora DB Cluster</a>. </p> <p>Default: 1</p> <p>Valid Values: 0 - 15</p>",
+        "ModifyDBInstanceMessage$PerformanceInsightsRetentionPeriod":"<p>The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years). </p>",
+        "Option$Port":"<p>If required, the port configured for this option to use.</p>",
+        "OptionConfiguration$Port":"<p>The optional port for the option.</p>",
+        "OptionGroupOption$DefaultPort":"<p>If the option requires a port, specifies the default port for the option.</p>",
+        "OrderableDBInstanceOption$MinStorageSize":"<p>Minimum storage size for a DB instance.</p>",
+        "OrderableDBInstanceOption$MaxStorageSize":"<p>Maximum storage size for a DB instance.</p>",
+        "OrderableDBInstanceOption$MinIopsPerDbInstance":"<p>Minimum total provisioned IOPS for a DB instance.</p>",
+        "OrderableDBInstanceOption$MaxIopsPerDbInstance":"<p>Maximum total provisioned IOPS for a DB instance.</p>",
+        "PendingModifiedValues$AllocatedStorage":"<p> Contains the new <code>AllocatedStorage</code> size for the DB instance that will be applied or is currently being applied. </p>",
+        "PendingModifiedValues$Port":"<p>Specifies the pending port for the DB instance.</p>",
+        "PendingModifiedValues$BackupRetentionPeriod":"<p>Specifies the pending number of days for which automated backups are retained.</p>",
+        "PendingModifiedValues$Iops":"<p>Specifies the new Provisioned IOPS value for the DB instance that will be applied or is currently being applied.</p>",
+        "PromoteReadReplicaMessage$BackupRetentionPeriod":"<p>The number of days to retain automated backups. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 0 to 8</p> </li> </ul>",
+        "PurchaseReservedDBInstancesOfferingMessage$DBInstanceCount":"<p>The number of instances to reserve.</p> <p>Default: <code>1</code> </p>",
+        "Range$Step":"<p>The step value for the range. For example, if you have a range of 5,000 to 10,000, with a step value of 1,000, the valid values start at 5,000 and step up by 1,000. Even though 7,500 is within the range, it isn't a valid value for the range. The valid values are 5,000, 6,000, 7,000, 8,000... </p>",
+        "RestoreDBClusterFromS3Message$BackupRetentionPeriod":"<p>The number of days for which automated backups of the restored DB cluster are retained. You must specify a minimum value of 1.</p> <p>Default: 1</p> <p>Constraints:</p> <ul> <li> <p>Must be a value from 1 to 35</p> </li> </ul>",
+        "RestoreDBClusterFromS3Message$Port":"<p>The port number on which the instances in the restored DB cluster accept connections.</p> <p> Default: <code>3306</code> </p>",
+        "RestoreDBClusterFromSnapshotMessage$Port":"<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB cluster.</p>",
+        "RestoreDBClusterToPointInTimeMessage$Port":"<p>The port number on which the new DB cluster accepts connections.</p> <p>Constraints: A value from <code>1150-65535</code>. </p> <p>Default: The default port for the engine.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$Port":"<p>The port number on which the database accepts connections.</p> <p>Default: The same port as the original DB instance</p> <p>Constraints: Value must be <code>1150-65535</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$Iops":"<p>Specifies the amount of provisioned IOPS for the DB instance, expressed in I/O operations per second. If this parameter is not specified, the IOPS value is taken from the backup. If this parameter is set to 0, the new instance is converted to a non-PIOPS instance. The conversion takes additional time, though your DB instance is available for connections before the conversion starts. </p> <p>The provisioned IOPS value must follow the requirements for your database engine. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p> <p>Constraints: Must be an integer greater than 1000.</p>",
+        "RestoreDBInstanceFromS3Message$AllocatedStorage":"<p>The amount of storage (in gigabytes) to allocate initially for the DB instance. Follow the allocation rules specified in <a>CreateDBInstance</a>. </p> <note> <p>Be sure to allocate enough memory for your new DB instance so that the restore operation can succeed. You can also allocate additional memory for future growth. </p> </note>",
+        "RestoreDBInstanceFromS3Message$BackupRetentionPeriod":"<p>The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. For more information, see <a>CreateDBInstance</a>. </p>",
+        "RestoreDBInstanceFromS3Message$Port":"<p>The port number on which the database accepts connections. </p> <p>Type: Integer </p> <p>Valid Values: <code>1150</code>-<code>65535</code> </p> <p>Default: <code>3306</code> </p>",
+        "RestoreDBInstanceFromS3Message$Iops":"<p>The amount of Provisioned IOPS (input/output operations per second) to allocate initially for the DB instance. For information about valid Iops values, see see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#USER_PIOPS\">Amazon RDS Provisioned IOPS Storage to Improve Performance</a>. </p>",
+        "RestoreDBInstanceFromS3Message$MonitoringInterval":"<p>The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. </p> <p>If <code>MonitoringRoleArn</code> is specified, then you must also set <code>MonitoringInterval</code> to a value other than 0. </p> <p>Valid Values: 0, 1, 5, 10, 15, 30, 60 </p> <p>Default: <code>0</code> </p>",
+        "RestoreDBInstanceFromS3Message$PerformanceInsightsRetentionPeriod":"<p>The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731 (2 years). </p>",
+        "RestoreDBInstanceToPointInTimeMessage$Port":"<p>The port number on which the database accepts connections.</p> <p>Constraints: Value must be <code>1150-65535</code> </p> <p>Default: The same port as the original DB instance.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$Iops":"<p>The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for the DB instance.</p> <p>Constraints: Must be an integer greater than 1000.</p> <p> <b>SQL Server</b> </p> <p>Setting the IOPS value for the SQL Server database engine is not supported.</p>"
       }
     },
-    "InvalidDBClusterSnapshotStateFault": {
-      "base": "<p>The supplied value isn't a valid DB cluster snapshot state.</p>",
-      "refs": {
+    "InvalidDBClusterSnapshotStateFault":{
+      "base":"<p>The supplied value isn't a valid DB cluster snapshot state.</p>",
+      "refs":{
       }
     },
-    "InvalidDBClusterStateFault": {
-      "base": "<p>The DB cluster isn't in a valid state.</p>",
-      "refs": {
+    "InvalidDBClusterStateFault":{
+      "base":"<p>The DB cluster isn't in a valid state.</p>",
+      "refs":{
       }
     },
-    "InvalidDBInstanceStateFault": {
-      "base": "<p> The specified DB instance isn't in the <i>available</i> state. </p>",
-      "refs": {
+    "InvalidDBInstanceStateFault":{
+      "base":"<p> The specified DB instance isn't in the <i>available</i> state. </p>",
+      "refs":{
       }
     },
-    "InvalidDBParameterGroupStateFault": {
-      "base": "<p>The DB parameter group is in use or is in an invalid state. If you are attempting to delete the parameter group, you can't delete it when the parameter group is in this state.</p>",
-      "refs": {
+    "InvalidDBParameterGroupStateFault":{
+      "base":"<p>The DB parameter group is in use or is in an invalid state. If you are attempting to delete the parameter group, you can't delete it when the parameter group is in this state.</p>",
+      "refs":{
       }
     },
-    "InvalidDBSecurityGroupStateFault": {
-      "base": "<p>The state of the DB security group doesn't allow deletion.</p>",
-      "refs": {
+    "InvalidDBSecurityGroupStateFault":{
+      "base":"<p>The state of the DB security group doesn't allow deletion.</p>",
+      "refs":{
       }
     },
-    "InvalidDBSnapshotStateFault": {
-      "base": "<p>The state of the DB snapshot doesn't allow deletion.</p>",
-      "refs": {
+    "InvalidDBSnapshotStateFault":{
+      "base":"<p>The state of the DB snapshot doesn't allow deletion.</p>",
+      "refs":{
       }
     },
-    "InvalidDBSubnetGroupFault": {
-      "base": "<p>The DBSubnetGroup doesn't belong to the same VPC as that of an existing cross-region read replica of the same source instance.</p>",
-      "refs": {
+    "InvalidDBSubnetGroupFault":{
+      "base":"<p>The DBSubnetGroup doesn't belong to the same VPC as that of an existing cross-region read replica of the same source instance.</p>",
+      "refs":{
       }
     },
-    "InvalidDBSubnetGroupStateFault": {
-      "base": "<p>The DB subnet group cannot be deleted because it's in use.</p>",
-      "refs": {
+    "InvalidDBSubnetGroupStateFault":{
+      "base":"<p>The DB subnet group cannot be deleted because it's in use.</p>",
+      "refs":{
       }
     },
-    "InvalidDBSubnetStateFault": {
-      "base": "<p> The DB subnet isn't in the <i>available</i> state. </p>",
-      "refs": {
+    "InvalidDBSubnetStateFault":{
+      "base":"<p> The DB subnet isn't in the <i>available</i> state. </p>",
+      "refs":{
       }
     },
-    "InvalidEventSubscriptionStateFault": {
-      "base": "<p>This error can occur if someone else is modifying a subscription. You should retry the action.</p>",
-      "refs": {
+    "InvalidEventSubscriptionStateFault":{
+      "base":"<p>This error can occur if someone else is modifying a subscription. You should retry the action.</p>",
+      "refs":{
       }
     },
-    "InvalidOptionGroupStateFault": {
-      "base": "<p> The option group isn't in the <i>available</i> state. </p>",
-      "refs": {
+    "InvalidOptionGroupStateFault":{
+      "base":"<p> The option group isn't in the <i>available</i> state. </p>",
+      "refs":{
       }
     },
-    "InvalidRestoreFault": {
-      "base": "<p>Cannot restore from VPC backup to non-VPC DB instance.</p>",
-      "refs": {
+    "InvalidRestoreFault":{
+      "base":"<p>Cannot restore from VPC backup to non-VPC DB instance.</p>",
+      "refs":{
       }
     },
-    "InvalidS3BucketFault": {
-      "base": "<p>The specified Amazon S3 bucket name can't be found or Amazon RDS isn't authorized to access the specified Amazon S3 bucket. Verify the <b>SourceS3BucketName</b> and <b>S3IngestionRoleArn</b> values and try again.</p>",
-      "refs": {
+    "InvalidS3BucketFault":{
+      "base":"<p>The specified Amazon S3 bucket name can't be found or Amazon RDS isn't authorized to access the specified Amazon S3 bucket. Verify the <b>SourceS3BucketName</b> and <b>S3IngestionRoleArn</b> values and try again.</p>",
+      "refs":{
       }
     },
-    "InvalidSubnet": {
-      "base": "<p>The requested subnet is invalid, or multiple subnets were requested that are not all in a common VPC.</p>",
-      "refs": {
+    "InvalidSubnet":{
+      "base":"<p>The requested subnet is invalid, or multiple subnets were requested that are not all in a common VPC.</p>",
+      "refs":{
       }
     },
-    "InvalidVPCNetworkStateFault": {
-      "base": "<p>The DB subnet group doesn't cover all Availability Zones after it's created because of users' change.</p>",
-      "refs": {
+    "InvalidVPCNetworkStateFault":{
+      "base":"<p>The DB subnet group doesn't cover all Availability Zones after it's created because of users' change.</p>",
+      "refs":{
       }
     },
-    "KMSKeyNotAccessibleFault": {
-      "base": "<p>An error occurred accessing an AWS KMS key.</p>",
-      "refs": {
+    "KMSKeyNotAccessibleFault":{
+      "base":"<p>An error occurred accessing an AWS KMS key.</p>",
+      "refs":{
       }
     },
-    "KeyList": {
-      "base": null,
-      "refs": {
-        "RemoveTagsFromResourceMessage$TagKeys": "<p>The tag key (name) of the tag to be removed.</p>"
+    "KeyList":{
+      "base":null,
+      "refs":{
+        "RemoveTagsFromResourceMessage$TagKeys":"<p>The tag key (name) of the tag to be removed.</p>"
       }
     },
-    "ListTagsForResourceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ListTagsForResourceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "LogTypeList": {
-      "base": null,
-      "refs": {
-        "CloudwatchLogsExportConfiguration$EnableLogTypes": "<p>The list of log types to enable.</p>",
-        "CloudwatchLogsExportConfiguration$DisableLogTypes": "<p>The list of log types to disable.</p>",
-        "CreateDBClusterMessage$EnableCloudwatchLogsExports": "<p>The list of log types that need to be enabled for exporting to CloudWatch Logs.</p>",
-        "CreateDBInstanceMessage$EnableCloudwatchLogsExports": "<p>The list of log types that need to be enabled for exporting to CloudWatch Logs.</p>",
-        "CreateDBInstanceReadReplicaMessage$EnableCloudwatchLogsExports": "<p>The list of logs that the new DB instance is to export to CloudWatch Logs.</p>",
-        "DBCluster$EnabledCloudwatchLogsExports": "<p>A list of log types that this DB cluster is configured to export to CloudWatch Logs.</p>",
-        "DBEngineVersion$ExportableLogTypes": "<p>The types of logs that the database engine has available for export to CloudWatch Logs.</p>",
-        "DBInstance$EnabledCloudwatchLogsExports": "<p>A list of log types that this DB instance is configured to export to CloudWatch Logs.</p>",
-        "PendingCloudwatchLogsExports$LogTypesToEnable": "<p>Log types that are in the process of being deactivated. After they are deactivated, these log types aren't exported to CloudWatch Logs.</p>",
-        "PendingCloudwatchLogsExports$LogTypesToDisable": "<p>Log types that are in the process of being enabled. After they are enabled, these log types are exported to CloudWatch Logs.</p>",
-        "RestoreDBClusterFromS3Message$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
-        "RestoreDBClusterFromSnapshotMessage$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
-        "RestoreDBClusterToPointInTimeMessage$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>",
-        "RestoreDBInstanceFromS3Message$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$EnableCloudwatchLogsExports": "<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>"
+    "LogTypeList":{
+      "base":null,
+      "refs":{
+        "CloudwatchLogsExportConfiguration$EnableLogTypes":"<p>The list of log types to enable.</p>",
+        "CloudwatchLogsExportConfiguration$DisableLogTypes":"<p>The list of log types to disable.</p>",
+        "CreateDBClusterMessage$EnableCloudwatchLogsExports":"<p>The list of log types that need to be enabled for exporting to CloudWatch Logs.</p>",
+        "CreateDBInstanceMessage$EnableCloudwatchLogsExports":"<p>The list of log types that need to be enabled for exporting to CloudWatch Logs.</p>",
+        "CreateDBInstanceReadReplicaMessage$EnableCloudwatchLogsExports":"<p>The list of logs that the new DB instance is to export to CloudWatch Logs.</p>",
+        "DBCluster$EnabledCloudwatchLogsExports":"<p>A list of log types that this DB cluster is configured to export to CloudWatch Logs.</p>",
+        "DBEngineVersion$ExportableLogTypes":"<p>The types of logs that the database engine has available for export to CloudWatch Logs.</p>",
+        "DBInstance$EnabledCloudwatchLogsExports":"<p>A list of log types that this DB instance is configured to export to CloudWatch Logs.</p>",
+        "PendingCloudwatchLogsExports$LogTypesToEnable":"<p>Log types that are in the process of being deactivated. After they are deactivated, these log types aren't exported to CloudWatch Logs.</p>",
+        "PendingCloudwatchLogsExports$LogTypesToDisable":"<p>Log types that are in the process of being enabled. After they are enabled, these log types are exported to CloudWatch Logs.</p>",
+        "RestoreDBClusterFromS3Message$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
+        "RestoreDBClusterFromSnapshotMessage$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
+        "RestoreDBClusterToPointInTimeMessage$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB cluster is to export to CloudWatch Logs.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>",
+        "RestoreDBInstanceFromS3Message$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$EnableCloudwatchLogsExports":"<p>The list of logs that the restored DB instance is to export to CloudWatch Logs.</p>"
       }
     },
-    "Long": {
-      "base": null,
-      "refs": {
-        "AccountQuota$Used": "<p>The amount currently used toward the quota maximum.</p>",
-        "AccountQuota$Max": "<p>The maximum allowed value for the quota.</p>",
-        "DescribeDBLogFilesDetails$LastWritten": "<p>A POSIX timestamp when the last log entry was written.</p>",
-        "DescribeDBLogFilesDetails$Size": "<p>The size, in bytes, of the log file for the specified DB instance.</p>",
-        "DescribeDBLogFilesMessage$FileLastWritten": "<p>Filters the available log files for files written since the specified date, in POSIX timestamp format with milliseconds.</p>",
-        "DescribeDBLogFilesMessage$FileSize": "<p>Filters the available log files for files larger than the specified size.</p>"
+    "Long":{
+      "base":null,
+      "refs":{
+        "AccountQuota$Used":"<p>The amount currently used toward the quota maximum.</p>",
+        "AccountQuota$Max":"<p>The maximum allowed value for the quota.</p>",
+        "DescribeDBLogFilesDetails$LastWritten":"<p>A POSIX timestamp when the last log entry was written.</p>",
+        "DescribeDBLogFilesDetails$Size":"<p>The size, in bytes, of the log file for the specified DB instance.</p>",
+        "DescribeDBLogFilesMessage$FileLastWritten":"<p>Filters the available log files for files written since the specified date, in POSIX timestamp format with milliseconds.</p>",
+        "DescribeDBLogFilesMessage$FileSize":"<p>Filters the available log files for files larger than the specified size.</p>"
       }
     },
-    "LongOptional": {
-      "base": null,
-      "refs": {
-        "CreateDBClusterMessage$BacktrackWindow": "<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0. </p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
-        "DBCluster$BacktrackWindow": "<p>The target backtrack window, in seconds. If this value is set to 0, backtracking is disabled for the DB cluster. Otherwise, backtracking is enabled.</p>",
-        "DBCluster$BacktrackConsumedChangeRecords": "<p>The number of change records stored for Backtrack.</p>",
-        "ModifyDBClusterMessage$BacktrackWindow": "<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
-        "RestoreDBClusterFromS3Message$BacktrackWindow": "<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
-        "RestoreDBClusterFromSnapshotMessage$BacktrackWindow": "<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
-        "RestoreDBClusterToPointInTimeMessage$BacktrackWindow": "<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>"
+    "LongOptional":{
+      "base":null,
+      "refs":{
+        "CreateDBClusterMessage$BacktrackWindow":"<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0. </p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
+        "DBCluster$BacktrackWindow":"<p>The target backtrack window, in seconds. If this value is set to 0, backtracking is disabled for the DB cluster. Otherwise, backtracking is enabled.</p>",
+        "DBCluster$BacktrackConsumedChangeRecords":"<p>The number of change records stored for Backtrack.</p>",
+        "ModifyDBClusterMessage$BacktrackWindow":"<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
+        "RestoreDBClusterFromS3Message$BacktrackWindow":"<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
+        "RestoreDBClusterFromSnapshotMessage$BacktrackWindow":"<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>",
+        "RestoreDBClusterToPointInTimeMessage$BacktrackWindow":"<p>The target backtrack window, in seconds. To disable backtracking, set this value to 0.</p> <p>Default: 0</p> <p>Constraints:</p> <ul> <li> <p>If specified, this value must be set to a number from 0 to 259,200 (72 hours).</p> </li> </ul>"
       }
     },
-    "ModifyDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBClusterParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBClusterParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBClusterResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBClusterResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBClusterSnapshotAttributeMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBClusterSnapshotAttributeMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBClusterSnapshotAttributeResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBClusterSnapshotAttributeResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBInstanceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBInstanceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBInstanceResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBSnapshotAttributeMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBSnapshotAttributeMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBSnapshotAttributeResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBSnapshotAttributeResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBSnapshotMessage": {
-      "base": null,
-      "refs": {
+    "ModifyDBSnapshotMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBSnapshotResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyDBSubnetGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyDBSubnetGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyDBSubnetGroupResult": {
-      "base": null,
-      "refs": {
+    "ModifyDBSubnetGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyEventSubscriptionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyEventSubscriptionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyEventSubscriptionResult": {
-      "base": null,
-      "refs": {
+    "ModifyEventSubscriptionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ModifyOptionGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ModifyOptionGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ModifyOptionGroupResult": {
-      "base": null,
-      "refs": {
+    "ModifyOptionGroupResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "Option": {
-      "base": "<p>Option details.</p>",
-      "refs": {
-        "OptionsList$member": null
+    "Option":{
+      "base":"<p>Option details.</p>",
+      "refs":{
+        "OptionsList$member":null
       }
     },
-    "OptionConfiguration": {
-      "base": "<p>A list of all available options</p>",
-      "refs": {
-        "OptionConfigurationList$member": null
+    "OptionConfiguration":{
+      "base":"<p>A list of all available options</p>",
+      "refs":{
+        "OptionConfigurationList$member":null
       }
     },
-    "OptionConfigurationList": {
-      "base": null,
-      "refs": {
-        "ModifyOptionGroupMessage$OptionsToInclude": "<p>Options in this list are added to the option group or, if already present, the specified configuration is used to update the existing configuration.</p>"
+    "OptionConfigurationList":{
+      "base":null,
+      "refs":{
+        "ModifyOptionGroupMessage$OptionsToInclude":"<p>Options in this list are added to the option group or, if already present, the specified configuration is used to update the existing configuration.</p>"
       }
     },
-    "OptionGroup": {
-      "base": "<p/>",
-      "refs": {
-        "CopyOptionGroupResult$OptionGroup": null,
-        "CreateOptionGroupResult$OptionGroup": null,
-        "ModifyOptionGroupResult$OptionGroup": null,
-        "OptionGroupsList$member": null
+    "OptionGroup":{
+      "base":"<p/>",
+      "refs":{
+        "CopyOptionGroupResult$OptionGroup":null,
+        "CreateOptionGroupResult$OptionGroup":null,
+        "ModifyOptionGroupResult$OptionGroup":null,
+        "OptionGroupsList$member":null
       }
     },
-    "OptionGroupAlreadyExistsFault": {
-      "base": "<p>The option group you are trying to create already exists.</p>",
-      "refs": {
+    "OptionGroupAlreadyExistsFault":{
+      "base":"<p>The option group you are trying to create already exists.</p>",
+      "refs":{
       }
     },
-    "OptionGroupMembership": {
-      "base": "<p>Provides information on the option groups the DB instance is a member of.</p>",
-      "refs": {
-        "OptionGroupMembershipList$member": null
+    "OptionGroupMembership":{
+      "base":"<p>Provides information on the option groups the DB instance is a member of.</p>",
+      "refs":{
+        "OptionGroupMembershipList$member":null
       }
     },
-    "OptionGroupMembershipList": {
-      "base": null,
-      "refs": {
-        "DBInstance$OptionGroupMemberships": "<p>Provides the list of option group memberships for this DB instance.</p>"
+    "OptionGroupMembershipList":{
+      "base":null,
+      "refs":{
+        "DBInstance$OptionGroupMemberships":"<p>Provides the list of option group memberships for this DB instance.</p>"
       }
     },
-    "OptionGroupNotFoundFault": {
-      "base": "<p>The specified option group could not be found.</p>",
-      "refs": {
+    "OptionGroupNotFoundFault":{
+      "base":"<p>The specified option group could not be found.</p>",
+      "refs":{
       }
     },
-    "OptionGroupOption": {
-      "base": "<p>Available option.</p>",
-      "refs": {
-        "OptionGroupOptionsList$member": null
+    "OptionGroupOption":{
+      "base":"<p>Available option.</p>",
+      "refs":{
+        "OptionGroupOptionsList$member":null
       }
     },
-    "OptionGroupOptionSetting": {
-      "base": "<p>Option group option settings are used to display settings available for each option with their default values and other information. These values are used with the DescribeOptionGroupOptions action.</p>",
-      "refs": {
-        "OptionGroupOptionSettingsList$member": null
+    "OptionGroupOptionSetting":{
+      "base":"<p>Option group option settings are used to display settings available for each option with their default values and other information. These values are used with the DescribeOptionGroupOptions action.</p>",
+      "refs":{
+        "OptionGroupOptionSettingsList$member":null
       }
     },
-    "OptionGroupOptionSettingsList": {
-      "base": null,
-      "refs": {
-        "OptionGroupOption$OptionGroupOptionSettings": "<p>The option settings that are available (and the default value) for each option in an option group.</p>"
+    "OptionGroupOptionSettingsList":{
+      "base":null,
+      "refs":{
+        "OptionGroupOption$OptionGroupOptionSettings":"<p>The option settings that are available (and the default value) for each option in an option group.</p>"
       }
     },
-    "OptionGroupOptionVersionsList": {
-      "base": null,
-      "refs": {
-        "OptionGroupOption$OptionGroupOptionVersions": "<p>The versions that are available for the option.</p>"
+    "OptionGroupOptionVersionsList":{
+      "base":null,
+      "refs":{
+        "OptionGroupOption$OptionGroupOptionVersions":"<p>The versions that are available for the option.</p>"
       }
     },
-    "OptionGroupOptionsList": {
-      "base": "<p>List of available option group options.</p>",
-      "refs": {
-        "OptionGroupOptionsMessage$OptionGroupOptions": null
+    "OptionGroupOptionsList":{
+      "base":"<p>List of available option group options.</p>",
+      "refs":{
+        "OptionGroupOptionsMessage$OptionGroupOptions":null
       }
     },
-    "OptionGroupOptionsMessage": {
-      "base": "<p/>",
-      "refs": {
+    "OptionGroupOptionsMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "OptionGroupQuotaExceededFault": {
-      "base": "<p>The quota of 20 option groups was exceeded for this AWS account.</p>",
-      "refs": {
+    "OptionGroupQuotaExceededFault":{
+      "base":"<p>The quota of 20 option groups was exceeded for this AWS account.</p>",
+      "refs":{
       }
     },
-    "OptionGroups": {
-      "base": "<p>List of option groups.</p>",
-      "refs": {
+    "OptionGroups":{
+      "base":"<p>List of option groups.</p>",
+      "refs":{
       }
     },
-    "OptionGroupsList": {
-      "base": null,
-      "refs": {
-        "OptionGroups$OptionGroupsList": "<p>List of option groups.</p>"
+    "OptionGroupsList":{
+      "base":null,
+      "refs":{
+        "OptionGroups$OptionGroupsList":"<p>List of option groups.</p>"
       }
     },
-    "OptionNamesList": {
-      "base": null,
-      "refs": {
-        "ModifyOptionGroupMessage$OptionsToRemove": "<p>Options in this list are removed from the option group.</p>"
+    "OptionNamesList":{
+      "base":null,
+      "refs":{
+        "ModifyOptionGroupMessage$OptionsToRemove":"<p>Options in this list are removed from the option group.</p>"
       }
     },
-    "OptionSetting": {
-      "base": "<p>Option settings are the actual settings being applied or configured for that option. It is used when you modify an option group or describe option groups. For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER that can have several different values.</p>",
-      "refs": {
-        "OptionSettingConfigurationList$member": null,
-        "OptionSettingsList$member": null
+    "OptionSetting":{
+      "base":"<p>Option settings are the actual settings being applied or configured for that option. It is used when you modify an option group or describe option groups. For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER that can have several different values.</p>",
+      "refs":{
+        "OptionSettingConfigurationList$member":null,
+        "OptionSettingsList$member":null
       }
     },
-    "OptionSettingConfigurationList": {
-      "base": null,
-      "refs": {
-        "Option$OptionSettings": "<p>The option settings for this option.</p>"
+    "OptionSettingConfigurationList":{
+      "base":null,
+      "refs":{
+        "Option$OptionSettings":"<p>The option settings for this option.</p>"
       }
     },
-    "OptionSettingsList": {
-      "base": null,
-      "refs": {
-        "OptionConfiguration$OptionSettings": "<p>The option settings to include in an option group.</p>"
+    "OptionSettingsList":{
+      "base":null,
+      "refs":{
+        "OptionConfiguration$OptionSettings":"<p>The option settings to include in an option group.</p>"
       }
     },
-    "OptionVersion": {
-      "base": "<p>The version for an option. Option group option versions are returned by the <a>DescribeOptionGroupOptions</a> action.</p>",
-      "refs": {
-        "OptionGroupOptionVersionsList$member": null
+    "OptionVersion":{
+      "base":"<p>The version for an option. Option group option versions are returned by the <a>DescribeOptionGroupOptions</a> action.</p>",
+      "refs":{
+        "OptionGroupOptionVersionsList$member":null
       }
     },
-    "OptionsConflictsWith": {
-      "base": null,
-      "refs": {
-        "OptionGroupOption$OptionsConflictsWith": "<p>The options that conflict with this option.</p>"
+    "OptionsConflictsWith":{
+      "base":null,
+      "refs":{
+        "OptionGroupOption$OptionsConflictsWith":"<p>The options that conflict with this option.</p>"
       }
     },
-    "OptionsDependedOn": {
-      "base": null,
-      "refs": {
-        "OptionGroupOption$OptionsDependedOn": "<p>The options that are prerequisites for this option.</p>"
+    "OptionsDependedOn":{
+      "base":null,
+      "refs":{
+        "OptionGroupOption$OptionsDependedOn":"<p>The options that are prerequisites for this option.</p>"
       }
     },
-    "OptionsList": {
-      "base": null,
-      "refs": {
-        "OptionGroup$Options": "<p>Indicates what options are available in the option group.</p>"
+    "OptionsList":{
+      "base":null,
+      "refs":{
+        "OptionGroup$Options":"<p>Indicates what options are available in the option group.</p>"
       }
     },
-    "OrderableDBInstanceOption": {
-      "base": "<p>Contains a list of available options for a DB instance.</p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
-      "refs": {
-        "OrderableDBInstanceOptionsList$member": null
+    "OrderableDBInstanceOption":{
+      "base":"<p>Contains a list of available options for a DB instance.</p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
+      "refs":{
+        "OrderableDBInstanceOptionsList$member":null
       }
     },
-    "OrderableDBInstanceOptionsList": {
-      "base": null,
-      "refs": {
-        "OrderableDBInstanceOptionsMessage$OrderableDBInstanceOptions": "<p>An <a>OrderableDBInstanceOption</a> structure containing information about orderable options for the DB instance.</p>"
+    "OrderableDBInstanceOptionsList":{
+      "base":null,
+      "refs":{
+        "OrderableDBInstanceOptionsMessage$OrderableDBInstanceOptions":"<p>An <a>OrderableDBInstanceOption</a> structure containing information about orderable options for the DB instance.</p>"
       }
     },
-    "OrderableDBInstanceOptionsMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
-      "refs": {
+    "OrderableDBInstanceOptionsMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
+      "refs":{
       }
     },
-    "Parameter": {
-      "base": "<p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>",
-      "refs": {
-        "ParametersList$member": null
+    "Parameter":{
+      "base":"<p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>",
+      "refs":{
+        "ParametersList$member":null
       }
     },
-    "ParametersList": {
-      "base": null,
-      "refs": {
-        "DBClusterParameterGroupDetails$Parameters": "<p>Provides a list of parameters for the DB cluster parameter group.</p>",
-        "DBParameterGroupDetails$Parameters": "<p> A list of <a>Parameter</a> values. </p>",
-        "EngineDefaults$Parameters": "<p>Contains a list of engine default parameters.</p>",
-        "ModifyDBClusterParameterGroupMessage$Parameters": "<p>A list of parameters in the DB cluster parameter group to modify.</p>",
-        "ModifyDBParameterGroupMessage$Parameters": "<p>An array of parameter names, values, and the apply method for the parameter update. At least one parameter name, value, and apply method must be supplied; subsequent arguments are optional. A maximum of 20 parameters can be modified in a single request.</p> <p>Valid Values (for the application method): <code>immediate | pending-reboot</code> </p> <note> <p>You can use the immediate value with dynamic parameters only. You can use the pending-reboot value for both dynamic and static parameters, and changes are applied when you reboot the DB instance without failover.</p> </note>",
-        "ResetDBClusterParameterGroupMessage$Parameters": "<p>A list of parameter names in the DB cluster parameter group to reset to the default values. You can't use this parameter if the <code>ResetAllParameters</code> parameter is set to <code>true</code>.</p>",
-        "ResetDBParameterGroupMessage$Parameters": "<p>To reset the entire DB parameter group, specify the <code>DBParameterGroup</code> name and <code>ResetAllParameters</code> parameters. To reset specific parameters, provide a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request.</p> <p> <b>MySQL</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>MariaDB</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>Oracle</b> </p> <p>Valid Values (for Apply method): <code>pending-reboot</code> </p>"
+    "ParametersList":{
+      "base":null,
+      "refs":{
+        "DBClusterParameterGroupDetails$Parameters":"<p>Provides a list of parameters for the DB cluster parameter group.</p>",
+        "DBParameterGroupDetails$Parameters":"<p> A list of <a>Parameter</a> values. </p>",
+        "EngineDefaults$Parameters":"<p>Contains a list of engine default parameters.</p>",
+        "ModifyDBClusterParameterGroupMessage$Parameters":"<p>A list of parameters in the DB cluster parameter group to modify.</p>",
+        "ModifyDBParameterGroupMessage$Parameters":"<p>An array of parameter names, values, and the apply method for the parameter update. At least one parameter name, value, and apply method must be supplied; subsequent arguments are optional. A maximum of 20 parameters can be modified in a single request.</p> <p>Valid Values (for the application method): <code>immediate | pending-reboot</code> </p> <note> <p>You can use the immediate value with dynamic parameters only. You can use the pending-reboot value for both dynamic and static parameters, and changes are applied when you reboot the DB instance without failover.</p> </note>",
+        "ResetDBClusterParameterGroupMessage$Parameters":"<p>A list of parameter names in the DB cluster parameter group to reset to the default values. You can't use this parameter if the <code>ResetAllParameters</code> parameter is set to <code>true</code>.</p>",
+        "ResetDBParameterGroupMessage$Parameters":"<p>To reset the entire DB parameter group, specify the <code>DBParameterGroup</code> name and <code>ResetAllParameters</code> parameters. To reset specific parameters, provide a list of the following: <code>ParameterName</code> and <code>ApplyMethod</code>. A maximum of 20 parameters can be modified in a single request.</p> <p> <b>MySQL</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>MariaDB</b> </p> <p>Valid Values (for Apply method): <code>immediate</code> | <code>pending-reboot</code> </p> <p>You can use the immediate value with dynamic parameters only. You can use the <code>pending-reboot</code> value for both dynamic and static parameters, and changes are applied when DB instance reboots.</p> <p> <b>Oracle</b> </p> <p>Valid Values (for Apply method): <code>pending-reboot</code> </p>"
       }
     },
-    "PendingCloudwatchLogsExports": {
-      "base": "<p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>",
-      "refs": {
-        "PendingModifiedValues$PendingCloudwatchLogsExports": null
+    "PendingCloudwatchLogsExports":{
+      "base":"<p>A list of the log types whose configuration is still pending. In other words, these log types are in the process of being activated or deactivated.</p>",
+      "refs":{
+        "PendingModifiedValues$PendingCloudwatchLogsExports":null
       }
     },
-    "PendingMaintenanceAction": {
-      "base": "<p>Provides information about a pending maintenance action for a resource.</p>",
-      "refs": {
-        "PendingMaintenanceActionDetails$member": null
+    "PendingMaintenanceAction":{
+      "base":"<p>Provides information about a pending maintenance action for a resource.</p>",
+      "refs":{
+        "PendingMaintenanceActionDetails$member":null
       }
     },
-    "PendingMaintenanceActionDetails": {
-      "base": null,
-      "refs": {
-        "ResourcePendingMaintenanceActions$PendingMaintenanceActionDetails": "<p>A list that provides details about the pending maintenance actions for the resource.</p>"
+    "PendingMaintenanceActionDetails":{
+      "base":null,
+      "refs":{
+        "ResourcePendingMaintenanceActions$PendingMaintenanceActionDetails":"<p>A list that provides details about the pending maintenance actions for the resource.</p>"
       }
     },
-    "PendingMaintenanceActions": {
-      "base": null,
-      "refs": {
-        "PendingMaintenanceActionsMessage$PendingMaintenanceActions": "<p>A list of the pending maintenance actions for the resource.</p>"
+    "PendingMaintenanceActions":{
+      "base":null,
+      "refs":{
+        "PendingMaintenanceActionsMessage$PendingMaintenanceActions":"<p>A list of the pending maintenance actions for the resource.</p>"
       }
     },
-    "PendingMaintenanceActionsMessage": {
-      "base": "<p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>",
-      "refs": {
+    "PendingMaintenanceActionsMessage":{
+      "base":"<p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>",
+      "refs":{
       }
     },
-    "PendingModifiedValues": {
-      "base": "<p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>",
-      "refs": {
-        "DBInstance$PendingModifiedValues": "<p>Specifies that changes to the DB instance are pending. This element is only included when changes are pending. Specific changes are identified by subelements.</p>"
+    "PendingModifiedValues":{
+      "base":"<p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>",
+      "refs":{
+        "DBInstance$PendingModifiedValues":"<p>Specifies that changes to the DB instance are pending. This element is only included when changes are pending. Specific changes are identified by subelements.</p>"
       }
     },
-    "PointInTimeRestoreNotEnabledFault": {
-      "base": "<p> <i>SourceDBInstanceIdentifier</i> refers to a DB instance with <i>BackupRetentionPeriod</i> equal to 0. </p>",
-      "refs": {
+    "PointInTimeRestoreNotEnabledFault":{
+      "base":"<p> <i>SourceDBInstanceIdentifier</i> refers to a DB instance with <i>BackupRetentionPeriod</i> equal to 0. </p>",
+      "refs":{
       }
     },
-    "ProcessorFeature": {
-      "base": "<p>Contains the processor features of a DB instance class.</p> <p>To specify the number of CPU cores, use the <code>coreCount</code> feature name for the <code>Name</code> parameter. To specify the number of threads per core, use the <code>threadsPerCore</code> feature name for the <code>Name</code> parameter.</p> <p>You can set the processor features of the DB instance class for a DB instance when you call one of the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromS3</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul> <p>You can view the valid processor values for a particular instance class by calling the <a>DescribeOrderableDBInstanceOptions</a> action and specifying the instance class for the <code>DBInstanceClass</code> parameter.</p> <p>In addition, you can use the following actions for DB instance class processor information:</p> <ul> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DescribeDBSnapshots</a> </p> </li> <li> <p> <a>DescribeValidDBInstanceModifications</a> </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#USER_ConfigureProcessor\">Configuring the Processor of the DB Instance Class</a> in the <i>Amazon RDS User Guide. </i> </p>",
-      "refs": {
-        "ProcessorFeatureList$member": null
+    "ProcessorFeature":{
+      "base":"<p>Contains the processor features of a DB instance class.</p> <p>To specify the number of CPU cores, use the <code>coreCount</code> feature name for the <code>Name</code> parameter. To specify the number of threads per core, use the <code>threadsPerCore</code> feature name for the <code>Name</code> parameter.</p> <p>You can set the processor features of the DB instance class for a DB instance when you call one of the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromDBSnapshot</a> </p> </li> <li> <p> <a>RestoreDBInstanceFromS3</a> </p> </li> <li> <p> <a>RestoreDBInstanceToPointInTime</a> </p> </li> </ul> <p>You can view the valid processor values for a particular instance class by calling the <a>DescribeOrderableDBInstanceOptions</a> action and specifying the instance class for the <code>DBInstanceClass</code> parameter.</p> <p>In addition, you can use the following actions for DB instance class processor information:</p> <ul> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DescribeDBSnapshots</a> </p> </li> <li> <p> <a>DescribeValidDBInstanceModifications</a> </p> </li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#USER_ConfigureProcessor\">Configuring the Processor of the DB Instance Class</a> in the <i>Amazon RDS User Guide. </i> </p>",
+      "refs":{
+        "ProcessorFeatureList$member":null
       }
     },
-    "ProcessorFeatureList": {
-      "base": null,
-      "refs": {
-        "CreateDBInstanceMessage$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "CreateDBInstanceReadReplicaMessage$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "DBInstance$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "DBSnapshot$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance when the DB snapshot was created.</p>",
-        "ModifyDBInstanceMessage$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "PendingModifiedValues$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "RestoreDBInstanceFromS3Message$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$ProcessorFeatures": "<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>"
+    "ProcessorFeatureList":{
+      "base":null,
+      "refs":{
+        "CreateDBInstanceMessage$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "CreateDBInstanceReadReplicaMessage$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "DBInstance$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "DBSnapshot$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance when the DB snapshot was created.</p>",
+        "ModifyDBInstanceMessage$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "PendingModifiedValues$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "RestoreDBInstanceFromS3Message$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$ProcessorFeatures":"<p>The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.</p>"
       }
     },
-    "PromoteReadReplicaDBClusterMessage": {
-      "base": "<p/>",
-      "refs": {
+    "PromoteReadReplicaDBClusterMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "PromoteReadReplicaDBClusterResult": {
-      "base": null,
-      "refs": {
+    "PromoteReadReplicaDBClusterResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "PromoteReadReplicaMessage": {
-      "base": "<p/>",
-      "refs": {
+    "PromoteReadReplicaMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "PromoteReadReplicaResult": {
-      "base": null,
-      "refs": {
+    "PromoteReadReplicaResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "ProvisionedIopsNotAvailableInAZFault": {
-      "base": "<p>Provisioned IOPS not available in the specified Availability Zone.</p>",
-      "refs": {
+    "ProvisionedIopsNotAvailableInAZFault":{
+      "base":"<p>Provisioned IOPS not available in the specified Availability Zone.</p>",
+      "refs":{
       }
     },
-    "PurchaseReservedDBInstancesOfferingMessage": {
-      "base": "<p/>",
-      "refs": {
+    "PurchaseReservedDBInstancesOfferingMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "PurchaseReservedDBInstancesOfferingResult": {
-      "base": null,
-      "refs": {
+    "PurchaseReservedDBInstancesOfferingResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "Range": {
-      "base": "<p>A range of integer values.</p>",
-      "refs": {
-        "RangeList$member": null
+    "Range":{
+      "base":"<p>A range of integer values.</p>",
+      "refs":{
+        "RangeList$member":null
       }
     },
-    "RangeList": {
-      "base": null,
-      "refs": {
-        "ValidStorageOptions$StorageSize": "<p>The valid range of storage in gibibytes. For example, 100 to 16384. </p>",
-        "ValidStorageOptions$ProvisionedIops": "<p>The valid range of provisioned IOPS. For example, 1000-20000. </p>"
+    "RangeList":{
+      "base":null,
+      "refs":{
+        "ValidStorageOptions$StorageSize":"<p>The valid range of storage in gibibytes. For example, 100 to 16384. </p>",
+        "ValidStorageOptions$ProvisionedIops":"<p>The valid range of provisioned IOPS. For example, 1000-20000. </p>"
       }
     },
-    "ReadReplicaDBClusterIdentifierList": {
-      "base": null,
-      "refs": {
-        "DBInstance$ReadReplicaDBClusterIdentifiers": "<p>Contains one or more identifiers of Aurora DB clusters that are Read Replicas of this DB instance.</p>"
+    "ReadReplicaDBClusterIdentifierList":{
+      "base":null,
+      "refs":{
+        "DBInstance$ReadReplicaDBClusterIdentifiers":"<p>Contains one or more identifiers of Aurora DB clusters that are Read Replicas of this DB instance.</p>"
       }
     },
-    "ReadReplicaDBInstanceIdentifierList": {
-      "base": null,
-      "refs": {
-        "DBInstance$ReadReplicaDBInstanceIdentifiers": "<p>Contains one or more identifiers of the Read Replicas associated with this DB instance.</p>"
+    "ReadReplicaDBInstanceIdentifierList":{
+      "base":null,
+      "refs":{
+        "DBInstance$ReadReplicaDBInstanceIdentifiers":"<p>Contains one or more identifiers of the Read Replicas associated with this DB instance.</p>"
       }
     },
-    "ReadReplicaIdentifierList": {
-      "base": null,
-      "refs": {
-        "DBCluster$ReadReplicaIdentifiers": "<p>Contains one or more identifiers of the Read Replicas associated with this DB cluster.</p>"
+    "ReadReplicaIdentifierList":{
+      "base":null,
+      "refs":{
+        "DBCluster$ReadReplicaIdentifiers":"<p>Contains one or more identifiers of the Read Replicas associated with this DB cluster.</p>"
       }
     },
-    "RebootDBInstanceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RebootDBInstanceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RebootDBInstanceResult": {
-      "base": null,
-      "refs": {
+    "RebootDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RecurringCharge": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>DescribeReservedDBInstancesOfferings</a> actions. </p>",
-      "refs": {
-        "RecurringChargeList$member": null
+    "RecurringCharge":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>DescribeReservedDBInstancesOfferings</a> actions. </p>",
+      "refs":{
+        "RecurringChargeList$member":null
       }
     },
-    "RecurringChargeList": {
-      "base": null,
-      "refs": {
-        "ReservedDBInstance$RecurringCharges": "<p>The recurring price charged to run this reserved DB instance.</p>",
-        "ReservedDBInstancesOffering$RecurringCharges": "<p>The recurring price charged to run this reserved DB instance.</p>"
+    "RecurringChargeList":{
+      "base":null,
+      "refs":{
+        "ReservedDBInstance$RecurringCharges":"<p>The recurring price charged to run this reserved DB instance.</p>",
+        "ReservedDBInstancesOffering$RecurringCharges":"<p>The recurring price charged to run this reserved DB instance.</p>"
       }
     },
-    "RemoveRoleFromDBClusterMessage": {
-      "base": null,
-      "refs": {
+    "RemoveRoleFromDBClusterMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "RemoveSourceIdentifierFromSubscriptionMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RemoveSourceIdentifierFromSubscriptionMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RemoveSourceIdentifierFromSubscriptionResult": {
-      "base": null,
-      "refs": {
+    "RemoveSourceIdentifierFromSubscriptionResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RemoveTagsFromResourceMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RemoveTagsFromResourceMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ReservedDBInstance": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>PurchaseReservedDBInstancesOffering</a> actions. </p>",
-      "refs": {
-        "PurchaseReservedDBInstancesOfferingResult$ReservedDBInstance": null,
-        "ReservedDBInstanceList$member": null
+    "ReservedDBInstance":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>PurchaseReservedDBInstancesOffering</a> actions. </p>",
+      "refs":{
+        "PurchaseReservedDBInstancesOfferingResult$ReservedDBInstance":null,
+        "ReservedDBInstanceList$member":null
       }
     },
-    "ReservedDBInstanceAlreadyExistsFault": {
-      "base": "<p>User already has a reservation with the given identifier.</p>",
-      "refs": {
+    "ReservedDBInstanceAlreadyExistsFault":{
+      "base":"<p>User already has a reservation with the given identifier.</p>",
+      "refs":{
       }
     },
-    "ReservedDBInstanceList": {
-      "base": null,
-      "refs": {
-        "ReservedDBInstanceMessage$ReservedDBInstances": "<p>A list of reserved DB instances.</p>"
+    "ReservedDBInstanceList":{
+      "base":null,
+      "refs":{
+        "ReservedDBInstanceMessage$ReservedDBInstances":"<p>A list of reserved DB instances.</p>"
       }
     },
-    "ReservedDBInstanceMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstances</a> action. </p>",
-      "refs": {
+    "ReservedDBInstanceMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstances</a> action. </p>",
+      "refs":{
       }
     },
-    "ReservedDBInstanceNotFoundFault": {
-      "base": "<p>The specified reserved DB Instance not found.</p>",
-      "refs": {
+    "ReservedDBInstanceNotFoundFault":{
+      "base":"<p>The specified reserved DB Instance not found.</p>",
+      "refs":{
       }
     },
-    "ReservedDBInstanceQuotaExceededFault": {
-      "base": "<p>Request would exceed the user's DB Instance quota.</p>",
-      "refs": {
+    "ReservedDBInstanceQuotaExceededFault":{
+      "base":"<p>Request would exceed the user's DB Instance quota.</p>",
+      "refs":{
       }
     },
-    "ReservedDBInstancesOffering": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
-      "refs": {
-        "ReservedDBInstancesOfferingList$member": null
+    "ReservedDBInstancesOffering":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
+      "refs":{
+        "ReservedDBInstancesOfferingList$member":null
       }
     },
-    "ReservedDBInstancesOfferingList": {
-      "base": null,
-      "refs": {
-        "ReservedDBInstancesOfferingMessage$ReservedDBInstancesOfferings": "<p>A list of reserved DB instance offerings.</p>"
+    "ReservedDBInstancesOfferingList":{
+      "base":null,
+      "refs":{
+        "ReservedDBInstancesOfferingMessage$ReservedDBInstancesOfferings":"<p>A list of reserved DB instance offerings.</p>"
       }
     },
-    "ReservedDBInstancesOfferingMessage": {
-      "base": "<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
-      "refs": {
+    "ReservedDBInstancesOfferingMessage":{
+      "base":"<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
+      "refs":{
       }
     },
-    "ReservedDBInstancesOfferingNotFoundFault": {
-      "base": "<p>Specified offering does not exist.</p>",
-      "refs": {
+    "ReservedDBInstancesOfferingNotFoundFault":{
+      "base":"<p>Specified offering does not exist.</p>",
+      "refs":{
       }
     },
-    "ResetDBClusterParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ResetDBClusterParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ResetDBParameterGroupMessage": {
-      "base": "<p/>",
-      "refs": {
+    "ResetDBParameterGroupMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "ResourceNotFoundFault": {
-      "base": "<p>The specified resource ID was not found.</p>",
-      "refs": {
+    "ResourceNotFoundFault":{
+      "base":"<p>The specified resource ID was not found.</p>",
+      "refs":{
       }
     },
-    "ResourcePendingMaintenanceActions": {
-      "base": "<p>Describes the pending maintenance actions for a resource.</p>",
-      "refs": {
-        "ApplyPendingMaintenanceActionResult$ResourcePendingMaintenanceActions": null,
-        "PendingMaintenanceActions$member": null
+    "ResourcePendingMaintenanceActions":{
+      "base":"<p>Describes the pending maintenance actions for a resource.</p>",
+      "refs":{
+        "ApplyPendingMaintenanceActionResult$ResourcePendingMaintenanceActions":null,
+        "PendingMaintenanceActions$member":null
       }
     },
-    "RestoreDBClusterFromS3Message": {
-      "base": null,
-      "refs": {
+    "RestoreDBClusterFromS3Message":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBClusterFromS3Result": {
-      "base": null,
-      "refs": {
+    "RestoreDBClusterFromS3Result":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBClusterFromSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RestoreDBClusterFromSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RestoreDBClusterFromSnapshotResult": {
-      "base": null,
-      "refs": {
+    "RestoreDBClusterFromSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBClusterToPointInTimeMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RestoreDBClusterToPointInTimeMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RestoreDBClusterToPointInTimeResult": {
-      "base": null,
-      "refs": {
+    "RestoreDBClusterToPointInTimeResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBInstanceFromDBSnapshotMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RestoreDBInstanceFromDBSnapshotMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RestoreDBInstanceFromDBSnapshotResult": {
-      "base": null,
-      "refs": {
+    "RestoreDBInstanceFromDBSnapshotResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBInstanceFromS3Message": {
-      "base": null,
-      "refs": {
+    "RestoreDBInstanceFromS3Message":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBInstanceFromS3Result": {
-      "base": null,
-      "refs": {
+    "RestoreDBInstanceFromS3Result":{
+      "base":null,
+      "refs":{
       }
     },
-    "RestoreDBInstanceToPointInTimeMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RestoreDBInstanceToPointInTimeMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RestoreDBInstanceToPointInTimeResult": {
-      "base": null,
-      "refs": {
+    "RestoreDBInstanceToPointInTimeResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "RevokeDBSecurityGroupIngressMessage": {
-      "base": "<p/>",
-      "refs": {
+    "RevokeDBSecurityGroupIngressMessage":{
+      "base":"<p/>",
+      "refs":{
       }
     },
-    "RevokeDBSecurityGroupIngressResult": {
-      "base": null,
-      "refs": {
+    "RevokeDBSecurityGroupIngressResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "SNSInvalidTopicFault": {
-      "base": "<p>SNS has responded that there is a problem with the SND topic specified.</p>",
-      "refs": {
+    "SNSInvalidTopicFault":{
+      "base":"<p>SNS has responded that there is a problem with the SND topic specified.</p>",
+      "refs":{
       }
     },
-    "SNSNoAuthorizationFault": {
-      "base": "<p>You do not have permission to publish to the SNS topic ARN.</p>",
-      "refs": {
+    "SNSNoAuthorizationFault":{
+      "base":"<p>You do not have permission to publish to the SNS topic ARN.</p>",
+      "refs":{
       }
     },
-    "SNSTopicArnNotFoundFault": {
-      "base": "<p>The SNS topic ARN does not exist.</p>",
-      "refs": {
+    "SNSTopicArnNotFoundFault":{
+      "base":"<p>The SNS topic ARN does not exist.</p>",
+      "refs":{
       }
     },
-    "SharedSnapshotQuotaExceededFault": {
-      "base": "<p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>",
-      "refs": {
+    "SharedSnapshotQuotaExceededFault":{
+      "base":"<p>You have exceeded the maximum number of accounts that you can share a manual DB snapshot with.</p>",
+      "refs":{
       }
     },
-    "SnapshotQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed number of DB snapshots.</p>",
-      "refs": {
+    "SnapshotQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed number of DB snapshots.</p>",
+      "refs":{
       }
     },
-    "SourceIdsList": {
-      "base": null,
-      "refs": {
-        "CreateEventSubscriptionMessage$SourceIds": "<p>The list of identifiers of the event sources for which events are returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it can't end with a hyphen or contain two consecutive hyphens.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIds are supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>",
-        "EventSubscription$SourceIdsList": "<p>A list of source IDs for the RDS event notification subscription.</p>"
+    "SourceIdsList":{
+      "base":null,
+      "refs":{
+        "CreateEventSubscriptionMessage$SourceIds":"<p>The list of identifiers of the event sources for which events are returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it can't end with a hyphen or contain two consecutive hyphens.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIds are supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>",
+        "EventSubscription$SourceIdsList":"<p>A list of source IDs for the RDS event notification subscription.</p>"
       }
     },
-    "SourceNotFoundFault": {
-      "base": "<p>The requested source could not be found.</p>",
-      "refs": {
+    "SourceNotFoundFault":{
+      "base":"<p>The requested source could not be found.</p>",
+      "refs":{
       }
     },
-    "SourceRegion": {
-      "base": "<p>Contains an AWS Region name as the result of a successful call to the <a>DescribeSourceRegions</a> action.</p>",
-      "refs": {
-        "SourceRegionList$member": null
+    "SourceRegion":{
+      "base":"<p>Contains an AWS Region name as the result of a successful call to the <a>DescribeSourceRegions</a> action.</p>",
+      "refs":{
+        "SourceRegionList$member":null
       }
     },
-    "SourceRegionList": {
-      "base": null,
-      "refs": {
-        "SourceRegionMessage$SourceRegions": "<p>A list of SourceRegion instances that contains each source AWS Region that the current AWS Region can get a Read Replica or a DB snapshot from.</p>"
+    "SourceRegionList":{
+      "base":null,
+      "refs":{
+        "SourceRegionMessage$SourceRegions":"<p>A list of SourceRegion instances that contains each source AWS Region that the current AWS Region can get a Read Replica or a DB snapshot from.</p>"
       }
     },
-    "SourceRegionMessage": {
-      "base": "<p>Contains the result of a successful invocation of the <a>DescribeSourceRegions</a> action.</p>",
-      "refs": {
+    "SourceRegionMessage":{
+      "base":"<p>Contains the result of a successful invocation of the <a>DescribeSourceRegions</a> action.</p>",
+      "refs":{
       }
     },
-    "SourceType": {
-      "base": null,
-      "refs": {
-        "DescribeEventsMessage$SourceType": "<p>The event source to retrieve events for. If no value is specified, all events are returned.</p>",
-        "Event$SourceType": "<p>Specifies the source type for this event.</p>"
+    "SourceType":{
+      "base":null,
+      "refs":{
+        "DescribeEventsMessage$SourceType":"<p>The event source to retrieve events for. If no value is specified, all events are returned.</p>",
+        "Event$SourceType":"<p>Specifies the source type for this event.</p>"
       }
     },
-    "StartDBInstanceMessage": {
-      "base": null,
-      "refs": {
+    "StartDBInstanceMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "StartDBInstanceResult": {
-      "base": null,
-      "refs": {
+    "StartDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "StopDBInstanceMessage": {
-      "base": null,
-      "refs": {
+    "StopDBInstanceMessage":{
+      "base":null,
+      "refs":{
       }
     },
-    "StopDBInstanceResult": {
-      "base": null,
-      "refs": {
+    "StopDBInstanceResult":{
+      "base":null,
+      "refs":{
       }
     },
-    "StorageQuotaExceededFault": {
-      "base": "<p>The request would result in the user exceeding the allowed amount of storage available across all DB instances.</p>",
-      "refs": {
+    "StorageQuotaExceededFault":{
+      "base":"<p>The request would result in the user exceeding the allowed amount of storage available across all DB instances.</p>",
+      "refs":{
       }
     },
-    "StorageTypeNotSupportedFault": {
-      "base": "<p>Storage of the <i>StorageType</i> specified can't be associated with the DB instance. </p>",
-      "refs": {
+    "StorageTypeNotSupportedFault":{
+      "base":"<p>Storage of the <i>StorageType</i> specified can't be associated with the DB instance. </p>",
+      "refs":{
       }
     },
-    "String": {
-      "base": null,
-      "refs": {
-        "AccountQuota$AccountQuotaName": "<p>The name of the Amazon RDS quota for this AWS account.</p>",
-        "AddRoleToDBClusterMessage$DBClusterIdentifier": "<p>The name of the DB cluster to associate the IAM role with.</p>",
-        "AddRoleToDBClusterMessage$RoleArn": "<p>The Amazon Resource Name (ARN) of the IAM role to associate with the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>",
-        "AddSourceIdentifierToSubscriptionMessage$SubscriptionName": "<p>The name of the RDS event notification subscription you want to add a source identifier to.</p>",
-        "AddSourceIdentifierToSubscriptionMessage$SourceIdentifier": "<p>The identifier of the event source to be added.</p> <p>Constraints:</p> <ul> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>",
-        "AddTagsToResourceMessage$ResourceName": "<p>The Amazon RDS resource that the tags are added to. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
-        "ApplyPendingMaintenanceActionMessage$ResourceIdentifier": "<p>The RDS Amazon Resource Name (ARN) of the resource that the pending maintenance action applies to. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
-        "ApplyPendingMaintenanceActionMessage$ApplyAction": "<p>The pending maintenance action to apply to this resource.</p> <p>Valid values: <code>system-update</code>, <code>db-upgrade</code> </p>",
-        "ApplyPendingMaintenanceActionMessage$OptInType": "<p>A value that specifies the type of opt-in request, or undoes an opt-in request. An opt-in request of type <code>immediate</code> can't be undone.</p> <p>Valid values:</p> <ul> <li> <p> <code>immediate</code> - Apply the maintenance action immediately.</p> </li> <li> <p> <code>next-maintenance</code> - Apply the maintenance action during the next maintenance window for the resource.</p> </li> <li> <p> <code>undo-opt-in</code> - Cancel any existing <code>next-maintenance</code> opt-in requests.</p> </li> </ul>",
-        "AttributeValueList$member": null,
-        "AuthorizeDBSecurityGroupIngressMessage$DBSecurityGroupName": "<p>The name of the DB security group to add authorization to.</p>",
-        "AuthorizeDBSecurityGroupIngressMessage$CIDRIP": "<p>The IP range to authorize.</p>",
-        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupName": "<p> Name of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupId": "<p> Id of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupOwnerId": "<p> AWS account number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "AvailabilityZone$Name": "<p>The name of the Availability Zone.</p>",
-        "AvailabilityZones$member": null,
-        "AvailableProcessorFeature$Name": "<p>The name of the processor feature. Valid names are <code>coreCount</code> and <code>threadsPerCore</code>.</p>",
-        "AvailableProcessorFeature$DefaultValue": "<p>The default value for the processor feature of the DB instance class.</p>",
-        "AvailableProcessorFeature$AllowedValues": "<p>The allowed values for the processor feature of the DB instance class.</p>",
-        "BacktrackDBClusterMessage$DBClusterIdentifier": "<p>The DB cluster identifier of the DB cluster to be backtracked. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
-        "Certificate$CertificateIdentifier": "<p>The unique key that identifies a certificate.</p>",
-        "Certificate$CertificateType": "<p>The type of the certificate.</p>",
-        "Certificate$Thumbprint": "<p>The thumbprint of the certificate.</p>",
-        "Certificate$CertificateArn": "<p>The Amazon Resource Name (ARN) for the certificate.</p>",
-        "CertificateMessage$Marker": "<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "CharacterSet$CharacterSetName": "<p>The name of the character set.</p>",
-        "CharacterSet$CharacterSetDescription": "<p>The description of the character set.</p>",
-        "CopyDBClusterParameterGroupMessage$SourceDBClusterParameterGroupIdentifier": "<p>The identifier or Amazon Resource Name (ARN) for the source DB cluster parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB cluster parameter group.</p> </li> <li> <p>If the source DB cluster parameter group is in the same AWS Region as the copy, specify a valid DB parameter group identifier, for example <code>my-db-cluster-param-group</code>, or a valid ARN.</p> </li> <li> <p>If the source DB parameter group is in a different AWS Region than the copy, specify a valid DB cluster parameter group ARN, for example <code>arn:aws:rds:us-east-1:123456789012:cluster-pg:custom-cluster-group1</code>.</p> </li> </ul>",
-        "CopyDBClusterParameterGroupMessage$TargetDBClusterParameterGroupIdentifier": "<p>The identifier for the copied DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster-param-group1</code> </p>",
-        "CopyDBClusterParameterGroupMessage$TargetDBClusterParameterGroupDescription": "<p>A description for the copied DB cluster parameter group.</p>",
-        "CopyDBClusterSnapshotMessage$SourceDBClusterSnapshotIdentifier": "<p>The identifier of the DB cluster snapshot to copy. This parameter is not case-sensitive.</p> <p>You can't copy an encrypted, shared DB cluster snapshot from one AWS Region to another.</p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> <li> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier.</p> </li> <li> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB cluster snapshot ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html\"> Copying a DB Snapshot or DB Cluster Snapshot</a>.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot1</code> </p>",
-        "CopyDBClusterSnapshotMessage$TargetDBClusterSnapshotIdentifier": "<p>The identifier of the new DB cluster snapshot to create from the source DB cluster snapshot. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot2</code> </p>",
-        "CopyDBClusterSnapshotMessage$KmsKeyId": "<p>The AWS AWS KMS key ID for an encrypted DB cluster snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an encrypted DB cluster snapshot from your AWS account, you can specify a value for <code>KmsKeyId</code> to encrypt the copy with a new KMS encryption key. If you don't specify a value for <code>KmsKeyId</code>, then the copy of the DB cluster snapshot is encrypted with the same KMS key as the source DB cluster snapshot. </p> <p>If you copy an encrypted DB cluster snapshot that is shared from another AWS account, then you must specify a value for <code>KmsKeyId</code>. </p> <p>To copy an encrypted DB cluster snapshot to another AWS Region, you must set <code>KmsKeyId</code> to the KMS key ID you want to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region.</p> <p>If you copy an unencrypted DB cluster snapshot and specify a value for the <code>KmsKeyId</code> parameter, an error is returned.</p>",
-        "CopyDBClusterSnapshotMessage$PreSignedUrl": "<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBClusterSnapshot</code> API action in the AWS Region that contains the source DB cluster snapshot to copy. The <code>PreSignedUrl</code> parameter must be used when copying an encrypted DB cluster snapshot from another AWS Region.</p> <p>The pre-signed URL must be a valid request for the <code>CopyDBSClusterSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster snapshot to be copied. The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBClusterSnapshot</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that the DB cluster snapshot will be created in.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster snapshot from the us-west-2 AWS Region, then your <code>SourceDBClusterSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>",
-        "CopyDBParameterGroupMessage$SourceDBParameterGroupIdentifier": "<p> The identifier or ARN for the source DB parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB parameter group.</p> </li> <li> <p>Must specify a valid DB parameter group identifier, for example <code>my-db-param-group</code>, or a valid ARN.</p> </li> </ul>",
-        "CopyDBParameterGroupMessage$TargetDBParameterGroupIdentifier": "<p>The identifier for the copied DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-parameter-group</code> </p>",
-        "CopyDBParameterGroupMessage$TargetDBParameterGroupDescription": "<p>A description for the copied DB parameter group.</p>",
-        "CopyDBSnapshotMessage$SourceDBSnapshotIdentifier": "<p>The identifier for the source DB snapshot.</p> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier. For example, you might specify <code>rds:mysql-instance1-snapshot-20130805</code>. </p> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB snapshot ARN. For example, you might specify <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code>. </p> <p>If you are copying from a shared manual DB snapshot, this parameter must be the Amazon Resource Name (ARN) of the shared DB snapshot. </p> <p>If you are copying an encrypted snapshot this parameter must be in the ARN format for the source AWS Region, and must match the <code>SourceDBSnapshotIdentifier</code> in the <code>PreSignedUrl</code> parameter. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> </ul> <p>Example: <code>rds:mydb-2012-04-02-00-01</code> </p> <p>Example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code> </p>",
-        "CopyDBSnapshotMessage$TargetDBSnapshotIdentifier": "<p>The identifier for the copy of the snapshot. </p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-snapshot</code> </p>",
-        "CopyDBSnapshotMessage$KmsKeyId": "<p>The AWS KMS key ID for an encrypted DB snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an encrypted DB snapshot from your AWS account, you can specify a value for this parameter to encrypt the copy with a new KMS encryption key. If you don't specify a value for this parameter, then the copy of the DB snapshot is encrypted with the same KMS key as the source DB snapshot. </p> <p>If you copy an encrypted DB snapshot that is shared from another AWS account, then you must specify a value for this parameter. </p> <p>If you specify this parameter when you copy an unencrypted snapshot, the copy is encrypted. </p> <p>If you copy an encrypted snapshot to a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region. </p>",
-        "CopyDBSnapshotMessage$PreSignedUrl": "<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBSnapshot</code> API action in the source AWS Region that contains the source DB snapshot to copy. </p> <p>You must specify this parameter when you copy an encrypted DB snapshot from another AWS Region by using the Amazon RDS API. You can specify the <code>--source-region</code> option instead of this parameter when you copy an encrypted DB snapshot from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CopyDBSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB snapshot to be copied. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted DB snapshot is copied to. This AWS Region is the same one where the <code>CopyDBSnapshot</code> action is called that contains this presigned URL. </p> <p>For example, if you copy an encrypted DB snapshot from the us-west-2 AWS Region to the us-east-1 AWS Region, then you call the <code>CopyDBSnapshot</code> action in the us-east-1 AWS Region and provide a presigned URL that contains a call to the <code>CopyDBSnapshot</code> action in the us-west-2 AWS Region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 AWS Region. </p> </li> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBSnapshot</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBSnapshotIdentifier</code> - The DB snapshot identifier for the encrypted snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB snapshot from the us-west-2 AWS Region, then your <code>SourceDBSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>",
-        "CopyDBSnapshotMessage$OptionGroupName": "<p>The name of an option group to associate with the copy of the snapshot.</p> <p>Specify this option if you are copying a snapshot from one AWS Region to another, and your DB instance uses a nondefault option group. If your source DB instance uses Transparent Data Encryption for Oracle or Microsoft SQL Server, you must specify this option when copying across AWS Regions. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopySnapshot.Options\">Option Group Considerations</a>. </p>",
-        "CopyOptionGroupMessage$SourceOptionGroupIdentifier": "<p>The identifier or ARN for the source option group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid option group.</p> </li> <li> <p>If the source option group is in the same AWS Region as the copy, specify a valid option group identifier, for example <code>my-option-group</code>, or a valid ARN.</p> </li> <li> <p>If the source option group is in a different AWS Region than the copy, specify a valid option group ARN, for example <code>arn:aws:rds:us-west-2:123456789012:og:special-options</code>.</p> </li> </ul>",
-        "CopyOptionGroupMessage$TargetOptionGroupIdentifier": "<p>The identifier for the copied option group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-option-group</code> </p>",
-        "CopyOptionGroupMessage$TargetOptionGroupDescription": "<p>The description for the copied option group.</p>",
-        "CreateDBClusterMessage$CharacterSetName": "<p>A value that indicates that the DB cluster should be associated with the specified CharacterSet.</p>",
-        "CreateDBClusterMessage$DatabaseName": "<p>The name for your database of up to 64 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create a database in the DB cluster you are creating.</p>",
-        "CreateDBClusterMessage$DBClusterIdentifier": "<p>The DB cluster identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
-        "CreateDBClusterMessage$DBClusterParameterGroupName": "<p> The name of the DB cluster parameter group to associate with this DB cluster. If this argument is omitted, <code>default.aurora5.6</code> is used. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
-        "CreateDBClusterMessage$DBSubnetGroupName": "<p>A DB subnet group to associate with this DB cluster.</p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "CreateDBClusterMessage$Engine": "<p>The name of the database engine to be used for this DB cluster.</p> <p>Valid Values: <code>aurora</code> (for MySQL 5.6-compatible Aurora), <code>aurora-mysql</code> (for MySQL 5.7-compatible Aurora), and <code>aurora-postgresql</code> </p>",
-        "CreateDBClusterMessage$EngineVersion": "<p>The version number of the database engine to use.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>5.6.10a</code>, <code>5.7.12</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>9.6.3</code> </p>",
-        "CreateDBClusterMessage$MasterUsername": "<p>The name of the master user for the DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
-        "CreateDBClusterMessage$MasterUserPassword": "<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
-        "CreateDBClusterMessage$OptionGroupName": "<p>A value that indicates that the DB cluster should be associated with the specified option group.</p> <p>Permanent options can't be removed from an option group. The option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
-        "CreateDBClusterMessage$PreferredBackupWindow": "<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "CreateDBClusterMessage$PreferredMaintenanceWindow": "<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
-        "CreateDBClusterMessage$ReplicationSourceIdentifier": "<p>The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica.</p>",
-        "CreateDBClusterMessage$KmsKeyId": "<p>The AWS KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If an encryption key is not specified in <code>KmsKeyId</code>:</p> <ul> <li> <p>If <code>ReplicationSourceIdentifier</code> identifies an encrypted source, then Amazon RDS will use the encryption key used to encrypt the source. Otherwise, Amazon RDS will use your default encryption key. </p> </li> <li> <p>If the <code>StorageEncrypted</code> parameter is true and <code>ReplicationSourceIdentifier</code> is not specified, then Amazon RDS will use your default encryption key.</p> </li> </ul> <p>AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p> <p>If you create a Read Replica of an encrypted DB cluster in another AWS Region, you must set <code>KmsKeyId</code> to a KMS key ID that is valid in the destination AWS Region. This key is used to encrypt the Read Replica in that AWS Region.</p>",
-        "CreateDBClusterMessage$PreSignedUrl": "<p>A URL that contains a Signature Version 4 signed request for the <code>CreateDBCluster</code> action to be called in the source AWS Region where the DB cluster is replicated from. You only need to specify <code>PreSignedUrl</code> when you are performing cross-region replication from an encrypted DB cluster.</p> <p>The pre-signed URL must be a valid request for the <code>CreateDBCluster</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster to be copied.</p> <p>The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB cluster in the destination AWS Region. This should refer to the same KMS key for both the <code>CreateDBCluster</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that Aurora Read Replica will be created in.</p> </li> <li> <p> <code>ReplicationSourceIdentifier</code> - The DB cluster identifier for the encrypted DB cluster to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster from the us-west-2 AWS Region, then your <code>ReplicationSourceIdentifier</code> would look like Example: <code>arn:aws:rds:us-west-2:123456789012:cluster:aurora-cluster1</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>",
-        "CreateDBClusterParameterGroupMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBClusterParameterGroup.</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
-        "CreateDBClusterParameterGroupMessage$DBParameterGroupFamily": "<p>The DB cluster parameter group family name. A DB cluster parameter group can be associated with one and only one DB cluster parameter group family, and can be applied only to a DB cluster running a database engine and engine version compatible with that DB cluster parameter group family.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>aurora5.6</code>, <code>aurora-mysql5.7</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>aurora-postgresql9.6</code> </p>",
-        "CreateDBClusterParameterGroupMessage$Description": "<p>The description for the DB cluster parameter group.</p>",
-        "CreateDBClusterSnapshotMessage$DBClusterSnapshotIdentifier": "<p>The identifier of the DB cluster snapshot. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1-snapshot1</code> </p>",
-        "CreateDBClusterSnapshotMessage$DBClusterIdentifier": "<p>The identifier of the DB cluster to create a snapshot for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
-        "CreateDBInstanceMessage$DBName": "<p>The meaning of this parameter differs according to the database engine you use.</p> <p>Type: String</p> <p> <b>MySQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, the default \"postgres\" database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 63 letters, numbers, or underscores.</p> </li> <li> <p>Must begin with a letter or an underscore. Subsequent characters can be letters, underscores, or digits (0-9).</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>Oracle</b> </p> <p>The Oracle System ID (SID) of the created DB instance. If you specify <code>null</code>, the default value <code>ORCL</code> is used. You can't specify the string NULL, or any other reserved word, for <code>DBName</code>. </p> <p>Default: <code>ORCL</code> </p> <p>Constraints:</p> <ul> <li> <p>Cannot be longer than 8 characters</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Not applicable. Must be null.</p> <p> <b>Amazon Aurora</b> </p> <p>The name of the database to create when the primary instance of the DB cluster is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul>",
-        "CreateDBInstanceMessage$DBInstanceIdentifier": "<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
-        "CreateDBInstanceMessage$DBInstanceClass": "<p>The compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p>",
-        "CreateDBInstanceMessage$Engine": "<p>The name of the database engine to be used for this instance. </p> <p>Not every database engine is available for every AWS Region. </p> <p>Valid Values: </p> <ul> <li> <p> <code>aurora</code> (for MySQL 5.6-compatible Aurora)</p> </li> <li> <p> <code>aurora-mysql</code> (for MySQL 5.7-compatible Aurora)</p> </li> <li> <p> <code>aurora-postgresql</code> </p> </li> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
-        "CreateDBInstanceMessage$MasterUsername": "<p>The name for the master user.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The name for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>. </p> <p> <b>MariaDB</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for MariaDB.</p> </li> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for SQL Server.</p> </li> <li> <p>Must be 1 to 128 letters or numbers.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>MySQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for MySQL.</p> </li> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for Oracle.</p> </li> <li> <p>Must be 1 to 30 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for PostgreSQL.</p> </li> <li> <p>Must be 1 to 63 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
-        "CreateDBInstanceMessage$MasterUserPassword": "<p>The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <p> <b>MySQL</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Oracle</b> </p> <p>Constraints: Must contain from 8 to 30 characters.</p> <p> <b>PostgreSQL</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p>",
-        "CreateDBInstanceMessage$AvailabilityZone": "<p> The EC2 Availability Zone that the DB instance is created in. For information on AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p> <p> Constraint: The AvailabilityZone parameter can't be specified if the MultiAZ parameter is set to <code>true</code>. The specified Availability Zone must be in the same AWS Region as the current endpoint. </p>",
-        "CreateDBInstanceMessage$DBSubnetGroupName": "<p>A DB subnet group to associate with this DB instance.</p> <p>If there is no DB subnet group, then it is a non-VPC DB instance.</p>",
-        "CreateDBInstanceMessage$PreferredMaintenanceWindow": "<p>The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC). For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance\">Amazon RDS Maintenance Window</a>. </p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
-        "CreateDBInstanceMessage$DBParameterGroupName": "<p>The name of the DB parameter group to associate with this DB instance. If this argument is omitted, the default DBParameterGroup for the specified engine is used.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
-        "CreateDBInstanceMessage$PreferredBackupWindow": "<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupWindow\">The Backup Window</a>. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow\"> Adjusting the Preferred DB Instance Maintenance Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "CreateDBInstanceMessage$EngineVersion": "<p>The version number of the database engine to use.</p> <p>For a list of valid engine versions, call <a>DescribeDBEngineVersions</a>.</p> <p>The following are the database engines and links to information about the major and minor versions that are available with Amazon RDS. Not every database engine is available for every AWS Region.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The version number of the database engine to be used by the DB instance is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MariaDB.html#MariaDB.Concepts.VersionMgmt\">MariaDB on Amazon RDS Versions</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>Microsoft SQL Server</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.FeatureSupport\">Version and Feature Support on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>MySQL</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt\">MySQL on Amazon RDS Versions</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>Oracle</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.PatchComposition.html\">Oracle Database Engine Release Notes</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>PostgreSQL</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions\">Supported PostgreSQL Database Versions</a> in the <i>Amazon RDS User Guide.</i> </p>",
-        "CreateDBInstanceMessage$LicenseModel": "<p>License model information for this DB instance.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
-        "CreateDBInstanceMessage$OptionGroupName": "<p>Indicates that the DB instance should be associated with the specified option group.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
-        "CreateDBInstanceMessage$CharacterSetName": "<p>For supported engines, indicates that the DB instance should be associated with the specified CharacterSet.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The character set is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p>",
-        "CreateDBInstanceMessage$DBClusterIdentifier": "<p>The identifier of the DB cluster that the instance will belong to.</p> <p>For information on creating a DB cluster, see <a>CreateDBCluster</a>.</p> <p>Type: String</p>",
-        "CreateDBInstanceMessage$StorageType": "<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
-        "CreateDBInstanceMessage$TdeCredentialArn": "<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
-        "CreateDBInstanceMessage$TdeCredentialPassword": "<p>The password for the given ARN from the key store in order to access the device.</p>",
-        "CreateDBInstanceMessage$KmsKeyId": "<p>The AWS KMS key identifier for an encrypted DB instance.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB instance with the same AWS account that owns the KMS encryption key used to encrypt the new DB instance, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The KMS key identifier is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>",
-        "CreateDBInstanceMessage$Domain": "<p>Specify the Active Directory Domain to create the instance in.</p>",
-        "CreateDBInstanceMessage$MonitoringRoleArn": "<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling\">Setting Up and Enabling Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
-        "CreateDBInstanceMessage$DomainIAMRoleName": "<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
-        "CreateDBInstanceMessage$Timezone": "<p>The time zone of the DB instance. The time zone parameter is currently supported only by <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone\">Microsoft SQL Server</a>. </p>",
-        "CreateDBInstanceMessage$PerformanceInsightsKMSKeyId": "<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
-        "CreateDBInstanceReadReplicaMessage$DBInstanceIdentifier": "<p>The DB instance identifier of the Read Replica. This identifier is the unique key that identifies a DB instance. This parameter is stored as a lowercase string.</p>",
-        "CreateDBInstanceReadReplicaMessage$SourceDBInstanceIdentifier": "<p>The identifier of the DB instance that will act as the source for the Read Replica. Each DB instance can have up to five Read Replicas.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier of an existing MySQL, MariaDB, or PostgreSQL DB instance.</p> </li> <li> <p>Can specify a DB instance that is a MySQL Read Replica only if the source is running MySQL 5.6.</p> </li> <li> <p>Can specify a DB instance that is a PostgreSQL DB instance only if the source is running PostgreSQL 9.3.5 or later (9.4.7 and higher for cross-region replication).</p> </li> <li> <p>The specified DB instance must have automatic backups enabled, its backup retention period must be greater than 0.</p> </li> <li> <p>If the source DB instance is in the same AWS Region as the Read Replica, specify a valid DB instance identifier.</p> </li> <li> <p>If the source DB instance is in a different AWS Region than the Read Replica, specify a valid DB instance ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing a Amazon RDS Amazon Resource Name (ARN)</a>.</p> </li> </ul>",
-        "CreateDBInstanceReadReplicaMessage$DBInstanceClass": "<p>The compute and memory capacity of the Read Replica, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: Inherits from the source DB instance.</p>",
-        "CreateDBInstanceReadReplicaMessage$AvailabilityZone": "<p>The Amazon EC2 Availability Zone that the Read Replica is created in.</p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p>",
-        "CreateDBInstanceReadReplicaMessage$OptionGroupName": "<p>The option group the DB instance is associated with. If omitted, the default option group for the engine specified is used.</p>",
-        "CreateDBInstanceReadReplicaMessage$DBSubnetGroupName": "<p>Specifies a DB subnet group for the DB instance. The new DB instance is created in the VPC associated with the DB subnet group. If no DB subnet group is specified, then the new DB instance is not created in a VPC.</p> <p>Constraints:</p> <ul> <li> <p>Can only be specified if the source DB instance identifier specifies a DB instance in another AWS Region.</p> </li> <li> <p>If supplied, must match the name of an existing DBSubnetGroup.</p> </li> <li> <p>The specified DB subnet group must be in the same AWS Region in which the operation is running.</p> </li> <li> <p>All Read Replicas in one AWS Region that are created from the same source DB instance must either:&gt;</p> <ul> <li> <p>Specify DB subnet groups from the same VPC. All these Read Replicas are created in the same VPC.</p> </li> <li> <p>Not specify a DB subnet group. All these Read Replicas are created outside of any VPC.</p> </li> </ul> </li> </ul> <p>Example: <code>mySubnetgroup</code> </p>",
-        "CreateDBInstanceReadReplicaMessage$StorageType": "<p>Specifies the storage type to be associated with the Read Replica.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
-        "CreateDBInstanceReadReplicaMessage$MonitoringRoleArn": "<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
-        "CreateDBInstanceReadReplicaMessage$KmsKeyId": "<p>The AWS KMS key ID for an encrypted Read Replica. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you specify this parameter when you create a Read Replica from an unencrypted DB instance, the Read Replica is encrypted. </p> <p>If you create an encrypted Read Replica in the same AWS Region as the source DB instance, then you do not have to specify a value for this parameter. The Read Replica is encrypted with the same KMS key as the source DB instance. </p> <p>If you create an encrypted Read Replica in a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region. </p>",
-        "CreateDBInstanceReadReplicaMessage$PreSignedUrl": "<p>The URL that contains a Signature Version 4 signed request for the <code>CreateDBInstanceReadReplica</code> API action in the source AWS Region that contains the source DB instance. </p> <p>You must specify this parameter when you create an encrypted Read Replica from another AWS Region by using the Amazon RDS API. You can specify the <code>--source-region</code> option instead of this parameter when you create an encrypted Read Replica from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CreateDBInstanceReadReplica</code> API action that can be executed in the source AWS Region that contains the encrypted source DB instance. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted Read Replica is created in. This AWS Region is the same one where the <code>CreateDBInstanceReadReplica</code> action is called that contains this presigned URL. </p> <p>For example, if you create an encrypted DB instance in the us-west-1 AWS Region, from a source DB instance in the us-east-2 AWS Region, then you call the <code>CreateDBInstanceReadReplica</code> action in the us-east-1 AWS Region and provide a presigned URL that contains a call to the <code>CreateDBInstanceReadReplica</code> action in the us-west-2 AWS Region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 AWS Region. </p> </li> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the Read Replica in the destination AWS Region. This is the same identifier for both the <code>CreateDBInstanceReadReplica</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBInstanceIdentifier</code> - The DB instance identifier for the encrypted DB instance to be replicated. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are creating an encrypted Read Replica from a DB instance in the us-west-2 AWS Region, then your <code>SourceDBInstanceIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:instance:mysql-instance1-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>",
-        "CreateDBInstanceReadReplicaMessage$PerformanceInsightsKMSKeyId": "<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
-        "CreateDBParameterGroupMessage$DBParameterGroupName": "<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
-        "CreateDBParameterGroupMessage$DBParameterGroupFamily": "<p>The DB parameter group family name. A DB parameter group can be associated with one and only one DB parameter group family, and can be applied only to a DB instance running a database engine and engine version compatible with that DB parameter group family.</p>",
-        "CreateDBParameterGroupMessage$Description": "<p>The description for the DB parameter group.</p>",
-        "CreateDBSecurityGroupMessage$DBSecurityGroupName": "<p>The name for the DB security group. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul> <p>Example: <code>mysecuritygroup</code> </p>",
-        "CreateDBSecurityGroupMessage$DBSecurityGroupDescription": "<p>The description for the DB security group.</p>",
-        "CreateDBSnapshotMessage$DBSnapshotIdentifier": "<p>The identifier for the DB snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
-        "CreateDBSnapshotMessage$DBInstanceIdentifier": "<p>The identifier of the DB instance that you want to create the snapshot of.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "CreateDBSubnetGroupMessage$DBSubnetGroupName": "<p>The name for the DB subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 letters, numbers, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "CreateDBSubnetGroupMessage$DBSubnetGroupDescription": "<p>The description for the DB subnet group.</p>",
-        "CreateEventSubscriptionMessage$SubscriptionName": "<p>The name of the subscription.</p> <p>Constraints: The name must be less than 255 characters.</p>",
-        "CreateEventSubscriptionMessage$SnsTopicArn": "<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>",
-        "CreateEventSubscriptionMessage$SourceType": "<p>The type of source that is generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: <code>db-instance</code> | <code>db-cluster</code> | <code>db-parameter-group</code> | <code>db-security-group</code> | <code>db-snapshot</code> | <code>db-cluster-snapshot</code> </p>",
-        "CreateOptionGroupMessage$OptionGroupName": "<p>Specifies the name of the option group to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>myoptiongroup</code> </p>",
-        "CreateOptionGroupMessage$EngineName": "<p>Specifies the name of the engine that this option group should be associated with.</p>",
-        "CreateOptionGroupMessage$MajorEngineVersion": "<p>Specifies the major version of the engine that this option group should be associated with.</p>",
-        "CreateOptionGroupMessage$OptionGroupDescription": "<p>The description of the option group.</p>",
-        "DBCluster$CharacterSetName": "<p>If present, specifies the name of the character set that this cluster is associated with.</p>",
-        "DBCluster$DatabaseName": "<p>Contains the name of the initial database of this DB cluster that was provided at create time, if one was specified when the DB cluster was created. This same name is returned for the life of the DB cluster.</p>",
-        "DBCluster$DBClusterIdentifier": "<p>Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster.</p>",
-        "DBCluster$DBClusterParameterGroup": "<p>Specifies the name of the DB cluster parameter group for the DB cluster.</p>",
-        "DBCluster$DBSubnetGroup": "<p>Specifies information on the subnet group associated with the DB cluster, including the name, description, and subnets in the subnet group.</p>",
-        "DBCluster$Status": "<p>Specifies the current state of this DB cluster.</p>",
-        "DBCluster$PercentProgress": "<p>Specifies the progress of the operation as a percentage.</p>",
-        "DBCluster$Endpoint": "<p>Specifies the connection endpoint for the primary instance of the DB cluster.</p>",
-        "DBCluster$ReaderEndpoint": "<p>The reader endpoint for the DB cluster. The reader endpoint for a DB cluster load-balances connections across the Aurora Replicas that are available in a DB cluster. As clients request new connections to the reader endpoint, Aurora distributes the connection requests among the Aurora Replicas in the DB cluster. This functionality can help balance your read workload across multiple Aurora Replicas in your DB cluster. </p> <p>If a failover occurs, and the Aurora Replica that you are connected to is promoted to be the primary instance, your connection is dropped. To continue sending your read workload to other Aurora Replicas in the cluster, you can then reconnect to the reader endpoint.</p>",
-        "DBCluster$Engine": "<p>Provides the name of the database engine to be used for this DB cluster.</p>",
-        "DBCluster$EngineVersion": "<p>Indicates the database engine version.</p>",
-        "DBCluster$MasterUsername": "<p>Contains the master username for the DB cluster.</p>",
-        "DBCluster$PreferredBackupWindow": "<p>Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>",
-        "DBCluster$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
-        "DBCluster$ReplicationSourceIdentifier": "<p>Contains the identifier of the source DB cluster if this DB cluster is a Read Replica.</p>",
-        "DBCluster$HostedZoneId": "<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
-        "DBCluster$KmsKeyId": "<p>If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB cluster.</p>",
-        "DBCluster$DbClusterResourceId": "<p>The AWS Region-unique, immutable identifier for the DB cluster. This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB cluster is accessed.</p>",
-        "DBCluster$DBClusterArn": "<p>The Amazon Resource Name (ARN) for the DB cluster.</p>",
-        "DBCluster$CloneGroupId": "<p>Identifies the clone group to which the DB cluster is associated.</p>",
-        "DBClusterBacktrack$DBClusterIdentifier": "<p>Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster.</p>",
-        "DBClusterBacktrack$BacktrackIdentifier": "<p>Contains the backtrack identifier.</p>",
-        "DBClusterBacktrack$Status": "<p>The status of the backtrack. This property returns one of the following values:</p> <ul> <li> <p> <code>applying</code> - The backtrack is currently being applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>completed</code> - The backtrack has successfully been applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>failed</code> - An error occurred while the backtrack was applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>pending</code> - The backtrack is currently pending application to or rollback from the DB cluster.</p> </li> </ul>",
-        "DBClusterBacktrackMessage$Marker": "<p>A pagination token that can be used in a subsequent <a>DescribeDBClusterBacktracks</a> request.</p>",
-        "DBClusterMember$DBInstanceIdentifier": "<p>Specifies the instance identifier for this member of the DB cluster.</p>",
-        "DBClusterMember$DBClusterParameterGroupStatus": "<p>Specifies the status of the DB cluster parameter group for this member of the DB cluster.</p>",
-        "DBClusterMessage$Marker": "<p>A pagination token that can be used in a subsequent DescribeDBClusters request.</p>",
-        "DBClusterOptionGroupStatus$DBClusterOptionGroupName": "<p>Specifies the name of the DB cluster option group.</p>",
-        "DBClusterOptionGroupStatus$Status": "<p>Specifies the status of the DB cluster option group.</p>",
-        "DBClusterParameterGroup$DBClusterParameterGroupName": "<p>Provides the name of the DB cluster parameter group.</p>",
-        "DBClusterParameterGroup$DBParameterGroupFamily": "<p>Provides the name of the DB parameter group family that this DB cluster parameter group is compatible with.</p>",
-        "DBClusterParameterGroup$Description": "<p>Provides the customer-specified description for this DB cluster parameter group.</p>",
-        "DBClusterParameterGroup$DBClusterParameterGroupArn": "<p>The Amazon Resource Name (ARN) for the DB cluster parameter group.</p>",
-        "DBClusterParameterGroupDetails$Marker": "<p> An optional pagination token provided by a previous DescribeDBClusterParameters request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "DBClusterParameterGroupNameMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters or numbers.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
-        "DBClusterParameterGroupsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBClusterRole$RoleArn": "<p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB cluster.</p>",
-        "DBClusterRole$Status": "<p>Describes the state of association between the IAM role and the DB cluster. The Status property returns one of the following values:</p> <ul> <li> <p> <code>ACTIVE</code> - the IAM role ARN is associated with the DB cluster and can be used to access other AWS services on your behalf.</p> </li> <li> <p> <code>PENDING</code> - the IAM role ARN is being associated with the DB cluster.</p> </li> <li> <p> <code>INVALID</code> - the IAM role ARN is associated with the DB cluster, but the DB cluster is unable to assume the IAM role in order to access other AWS services on your behalf.</p> </li> </ul>",
-        "DBClusterSnapshot$DBClusterSnapshotIdentifier": "<p>Specifies the identifier for the DB cluster snapshot.</p>",
-        "DBClusterSnapshot$DBClusterIdentifier": "<p>Specifies the DB cluster identifier of the DB cluster that this DB cluster snapshot was created from.</p>",
-        "DBClusterSnapshot$Engine": "<p>Specifies the name of the database engine.</p>",
-        "DBClusterSnapshot$Status": "<p>Specifies the status of this DB cluster snapshot.</p>",
-        "DBClusterSnapshot$VpcId": "<p>Provides the VPC ID associated with the DB cluster snapshot.</p>",
-        "DBClusterSnapshot$MasterUsername": "<p>Provides the master username for the DB cluster snapshot.</p>",
-        "DBClusterSnapshot$EngineVersion": "<p>Provides the version of the database engine for this DB cluster snapshot.</p>",
-        "DBClusterSnapshot$LicenseModel": "<p>Provides the license model information for this DB cluster snapshot.</p>",
-        "DBClusterSnapshot$SnapshotType": "<p>Provides the type of the DB cluster snapshot.</p>",
-        "DBClusterSnapshot$KmsKeyId": "<p>If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB cluster snapshot.</p>",
-        "DBClusterSnapshot$DBClusterSnapshotArn": "<p>The Amazon Resource Name (ARN) for the DB cluster snapshot.</p>",
-        "DBClusterSnapshot$SourceDBClusterSnapshotArn": "<p>If the DB cluster snapshot was copied from a source DB cluster snapshot, the Amazon Resource Name (ARN) for the source DB cluster snapshot, otherwise, a null value.</p>",
-        "DBClusterSnapshotAttribute$AttributeName": "<p>The name of the manual DB cluster snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
-        "DBClusterSnapshotAttributesResult$DBClusterSnapshotIdentifier": "<p>The identifier of the manual DB cluster snapshot that the attributes apply to.</p>",
-        "DBClusterSnapshotMessage$Marker": "<p> An optional pagination token provided by a previous <a>DescribeDBClusterSnapshots</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBEngineVersion$Engine": "<p>The name of the database engine.</p>",
-        "DBEngineVersion$EngineVersion": "<p>The version number of the database engine.</p>",
-        "DBEngineVersion$DBParameterGroupFamily": "<p>The name of the DB parameter group family for the database engine.</p>",
-        "DBEngineVersion$DBEngineDescription": "<p>The description of the database engine.</p>",
-        "DBEngineVersion$DBEngineVersionDescription": "<p>The description of the database engine version.</p>",
-        "DBEngineVersionMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBInstance$DBInstanceIdentifier": "<p>Contains a user-supplied database identifier. This identifier is the unique key that identifies a DB instance.</p>",
-        "DBInstance$DBInstanceClass": "<p>Contains the name of the compute and memory capacity class of the DB instance.</p>",
-        "DBInstance$Engine": "<p>Provides the name of the database engine to be used for this DB instance.</p>",
-        "DBInstance$DBInstanceStatus": "<p>Specifies the current state of this database.</p>",
-        "DBInstance$MasterUsername": "<p>Contains the master username for the DB instance.</p>",
-        "DBInstance$DBName": "<p>The meaning of this parameter differs according to the database engine you use. For example, this value returns MySQL, MariaDB, or PostgreSQL information when returning values from CreateDBInstanceReadReplica since Read Replicas are only supported for these engines.</p> <p> <b>MySQL, MariaDB, SQL Server, PostgreSQL</b> </p> <p>Contains the name of the initial database of this instance that was provided at create time, if one was specified when the DB instance was created. This same name is returned for the life of the DB instance.</p> <p>Type: String</p> <p> <b>Oracle</b> </p> <p>Contains the Oracle System ID (SID) of the created DB instance. Not shown when the returned parameters do not apply to an Oracle DB instance.</p>",
-        "DBInstance$PreferredBackupWindow": "<p> Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>",
-        "DBInstance$AvailabilityZone": "<p>Specifies the name of the Availability Zone the DB instance is located in.</p>",
-        "DBInstance$PreferredMaintenanceWindow": "<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
-        "DBInstance$EngineVersion": "<p>Indicates the database engine version.</p>",
-        "DBInstance$ReadReplicaSourceDBInstanceIdentifier": "<p>Contains the identifier of the source DB instance if this DB instance is a Read Replica.</p>",
-        "DBInstance$LicenseModel": "<p>License model information for this DB instance.</p>",
-        "DBInstance$CharacterSetName": "<p>If present, specifies the name of the character set that this instance is associated with.</p>",
-        "DBInstance$SecondaryAvailabilityZone": "<p>If present, specifies the name of the secondary Availability Zone for a DB instance with multi-AZ support.</p>",
-        "DBInstance$StorageType": "<p>Specifies the storage type associated with DB instance.</p>",
-        "DBInstance$TdeCredentialArn": "<p>The ARN from the key store with which the instance is associated for TDE encryption.</p>",
-        "DBInstance$DBClusterIdentifier": "<p>If the DB instance is a member of a DB cluster, contains the name of the DB cluster that the DB instance is a member of.</p>",
-        "DBInstance$KmsKeyId": "<p> If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB instance. </p>",
-        "DBInstance$DbiResourceId": "<p>The AWS Region-unique, immutable identifier for the DB instance. This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB instance is accessed.</p>",
-        "DBInstance$CACertificateIdentifier": "<p>The identifier of the CA certificate for this DB instance.</p>",
-        "DBInstance$EnhancedMonitoringResourceArn": "<p>The Amazon Resource Name (ARN) of the Amazon CloudWatch Logs log stream that receives the Enhanced Monitoring metrics data for the DB instance.</p>",
-        "DBInstance$MonitoringRoleArn": "<p>The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs.</p>",
-        "DBInstance$DBInstanceArn": "<p>The Amazon Resource Name (ARN) for the DB instance.</p>",
-        "DBInstance$Timezone": "<p>The time zone of the DB instance. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for Microsoft SQL Server DB instances that were created with a time zone specified. </p>",
-        "DBInstance$PerformanceInsightsKMSKeyId": "<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
-        "DBInstanceMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "DBInstanceStatusInfo$StatusType": "<p>This value is currently \"read replication.\"</p>",
-        "DBInstanceStatusInfo$Status": "<p>Status of the DB instance. For a StatusType of read replica, the values can be replicating, error, stopped, or terminated.</p>",
-        "DBInstanceStatusInfo$Message": "<p>Details of the error if there is an error for the instance. If the instance is not in an error state, this value is blank.</p>",
-        "DBParameterGroup$DBParameterGroupName": "<p>Provides the name of the DB parameter group.</p>",
-        "DBParameterGroup$DBParameterGroupFamily": "<p>Provides the name of the DB parameter group family that this DB parameter group is compatible with.</p>",
-        "DBParameterGroup$Description": "<p>Provides the customer-specified description for this DB parameter group.</p>",
-        "DBParameterGroup$DBParameterGroupArn": "<p>The Amazon Resource Name (ARN) for the DB parameter group.</p>",
-        "DBParameterGroupDetails$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBParameterGroupNameMessage$DBParameterGroupName": "<p>Provides the name of the DB parameter group.</p>",
-        "DBParameterGroupStatus$DBParameterGroupName": "<p>The name of the DP parameter group.</p>",
-        "DBParameterGroupStatus$ParameterApplyStatus": "<p>The status of parameter updates.</p>",
-        "DBParameterGroupsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBSecurityGroup$OwnerId": "<p>Provides the AWS ID of the owner of a specific DB security group.</p>",
-        "DBSecurityGroup$DBSecurityGroupName": "<p>Specifies the name of the DB security group.</p>",
-        "DBSecurityGroup$DBSecurityGroupDescription": "<p>Provides the description of the DB security group.</p>",
-        "DBSecurityGroup$VpcId": "<p>Provides the VpcId of the DB security group.</p>",
-        "DBSecurityGroup$DBSecurityGroupArn": "<p>The Amazon Resource Name (ARN) for the DB security group.</p>",
-        "DBSecurityGroupMembership$DBSecurityGroupName": "<p>The name of the DB security group.</p>",
-        "DBSecurityGroupMembership$Status": "<p>The status of the DB security group.</p>",
-        "DBSecurityGroupMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBSecurityGroupNameList$member": null,
-        "DBSnapshot$DBSnapshotIdentifier": "<p>Specifies the identifier for the DB snapshot.</p>",
-        "DBSnapshot$DBInstanceIdentifier": "<p>Specifies the DB instance identifier of the DB instance this DB snapshot was created from.</p>",
-        "DBSnapshot$Engine": "<p>Specifies the name of the database engine.</p>",
-        "DBSnapshot$Status": "<p>Specifies the status of this DB snapshot.</p>",
-        "DBSnapshot$AvailabilityZone": "<p>Specifies the name of the Availability Zone the DB instance was located in at the time of the DB snapshot.</p>",
-        "DBSnapshot$VpcId": "<p>Provides the VPC ID associated with the DB snapshot.</p>",
-        "DBSnapshot$MasterUsername": "<p>Provides the master username for the DB snapshot.</p>",
-        "DBSnapshot$EngineVersion": "<p>Specifies the version of the database engine.</p>",
-        "DBSnapshot$LicenseModel": "<p>License model information for the restored DB instance.</p>",
-        "DBSnapshot$SnapshotType": "<p>Provides the type of the DB snapshot.</p>",
-        "DBSnapshot$OptionGroupName": "<p>Provides the option group name for the DB snapshot.</p>",
-        "DBSnapshot$SourceRegion": "<p>The AWS Region that the DB snapshot was created in or copied from.</p>",
-        "DBSnapshot$SourceDBSnapshotIdentifier": "<p>The DB snapshot Amazon Resource Name (ARN) that the DB snapshot was copied from. It only has value in case of cross-customer or cross-region copy.</p>",
-        "DBSnapshot$StorageType": "<p>Specifies the storage type associated with DB snapshot.</p>",
-        "DBSnapshot$TdeCredentialArn": "<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
-        "DBSnapshot$KmsKeyId": "<p> If <code>Encrypted</code> is true, the AWS KMS key identifier for the encrypted DB snapshot. </p>",
-        "DBSnapshot$DBSnapshotArn": "<p>The Amazon Resource Name (ARN) for the DB snapshot.</p>",
-        "DBSnapshot$Timezone": "<p>The time zone of the DB snapshot. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for snapshots taken from Microsoft SQL Server DB instances that were created with a time zone specified. </p>",
-        "DBSnapshotAttribute$AttributeName": "<p>The name of the manual DB snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
-        "DBSnapshotAttributesResult$DBSnapshotIdentifier": "<p>The identifier of the manual DB snapshot that the attributes apply to.</p>",
-        "DBSnapshotMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DBSubnetGroup$DBSubnetGroupName": "<p>The name of the DB subnet group.</p>",
-        "DBSubnetGroup$DBSubnetGroupDescription": "<p>Provides the description of the DB subnet group.</p>",
-        "DBSubnetGroup$VpcId": "<p>Provides the VpcId of the DB subnet group.</p>",
-        "DBSubnetGroup$SubnetGroupStatus": "<p>Provides the status of the DB subnet group.</p>",
-        "DBSubnetGroup$DBSubnetGroupArn": "<p>The Amazon Resource Name (ARN) for the DB subnet group.</p>",
-        "DBSubnetGroupMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DeleteDBClusterMessage$DBClusterIdentifier": "<p>The DB cluster identifier for the DB cluster to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing DBClusterIdentifier.</p> </li> </ul>",
-        "DeleteDBClusterMessage$FinalDBSnapshotIdentifier": "<p> The DB cluster snapshot identifier of the new DB cluster snapshot created when <code>SkipFinalSnapshot</code> is set to <code>false</code>. </p> <note> <p> Specifying this parameter and also setting the <code>SkipFinalShapshot</code> parameter to true results in an error. </p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
-        "DeleteDBClusterParameterGroupMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB cluster parameter group.</p> </li> <li> <p>You can't delete a default DB cluster parameter group.</p> </li> <li> <p>Cannot be associated with any DB clusters.</p> </li> </ul>",
-        "DeleteDBClusterSnapshotMessage$DBClusterSnapshotIdentifier": "<p>The identifier of the DB cluster snapshot to delete.</p> <p>Constraints: Must be the name of an existing DB cluster snapshot in the <code>available</code> state.</p>",
-        "DeleteDBInstanceMessage$DBInstanceIdentifier": "<p>The DB instance identifier for the DB instance to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DB instance.</p> </li> </ul>",
-        "DeleteDBInstanceMessage$FinalDBSnapshotIdentifier": "<p> The DBSnapshotIdentifier of the new DBSnapshot created when SkipFinalSnapshot is set to <code>false</code>. </p> <note> <p>Specifying this parameter and also setting the SkipFinalShapshot parameter to true results in an error.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters or numbers.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Cannot be specified when deleting a Read Replica.</p> </li> </ul>",
-        "DeleteDBParameterGroupMessage$DBParameterGroupName": "<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB parameter group</p> </li> <li> <p>You can't delete a default DB parameter group</p> </li> <li> <p>Cannot be associated with any DB instances</p> </li> </ul>",
-        "DeleteDBSecurityGroupMessage$DBSecurityGroupName": "<p>The name of the DB security group to delete.</p> <note> <p>You can't delete the default DB security group.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul>",
-        "DeleteDBSnapshotMessage$DBSnapshotIdentifier": "<p>The DBSnapshot identifier.</p> <p>Constraints: Must be the name of an existing DB snapshot in the <code>available</code> state.</p>",
-        "DeleteDBSubnetGroupMessage$DBSubnetGroupName": "<p>The name of the database subnet group to delete.</p> <note> <p>You can't delete the default subnet group.</p> </note> <p>Constraints:</p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "DeleteEventSubscriptionMessage$SubscriptionName": "<p>The name of the RDS event notification subscription you want to delete.</p>",
-        "DeleteOptionGroupMessage$OptionGroupName": "<p>The name of the option group to be deleted.</p> <note> <p>You can't delete default option groups.</p> </note>",
-        "DescribeCertificatesMessage$CertificateIdentifier": "<p>The user-supplied certificate identifier. If this parameter is specified, information for only the identified certificate is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing CertificateIdentifier.</p> </li> </ul>",
-        "DescribeCertificatesMessage$Marker": "<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBClusterBacktracksMessage$DBClusterIdentifier": "<p>The DB cluster identifier of the DB cluster to be described. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
-        "DescribeDBClusterBacktracksMessage$BacktrackIdentifier": "<p>If specified, this value is the backtrack identifier of the backtrack to be described.</p> <p>Constraints:</p> <ul> <li> <p>Must contain a valid universally unique identifier (UUID). For more information about UUIDs, see <a href=\"http://www.ietf.org/rfc/rfc4122.txt\">A Universally Unique Identifier (UUID) URN Namespace</a>.</p> </li> </ul> <p>Example: <code>123e4567-e89b-12d3-a456-426655440000</code> </p>",
-        "DescribeDBClusterBacktracksMessage$Marker": "<p> An optional pagination token provided by a previous <a>DescribeDBClusterBacktracks</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBClusterParameterGroupsMessage$DBClusterParameterGroupName": "<p>The name of a specific DB cluster parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
-        "DescribeDBClusterParameterGroupsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBClusterParametersMessage$DBClusterParameterGroupName": "<p>The name of a specific DB cluster parameter group to return parameter details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
-        "DescribeDBClusterParametersMessage$Source": "<p> A value that indicates to return only parameters for a specific source. Parameter sources can be <code>engine</code>, <code>service</code>, or <code>customer</code>. </p>",
-        "DescribeDBClusterParametersMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBClusterSnapshotAttributesMessage$DBClusterSnapshotIdentifier": "<p>The identifier for the DB cluster snapshot to describe the attributes for.</p>",
-        "DescribeDBClusterSnapshotsMessage$DBClusterIdentifier": "<p>The ID of the DB cluster to retrieve the list of DB cluster snapshots for. This parameter can't be used in conjunction with the <code>DBClusterSnapshotIdentifier</code> parameter. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBCluster.</p> </li> </ul>",
-        "DescribeDBClusterSnapshotsMessage$DBClusterSnapshotIdentifier": "<p>A specific DB cluster snapshot identifier to describe. This parameter can't be used in conjunction with the <code>DBClusterIdentifier</code> parameter. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBClusterSnapshot.</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>",
-        "DescribeDBClusterSnapshotsMessage$SnapshotType": "<p>The type of DB cluster snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB cluster snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB cluster snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB cluster snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB cluster snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual DB cluster snapshots are returned. You can include shared DB cluster snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public DB cluster snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>",
-        "DescribeDBClusterSnapshotsMessage$Marker": "<p>An optional pagination token provided by a previous <code>DescribeDBClusterSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBClustersMessage$DBClusterIdentifier": "<p>The user-supplied DB cluster identifier. If this parameter is specified, information from only the specific DB cluster is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBClusterIdentifier.</p> </li> </ul>",
-        "DescribeDBClustersMessage$Marker": "<p>An optional pagination token provided by a previous <a>DescribeDBClusters</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBEngineVersionsMessage$Engine": "<p>The database engine to return.</p>",
-        "DescribeDBEngineVersionsMessage$EngineVersion": "<p>The database engine version to return.</p> <p>Example: <code>5.1.49</code> </p>",
-        "DescribeDBEngineVersionsMessage$DBParameterGroupFamily": "<p>The name of a specific DB parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBParameterGroupFamily.</p> </li> </ul>",
-        "DescribeDBEngineVersionsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBInstancesMessage$DBInstanceIdentifier": "<p>The user-supplied instance identifier. If this parameter is specified, information from only the specific DB instance is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "DescribeDBInstancesMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBInstances</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBLogFilesDetails$LogFileName": "<p>The name of the log file for the specified DB instance.</p>",
-        "DescribeDBLogFilesMessage$DBInstanceIdentifier": "<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "DescribeDBLogFilesMessage$FilenameContains": "<p>Filters the available log files for log file names that contain the specified string.</p>",
-        "DescribeDBLogFilesMessage$Marker": "<p>The pagination token provided in the previous request. If this parameter is specified the response includes only records beyond the marker, up to MaxRecords.</p>",
-        "DescribeDBLogFilesResponse$Marker": "<p>A pagination token that can be used in a subsequent DescribeDBLogFiles request.</p>",
-        "DescribeDBParameterGroupsMessage$DBParameterGroupName": "<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
-        "DescribeDBParameterGroupsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBParametersMessage$DBParameterGroupName": "<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul>",
-        "DescribeDBParametersMessage$Source": "<p>The parameter types to return.</p> <p>Default: All parameter types returned</p> <p>Valid Values: <code>user | system | engine-default</code> </p>",
-        "DescribeDBParametersMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBSecurityGroupsMessage$DBSecurityGroupName": "<p>The name of the DB security group to return details for.</p>",
-        "DescribeDBSecurityGroupsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBSecurityGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBSnapshotAttributesMessage$DBSnapshotIdentifier": "<p>The identifier for the DB snapshot to describe the attributes for.</p>",
-        "DescribeDBSnapshotsMessage$DBInstanceIdentifier": "<p>The ID of the DB instance to retrieve the list of DB snapshots for. This parameter can't be used in conjunction with <code>DBSnapshotIdentifier</code>. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "DescribeDBSnapshotsMessage$DBSnapshotIdentifier": "<p> A specific DB snapshot identifier to describe. This parameter can't be used in conjunction with <code>DBInstanceIdentifier</code>. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBSnapshot.</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>",
-        "DescribeDBSnapshotsMessage$SnapshotType": "<p>The type of snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. You can include shared snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>",
-        "DescribeDBSnapshotsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeDBSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeDBSubnetGroupsMessage$DBSubnetGroupName": "<p>The name of the DB subnet group to return details for.</p>",
-        "DescribeDBSubnetGroupsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeDBSubnetGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeEngineDefaultClusterParametersMessage$DBParameterGroupFamily": "<p>The name of the DB cluster parameter group family to return engine parameter information for.</p>",
-        "DescribeEngineDefaultClusterParametersMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeEngineDefaultParametersMessage$DBParameterGroupFamily": "<p>The name of the DB parameter group family.</p>",
-        "DescribeEngineDefaultParametersMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeEventCategoriesMessage$SourceType": "<p>The type of source that is generating the events.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>",
-        "DescribeEventSubscriptionsMessage$SubscriptionName": "<p>The name of the RDS event notification subscription you want to describe.</p>",
-        "DescribeEventSubscriptionsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "DescribeEventsMessage$SourceIdentifier": "<p>The identifier of the event source for which events are returned. If not specified, then all sources are included in the response.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIdentifier is supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is <code>DBInstance</code>, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSecurityGroup</code>, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBParameterGroup</code>, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSnapshot</code>, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
-        "DescribeEventsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeEvents request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeOptionGroupOptionsMessage$EngineName": "<p>A required parameter. Options available for the given engine name are described.</p>",
-        "DescribeOptionGroupOptionsMessage$MajorEngineVersion": "<p>If specified, filters the results to include only options for the specified major engine version.</p>",
-        "DescribeOptionGroupOptionsMessage$Marker": "<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "DescribeOptionGroupsMessage$OptionGroupName": "<p>The name of the option group to describe. Cannot be supplied together with EngineName or MajorEngineVersion.</p>",
-        "DescribeOptionGroupsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeOptionGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeOptionGroupsMessage$EngineName": "<p>Filters the list of option groups to only include groups associated with a specific database engine.</p>",
-        "DescribeOptionGroupsMessage$MajorEngineVersion": "<p>Filters the list of option groups to only include groups associated with a specific database engine version. If specified, then EngineName must also be specified.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$Engine": "<p>The name of the engine to retrieve DB instance options for.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$EngineVersion": "<p>The engine version filter value. Specify this parameter to show only the available offerings matching the specified engine version.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$DBInstanceClass": "<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$LicenseModel": "<p>The license model filter value. Specify this parameter to show only the available offerings matching the specified license model.</p>",
-        "DescribeOrderableDBInstanceOptionsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "DescribePendingMaintenanceActionsMessage$ResourceIdentifier": "<p>The ARN of a resource to return pending maintenance actions for.</p>",
-        "DescribePendingMaintenanceActionsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>",
-        "DescribeReservedDBInstancesMessage$ReservedDBInstanceId": "<p>The reserved DB instance identifier filter value. Specify this parameter to show only the reservation that matches the specified reservation ID.</p>",
-        "DescribeReservedDBInstancesMessage$ReservedDBInstancesOfferingId": "<p>The offering identifier filter value. Specify this parameter to show only purchased reservations matching the specified offering identifier.</p>",
-        "DescribeReservedDBInstancesMessage$DBInstanceClass": "<p>The DB instance class filter value. Specify this parameter to show only those reservations matching the specified DB instances class.</p>",
-        "DescribeReservedDBInstancesMessage$Duration": "<p>The duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
-        "DescribeReservedDBInstancesMessage$ProductDescription": "<p>The product description filter value. Specify this parameter to show only those reservations matching the specified product description.</p>",
-        "DescribeReservedDBInstancesMessage$OfferingType": "<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>",
-        "DescribeReservedDBInstancesMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeReservedDBInstancesOfferingsMessage$ReservedDBInstancesOfferingId": "<p>The offering identifier filter value. Specify this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
-        "DescribeReservedDBInstancesOfferingsMessage$DBInstanceClass": "<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>",
-        "DescribeReservedDBInstancesOfferingsMessage$Duration": "<p>Duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
-        "DescribeReservedDBInstancesOfferingsMessage$ProductDescription": "<p>Product description filter value. Specify this parameter to show only the available offerings that contain the specified product description.</p> <note> <p>The results show offerings that partially match the filter value.</p> </note>",
-        "DescribeReservedDBInstancesOfferingsMessage$OfferingType": "<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>",
-        "DescribeReservedDBInstancesOfferingsMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "DescribeSourceRegionsMessage$RegionName": "<p>The source AWS Region name. For example, <code>us-east-1</code>.</p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid AWS Region name.</p> </li> </ul>",
-        "DescribeSourceRegionsMessage$Marker": "<p>An optional pagination token provided by a previous <a>DescribeSourceRegions</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "DescribeValidDBInstanceModificationsMessage$DBInstanceIdentifier": "<p>The customer identifier or the ARN of your DB instance. </p>",
-        "DomainMembership$Domain": "<p>The identifier of the Active Directory Domain.</p>",
-        "DomainMembership$Status": "<p>The status of the DB instance's Active Directory Domain membership, such as joined, pending-join, failed etc).</p>",
-        "DomainMembership$FQDN": "<p>The fully qualified domain name of the Active Directory Domain.</p>",
-        "DomainMembership$IAMRoleName": "<p>The name of the IAM role to be used when making API calls to the Directory Service.</p>",
-        "DownloadDBLogFilePortionDetails$LogFileData": "<p>Entries from the specified log file.</p>",
-        "DownloadDBLogFilePortionDetails$Marker": "<p>A pagination token that can be used in a subsequent DownloadDBLogFilePortion request.</p>",
-        "DownloadDBLogFilePortionMessage$DBInstanceIdentifier": "<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "DownloadDBLogFilePortionMessage$LogFileName": "<p>The name of the log file to be downloaded.</p>",
-        "DownloadDBLogFilePortionMessage$Marker": "<p>The pagination token provided in the previous request or \"0\". If the Marker parameter is specified the response includes only records beyond the marker until the end of the file or up to NumberOfLines.</p>",
-        "EC2SecurityGroup$Status": "<p>Provides the status of the EC2 security group. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>",
-        "EC2SecurityGroup$EC2SecurityGroupName": "<p>Specifies the name of the EC2 security group.</p>",
-        "EC2SecurityGroup$EC2SecurityGroupId": "<p>Specifies the id of the EC2 security group.</p>",
-        "EC2SecurityGroup$EC2SecurityGroupOwnerId": "<p> Specifies the AWS ID of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> field. </p>",
-        "Endpoint$Address": "<p>Specifies the DNS address of the DB instance.</p>",
-        "Endpoint$HostedZoneId": "<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
-        "EngineDefaults$DBParameterGroupFamily": "<p>Specifies the name of the DB parameter group family that the engine default parameters apply to.</p>",
-        "EngineDefaults$Marker": "<p> An optional pagination token provided by a previous EngineDefaults request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "Event$SourceIdentifier": "<p>Provides the identifier for the source of the event.</p>",
-        "Event$Message": "<p>Provides the text of this event.</p>",
-        "Event$SourceArn": "<p>The Amazon Resource Name (ARN) for the event.</p>",
-        "EventCategoriesList$member": null,
-        "EventCategoriesMap$SourceType": "<p>The source type that the returned categories belong to</p>",
-        "EventSubscription$CustomerAwsId": "<p>The AWS customer account associated with the RDS event notification subscription.</p>",
-        "EventSubscription$CustSubscriptionId": "<p>The RDS event notification subscription Id.</p>",
-        "EventSubscription$SnsTopicArn": "<p>The topic ARN of the RDS event notification subscription.</p>",
-        "EventSubscription$Status": "<p>The status of the RDS event notification subscription.</p> <p>Constraints:</p> <p>Can be one of the following: creating | modifying | deleting | active | no-permission | topic-not-exist</p> <p>The status \"no-permission\" indicates that RDS no longer has permission to post to the SNS topic. The status \"topic-not-exist\" indicates that the topic was deleted after the subscription was created.</p>",
-        "EventSubscription$SubscriptionCreationTime": "<p>The time the RDS event notification subscription was created.</p>",
-        "EventSubscription$SourceType": "<p>The source type for the RDS event notification subscription.</p>",
-        "EventSubscription$EventSubscriptionArn": "<p>The Amazon Resource Name (ARN) for the event subscription.</p>",
-        "EventSubscriptionsMessage$Marker": "<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "EventsMessage$Marker": "<p> An optional pagination token provided by a previous Events request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "FailoverDBClusterMessage$DBClusterIdentifier": "<p>A DB cluster identifier to force a failover for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
-        "FailoverDBClusterMessage$TargetDBInstanceIdentifier": "<p>The name of the instance to promote to the primary instance.</p> <p>You must specify the instance identifier for an Aurora Replica in the DB cluster. For example, <code>mydbcluster-replica1</code>.</p>",
-        "Filter$Name": "<p>The name of the filter. Filter names are case-sensitive.</p>",
-        "FilterValueList$member": null,
-        "IPRange$Status": "<p>Specifies the status of the IP range. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>",
-        "IPRange$CIDRIP": "<p>Specifies the IP range.</p>",
-        "KeyList$member": null,
-        "ListTagsForResourceMessage$ResourceName": "<p>The Amazon RDS resource with tags to be listed. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
-        "LogTypeList$member": null,
-        "ModifyDBClusterMessage$DBClusterIdentifier": "<p>The DB cluster identifier for the cluster being modified. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
-        "ModifyDBClusterMessage$NewDBClusterIdentifier": "<p>The new DB cluster identifier for the DB cluster when renaming a DB cluster. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>The first character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster2</code> </p>",
-        "ModifyDBClusterMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group to use for the DB cluster.</p>",
-        "ModifyDBClusterMessage$MasterUserPassword": "<p>The new password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
-        "ModifyDBClusterMessage$OptionGroupName": "<p>A value that indicates that the DB cluster should be associated with the specified option group. Changing this parameter doesn't result in an outage except in the following case, and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options can't be removed from an option group. The option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
-        "ModifyDBClusterMessage$PreferredBackupWindow": "<p>The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "ModifyDBClusterMessage$PreferredMaintenanceWindow": "<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
-        "ModifyDBClusterMessage$EngineVersion": "<p>The version number of the database engine to which you want to upgrade. Changing this parameter results in an outage. The change is applied during the next maintenance window unless the ApplyImmediately parameter is set to true.</p> <p>For a list of valid engine versions, see <a>CreateDBCluster</a>, or call <a>DescribeDBEngineVersions</a>.</p>",
-        "ModifyDBClusterParameterGroupMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group to modify.</p>",
-        "ModifyDBClusterSnapshotAttributeMessage$DBClusterSnapshotIdentifier": "<p>The identifier for the DB cluster snapshot to modify the attributes for.</p>",
-        "ModifyDBClusterSnapshotAttributeMessage$AttributeName": "<p>The name of the DB cluster snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this value to <code>restore</code>.</p>",
-        "ModifyDBInstanceMessage$DBInstanceIdentifier": "<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "ModifyDBInstanceMessage$DBInstanceClass": "<p>The new compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>If you modify the DB instance class, an outage occurs during the change. The change is applied during the next maintenance window, unless <code>ApplyImmediately</code> is specified as <code>true</code> for this request. </p> <p>Default: Uses existing setting</p>",
-        "ModifyDBInstanceMessage$DBSubnetGroupName": "<p>The new DB subnet group for the DB instance. You can use this parameter to move your DB instance to a different VPC. If your DB instance is not in a VPC, you can also use this parameter to move your DB instance into a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Non-VPC2VPC\">Updating the VPC for a DB Instance</a>. </p> <p>Changing the subnet group causes an outage during the change. The change is applied during the next maintenance window, unless you specify <code>true</code> for the <code>ApplyImmediately</code> parameter. </p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetGroup</code> </p>",
-        "ModifyDBInstanceMessage$MasterUserPassword": "<p>The new password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible. Between the time of the request and the completion of the request, the <code>MasterUserPassword</code> element exists in the <code>PendingModifiedValues</code> element of the operation response. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>. </p> <p>Default: Uses existing setting</p> <p> <b>MariaDB</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <p> <b>MySQL</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Oracle</b> </p> <p>Constraints: Must contain from 8 to 30 characters.</p> <p> <b>PostgreSQL</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <note> <p>Amazon RDS API actions never return the password, so this action provides a way to regain access to a primary instance user if the password is lost. This includes restoring privileges that might have been accidentally revoked. </p> </note>",
-        "ModifyDBInstanceMessage$DBParameterGroupName": "<p>The name of the DB parameter group to apply to the DB instance. Changing this setting doesn't result in an outage. The parameter group name itself is changed immediately, but the actual parameter changes are not applied until you reboot the instance without failover. The db instance will NOT be rebooted automatically and the parameter changes will NOT be applied during the next maintenance window.</p> <p>Default: Uses existing setting</p> <p>Constraints: The DB parameter group must be in the same DB parameter group family as this DB instance.</p>",
-        "ModifyDBInstanceMessage$PreferredBackupWindow": "<p> The daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code> parameter. Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>Must be in the format hh24:mi-hh24:mi</p> </li> <li> <p>Must be in Universal Time Coordinated (UTC)</p> </li> <li> <p>Must not conflict with the preferred maintenance window</p> </li> <li> <p>Must be at least 30 minutes</p> </li> </ul>",
-        "ModifyDBInstanceMessage$PreferredMaintenanceWindow": "<p>The weekly time range (in UTC) during which system maintenance can occur, which might result in an outage. Changing this parameter doesn't result in an outage, except in the following situation, and the change is asynchronously applied as soon as possible. If there are pending actions that cause a reboot, and the maintenance window is changed to include the current time, then changing this parameter will cause a reboot of the DB instance. If moving this window to the current time, there must be at least 30 minutes between the current time and end of the window to ensure pending changes are applied.</p> <p>Default: Uses existing setting</p> <p>Format: ddd:hh24:mi-ddd:hh24:mi</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Must be at least 30 minutes</p>",
-        "ModifyDBInstanceMessage$EngineVersion": "<p> The version number of the database engine to upgrade to. Changing this parameter results in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p> <p>For major version upgrades, if a nondefault DB parameter group is currently in use, a new DB parameter group in the DB parameter group family for the new engine version must be specified. The new DB parameter group can be the default for that DB parameter group family.</p> <p>For information about valid engine versions, see <a>CreateDBInstance</a>, or call <a>DescribeDBEngineVersions</a>.</p>",
-        "ModifyDBInstanceMessage$LicenseModel": "<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
-        "ModifyDBInstanceMessage$OptionGroupName": "<p> Indicates that the DB instance should be associated with the specified option group. Changing this parameter doesn't result in an outage except in the following case and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
-        "ModifyDBInstanceMessage$NewDBInstanceIdentifier": "<p> The new DB instance identifier for the DB instance when renaming a DB instance. When you change the DB instance identifier, an instance reboot will occur immediately if you set <code>Apply Immediately</code> to true, or will occur during the next maintenance window if <code>Apply Immediately</code> to false. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
-        "ModifyDBInstanceMessage$StorageType": "<p>Specifies the storage type to be associated with the DB instance. </p> <p>If you specify Provisioned IOPS (<code>io1</code>), you must also include a value for the <code>Iops</code> parameter. </p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance is available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance are suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance. </p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p>Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
-        "ModifyDBInstanceMessage$TdeCredentialArn": "<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
-        "ModifyDBInstanceMessage$TdeCredentialPassword": "<p>The password for the given ARN from the key store in order to access the device.</p>",
-        "ModifyDBInstanceMessage$CACertificateIdentifier": "<p>Indicates the certificate that needs to be associated with the instance.</p>",
-        "ModifyDBInstanceMessage$Domain": "<p>The Active Directory Domain to move the instance to. Specify <code>none</code> to remove the instance from its current domain. The domain must be created prior to this operation. Currently only a Microsoft SQL Server instance can be created in a Active Directory Domain. </p>",
-        "ModifyDBInstanceMessage$MonitoringRoleArn": "<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
-        "ModifyDBInstanceMessage$DomainIAMRoleName": "<p>The name of the IAM role to use when making API calls to the Directory Service.</p>",
-        "ModifyDBInstanceMessage$PerformanceInsightsKMSKeyId": "<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
-        "ModifyDBParameterGroupMessage$DBParameterGroupName": "<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul>",
-        "ModifyDBSnapshotAttributeMessage$DBSnapshotIdentifier": "<p>The identifier for the DB snapshot to modify the attributes for.</p>",
-        "ModifyDBSnapshotAttributeMessage$AttributeName": "<p>The name of the DB snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB snapshot, set this value to <code>restore</code>.</p>",
-        "ModifyDBSnapshotMessage$DBSnapshotIdentifier": "<p>The identifier of the DB snapshot to modify.</p>",
-        "ModifyDBSnapshotMessage$EngineVersion": "<p>The engine version to upgrade the DB snapshot to. </p> <p>The following are the database engines and engine versions that are available when you upgrade a DB snapshot. </p> <p> <b>MySQL</b> </p> <ul> <li> <p> <code>5.5.46</code> (supported for 5.1 DB snapshots)</p> </li> </ul> <p> <b>Oracle</b> </p> <ul> <li> <p> <code>12.1.0.2.v8</code> (supported for 12.1.0.1 DB snapshots)</p> </li> <li> <p> <code>11.2.0.4.v12</code> (supported for 11.2.0.2 DB snapshots)</p> </li> <li> <p> <code>11.2.0.4.v11</code> (supported for 11.2.0.3 DB snapshots)</p> </li> </ul>",
-        "ModifyDBSnapshotMessage$OptionGroupName": "<p>The option group to identify with the upgraded DB snapshot. </p> <p>You can specify this parameter when you upgrade an Oracle DB snapshot. The same option group considerations apply when upgrading a DB snapshot as when upgrading a DB instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Oracle.html#USER_UpgradeDBInstance.Oracle.OGPG.OG\">Option Group Considerations</a>. </p>",
-        "ModifyDBSubnetGroupMessage$DBSubnetGroupName": "<p>The name for the DB subnet group. This value is stored as a lowercase string. You can't modify the default subnet group. </p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "ModifyDBSubnetGroupMessage$DBSubnetGroupDescription": "<p>The description for the DB subnet group.</p>",
-        "ModifyEventSubscriptionMessage$SubscriptionName": "<p>The name of the RDS event notification subscription.</p>",
-        "ModifyEventSubscriptionMessage$SnsTopicArn": "<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>",
-        "ModifyEventSubscriptionMessage$SourceType": "<p>The type of source that is generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>",
-        "ModifyOptionGroupMessage$OptionGroupName": "<p>The name of the option group to be modified.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
-        "Option$OptionName": "<p>The name of the option.</p>",
-        "Option$OptionDescription": "<p>The description of the option.</p>",
-        "Option$OptionVersion": "<p>The version of the option.</p>",
-        "OptionConfiguration$OptionName": "<p>The configuration of options to include in a group.</p>",
-        "OptionConfiguration$OptionVersion": "<p>The version for the option.</p>",
-        "OptionGroup$OptionGroupName": "<p>Specifies the name of the option group.</p>",
-        "OptionGroup$OptionGroupDescription": "<p>Provides a description of the option group.</p>",
-        "OptionGroup$EngineName": "<p>Indicates the name of the engine that this option group can be applied to.</p>",
-        "OptionGroup$MajorEngineVersion": "<p>Indicates the major engine version associated with this option group.</p>",
-        "OptionGroup$VpcId": "<p>If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>false</code>, this field is blank. If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>true</code> and this field is blank, then this option group can be applied to both VPC and non-VPC instances. If this field contains a value, then this option group can only be applied to instances that are in the VPC indicated by this field. </p>",
-        "OptionGroup$OptionGroupArn": "<p>The Amazon Resource Name (ARN) for the option group.</p>",
-        "OptionGroupMembership$OptionGroupName": "<p>The name of the option group that the instance belongs to.</p>",
-        "OptionGroupMembership$Status": "<p>The status of the DB instance's option group membership. Valid values are: <code>in-sync</code>, <code>pending-apply</code>, <code>pending-removal</code>, <code>pending-maintenance-apply</code>, <code>pending-maintenance-removal</code>, <code>applying</code>, <code>removing</code>, and <code>failed</code>. </p>",
-        "OptionGroupOption$Name": "<p>The name of the option.</p>",
-        "OptionGroupOption$Description": "<p>The description of the option.</p>",
-        "OptionGroupOption$EngineName": "<p>The name of the engine that this option can be applied to.</p>",
-        "OptionGroupOption$MajorEngineVersion": "<p>Indicates the major engine version that the option is available for.</p>",
-        "OptionGroupOption$MinimumRequiredMinorEngineVersion": "<p>The minimum required engine version for the option to be applied.</p>",
-        "OptionGroupOptionSetting$SettingName": "<p>The name of the option group option.</p>",
-        "OptionGroupOptionSetting$SettingDescription": "<p>The description of the option group option.</p>",
-        "OptionGroupOptionSetting$DefaultValue": "<p>The default value for the option group option.</p>",
-        "OptionGroupOptionSetting$ApplyType": "<p>The DB engine specific parameter type for the option group option.</p>",
-        "OptionGroupOptionSetting$AllowedValues": "<p>Indicates the acceptable values for the option group option.</p>",
-        "OptionGroupOptionsMessage$Marker": "<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
-        "OptionGroups$Marker": "<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "OptionNamesList$member": null,
-        "OptionSetting$Name": "<p>The name of the option that has settings that you can set.</p>",
-        "OptionSetting$Value": "<p>The current value of the option setting.</p>",
-        "OptionSetting$DefaultValue": "<p>The default value of the option setting.</p>",
-        "OptionSetting$Description": "<p>The description of the option setting.</p>",
-        "OptionSetting$ApplyType": "<p>The DB engine specific parameter type.</p>",
-        "OptionSetting$DataType": "<p>The data type of the option setting.</p>",
-        "OptionSetting$AllowedValues": "<p>The allowed values of the option setting.</p>",
-        "OptionVersion$Version": "<p>The version of the option.</p>",
-        "OptionsConflictsWith$member": null,
-        "OptionsDependedOn$member": null,
-        "OrderableDBInstanceOption$Engine": "<p>The engine type of a DB instance.</p>",
-        "OrderableDBInstanceOption$EngineVersion": "<p>The engine version of a DB instance.</p>",
-        "OrderableDBInstanceOption$DBInstanceClass": "<p>The DB instance class for a DB instance.</p>",
-        "OrderableDBInstanceOption$LicenseModel": "<p>The license model for a DB instance.</p>",
-        "OrderableDBInstanceOption$StorageType": "<p>Indicates the storage type for a DB instance.</p>",
-        "OrderableDBInstanceOptionsMessage$Marker": "<p> An optional pagination token provided by a previous OrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
-        "Parameter$ParameterName": "<p>Specifies the name of the parameter.</p>",
-        "Parameter$ParameterValue": "<p>Specifies the value of the parameter.</p>",
-        "Parameter$Description": "<p>Provides a description of the parameter.</p>",
-        "Parameter$Source": "<p>Indicates the source of the parameter value.</p>",
-        "Parameter$ApplyType": "<p>Specifies the engine specific parameters type.</p>",
-        "Parameter$DataType": "<p>Specifies the valid data type for the parameter.</p>",
-        "Parameter$AllowedValues": "<p>Specifies the valid range of values for the parameter.</p>",
-        "Parameter$MinimumEngineVersion": "<p>The earliest engine version to which the parameter can apply.</p>",
-        "PendingMaintenanceAction$Action": "<p>The type of pending maintenance action that is available for the resource.</p>",
-        "PendingMaintenanceAction$OptInStatus": "<p>Indicates the type of opt-in request that has been received for the resource.</p>",
-        "PendingMaintenanceAction$Description": "<p>A description providing more detail about the maintenance action.</p>",
-        "PendingMaintenanceActionsMessage$Marker": "<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>",
-        "PendingModifiedValues$DBInstanceClass": "<p> Contains the new <code>DBInstanceClass</code> for the DB instance that will be applied or is currently being applied. </p>",
-        "PendingModifiedValues$MasterUserPassword": "<p>Contains the pending or currently-in-progress change of the master credentials for the DB instance.</p>",
-        "PendingModifiedValues$EngineVersion": "<p>Indicates the database engine version.</p>",
-        "PendingModifiedValues$LicenseModel": "<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
-        "PendingModifiedValues$DBInstanceIdentifier": "<p> Contains the new <code>DBInstanceIdentifier</code> for the DB instance that will be applied or is currently being applied. </p>",
-        "PendingModifiedValues$StorageType": "<p>Specifies the storage type to be associated with the DB instance.</p>",
-        "PendingModifiedValues$CACertificateIdentifier": "<p>Specifies the identifier of the CA certificate for the DB instance.</p>",
-        "PendingModifiedValues$DBSubnetGroupName": "<p>The new DB subnet group for the DB instance. </p>",
-        "ProcessorFeature$Name": "<p>The name of the processor feature. Valid names are <code>coreCount</code> and <code>threadsPerCore</code>.</p>",
-        "ProcessorFeature$Value": "<p>The value of a processor feature name.</p>",
-        "PromoteReadReplicaDBClusterMessage$DBClusterIdentifier": "<p>The identifier of the DB cluster Read Replica to promote. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster Read Replica.</p> </li> </ul> <p>Example: <code>my-cluster-replica1</code> </p>",
-        "PromoteReadReplicaMessage$DBInstanceIdentifier": "<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing Read Replica DB instance.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
-        "PromoteReadReplicaMessage$PreferredBackupWindow": "<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p> The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "PurchaseReservedDBInstancesOfferingMessage$ReservedDBInstancesOfferingId": "<p>The ID of the Reserved DB instance offering to purchase.</p> <p>Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706</p>",
-        "PurchaseReservedDBInstancesOfferingMessage$ReservedDBInstanceId": "<p>Customer-specified identifier to track this reservation.</p> <p>Example: myreservationID</p>",
-        "ReadReplicaDBClusterIdentifierList$member": null,
-        "ReadReplicaDBInstanceIdentifierList$member": null,
-        "ReadReplicaIdentifierList$member": null,
-        "RebootDBInstanceMessage$DBInstanceIdentifier": "<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
-        "RecurringCharge$RecurringChargeFrequency": "<p>The frequency of the recurring charge.</p>",
-        "RemoveRoleFromDBClusterMessage$DBClusterIdentifier": "<p>The name of the DB cluster to disassociate the IAM role from.</p>",
-        "RemoveRoleFromDBClusterMessage$RoleArn": "<p>The Amazon Resource Name (ARN) of the IAM role to disassociate from the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>",
-        "RemoveSourceIdentifierFromSubscriptionMessage$SubscriptionName": "<p>The name of the RDS event notification subscription you want to remove a source identifier from.</p>",
-        "RemoveSourceIdentifierFromSubscriptionMessage$SourceIdentifier": "<p> The source identifier to be removed from the subscription, such as the <b>DB instance identifier</b> for a DB instance or the name of a security group. </p>",
-        "RemoveTagsFromResourceMessage$ResourceName": "<p>The Amazon RDS resource that the tags are removed from. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
-        "ReservedDBInstance$ReservedDBInstanceId": "<p>The unique identifier for the reservation.</p>",
-        "ReservedDBInstance$ReservedDBInstancesOfferingId": "<p>The offering identifier.</p>",
-        "ReservedDBInstance$DBInstanceClass": "<p>The DB instance class for the reserved DB instance.</p>",
-        "ReservedDBInstance$CurrencyCode": "<p>The currency code for the reserved DB instance.</p>",
-        "ReservedDBInstance$ProductDescription": "<p>The description of the reserved DB instance.</p>",
-        "ReservedDBInstance$OfferingType": "<p>The offering type of this reserved DB instance.</p>",
-        "ReservedDBInstance$State": "<p>The state of the reserved DB instance.</p>",
-        "ReservedDBInstance$ReservedDBInstanceArn": "<p>The Amazon Resource Name (ARN) for the reserved DB instance.</p>",
-        "ReservedDBInstanceMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "ReservedDBInstancesOffering$ReservedDBInstancesOfferingId": "<p>The offering identifier.</p>",
-        "ReservedDBInstancesOffering$DBInstanceClass": "<p>The DB instance class for the reserved DB instance.</p>",
-        "ReservedDBInstancesOffering$CurrencyCode": "<p>The currency code for the reserved DB instance offering.</p>",
-        "ReservedDBInstancesOffering$ProductDescription": "<p>The database engine used by the offering.</p>",
-        "ReservedDBInstancesOffering$OfferingType": "<p>The offering type.</p>",
-        "ReservedDBInstancesOfferingMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "ResetDBClusterParameterGroupMessage$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group to reset.</p>",
-        "ResetDBParameterGroupMessage$DBParameterGroupName": "<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBParameterGroup.</p> </li> </ul>",
-        "ResourcePendingMaintenanceActions$ResourceIdentifier": "<p>The ARN of the resource that has pending maintenance actions.</p>",
-        "RestoreDBClusterFromS3Message$CharacterSetName": "<p>A value that indicates that the restored DB cluster should be associated with the specified CharacterSet.</p>",
-        "RestoreDBClusterFromS3Message$DatabaseName": "<p>The database name for the restored DB cluster.</p>",
-        "RestoreDBClusterFromS3Message$DBClusterIdentifier": "<p>The name of the DB cluster to create from the source data in the Amazon S3 bucket. This parameter is isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
-        "RestoreDBClusterFromS3Message$DBClusterParameterGroupName": "<p>The name of the DB cluster parameter group to associate with the restored DB cluster. If this argument is omitted, <code>default.aurora5.6</code> is used. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
-        "RestoreDBClusterFromS3Message$DBSubnetGroupName": "<p>A DB subnet group to associate with the restored DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup. </p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "RestoreDBClusterFromS3Message$Engine": "<p>The name of the database engine to be used for the restored DB cluster.</p> <p>Valid Values: <code>aurora</code>, <code>aurora-postgresql</code> </p>",
-        "RestoreDBClusterFromS3Message$EngineVersion": "<p>The version number of the database engine to use.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>5.6.10a</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>9.6.3</code> </p>",
-        "RestoreDBClusterFromS3Message$MasterUsername": "<p>The name of the master user for the restored DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
-        "RestoreDBClusterFromS3Message$MasterUserPassword": "<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
-        "RestoreDBClusterFromS3Message$OptionGroupName": "<p>A value that indicates that the restored DB cluster should be associated with the specified option group.</p> <p>Permanent options can't be removed from an option group. An option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
-        "RestoreDBClusterFromS3Message$PreferredBackupWindow": "<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "RestoreDBClusterFromS3Message$PreferredMaintenanceWindow": "<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
-        "RestoreDBClusterFromS3Message$KmsKeyId": "<p>The AWS KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>",
-        "RestoreDBClusterFromS3Message$SourceEngine": "<p>The identifier for the database engine that was backed up to create the files stored in the Amazon S3 bucket. </p> <p>Valid values: <code>mysql</code> </p>",
-        "RestoreDBClusterFromS3Message$SourceEngineVersion": "<p>The version of the database that the backup files were created from.</p> <p>MySQL version 5.5 and 5.6 are supported. </p> <p>Example: <code>5.6.22</code> </p>",
-        "RestoreDBClusterFromS3Message$S3BucketName": "<p>The name of the Amazon S3 bucket that contains the data used to create the Amazon Aurora DB cluster.</p>",
-        "RestoreDBClusterFromS3Message$S3Prefix": "<p>The prefix for all of the file names that contain the data used to create the Amazon Aurora DB cluster. If you do not specify a <b>SourceS3Prefix</b> value, then the Amazon Aurora DB cluster is created by using all of the files in the Amazon S3 bucket.</p>",
-        "RestoreDBClusterFromS3Message$S3IngestionRoleArn": "<p>The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that authorizes Amazon RDS to access the Amazon S3 bucket on your behalf.</p>",
-        "RestoreDBClusterFromSnapshotMessage$DBClusterIdentifier": "<p>The name of the DB cluster to create from the DB snapshot or DB cluster snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
-        "RestoreDBClusterFromSnapshotMessage$SnapshotIdentifier": "<p>The identifier for the DB snapshot or DB cluster snapshot to restore from.</p> <p>You can use either the name or the Amazon Resource Name (ARN) to specify a DB cluster snapshot. However, you can use only the ARN to specify a DB snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing Snapshot.</p> </li> </ul>",
-        "RestoreDBClusterFromSnapshotMessage$Engine": "<p>The database engine to use for the new DB cluster.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p>",
-        "RestoreDBClusterFromSnapshotMessage$EngineVersion": "<p>The version of the database engine to use for the new DB cluster.</p>",
-        "RestoreDBClusterFromSnapshotMessage$DBSubnetGroupName": "<p>The name of the DB subnet group to use for the new DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "RestoreDBClusterFromSnapshotMessage$DatabaseName": "<p>The database name for the restored DB cluster.</p>",
-        "RestoreDBClusterFromSnapshotMessage$OptionGroupName": "<p>The name of the option group to use for the restored DB cluster.</p>",
-        "RestoreDBClusterFromSnapshotMessage$KmsKeyId": "<p>The AWS KMS key identifier to use when restoring an encrypted DB cluster from a DB snapshot or DB cluster snapshot.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB snapshot or DB cluster snapshot in <code>SnapshotIdentifier</code> is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the DB snapshot or DB cluster snapshot.</p> </li> <li> <p>If the DB snapshot or DB cluster snapshot in <code>SnapshotIdentifier</code> is not encrypted, then the restored DB cluster is not encrypted.</p> </li> </ul>",
-        "RestoreDBClusterToPointInTimeMessage$DBClusterIdentifier": "<p>The name of the new DB cluster to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
-        "RestoreDBClusterToPointInTimeMessage$RestoreType": "<p>The type of restore to be performed. You can specify one of the following values:</p> <ul> <li> <p> <code>full-copy</code> - The new DB cluster is restored as a full copy of the source DB cluster.</p> </li> <li> <p> <code>copy-on-write</code> - The new DB cluster is restored as a clone of the source DB cluster.</p> </li> </ul> <p>Constraints: You can't specify <code>copy-on-write</code> if the engine version of the source DB cluster is earlier than 1.11.</p> <p>If you don't specify a <code>RestoreType</code> value, then the new DB cluster is restored as a full copy of the source DB cluster.</p>",
-        "RestoreDBClusterToPointInTimeMessage$SourceDBClusterIdentifier": "<p>The identifier of the source DB cluster from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
-        "RestoreDBClusterToPointInTimeMessage$DBSubnetGroupName": "<p>The DB subnet group name to use for the new DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "RestoreDBClusterToPointInTimeMessage$OptionGroupName": "<p>The name of the option group for the new DB cluster.</p>",
-        "RestoreDBClusterToPointInTimeMessage$KmsKeyId": "<p>The AWS KMS key identifier to use when restoring an encrypted DB cluster from an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>You can restore to a new DB cluster and encrypt the new DB cluster with a KMS key that is different than the KMS key used to encrypt the source DB cluster. The new DB cluster is encrypted with the KMS key identified by the <code>KmsKeyId</code> parameter.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB cluster is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the source DB cluster.</p> </li> <li> <p>If the DB cluster is not encrypted, then the restored DB cluster is not encrypted.</p> </li> </ul> <p>If <code>DBClusterIdentifier</code> refers to a DB cluster that is not encrypted, then the restore request is rejected.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DBInstanceIdentifier": "<p>Name of the DB instance to create from the DB snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 numbers, letters, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DBSnapshotIdentifier": "<p>The identifier for the DB snapshot to restore from.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBSnapshot.</p> </li> <li> <p>If you are restoring from a shared manual DB snapshot, the <code>DBSnapshotIdentifier</code> must be the ARN of the shared DB snapshot.</p> </li> </ul>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DBInstanceClass": "<p>The compute and memory capacity of the Amazon RDS DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: The same DBInstanceClass as the original DB instance.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$AvailabilityZone": "<p>The EC2 Availability Zone that the DB instance is created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p> <p>Example: <code>us-east-1a</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DBSubnetGroupName": "<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$LicenseModel": "<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DBName": "<p>The database name for the restored DB instance.</p> <note> <p>This parameter doesn't apply to the MySQL, PostgreSQL, or MariaDB engines.</p> </note>",
-        "RestoreDBInstanceFromDBSnapshotMessage$Engine": "<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source. For example, you can restore a MariaDB 10.1 DB instance from a MySQL 5.6 snapshot.</p> <p>Valid Values:</p> <ul> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
-        "RestoreDBInstanceFromDBSnapshotMessage$OptionGroupName": "<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$StorageType": "<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$TdeCredentialArn": "<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$TdeCredentialPassword": "<p>The password for the given ARN from the key store in order to access the device.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$Domain": "<p>Specify the Active Directory Domain to restore the instance in.</p>",
-        "RestoreDBInstanceFromDBSnapshotMessage$DomainIAMRoleName": "<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
-        "RestoreDBInstanceFromS3Message$DBName": "<p>The name of the database to create when the DB instance is created. Follow the naming rules specified in <a>CreateDBInstance</a>. </p>",
-        "RestoreDBInstanceFromS3Message$DBInstanceIdentifier": "<p>The DB instance identifier. This parameter is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
-        "RestoreDBInstanceFromS3Message$DBInstanceClass": "<p>The compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Importing from Amazon S3 is not supported on the db.t2.micro DB instance class. </p>",
-        "RestoreDBInstanceFromS3Message$Engine": "<p>The name of the database engine to be used for this instance. </p> <p>Valid Values: <code>mysql</code> </p>",
-        "RestoreDBInstanceFromS3Message$MasterUsername": "<p>The name for the master user. </p> <p>Constraints: </p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
-        "RestoreDBInstanceFromS3Message$MasterUserPassword": "<p>The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\". </p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
-        "RestoreDBInstanceFromS3Message$AvailabilityZone": "<p>The Availability Zone that the DB instance is created in. For information about AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region. </p> <p> Example: <code>us-east-1d</code> </p> <p>Constraint: The AvailabilityZone parameter can't be specified if the MultiAZ parameter is set to <code>true</code>. The specified Availability Zone must be in the same AWS Region as the current endpoint. </p>",
-        "RestoreDBInstanceFromS3Message$DBSubnetGroupName": "<p>A DB subnet group to associate with this DB instance.</p>",
-        "RestoreDBInstanceFromS3Message$PreferredMaintenanceWindow": "<p>The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC). For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance\">Amazon RDS Maintenance Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>ddd:hh24:mi-ddd:hh24:mi</code>.</p> </li> <li> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred backup window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "RestoreDBInstanceFromS3Message$DBParameterGroupName": "<p>The name of the DB parameter group to associate with this DB instance. If this argument is omitted, the default parameter group for the specified engine is used. </p>",
-        "RestoreDBInstanceFromS3Message$PreferredBackupWindow": "<p>The time range each day during which automated backups are created if automated backups are enabled. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupWindow\">The Backup Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
-        "RestoreDBInstanceFromS3Message$EngineVersion": "<p>The version number of the database engine to use. Choose the latest minor version of your database engine. For information about engine versions, see <a>CreateDBInstance</a>, or call <a>DescribeDBEngineVersions</a>. </p>",
-        "RestoreDBInstanceFromS3Message$LicenseModel": "<p>The license model for this DB instance. Use <code>general-public-license</code>. </p>",
-        "RestoreDBInstanceFromS3Message$OptionGroupName": "<p>The name of the option group to associate with this DB instance. If this argument is omitted, the default option group for the specified engine is used. </p>",
-        "RestoreDBInstanceFromS3Message$StorageType": "<p>Specifies the storage type to be associated with the DB instance. </p> <p>Valid values: <code>standard</code> | <code>gp2</code> | <code>io1</code> </p> <p>If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p>Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>",
-        "RestoreDBInstanceFromS3Message$KmsKeyId": "<p>The AWS KMS key identifier for an encrypted DB instance. </p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB instance with the same AWS account that owns the KMS encryption key used to encrypt the new DB instance, then you can use the KMS key alias instead of the ARN for the KM encryption key. </p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region. </p>",
-        "RestoreDBInstanceFromS3Message$MonitoringRoleArn": "<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling\">Setting Up and Enabling Enhanced Monitoring</a>. </p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value. </p>",
-        "RestoreDBInstanceFromS3Message$SourceEngine": "<p>The name of the engine of your source database. </p> <p>Valid Values: <code>mysql</code> </p>",
-        "RestoreDBInstanceFromS3Message$SourceEngineVersion": "<p>The engine version of your source database. </p> <p>Valid Values: <code>5.6</code> </p>",
-        "RestoreDBInstanceFromS3Message$S3BucketName": "<p>The name of your Amazon S3 bucket that contains your database backup file. </p>",
-        "RestoreDBInstanceFromS3Message$S3Prefix": "<p>The prefix of your Amazon S3 bucket. </p>",
-        "RestoreDBInstanceFromS3Message$S3IngestionRoleArn": "<p>An AWS Identity and Access Management (IAM) role to allow Amazon RDS to access your Amazon S3 bucket. </p>",
-        "RestoreDBInstanceFromS3Message$PerformanceInsightsKMSKeyId": "<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), the KMS key identifier, or the KMS key alias for the KMS encryption key. </p>",
-        "RestoreDBInstanceToPointInTimeMessage$SourceDBInstanceIdentifier": "<p>The identifier of the source DB instance from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DB instance.</p> </li> </ul>",
-        "RestoreDBInstanceToPointInTimeMessage$TargetDBInstanceIdentifier": "<p>The name of the new DB instance to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
-        "RestoreDBInstanceToPointInTimeMessage$DBInstanceClass": "<p>The compute and memory capacity of the Amazon RDS DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: The same DBInstanceClass as the original DB instance.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$AvailabilityZone": "<p>The EC2 Availability Zone that the DB instance is created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p> <p>Example: <code>us-east-1a</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$DBSubnetGroupName": "<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$LicenseModel": "<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$DBName": "<p>The database name for the restored DB instance.</p> <note> <p>This parameter is not used for the MySQL or MariaDB engines.</p> </note>",
-        "RestoreDBInstanceToPointInTimeMessage$Engine": "<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p> <p>Valid Values:</p> <ul> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
-        "RestoreDBInstanceToPointInTimeMessage$OptionGroupName": "<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
-        "RestoreDBInstanceToPointInTimeMessage$StorageType": "<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$TdeCredentialArn": "<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$TdeCredentialPassword": "<p>The password for the given ARN from the key store in order to access the device.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$Domain": "<p>Specify the Active Directory Domain to restore the instance in.</p>",
-        "RestoreDBInstanceToPointInTimeMessage$DomainIAMRoleName": "<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
-        "RevokeDBSecurityGroupIngressMessage$DBSecurityGroupName": "<p>The name of the DB security group to revoke ingress from.</p>",
-        "RevokeDBSecurityGroupIngressMessage$CIDRIP": "<p> The IP range to revoke access from. Must be a valid CIDR range. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code>, <code>EC2SecurityGroupId</code> and <code>EC2SecurityGroupOwnerId</code> can't be provided. </p>",
-        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupName": "<p> The name of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupId": "<p> The id of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupOwnerId": "<p> The AWS Account Number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
-        "SourceIdsList$member": null,
-        "SourceRegion$RegionName": "<p>The name of the source AWS Region.</p>",
-        "SourceRegion$Endpoint": "<p>The endpoint for the source AWS Region endpoint.</p>",
-        "SourceRegion$Status": "<p>The status of the source AWS Region.</p>",
-        "SourceRegionMessage$Marker": "<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
-        "StartDBInstanceMessage$DBInstanceIdentifier": "<p> The user-supplied instance identifier. </p>",
-        "StopDBInstanceMessage$DBInstanceIdentifier": "<p> The user-supplied instance identifier. </p>",
-        "StopDBInstanceMessage$DBSnapshotIdentifier": "<p> The user-supplied instance identifier of the DB Snapshot created immediately before the DB instance is stopped. </p>",
-        "Subnet$SubnetIdentifier": "<p>Specifies the identifier of the subnet.</p>",
-        "Subnet$SubnetStatus": "<p>Specifies the status of the subnet.</p>",
-        "SubnetIdentifierList$member": null,
-        "Tag$Key": "<p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and can't be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
-        "Tag$Value": "<p>A value is the optional value of the tag. The string value can be from 1 to 256 Unicode characters in length and can't be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
-        "Timezone$TimezoneName": "<p>The name of the time zone.</p>",
-        "UpgradeTarget$Engine": "<p>The name of the upgrade target database engine.</p>",
-        "UpgradeTarget$EngineVersion": "<p>The version number of the upgrade target database engine.</p>",
-        "UpgradeTarget$Description": "<p>The version of the database engine that a DB instance can be upgraded to.</p>",
-        "ValidStorageOptions$StorageType": "<p>The valid storage types for your DB instance. For example, gp2, io1. </p>",
-        "VpcSecurityGroupIdList$member": null,
-        "VpcSecurityGroupMembership$VpcSecurityGroupId": "<p>The name of the VPC security group.</p>",
-        "VpcSecurityGroupMembership$Status": "<p>The status of the VPC security group.</p>"
-      }
-    },
-    "Subnet": {
-      "base": "<p> This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>",
-      "refs": {
-        "SubnetList$member": null
-      }
-    },
-    "SubnetAlreadyInUse": {
-      "base": "<p>The DB subnet is already in use in the Availability Zone.</p>",
-      "refs": {
-      }
-    },
-    "SubnetIdentifierList": {
-      "base": null,
-      "refs": {
-        "CreateDBSubnetGroupMessage$SubnetIds": "<p>The EC2 Subnet IDs for the DB subnet group.</p>",
-        "ModifyDBSubnetGroupMessage$SubnetIds": "<p>The EC2 subnet IDs for the DB subnet group.</p>"
-      }
-    },
-    "SubnetList": {
-      "base": null,
-      "refs": {
-        "DBSubnetGroup$Subnets": "<p> Contains a list of <a>Subnet</a> elements. </p>"
-      }
-    },
-    "SubscriptionAlreadyExistFault": {
-      "base": "<p>The supplied subscription name already exists.</p>",
-      "refs": {
-      }
-    },
-    "SubscriptionCategoryNotFoundFault": {
-      "base": "<p>The supplied category does not exist.</p>",
-      "refs": {
-      }
-    },
-    "SubscriptionNotFoundFault": {
-      "base": "<p>The subscription name does not exist.</p>",
-      "refs": {
-      }
-    },
-    "SupportedCharacterSetsList": {
-      "base": null,
-      "refs": {
-        "DBEngineVersion$SupportedCharacterSets": "<p> A list of the character sets supported by this engine for the <code>CharacterSetName</code> parameter of the <code>CreateDBInstance</code> action. </p>"
-      }
-    },
-    "SupportedTimezonesList": {
-      "base": null,
-      "refs": {
-        "DBEngineVersion$SupportedTimezones": "<p>A list of the time zones supported by this engine for the <code>Timezone</code> parameter of the <code>CreateDBInstance</code> action. </p>"
-      }
-    },
-    "TStamp": {
-      "base": null,
-      "refs": {
-        "BacktrackDBClusterMessage$BacktrackTo": "<p>The timestamp of the time to backtrack the DB cluster to, specified in ISO 8601 format. For more information about ISO 8601, see the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <note> <p>If the specified time is not a consistent time for the DB cluster, Aurora automatically chooses the nearest possible consistent time for the DB cluster.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must contain a valid ISO 8601 timestamp.</p> </li> <li> <p>Cannot contain a timestamp set in the future.</p> </li> </ul> <p>Example: <code>2017-07-08T18:00Z</code> </p>",
-        "Certificate$ValidFrom": "<p>The starting date from which the certificate is valid.</p>",
-        "Certificate$ValidTill": "<p>The final date that the certificate continues to be valid.</p>",
-        "DBCluster$EarliestRestorableTime": "<p>The earliest time to which a database can be restored with point-in-time restore.</p>",
-        "DBCluster$LatestRestorableTime": "<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>",
-        "DBCluster$ClusterCreateTime": "<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>",
-        "DBCluster$EarliestBacktrackTime": "<p>The earliest time to which a DB cluster can be backtracked.</p>",
-        "DBClusterBacktrack$BacktrackTo": "<p>The timestamp of the time to which the DB cluster was backtracked.</p>",
-        "DBClusterBacktrack$BacktrackedFrom": "<p>The timestamp of the time from which the DB cluster was backtracked.</p>",
-        "DBClusterBacktrack$BacktrackRequestCreationTime": "<p>The timestamp of the time at which the backtrack was requested.</p>",
-        "DBClusterSnapshot$SnapshotCreateTime": "<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
-        "DBClusterSnapshot$ClusterCreateTime": "<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>",
-        "DBInstance$InstanceCreateTime": "<p>Provides the date and time the DB instance was created.</p>",
-        "DBInstance$LatestRestorableTime": "<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>",
-        "DBSnapshot$SnapshotCreateTime": "<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
-        "DBSnapshot$InstanceCreateTime": "<p>Specifies the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
-        "DescribeEventsMessage$StartTime": "<p> The beginning of the time interval to retrieve events for, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>",
-        "DescribeEventsMessage$EndTime": "<p> The end of the time interval for which to retrieve events, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>",
-        "Event$Date": "<p>Specifies the date and time of the event.</p>",
-        "PendingMaintenanceAction$AutoAppliedAfterDate": "<p>The date of the maintenance window when the action is applied. The maintenance action is applied to the resource during its first maintenance window after this date. If this date is specified, any <code>next-maintenance</code> opt-in requests are ignored.</p>",
-        "PendingMaintenanceAction$ForcedApplyDate": "<p>The date when the maintenance action is automatically applied. The maintenance action is applied to the resource on this date regardless of the maintenance window for the resource. If this date is specified, any <code>immediate</code> opt-in requests are ignored.</p>",
-        "PendingMaintenanceAction$CurrentApplyDate": "<p>The effective date when the pending maintenance action is applied to the resource. This date takes into account opt-in requests received from the <a>ApplyPendingMaintenanceAction</a> API, the <code>AutoAppliedAfterDate</code>, and the <code>ForcedApplyDate</code>. This value is blank if an opt-in request has not been received and nothing has been specified as <code>AutoAppliedAfterDate</code> or <code>ForcedApplyDate</code>.</p>",
-        "ReservedDBInstance$StartTime": "<p>The time the reservation started.</p>",
-        "RestoreDBClusterToPointInTimeMessage$RestoreToTime": "<p>The date and time to restore the DB cluster to.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Must be specified if <code>UseLatestRestorableTime</code> parameter is not provided</p> </li> <li> <p>Cannot be specified if <code>UseLatestRestorableTime</code> parameter is true</p> </li> <li> <p>Cannot be specified if <code>RestoreType</code> parameter is <code>copy-on-write</code> </p> </li> </ul> <p>Example: <code>2015-03-07T23:45:00Z</code> </p>",
-        "RestoreDBInstanceToPointInTimeMessage$RestoreTime": "<p>The date and time to restore from.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Cannot be specified if UseLatestRestorableTime parameter is true</p> </li> </ul> <p>Example: <code>2009-09-07T23:45:00Z</code> </p>"
-      }
-    },
-    "Tag": {
-      "base": "<p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>",
-      "refs": {
-        "TagList$member": null
-      }
-    },
-    "TagList": {
-      "base": "<p>A list of tags. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS Resources</a>. </p>",
-      "refs": {
-        "AddTagsToResourceMessage$Tags": "<p>The tags to be assigned to the Amazon RDS resource.</p>",
-        "CopyDBClusterParameterGroupMessage$Tags": null,
-        "CopyDBClusterSnapshotMessage$Tags": null,
-        "CopyDBParameterGroupMessage$Tags": null,
-        "CopyDBSnapshotMessage$Tags": null,
-        "CopyOptionGroupMessage$Tags": null,
-        "CreateDBClusterMessage$Tags": null,
-        "CreateDBClusterParameterGroupMessage$Tags": null,
-        "CreateDBClusterSnapshotMessage$Tags": "<p>The tags to be assigned to the DB cluster snapshot.</p>",
-        "CreateDBInstanceMessage$Tags": null,
-        "CreateDBInstanceReadReplicaMessage$Tags": null,
-        "CreateDBParameterGroupMessage$Tags": null,
-        "CreateDBSecurityGroupMessage$Tags": null,
-        "CreateDBSnapshotMessage$Tags": null,
-        "CreateDBSubnetGroupMessage$Tags": null,
-        "CreateEventSubscriptionMessage$Tags": null,
-        "CreateOptionGroupMessage$Tags": null,
-        "PurchaseReservedDBInstancesOfferingMessage$Tags": null,
-        "RestoreDBClusterFromS3Message$Tags": null,
-        "RestoreDBClusterFromSnapshotMessage$Tags": "<p>The tags to be assigned to the restored DB cluster.</p>",
-        "RestoreDBClusterToPointInTimeMessage$Tags": null,
-        "RestoreDBInstanceFromDBSnapshotMessage$Tags": null,
-        "RestoreDBInstanceFromS3Message$Tags": "<p>A list of tags to associate with this DB instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS Resources</a>. </p>",
-        "RestoreDBInstanceToPointInTimeMessage$Tags": null,
-        "TagListMessage$TagList": "<p>List of tags returned by the ListTagsForResource operation.</p>"
-      }
-    },
-    "TagListMessage": {
-      "base": "<p/>",
-      "refs": {
-      }
-    },
-    "Timezone": {
-      "base": "<p>A time zone associated with a <a>DBInstance</a> or a <a>DBSnapshot</a>. This data type is an element in the response to the <a>DescribeDBInstances</a>, the <a>DescribeDBSnapshots</a>, and the <a>DescribeDBEngineVersions</a> actions. </p>",
-      "refs": {
-        "SupportedTimezonesList$member": null
-      }
-    },
-    "UpgradeTarget": {
-      "base": "<p>The version of the database engine that a DB instance can be upgraded to.</p>",
-      "refs": {
-        "ValidUpgradeTargetList$member": null
-      }
-    },
-    "ValidDBInstanceModificationsMessage": {
-      "base": "<p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. You can use this information when you call <a>ModifyDBInstance</a>. </p>",
-      "refs": {
-        "DescribeValidDBInstanceModificationsResult$ValidDBInstanceModificationsMessage": null
-      }
-    },
-    "ValidStorageOptions": {
-      "base": "<p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. </p>",
-      "refs": {
-        "ValidStorageOptionsList$member": null
-      }
-    },
-    "ValidStorageOptionsList": {
-      "base": null,
-      "refs": {
-        "ValidDBInstanceModificationsMessage$Storage": "<p>Valid storage options for your DB instance. </p>"
-      }
-    },
-    "ValidUpgradeTargetList": {
-      "base": null,
-      "refs": {
-        "DBEngineVersion$ValidUpgradeTarget": "<p>A list of engine versions that this database engine version can be upgraded to.</p>"
-      }
-    },
-    "VpcSecurityGroupIdList": {
-      "base": null,
-      "refs": {
-        "CreateDBClusterMessage$VpcSecurityGroupIds": "<p>A list of EC2 VPC security groups to associate with this DB cluster.</p>",
-        "CreateDBInstanceMessage$VpcSecurityGroupIds": "<p>A list of EC2 VPC security groups to associate with this DB instance.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: The default EC2 VPC security group for the DB subnet group's VPC.</p>",
-        "ModifyDBClusterMessage$VpcSecurityGroupIds": "<p>A list of VPC security groups that the DB cluster will belong to.</p>",
-        "ModifyDBInstanceMessage$VpcSecurityGroupIds": "<p>A list of EC2 VPC security groups to authorize on this DB instance. This change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match existing VpcSecurityGroupIds.</p> </li> </ul>",
-        "OptionConfiguration$VpcSecurityGroupMemberships": "<p>A list of VpcSecurityGroupMemebrship name strings used for this option.</p>",
-        "RestoreDBClusterFromS3Message$VpcSecurityGroupIds": "<p>A list of EC2 VPC security groups to associate with the restored DB cluster.</p>",
-        "RestoreDBClusterFromSnapshotMessage$VpcSecurityGroupIds": "<p>A list of VPC security groups that the new DB cluster will belong to.</p>",
-        "RestoreDBClusterToPointInTimeMessage$VpcSecurityGroupIds": "<p>A list of VPC security groups that the new DB cluster belongs to.</p>",
-        "RestoreDBInstanceFromS3Message$VpcSecurityGroupIds": "<p>A list of VPC security groups to associate with this DB instance. </p>"
-      }
-    },
-    "VpcSecurityGroupMembership": {
-      "base": "<p>This data type is used as a response element for queries on VPC security group membership.</p>",
-      "refs": {
-        "VpcSecurityGroupMembershipList$member": null
-      }
-    },
-    "VpcSecurityGroupMembershipList": {
-      "base": null,
-      "refs": {
-        "DBCluster$VpcSecurityGroups": "<p>Provides a list of VPC security groups that the DB cluster belongs to.</p>",
-        "DBInstance$VpcSecurityGroups": "<p>Provides a list of VPC security group elements that the DB instance belongs to.</p>",
-        "Option$VpcSecurityGroupMemberships": "<p>If the option requires access to a port, then this VPC security group allows access to the port.</p>"
+    "String":{
+      "base":null,
+      "refs":{
+        "AccountQuota$AccountQuotaName":"<p>The name of the Amazon RDS quota for this AWS account.</p>",
+        "AddRoleToDBClusterMessage$DBClusterIdentifier":"<p>The name of the DB cluster to associate the IAM role with.</p>",
+        "AddRoleToDBClusterMessage$RoleArn":"<p>The Amazon Resource Name (ARN) of the IAM role to associate with the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>",
+        "AddSourceIdentifierToSubscriptionMessage$SubscriptionName":"<p>The name of the RDS event notification subscription you want to add a source identifier to.</p>",
+        "AddSourceIdentifierToSubscriptionMessage$SourceIdentifier":"<p>The identifier of the event source to be added.</p> <p>Constraints:</p> <ul> <li> <p>If the source type is a DB instance, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is a DB security group, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB parameter group, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is a DB snapshot, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> </ul>",
+        "AddTagsToResourceMessage$ResourceName":"<p>The Amazon RDS resource that the tags are added to. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
+        "ApplyPendingMaintenanceActionMessage$ResourceIdentifier":"<p>The RDS Amazon Resource Name (ARN) of the resource that the pending maintenance action applies to. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
+        "ApplyPendingMaintenanceActionMessage$ApplyAction":"<p>The pending maintenance action to apply to this resource.</p> <p>Valid values: <code>system-update</code>, <code>db-upgrade</code> </p>",
+        "ApplyPendingMaintenanceActionMessage$OptInType":"<p>A value that specifies the type of opt-in request, or undoes an opt-in request. An opt-in request of type <code>immediate</code> can't be undone.</p> <p>Valid values:</p> <ul> <li> <p> <code>immediate</code> - Apply the maintenance action immediately.</p> </li> <li> <p> <code>next-maintenance</code> - Apply the maintenance action during the next maintenance window for the resource.</p> </li> <li> <p> <code>undo-opt-in</code> - Cancel any existing <code>next-maintenance</code> opt-in requests.</p> </li> </ul>",
+        "AttributeValueList$member":null,
+        "AuthorizeDBSecurityGroupIngressMessage$DBSecurityGroupName":"<p>The name of the DB security group to add authorization to.</p>",
+        "AuthorizeDBSecurityGroupIngressMessage$CIDRIP":"<p>The IP range to authorize.</p>",
+        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupName":"<p> Name of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupId":"<p> Id of the EC2 security group to authorize. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "AuthorizeDBSecurityGroupIngressMessage$EC2SecurityGroupOwnerId":"<p> AWS account number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, <code>EC2SecurityGroupOwnerId</code> and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "AvailabilityZone$Name":"<p>The name of the Availability Zone.</p>",
+        "AvailabilityZones$member":null,
+        "AvailableProcessorFeature$Name":"<p>The name of the processor feature. Valid names are <code>coreCount</code> and <code>threadsPerCore</code>.</p>",
+        "AvailableProcessorFeature$DefaultValue":"<p>The default value for the processor feature of the DB instance class.</p>",
+        "AvailableProcessorFeature$AllowedValues":"<p>The allowed values for the processor feature of the DB instance class.</p>",
+        "BacktrackDBClusterMessage$DBClusterIdentifier":"<p>The DB cluster identifier of the DB cluster to be backtracked. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
+        "Certificate$CertificateIdentifier":"<p>The unique key that identifies a certificate.</p>",
+        "Certificate$CertificateType":"<p>The type of the certificate.</p>",
+        "Certificate$Thumbprint":"<p>The thumbprint of the certificate.</p>",
+        "Certificate$CertificateArn":"<p>The Amazon Resource Name (ARN) for the certificate.</p>",
+        "CertificateMessage$Marker":"<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "CharacterSet$CharacterSetName":"<p>The name of the character set.</p>",
+        "CharacterSet$CharacterSetDescription":"<p>The description of the character set.</p>",
+        "CopyDBClusterParameterGroupMessage$SourceDBClusterParameterGroupIdentifier":"<p>The identifier or Amazon Resource Name (ARN) for the source DB cluster parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB cluster parameter group.</p> </li> <li> <p>If the source DB cluster parameter group is in the same AWS Region as the copy, specify a valid DB parameter group identifier, for example <code>my-db-cluster-param-group</code>, or a valid ARN.</p> </li> <li> <p>If the source DB parameter group is in a different AWS Region than the copy, specify a valid DB cluster parameter group ARN, for example <code>arn:aws:rds:us-east-1:123456789012:cluster-pg:custom-cluster-group1</code>.</p> </li> </ul>",
+        "CopyDBClusterParameterGroupMessage$TargetDBClusterParameterGroupIdentifier":"<p>The identifier for the copied DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster-param-group1</code> </p>",
+        "CopyDBClusterParameterGroupMessage$TargetDBClusterParameterGroupDescription":"<p>A description for the copied DB cluster parameter group.</p>",
+        "CopyDBClusterSnapshotMessage$SourceDBClusterSnapshotIdentifier":"<p>The identifier of the DB cluster snapshot to copy. This parameter is not case-sensitive.</p> <p>You can't copy an encrypted, shared DB cluster snapshot from one AWS Region to another.</p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> <li> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier.</p> </li> <li> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB cluster snapshot ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html\"> Copying a DB Snapshot or DB Cluster Snapshot</a>.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot1</code> </p>",
+        "CopyDBClusterSnapshotMessage$TargetDBClusterSnapshotIdentifier":"<p>The identifier of the new DB cluster snapshot to create from the source DB cluster snapshot. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster-snapshot2</code> </p>",
+        "CopyDBClusterSnapshotMessage$KmsKeyId":"<p>The AWS AWS KMS key ID for an encrypted DB cluster snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an encrypted DB cluster snapshot from your AWS account, you can specify a value for <code>KmsKeyId</code> to encrypt the copy with a new KMS encryption key. If you don't specify a value for <code>KmsKeyId</code>, then the copy of the DB cluster snapshot is encrypted with the same KMS key as the source DB cluster snapshot. </p> <p>If you copy an encrypted DB cluster snapshot that is shared from another AWS account, then you must specify a value for <code>KmsKeyId</code>. </p> <p>To copy an encrypted DB cluster snapshot to another AWS Region, you must set <code>KmsKeyId</code> to the KMS key ID you want to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region.</p> <p>If you copy an unencrypted DB cluster snapshot and specify a value for the <code>KmsKeyId</code> parameter, an error is returned.</p>",
+        "CopyDBClusterSnapshotMessage$PreSignedUrl":"<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBClusterSnapshot</code> API action in the AWS Region that contains the source DB cluster snapshot to copy. The <code>PreSignedUrl</code> parameter must be used when copying an encrypted DB cluster snapshot from another AWS Region.</p> <p>The pre-signed URL must be a valid request for the <code>CopyDBSClusterSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster snapshot to be copied. The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB cluster snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBClusterSnapshot</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that the DB cluster snapshot will be created in.</p> </li> <li> <p> <code>SourceDBClusterSnapshotIdentifier</code> - The DB cluster snapshot identifier for the encrypted DB cluster snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster snapshot from the us-west-2 AWS Region, then your <code>SourceDBClusterSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:cluster-snapshot:aurora-cluster1-snapshot-20161115</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>",
+        "CopyDBParameterGroupMessage$SourceDBParameterGroupIdentifier":"<p> The identifier or ARN for the source DB parameter group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid DB parameter group.</p> </li> <li> <p>Must specify a valid DB parameter group identifier, for example <code>my-db-param-group</code>, or a valid ARN.</p> </li> </ul>",
+        "CopyDBParameterGroupMessage$TargetDBParameterGroupIdentifier":"<p>The identifier for the copied DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-parameter-group</code> </p>",
+        "CopyDBParameterGroupMessage$TargetDBParameterGroupDescription":"<p>A description for the copied DB parameter group.</p>",
+        "CopyDBSnapshotMessage$SourceDBSnapshotIdentifier":"<p>The identifier for the source DB snapshot.</p> <p>If the source snapshot is in the same AWS Region as the copy, specify a valid DB snapshot identifier. For example, you might specify <code>rds:mysql-instance1-snapshot-20130805</code>. </p> <p>If the source snapshot is in a different AWS Region than the copy, specify a valid DB snapshot ARN. For example, you might specify <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code>. </p> <p>If you are copying from a shared manual DB snapshot, this parameter must be the Amazon Resource Name (ARN) of the shared DB snapshot. </p> <p>If you are copying an encrypted snapshot this parameter must be in the ARN format for the source AWS Region, and must match the <code>SourceDBSnapshotIdentifier</code> in the <code>PreSignedUrl</code> parameter. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid system snapshot in the \"available\" state.</p> </li> </ul> <p>Example: <code>rds:mydb-2012-04-02-00-01</code> </p> <p>Example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20130805</code> </p>",
+        "CopyDBSnapshotMessage$TargetDBSnapshotIdentifier":"<p>The identifier for the copy of the snapshot. </p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-db-snapshot</code> </p>",
+        "CopyDBSnapshotMessage$KmsKeyId":"<p>The AWS KMS key ID for an encrypted DB snapshot. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you copy an encrypted DB snapshot from your AWS account, you can specify a value for this parameter to encrypt the copy with a new KMS encryption key. If you don't specify a value for this parameter, then the copy of the DB snapshot is encrypted with the same KMS key as the source DB snapshot. </p> <p>If you copy an encrypted DB snapshot that is shared from another AWS account, then you must specify a value for this parameter. </p> <p>If you specify this parameter when you copy an unencrypted snapshot, the copy is encrypted. </p> <p>If you copy an encrypted snapshot to a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region. </p>",
+        "CopyDBSnapshotMessage$PreSignedUrl":"<p>The URL that contains a Signature Version 4 signed request for the <code>CopyDBSnapshot</code> API action in the source AWS Region that contains the source DB snapshot to copy. </p> <p>You must specify this parameter when you copy an encrypted DB snapshot from another AWS Region by using the Amazon RDS API. You can specify the <code>--source-region</code> option instead of this parameter when you copy an encrypted DB snapshot from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CopyDBSnapshot</code> API action that can be executed in the source AWS Region that contains the encrypted DB snapshot to be copied. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted DB snapshot is copied to. This AWS Region is the same one where the <code>CopyDBSnapshot</code> action is called that contains this presigned URL. </p> <p>For example, if you copy an encrypted DB snapshot from the us-west-2 AWS Region to the us-east-1 AWS Region, then you call the <code>CopyDBSnapshot</code> action in the us-east-1 AWS Region and provide a presigned URL that contains a call to the <code>CopyDBSnapshot</code> action in the us-west-2 AWS Region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 AWS Region. </p> </li> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB snapshot in the destination AWS Region. This is the same identifier for both the <code>CopyDBSnapshot</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBSnapshotIdentifier</code> - The DB snapshot identifier for the encrypted snapshot to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB snapshot from the us-west-2 AWS Region, then your <code>SourceDBSnapshotIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:snapshot:mysql-instance1-snapshot-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>",
+        "CopyDBSnapshotMessage$OptionGroupName":"<p>The name of an option group to associate with the copy of the snapshot.</p> <p>Specify this option if you are copying a snapshot from one AWS Region to another, and your DB instance uses a nondefault option group. If your source DB instance uses Transparent Data Encryption for Oracle or Microsoft SQL Server, you must specify this option when copying across AWS Regions. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CopySnapshot.html#USER_CopySnapshot.Options\">Option Group Considerations</a>. </p>",
+        "CopyOptionGroupMessage$SourceOptionGroupIdentifier":"<p>The identifier or ARN for the source option group. For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid option group.</p> </li> <li> <p>If the source option group is in the same AWS Region as the copy, specify a valid option group identifier, for example <code>my-option-group</code>, or a valid ARN.</p> </li> <li> <p>If the source option group is in a different AWS Region than the copy, specify a valid option group ARN, for example <code>arn:aws:rds:us-west-2:123456789012:og:special-options</code>.</p> </li> </ul>",
+        "CopyOptionGroupMessage$TargetOptionGroupIdentifier":"<p>The identifier for the copied option group.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-option-group</code> </p>",
+        "CopyOptionGroupMessage$TargetOptionGroupDescription":"<p>The description for the copied option group.</p>",
+        "CreateDBClusterMessage$CharacterSetName":"<p>A value that indicates that the DB cluster should be associated with the specified CharacterSet.</p>",
+        "CreateDBClusterMessage$DatabaseName":"<p>The name for your database of up to 64 alpha-numeric characters. If you do not provide a name, Amazon RDS will not create a database in the DB cluster you are creating.</p>",
+        "CreateDBClusterMessage$DBClusterIdentifier":"<p>The DB cluster identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
+        "CreateDBClusterMessage$DBClusterParameterGroupName":"<p> The name of the DB cluster parameter group to associate with this DB cluster. If this argument is omitted, <code>default.aurora5.6</code> is used. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
+        "CreateDBClusterMessage$DBSubnetGroupName":"<p>A DB subnet group to associate with this DB cluster.</p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "CreateDBClusterMessage$Engine":"<p>The name of the database engine to be used for this DB cluster.</p> <p>Valid Values: <code>aurora</code> (for MySQL 5.6-compatible Aurora), <code>aurora-mysql</code> (for MySQL 5.7-compatible Aurora), and <code>aurora-postgresql</code> </p>",
+        "CreateDBClusterMessage$EngineVersion":"<p>The version number of the database engine to use.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>5.6.10a</code>, <code>5.7.12</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>9.6.3</code> </p>",
+        "CreateDBClusterMessage$MasterUsername":"<p>The name of the master user for the DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
+        "CreateDBClusterMessage$MasterUserPassword":"<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
+        "CreateDBClusterMessage$OptionGroupName":"<p>A value that indicates that the DB cluster should be associated with the specified option group.</p> <p>Permanent options can't be removed from an option group. The option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
+        "CreateDBClusterMessage$PreferredBackupWindow":"<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "CreateDBClusterMessage$PreferredMaintenanceWindow":"<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
+        "CreateDBClusterMessage$ReplicationSourceIdentifier":"<p>The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica.</p>",
+        "CreateDBClusterMessage$KmsKeyId":"<p>The AWS KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If an encryption key is not specified in <code>KmsKeyId</code>:</p> <ul> <li> <p>If <code>ReplicationSourceIdentifier</code> identifies an encrypted source, then Amazon RDS will use the encryption key used to encrypt the source. Otherwise, Amazon RDS will use your default encryption key. </p> </li> <li> <p>If the <code>StorageEncrypted</code> parameter is true and <code>ReplicationSourceIdentifier</code> is not specified, then Amazon RDS will use your default encryption key.</p> </li> </ul> <p>AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p> <p>If you create a Read Replica of an encrypted DB cluster in another AWS Region, you must set <code>KmsKeyId</code> to a KMS key ID that is valid in the destination AWS Region. This key is used to encrypt the Read Replica in that AWS Region.</p>",
+        "CreateDBClusterMessage$PreSignedUrl":"<p>A URL that contains a Signature Version 4 signed request for the <code>CreateDBCluster</code> action to be called in the source AWS Region where the DB cluster is replicated from. You only need to specify <code>PreSignedUrl</code> when you are performing cross-region replication from an encrypted DB cluster.</p> <p>The pre-signed URL must be a valid request for the <code>CreateDBCluster</code> API action that can be executed in the source AWS Region that contains the encrypted DB cluster to be copied.</p> <p>The pre-signed URL request must contain the following parameter values:</p> <ul> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the copy of the DB cluster in the destination AWS Region. This should refer to the same KMS key for both the <code>CreateDBCluster</code> action that is called in the destination AWS Region, and the action contained in the pre-signed URL.</p> </li> <li> <p> <code>DestinationRegion</code> - The name of the AWS Region that Aurora Read Replica will be created in.</p> </li> <li> <p> <code>ReplicationSourceIdentifier</code> - The DB cluster identifier for the encrypted DB cluster to be copied. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are copying an encrypted DB cluster from the us-west-2 AWS Region, then your <code>ReplicationSourceIdentifier</code> would look like Example: <code>arn:aws:rds:us-west-2:123456789012:cluster:aurora-cluster1</code>.</p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\"> Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\"> Signature Version 4 Signing Process</a>.</p>",
+        "CreateDBClusterParameterGroupMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBClusterParameterGroup.</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
+        "CreateDBClusterParameterGroupMessage$DBParameterGroupFamily":"<p>The DB cluster parameter group family name. A DB cluster parameter group can be associated with one and only one DB cluster parameter group family, and can be applied only to a DB cluster running a database engine and engine version compatible with that DB cluster parameter group family.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>aurora5.6</code>, <code>aurora-mysql5.7</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>aurora-postgresql9.6</code> </p>",
+        "CreateDBClusterParameterGroupMessage$Description":"<p>The description for the DB cluster parameter group.</p>",
+        "CreateDBClusterSnapshotMessage$DBClusterSnapshotIdentifier":"<p>The identifier of the DB cluster snapshot. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1-snapshot1</code> </p>",
+        "CreateDBClusterSnapshotMessage$DBClusterIdentifier":"<p>The identifier of the DB cluster to create a snapshot for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
+        "CreateDBInstanceMessage$DBName":"<p>The meaning of this parameter differs according to the database engine you use.</p> <p>Type: String</p> <p> <b>MySQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>MariaDB</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>The name of the database to create when the DB instance is created. If this parameter is not specified, the default \"postgres\" database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 63 letters, numbers, or underscores.</p> </li> <li> <p>Must begin with a letter or an underscore. Subsequent characters can be letters, underscores, or digits (0-9).</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul> <p> <b>Oracle</b> </p> <p>The Oracle System ID (SID) of the created DB instance. If you specify <code>null</code>, the default value <code>ORCL</code> is used. You can't specify the string NULL, or any other reserved word, for <code>DBName</code>. </p> <p>Default: <code>ORCL</code> </p> <p>Constraints:</p> <ul> <li> <p>Cannot be longer than 8 characters</p> </li> </ul> <p> <b>SQL Server</b> </p> <p>Not applicable. Must be null.</p> <p> <b>Amazon Aurora</b> </p> <p>The name of the database to create when the primary instance of the DB cluster is created. If this parameter is not specified, no database is created in the DB instance.</p> <p>Constraints:</p> <ul> <li> <p>Must contain 1 to 64 letters or numbers.</p> </li> <li> <p>Cannot be a word reserved by the specified database engine</p> </li> </ul>",
+        "CreateDBInstanceMessage$DBInstanceIdentifier":"<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
+        "CreateDBInstanceMessage$DBInstanceClass":"<p>The compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p>",
+        "CreateDBInstanceMessage$Engine":"<p>The name of the database engine to be used for this instance. </p> <p>Not every database engine is available for every AWS Region. </p> <p>Valid Values: </p> <ul> <li> <p> <code>aurora</code> (for MySQL 5.6-compatible Aurora)</p> </li> <li> <p> <code>aurora-mysql</code> (for MySQL 5.7-compatible Aurora)</p> </li> <li> <p> <code>aurora-postgresql</code> </p> </li> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
+        "CreateDBInstanceMessage$MasterUsername":"<p>The name for the master user.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The name for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>. </p> <p> <b>MariaDB</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for MariaDB.</p> </li> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for SQL Server.</p> </li> <li> <p>Must be 1 to 128 letters or numbers.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>MySQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for MySQL.</p> </li> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>Oracle</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for Oracle.</p> </li> <li> <p>Must be 1 to 30 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul> <p> <b>PostgreSQL</b> </p> <p>Constraints:</p> <ul> <li> <p>Required for PostgreSQL.</p> </li> <li> <p>Must be 1 to 63 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
+        "CreateDBInstanceMessage$MasterUserPassword":"<p>The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <p> <b>MySQL</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Oracle</b> </p> <p>Constraints: Must contain from 8 to 30 characters.</p> <p> <b>PostgreSQL</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p>",
+        "CreateDBInstanceMessage$AvailabilityZone":"<p> The EC2 Availability Zone that the DB instance is created in. For information on AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p> <p> Constraint: The AvailabilityZone parameter can't be specified if the MultiAZ parameter is set to <code>true</code>. The specified Availability Zone must be in the same AWS Region as the current endpoint. </p>",
+        "CreateDBInstanceMessage$DBSubnetGroupName":"<p>A DB subnet group to associate with this DB instance.</p> <p>If there is no DB subnet group, then it is a non-VPC DB instance.</p>",
+        "CreateDBInstanceMessage$PreferredMaintenanceWindow":"<p>The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC). For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance\">Amazon RDS Maintenance Window</a>. </p> <p> Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
+        "CreateDBInstanceMessage$DBParameterGroupName":"<p>The name of the DB parameter group to associate with this DB instance. If this argument is omitted, the default DBParameterGroup for the specified engine is used.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "CreateDBInstanceMessage$PreferredBackupWindow":"<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupWindow\">The Backup Window</a>. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow\"> Adjusting the Preferred DB Instance Maintenance Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "CreateDBInstanceMessage$EngineVersion":"<p>The version number of the database engine to use.</p> <p>For a list of valid engine versions, call <a>DescribeDBEngineVersions</a>.</p> <p>The following are the database engines and links to information about the major and minor versions that are available with Amazon RDS. Not every database engine is available for every AWS Region.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The version number of the database engine to be used by the DB instance is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p> <b>MariaDB</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MariaDB.html#MariaDB.Concepts.VersionMgmt\">MariaDB on Amazon RDS Versions</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>Microsoft SQL Server</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.FeatureSupport\">Version and Feature Support on Amazon RDS</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>MySQL</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.VersionMgmt\">MySQL on Amazon RDS Versions</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>Oracle</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.Oracle.PatchComposition.html\">Oracle Database Engine Release Notes</a> in the <i>Amazon RDS User Guide.</i> </p> <p> <b>PostgreSQL</b> </p> <p>See <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.DBVersions\">Supported PostgreSQL Database Versions</a> in the <i>Amazon RDS User Guide.</i> </p>",
+        "CreateDBInstanceMessage$LicenseModel":"<p>License model information for this DB instance.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
+        "CreateDBInstanceMessage$OptionGroupName":"<p>Indicates that the DB instance should be associated with the specified option group.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
+        "CreateDBInstanceMessage$CharacterSetName":"<p>For supported engines, indicates that the DB instance should be associated with the specified CharacterSet.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The character set is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p>",
+        "CreateDBInstanceMessage$DBClusterIdentifier":"<p>The identifier of the DB cluster that the instance will belong to.</p> <p>For information on creating a DB cluster, see <a>CreateDBCluster</a>.</p> <p>Type: String</p>",
+        "CreateDBInstanceMessage$StorageType":"<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
+        "CreateDBInstanceMessage$TdeCredentialArn":"<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
+        "CreateDBInstanceMessage$TdeCredentialPassword":"<p>The password for the given ARN from the key store in order to access the device.</p>",
+        "CreateDBInstanceMessage$KmsKeyId":"<p>The AWS KMS key identifier for an encrypted DB instance.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB instance with the same AWS account that owns the KMS encryption key used to encrypt the new DB instance, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The KMS key identifier is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>",
+        "CreateDBInstanceMessage$Domain":"<p>Specify the Active Directory Domain to create the instance in.</p>",
+        "CreateDBInstanceMessage$MonitoringRoleArn":"<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling\">Setting Up and Enabling Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
+        "CreateDBInstanceMessage$DomainIAMRoleName":"<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
+        "CreateDBInstanceMessage$Timezone":"<p>The time zone of the DB instance. The time zone parameter is currently supported only by <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone\">Microsoft SQL Server</a>. </p>",
+        "CreateDBInstanceMessage$PerformanceInsightsKMSKeyId":"<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
+        "CreateDBInstanceReadReplicaMessage$DBInstanceIdentifier":"<p>The DB instance identifier of the Read Replica. This identifier is the unique key that identifies a DB instance. This parameter is stored as a lowercase string.</p>",
+        "CreateDBInstanceReadReplicaMessage$SourceDBInstanceIdentifier":"<p>The identifier of the DB instance that will act as the source for the Read Replica. Each DB instance can have up to five Read Replicas.</p> <p>Constraints:</p> <ul> <li> <p>Must be the identifier of an existing MySQL, MariaDB, or PostgreSQL DB instance.</p> </li> <li> <p>Can specify a DB instance that is a MySQL Read Replica only if the source is running MySQL 5.6.</p> </li> <li> <p>Can specify a DB instance that is a PostgreSQL DB instance only if the source is running PostgreSQL 9.3.5 or later (9.4.7 and higher for cross-region replication).</p> </li> <li> <p>The specified DB instance must have automatic backups enabled, its backup retention period must be greater than 0.</p> </li> <li> <p>If the source DB instance is in the same AWS Region as the Read Replica, specify a valid DB instance identifier.</p> </li> <li> <p>If the source DB instance is in a different AWS Region than the Read Replica, specify a valid DB instance ARN. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing a Amazon RDS Amazon Resource Name (ARN)</a>.</p> </li> </ul>",
+        "CreateDBInstanceReadReplicaMessage$DBInstanceClass":"<p>The compute and memory capacity of the Read Replica, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: Inherits from the source DB instance.</p>",
+        "CreateDBInstanceReadReplicaMessage$AvailabilityZone":"<p>The Amazon EC2 Availability Zone that the Read Replica is created in.</p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region.</p> <p> Example: <code>us-east-1d</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$OptionGroupName":"<p>The option group the DB instance is associated with. If omitted, the default option group for the engine specified is used.</p>",
+        "CreateDBInstanceReadReplicaMessage$DBSubnetGroupName":"<p>Specifies a DB subnet group for the DB instance. The new DB instance is created in the VPC associated with the DB subnet group. If no DB subnet group is specified, then the new DB instance is not created in a VPC.</p> <p>Constraints:</p> <ul> <li> <p>Can only be specified if the source DB instance identifier specifies a DB instance in another AWS Region.</p> </li> <li> <p>If supplied, must match the name of an existing DBSubnetGroup.</p> </li> <li> <p>The specified DB subnet group must be in the same AWS Region in which the operation is running.</p> </li> <li> <p>All Read Replicas in one AWS Region that are created from the same source DB instance must either:&gt;</p> <ul> <li> <p>Specify DB subnet groups from the same VPC. All these Read Replicas are created in the same VPC.</p> </li> <li> <p>Not specify a DB subnet group. All these Read Replicas are created outside of any VPC.</p> </li> </ul> </li> </ul> <p>Example: <code>mySubnetgroup</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$StorageType":"<p>Specifies the storage type to be associated with the Read Replica.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
+        "CreateDBInstanceReadReplicaMessage$MonitoringRoleArn":"<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
+        "CreateDBInstanceReadReplicaMessage$KmsKeyId":"<p>The AWS KMS key ID for an encrypted Read Replica. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key. </p> <p>If you specify this parameter when you create a Read Replica from an unencrypted DB instance, the Read Replica is encrypted. </p> <p>If you create an encrypted Read Replica in the same AWS Region as the source DB instance, then you do not have to specify a value for this parameter. The Read Replica is encrypted with the same KMS key as the source DB instance. </p> <p>If you create an encrypted Read Replica in a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the AWS Region that they are created in, and you can't use encryption keys from one AWS Region in another AWS Region. </p>",
+        "CreateDBInstanceReadReplicaMessage$PreSignedUrl":"<p>The URL that contains a Signature Version 4 signed request for the <code>CreateDBInstanceReadReplica</code> API action in the source AWS Region that contains the source DB instance. </p> <p>You must specify this parameter when you create an encrypted Read Replica from another AWS Region by using the Amazon RDS API. You can specify the <code>--source-region</code> option instead of this parameter when you create an encrypted Read Replica from another AWS Region by using the AWS CLI. </p> <p>The presigned URL must be a valid request for the <code>CreateDBInstanceReadReplica</code> API action that can be executed in the source AWS Region that contains the encrypted source DB instance. The presigned URL request must contain the following parameter values: </p> <ul> <li> <p> <code>DestinationRegion</code> - The AWS Region that the encrypted Read Replica is created in. This AWS Region is the same one where the <code>CreateDBInstanceReadReplica</code> action is called that contains this presigned URL. </p> <p>For example, if you create an encrypted DB instance in the us-west-1 AWS Region, from a source DB instance in the us-east-2 AWS Region, then you call the <code>CreateDBInstanceReadReplica</code> action in the us-east-1 AWS Region and provide a presigned URL that contains a call to the <code>CreateDBInstanceReadReplica</code> action in the us-west-2 AWS Region. For this example, the <code>DestinationRegion</code> in the presigned URL must be set to the us-east-1 AWS Region. </p> </li> <li> <p> <code>KmsKeyId</code> - The AWS KMS key identifier for the key to use to encrypt the Read Replica in the destination AWS Region. This is the same identifier for both the <code>CreateDBInstanceReadReplica</code> action that is called in the destination AWS Region, and the action contained in the presigned URL. </p> </li> <li> <p> <code>SourceDBInstanceIdentifier</code> - The DB instance identifier for the encrypted DB instance to be replicated. This identifier must be in the Amazon Resource Name (ARN) format for the source AWS Region. For example, if you are creating an encrypted Read Replica from a DB instance in the us-west-2 AWS Region, then your <code>SourceDBInstanceIdentifier</code> looks like the following example: <code>arn:aws:rds:us-west-2:123456789012:instance:mysql-instance1-20161115</code>. </p> </li> </ul> <p>To learn how to generate a Signature Version 4 signed request, see <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html\">Authenticating Requests: Using Query Parameters (AWS Signature Version 4)</a> and <a href=\"http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4 Signing Process</a>. </p>",
+        "CreateDBInstanceReadReplicaMessage$PerformanceInsightsKMSKeyId":"<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
+        "CreateDBParameterGroupMessage$DBParameterGroupName":"<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
+        "CreateDBParameterGroupMessage$DBParameterGroupFamily":"<p>The DB parameter group family name. A DB parameter group can be associated with one and only one DB parameter group family, and can be applied only to a DB instance running a database engine and engine version compatible with that DB parameter group family.</p> <p>To list all of the available parameter group families, use the following command:</p> <p> <code>aws rds describe-db-engine-versions --query \"DBEngineVersions[].DBParameterGroupFamily\"</code> </p> <note> <p>The output contains duplicates.</p> </note>",
+        "CreateDBParameterGroupMessage$Description":"<p>The description for the DB parameter group.</p>",
+        "CreateDBSecurityGroupMessage$DBSecurityGroupName":"<p>The name for the DB security group. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul> <p>Example: <code>mysecuritygroup</code> </p>",
+        "CreateDBSecurityGroupMessage$DBSecurityGroupDescription":"<p>The description for the DB security group.</p>",
+        "CreateDBSnapshotMessage$DBSnapshotIdentifier":"<p>The identifier for the DB snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Cannot be null, empty, or blank</p> </li> <li> <p>Must contain from 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
+        "CreateDBSnapshotMessage$DBInstanceIdentifier":"<p>The identifier of the DB instance that you want to create the snapshot of.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "CreateDBSubnetGroupMessage$DBSubnetGroupName":"<p>The name for the DB subnet group. This value is stored as a lowercase string.</p> <p>Constraints: Must contain no more than 255 letters, numbers, periods, underscores, spaces, or hyphens. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "CreateDBSubnetGroupMessage$DBSubnetGroupDescription":"<p>The description for the DB subnet group.</p>",
+        "CreateEventSubscriptionMessage$SubscriptionName":"<p>The name of the subscription.</p> <p>Constraints: The name must be less than 255 characters.</p>",
+        "CreateEventSubscriptionMessage$SnsTopicArn":"<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>",
+        "CreateEventSubscriptionMessage$SourceType":"<p>The type of source that is generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: <code>db-instance</code> | <code>db-cluster</code> | <code>db-parameter-group</code> | <code>db-security-group</code> | <code>db-snapshot</code> | <code>db-cluster-snapshot</code> </p>",
+        "CreateOptionGroupMessage$OptionGroupName":"<p>Specifies the name of the option group to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>myoptiongroup</code> </p>",
+        "CreateOptionGroupMessage$EngineName":"<p>Specifies the name of the engine that this option group should be associated with.</p>",
+        "CreateOptionGroupMessage$MajorEngineVersion":"<p>Specifies the major version of the engine that this option group should be associated with.</p>",
+        "CreateOptionGroupMessage$OptionGroupDescription":"<p>The description of the option group.</p>",
+        "DBCluster$CharacterSetName":"<p>If present, specifies the name of the character set that this cluster is associated with.</p>",
+        "DBCluster$DatabaseName":"<p>Contains the name of the initial database of this DB cluster that was provided at create time, if one was specified when the DB cluster was created. This same name is returned for the life of the DB cluster.</p>",
+        "DBCluster$DBClusterIdentifier":"<p>Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster.</p>",
+        "DBCluster$DBClusterParameterGroup":"<p>Specifies the name of the DB cluster parameter group for the DB cluster.</p>",
+        "DBCluster$DBSubnetGroup":"<p>Specifies information on the subnet group associated with the DB cluster, including the name, description, and subnets in the subnet group.</p>",
+        "DBCluster$Status":"<p>Specifies the current state of this DB cluster.</p>",
+        "DBCluster$PercentProgress":"<p>Specifies the progress of the operation as a percentage.</p>",
+        "DBCluster$Endpoint":"<p>Specifies the connection endpoint for the primary instance of the DB cluster.</p>",
+        "DBCluster$ReaderEndpoint":"<p>The reader endpoint for the DB cluster. The reader endpoint for a DB cluster load-balances connections across the Aurora Replicas that are available in a DB cluster. As clients request new connections to the reader endpoint, Aurora distributes the connection requests among the Aurora Replicas in the DB cluster. This functionality can help balance your read workload across multiple Aurora Replicas in your DB cluster. </p> <p>If a failover occurs, and the Aurora Replica that you are connected to is promoted to be the primary instance, your connection is dropped. To continue sending your read workload to other Aurora Replicas in the cluster, you can then reconnect to the reader endpoint.</p>",
+        "DBCluster$Engine":"<p>Provides the name of the database engine to be used for this DB cluster.</p>",
+        "DBCluster$EngineVersion":"<p>Indicates the database engine version.</p>",
+        "DBCluster$MasterUsername":"<p>Contains the master username for the DB cluster.</p>",
+        "DBCluster$PreferredBackupWindow":"<p>Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>",
+        "DBCluster$PreferredMaintenanceWindow":"<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
+        "DBCluster$ReplicationSourceIdentifier":"<p>Contains the identifier of the source DB cluster if this DB cluster is a Read Replica.</p>",
+        "DBCluster$HostedZoneId":"<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
+        "DBCluster$KmsKeyId":"<p>If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB cluster.</p>",
+        "DBCluster$DbClusterResourceId":"<p>The AWS Region-unique, immutable identifier for the DB cluster. This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB cluster is accessed.</p>",
+        "DBCluster$DBClusterArn":"<p>The Amazon Resource Name (ARN) for the DB cluster.</p>",
+        "DBCluster$CloneGroupId":"<p>Identifies the clone group to which the DB cluster is associated.</p>",
+        "DBClusterBacktrack$DBClusterIdentifier":"<p>Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster.</p>",
+        "DBClusterBacktrack$BacktrackIdentifier":"<p>Contains the backtrack identifier.</p>",
+        "DBClusterBacktrack$Status":"<p>The status of the backtrack. This property returns one of the following values:</p> <ul> <li> <p> <code>applying</code> - The backtrack is currently being applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>completed</code> - The backtrack has successfully been applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>failed</code> - An error occurred while the backtrack was applied to or rolled back from the DB cluster.</p> </li> <li> <p> <code>pending</code> - The backtrack is currently pending application to or rollback from the DB cluster.</p> </li> </ul>",
+        "DBClusterBacktrackMessage$Marker":"<p>A pagination token that can be used in a subsequent <a>DescribeDBClusterBacktracks</a> request.</p>",
+        "DBClusterMember$DBInstanceIdentifier":"<p>Specifies the instance identifier for this member of the DB cluster.</p>",
+        "DBClusterMember$DBClusterParameterGroupStatus":"<p>Specifies the status of the DB cluster parameter group for this member of the DB cluster.</p>",
+        "DBClusterMessage$Marker":"<p>A pagination token that can be used in a subsequent DescribeDBClusters request.</p>",
+        "DBClusterOptionGroupStatus$DBClusterOptionGroupName":"<p>Specifies the name of the DB cluster option group.</p>",
+        "DBClusterOptionGroupStatus$Status":"<p>Specifies the status of the DB cluster option group.</p>",
+        "DBClusterParameterGroup$DBClusterParameterGroupName":"<p>Provides the name of the DB cluster parameter group.</p>",
+        "DBClusterParameterGroup$DBParameterGroupFamily":"<p>Provides the name of the DB parameter group family that this DB cluster parameter group is compatible with.</p>",
+        "DBClusterParameterGroup$Description":"<p>Provides the customer-specified description for this DB cluster parameter group.</p>",
+        "DBClusterParameterGroup$DBClusterParameterGroupArn":"<p>The Amazon Resource Name (ARN) for the DB cluster parameter group.</p>",
+        "DBClusterParameterGroupDetails$Marker":"<p> An optional pagination token provided by a previous DescribeDBClusterParameters request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "DBClusterParameterGroupNameMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters or numbers.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <note> <p>This value is stored as a lowercase string.</p> </note>",
+        "DBClusterParameterGroupsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBClusterRole$RoleArn":"<p>The Amazon Resource Name (ARN) of the IAM role that is associated with the DB cluster.</p>",
+        "DBClusterRole$Status":"<p>Describes the state of association between the IAM role and the DB cluster. The Status property returns one of the following values:</p> <ul> <li> <p> <code>ACTIVE</code> - the IAM role ARN is associated with the DB cluster and can be used to access other AWS services on your behalf.</p> </li> <li> <p> <code>PENDING</code> - the IAM role ARN is being associated with the DB cluster.</p> </li> <li> <p> <code>INVALID</code> - the IAM role ARN is associated with the DB cluster, but the DB cluster is unable to assume the IAM role in order to access other AWS services on your behalf.</p> </li> </ul>",
+        "DBClusterSnapshot$DBClusterSnapshotIdentifier":"<p>Specifies the identifier for the DB cluster snapshot.</p>",
+        "DBClusterSnapshot$DBClusterIdentifier":"<p>Specifies the DB cluster identifier of the DB cluster that this DB cluster snapshot was created from.</p>",
+        "DBClusterSnapshot$Engine":"<p>Specifies the name of the database engine.</p>",
+        "DBClusterSnapshot$Status":"<p>Specifies the status of this DB cluster snapshot.</p>",
+        "DBClusterSnapshot$VpcId":"<p>Provides the VPC ID associated with the DB cluster snapshot.</p>",
+        "DBClusterSnapshot$MasterUsername":"<p>Provides the master username for the DB cluster snapshot.</p>",
+        "DBClusterSnapshot$EngineVersion":"<p>Provides the version of the database engine for this DB cluster snapshot.</p>",
+        "DBClusterSnapshot$LicenseModel":"<p>Provides the license model information for this DB cluster snapshot.</p>",
+        "DBClusterSnapshot$SnapshotType":"<p>Provides the type of the DB cluster snapshot.</p>",
+        "DBClusterSnapshot$KmsKeyId":"<p>If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB cluster snapshot.</p>",
+        "DBClusterSnapshot$DBClusterSnapshotArn":"<p>The Amazon Resource Name (ARN) for the DB cluster snapshot.</p>",
+        "DBClusterSnapshot$SourceDBClusterSnapshotArn":"<p>If the DB cluster snapshot was copied from a source DB cluster snapshot, the Amazon Resource Name (ARN) for the source DB cluster snapshot, otherwise, a null value.</p>",
+        "DBClusterSnapshotAttribute$AttributeName":"<p>The name of the manual DB cluster snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>",
+        "DBClusterSnapshotAttributesResult$DBClusterSnapshotIdentifier":"<p>The identifier of the manual DB cluster snapshot that the attributes apply to.</p>",
+        "DBClusterSnapshotMessage$Marker":"<p> An optional pagination token provided by a previous <a>DescribeDBClusterSnapshots</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBEngineVersion$Engine":"<p>The name of the database engine.</p>",
+        "DBEngineVersion$EngineVersion":"<p>The version number of the database engine.</p>",
+        "DBEngineVersion$DBParameterGroupFamily":"<p>The name of the DB parameter group family for the database engine.</p>",
+        "DBEngineVersion$DBEngineDescription":"<p>The description of the database engine.</p>",
+        "DBEngineVersion$DBEngineVersionDescription":"<p>The description of the database engine version.</p>",
+        "DBEngineVersionMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBInstance$DBInstanceIdentifier":"<p>Contains a user-supplied database identifier. This identifier is the unique key that identifies a DB instance.</p>",
+        "DBInstance$DBInstanceClass":"<p>Contains the name of the compute and memory capacity class of the DB instance.</p>",
+        "DBInstance$Engine":"<p>Provides the name of the database engine to be used for this DB instance.</p>",
+        "DBInstance$DBInstanceStatus":"<p>Specifies the current state of this database.</p>",
+        "DBInstance$MasterUsername":"<p>Contains the master username for the DB instance.</p>",
+        "DBInstance$DBName":"<p>The meaning of this parameter differs according to the database engine you use. For example, this value returns MySQL, MariaDB, or PostgreSQL information when returning values from CreateDBInstanceReadReplica since Read Replicas are only supported for these engines.</p> <p> <b>MySQL, MariaDB, SQL Server, PostgreSQL</b> </p> <p>Contains the name of the initial database of this instance that was provided at create time, if one was specified when the DB instance was created. This same name is returned for the life of the DB instance.</p> <p>Type: String</p> <p> <b>Oracle</b> </p> <p>Contains the Oracle System ID (SID) of the created DB instance. Not shown when the returned parameters do not apply to an Oracle DB instance.</p>",
+        "DBInstance$PreferredBackupWindow":"<p> Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code>. </p>",
+        "DBInstance$AvailabilityZone":"<p>Specifies the name of the Availability Zone the DB instance is located in.</p>",
+        "DBInstance$PreferredMaintenanceWindow":"<p>Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p>",
+        "DBInstance$EngineVersion":"<p>Indicates the database engine version.</p>",
+        "DBInstance$ReadReplicaSourceDBInstanceIdentifier":"<p>Contains the identifier of the source DB instance if this DB instance is a Read Replica.</p>",
+        "DBInstance$LicenseModel":"<p>License model information for this DB instance.</p>",
+        "DBInstance$CharacterSetName":"<p>If present, specifies the name of the character set that this instance is associated with.</p>",
+        "DBInstance$SecondaryAvailabilityZone":"<p>If present, specifies the name of the secondary Availability Zone for a DB instance with multi-AZ support.</p>",
+        "DBInstance$StorageType":"<p>Specifies the storage type associated with DB instance.</p>",
+        "DBInstance$TdeCredentialArn":"<p>The ARN from the key store with which the instance is associated for TDE encryption.</p>",
+        "DBInstance$DBClusterIdentifier":"<p>If the DB instance is a member of a DB cluster, contains the name of the DB cluster that the DB instance is a member of.</p>",
+        "DBInstance$KmsKeyId":"<p> If <code>StorageEncrypted</code> is true, the AWS KMS key identifier for the encrypted DB instance. </p>",
+        "DBInstance$DbiResourceId":"<p>The AWS Region-unique, immutable identifier for the DB instance. This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB instance is accessed.</p>",
+        "DBInstance$CACertificateIdentifier":"<p>The identifier of the CA certificate for this DB instance.</p>",
+        "DBInstance$EnhancedMonitoringResourceArn":"<p>The Amazon Resource Name (ARN) of the Amazon CloudWatch Logs log stream that receives the Enhanced Monitoring metrics data for the DB instance.</p>",
+        "DBInstance$MonitoringRoleArn":"<p>The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs.</p>",
+        "DBInstance$DBInstanceArn":"<p>The Amazon Resource Name (ARN) for the DB instance.</p>",
+        "DBInstance$Timezone":"<p>The time zone of the DB instance. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for Microsoft SQL Server DB instances that were created with a time zone specified. </p>",
+        "DBInstance$PerformanceInsightsKMSKeyId":"<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
+        "DBInstanceMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "DBInstanceStatusInfo$StatusType":"<p>This value is currently \"read replication.\"</p>",
+        "DBInstanceStatusInfo$Status":"<p>Status of the DB instance. For a StatusType of read replica, the values can be replicating, error, stopped, or terminated.</p>",
+        "DBInstanceStatusInfo$Message":"<p>Details of the error if there is an error for the instance. If the instance is not in an error state, this value is blank.</p>",
+        "DBParameterGroup$DBParameterGroupName":"<p>Provides the name of the DB parameter group.</p>",
+        "DBParameterGroup$DBParameterGroupFamily":"<p>Provides the name of the DB parameter group family that this DB parameter group is compatible with.</p>",
+        "DBParameterGroup$Description":"<p>Provides the customer-specified description for this DB parameter group.</p>",
+        "DBParameterGroup$DBParameterGroupArn":"<p>The Amazon Resource Name (ARN) for the DB parameter group.</p>",
+        "DBParameterGroupDetails$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBParameterGroupNameMessage$DBParameterGroupName":"<p>Provides the name of the DB parameter group.</p>",
+        "DBParameterGroupStatus$DBParameterGroupName":"<p>The name of the DP parameter group.</p>",
+        "DBParameterGroupStatus$ParameterApplyStatus":"<p>The status of parameter updates.</p>",
+        "DBParameterGroupsMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBSecurityGroup$OwnerId":"<p>Provides the AWS ID of the owner of a specific DB security group.</p>",
+        "DBSecurityGroup$DBSecurityGroupName":"<p>Specifies the name of the DB security group.</p>",
+        "DBSecurityGroup$DBSecurityGroupDescription":"<p>Provides the description of the DB security group.</p>",
+        "DBSecurityGroup$VpcId":"<p>Provides the VpcId of the DB security group.</p>",
+        "DBSecurityGroup$DBSecurityGroupArn":"<p>The Amazon Resource Name (ARN) for the DB security group.</p>",
+        "DBSecurityGroupMembership$DBSecurityGroupName":"<p>The name of the DB security group.</p>",
+        "DBSecurityGroupMembership$Status":"<p>The status of the DB security group.</p>",
+        "DBSecurityGroupMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBSecurityGroupNameList$member":null,
+        "DBSnapshot$DBSnapshotIdentifier":"<p>Specifies the identifier for the DB snapshot.</p>",
+        "DBSnapshot$DBInstanceIdentifier":"<p>Specifies the DB instance identifier of the DB instance this DB snapshot was created from.</p>",
+        "DBSnapshot$Engine":"<p>Specifies the name of the database engine.</p>",
+        "DBSnapshot$Status":"<p>Specifies the status of this DB snapshot.</p>",
+        "DBSnapshot$AvailabilityZone":"<p>Specifies the name of the Availability Zone the DB instance was located in at the time of the DB snapshot.</p>",
+        "DBSnapshot$VpcId":"<p>Provides the VPC ID associated with the DB snapshot.</p>",
+        "DBSnapshot$MasterUsername":"<p>Provides the master username for the DB snapshot.</p>",
+        "DBSnapshot$EngineVersion":"<p>Specifies the version of the database engine.</p>",
+        "DBSnapshot$LicenseModel":"<p>License model information for the restored DB instance.</p>",
+        "DBSnapshot$SnapshotType":"<p>Provides the type of the DB snapshot.</p>",
+        "DBSnapshot$OptionGroupName":"<p>Provides the option group name for the DB snapshot.</p>",
+        "DBSnapshot$SourceRegion":"<p>The AWS Region that the DB snapshot was created in or copied from.</p>",
+        "DBSnapshot$SourceDBSnapshotIdentifier":"<p>The DB snapshot Amazon Resource Name (ARN) that the DB snapshot was copied from. It only has value in case of cross-customer or cross-region copy.</p>",
+        "DBSnapshot$StorageType":"<p>Specifies the storage type associated with DB snapshot.</p>",
+        "DBSnapshot$TdeCredentialArn":"<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
+        "DBSnapshot$KmsKeyId":"<p> If <code>Encrypted</code> is true, the AWS KMS key identifier for the encrypted DB snapshot. </p>",
+        "DBSnapshot$DBSnapshotArn":"<p>The Amazon Resource Name (ARN) for the DB snapshot.</p>",
+        "DBSnapshot$Timezone":"<p>The time zone of the DB snapshot. In most cases, the <code>Timezone</code> element is empty. <code>Timezone</code> content appears only for snapshots taken from Microsoft SQL Server DB instances that were created with a time zone specified. </p>",
+        "DBSnapshotAttribute$AttributeName":"<p>The name of the manual DB snapshot attribute.</p> <p>The attribute named <code>restore</code> refers to the list of AWS accounts that have permission to copy or restore the manual DB cluster snapshot. For more information, see the <a>ModifyDBSnapshotAttribute</a> API action.</p>",
+        "DBSnapshotAttributesResult$DBSnapshotIdentifier":"<p>The identifier of the manual DB snapshot that the attributes apply to.</p>",
+        "DBSnapshotMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DBSubnetGroup$DBSubnetGroupName":"<p>The name of the DB subnet group.</p>",
+        "DBSubnetGroup$DBSubnetGroupDescription":"<p>Provides the description of the DB subnet group.</p>",
+        "DBSubnetGroup$VpcId":"<p>Provides the VpcId of the DB subnet group.</p>",
+        "DBSubnetGroup$SubnetGroupStatus":"<p>Provides the status of the DB subnet group.</p>",
+        "DBSubnetGroup$DBSubnetGroupArn":"<p>The Amazon Resource Name (ARN) for the DB subnet group.</p>",
+        "DBSubnetGroupMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DeleteDBClusterMessage$DBClusterIdentifier":"<p>The DB cluster identifier for the DB cluster to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing DBClusterIdentifier.</p> </li> </ul>",
+        "DeleteDBClusterMessage$FinalDBSnapshotIdentifier":"<p> The DB cluster snapshot identifier of the new DB cluster snapshot created when <code>SkipFinalSnapshot</code> is set to <code>false</code>. </p> <note> <p> Specifying this parameter and also setting the <code>SkipFinalShapshot</code> parameter to true results in an error. </p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "DeleteDBClusterParameterGroupMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB cluster parameter group.</p> </li> <li> <p>You can't delete a default DB cluster parameter group.</p> </li> <li> <p>Cannot be associated with any DB clusters.</p> </li> </ul>",
+        "DeleteDBClusterSnapshotMessage$DBClusterSnapshotIdentifier":"<p>The identifier of the DB cluster snapshot to delete.</p> <p>Constraints: Must be the name of an existing DB cluster snapshot in the <code>available</code> state.</p>",
+        "DeleteDBInstanceMessage$DBInstanceIdentifier":"<p>The DB instance identifier for the DB instance to be deleted. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DB instance.</p> </li> </ul>",
+        "DeleteDBInstanceMessage$FinalDBSnapshotIdentifier":"<p> The DBSnapshotIdentifier of the new DBSnapshot created when SkipFinalSnapshot is set to <code>false</code>. </p> <note> <p>Specifying this parameter and also setting the SkipFinalShapshot parameter to true results in an error.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters or numbers.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Cannot be specified when deleting a Read Replica.</p> </li> </ul>",
+        "DeleteDBParameterGroupMessage$DBParameterGroupName":"<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must be the name of an existing DB parameter group</p> </li> <li> <p>You can't delete a default DB parameter group</p> </li> <li> <p>Cannot be associated with any DB instances</p> </li> </ul>",
+        "DeleteDBSecurityGroupMessage$DBSecurityGroupName":"<p>The name of the DB security group to delete.</p> <note> <p>You can't delete the default DB security group.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 255 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> <li> <p>Must not be \"Default\"</p> </li> </ul>",
+        "DeleteDBSnapshotMessage$DBSnapshotIdentifier":"<p>The DBSnapshot identifier.</p> <p>Constraints: Must be the name of an existing DB snapshot in the <code>available</code> state.</p>",
+        "DeleteDBSubnetGroupMessage$DBSubnetGroupName":"<p>The name of the database subnet group to delete.</p> <note> <p>You can't delete the default subnet group.</p> </note> <p>Constraints:</p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "DeleteEventSubscriptionMessage$SubscriptionName":"<p>The name of the RDS event notification subscription you want to delete.</p>",
+        "DeleteOptionGroupMessage$OptionGroupName":"<p>The name of the option group to be deleted.</p> <note> <p>You can't delete default option groups.</p> </note>",
+        "DescribeCertificatesMessage$CertificateIdentifier":"<p>The user-supplied certificate identifier. If this parameter is specified, information for only the identified certificate is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match an existing CertificateIdentifier.</p> </li> </ul>",
+        "DescribeCertificatesMessage$Marker":"<p> An optional pagination token provided by a previous <a>DescribeCertificates</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBClusterBacktracksMessage$DBClusterIdentifier":"<p>The DB cluster identifier of the DB cluster to be described. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
+        "DescribeDBClusterBacktracksMessage$BacktrackIdentifier":"<p>If specified, this value is the backtrack identifier of the backtrack to be described.</p> <p>Constraints:</p> <ul> <li> <p>Must contain a valid universally unique identifier (UUID). For more information about UUIDs, see <a href=\"http://www.ietf.org/rfc/rfc4122.txt\">A Universally Unique Identifier (UUID) URN Namespace</a>.</p> </li> </ul> <p>Example: <code>123e4567-e89b-12d3-a456-426655440000</code> </p>",
+        "DescribeDBClusterBacktracksMessage$Marker":"<p> An optional pagination token provided by a previous <a>DescribeDBClusterBacktracks</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBClusterParameterGroupsMessage$DBClusterParameterGroupName":"<p>The name of a specific DB cluster parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
+        "DescribeDBClusterParameterGroupsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBClusterParametersMessage$DBClusterParameterGroupName":"<p>The name of a specific DB cluster parameter group to return parameter details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
+        "DescribeDBClusterParametersMessage$Source":"<p> A value that indicates to return only parameters for a specific source. Parameter sources can be <code>engine</code>, <code>service</code>, or <code>customer</code>. </p>",
+        "DescribeDBClusterParametersMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBClusterSnapshotAttributesMessage$DBClusterSnapshotIdentifier":"<p>The identifier for the DB cluster snapshot to describe the attributes for.</p>",
+        "DescribeDBClusterSnapshotsMessage$DBClusterIdentifier":"<p>The ID of the DB cluster to retrieve the list of DB cluster snapshots for. This parameter can't be used in conjunction with the <code>DBClusterSnapshotIdentifier</code> parameter. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBCluster.</p> </li> </ul>",
+        "DescribeDBClusterSnapshotsMessage$DBClusterSnapshotIdentifier":"<p>A specific DB cluster snapshot identifier to describe. This parameter can't be used in conjunction with the <code>DBClusterIdentifier</code> parameter. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBClusterSnapshot.</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>",
+        "DescribeDBClusterSnapshotsMessage$SnapshotType":"<p>The type of DB cluster snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB cluster snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB cluster snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB cluster snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB cluster snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual DB cluster snapshots are returned. You can include shared DB cluster snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public DB cluster snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>",
+        "DescribeDBClusterSnapshotsMessage$Marker":"<p>An optional pagination token provided by a previous <code>DescribeDBClusterSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBClustersMessage$DBClusterIdentifier":"<p>The user-supplied DB cluster identifier. If this parameter is specified, information from only the specific DB cluster is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBClusterIdentifier.</p> </li> </ul>",
+        "DescribeDBClustersMessage$Marker":"<p>An optional pagination token provided by a previous <a>DescribeDBClusters</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBEngineVersionsMessage$Engine":"<p>The database engine to return.</p>",
+        "DescribeDBEngineVersionsMessage$EngineVersion":"<p>The database engine version to return.</p> <p>Example: <code>5.1.49</code> </p>",
+        "DescribeDBEngineVersionsMessage$DBParameterGroupFamily":"<p>The name of a specific DB parameter group family to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match an existing DBParameterGroupFamily.</p> </li> </ul>",
+        "DescribeDBEngineVersionsMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBInstancesMessage$DBInstanceIdentifier":"<p>The user-supplied instance identifier. If this parameter is specified, information from only the specific DB instance is returned. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "DescribeDBInstancesMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBInstances</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBLogFilesDetails$LogFileName":"<p>The name of the log file for the specified DB instance.</p>",
+        "DescribeDBLogFilesMessage$DBInstanceIdentifier":"<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "DescribeDBLogFilesMessage$FilenameContains":"<p>Filters the available log files for log file names that contain the specified string.</p>",
+        "DescribeDBLogFilesMessage$Marker":"<p>The pagination token provided in the previous request. If this parameter is specified the response includes only records beyond the marker, up to MaxRecords.</p>",
+        "DescribeDBLogFilesResponse$Marker":"<p>A pagination token that can be used in a subsequent DescribeDBLogFiles request.</p>",
+        "DescribeDBParameterGroupsMessage$DBParameterGroupName":"<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
+        "DescribeDBParameterGroupsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBParameterGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBParametersMessage$DBParameterGroupName":"<p>The name of a specific DB parameter group to return details for.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul>",
+        "DescribeDBParametersMessage$Source":"<p>The parameter types to return.</p> <p>Default: All parameter types returned</p> <p>Valid Values: <code>user | system | engine-default</code> </p>",
+        "DescribeDBParametersMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBSecurityGroupsMessage$DBSecurityGroupName":"<p>The name of the DB security group to return details for.</p>",
+        "DescribeDBSecurityGroupsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBSecurityGroups</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBSnapshotAttributesMessage$DBSnapshotIdentifier":"<p>The identifier for the DB snapshot to describe the attributes for.</p>",
+        "DescribeDBSnapshotsMessage$DBInstanceIdentifier":"<p>The ID of the DB instance to retrieve the list of DB snapshots for. This parameter can't be used in conjunction with <code>DBSnapshotIdentifier</code>. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "DescribeDBSnapshotsMessage$DBSnapshotIdentifier":"<p> A specific DB snapshot identifier to describe. This parameter can't be used in conjunction with <code>DBInstanceIdentifier</code>. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the identifier of an existing DBSnapshot.</p> </li> <li> <p>If this identifier is for an automated snapshot, the <code>SnapshotType</code> parameter must also be specified.</p> </li> </ul>",
+        "DescribeDBSnapshotsMessage$SnapshotType":"<p>The type of snapshots to be returned. You can specify one of the following values:</p> <ul> <li> <p> <code>automated</code> - Return all DB snapshots that have been automatically taken by Amazon RDS for my AWS account.</p> </li> <li> <p> <code>manual</code> - Return all DB snapshots that have been taken by my AWS account.</p> </li> <li> <p> <code>shared</code> - Return all manual DB snapshots that have been shared to my AWS account.</p> </li> <li> <p> <code>public</code> - Return all DB snapshots that have been marked as public.</p> </li> </ul> <p>If you don't specify a <code>SnapshotType</code> value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not included in the returned results by default. You can include shared snapshots with these results by setting the <code>IncludeShared</code> parameter to <code>true</code>. You can include public snapshots with these results by setting the <code>IncludePublic</code> parameter to <code>true</code>.</p> <p>The <code>IncludeShared</code> and <code>IncludePublic</code> parameters don't apply for <code>SnapshotType</code> values of <code>manual</code> or <code>automated</code>. The <code>IncludePublic</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>shared</code>. The <code>IncludeShared</code> parameter doesn't apply when <code>SnapshotType</code> is set to <code>public</code>.</p>",
+        "DescribeDBSnapshotsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeDBSnapshots</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeDBSubnetGroupsMessage$DBSubnetGroupName":"<p>The name of the DB subnet group to return details for.</p>",
+        "DescribeDBSubnetGroupsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeDBSubnetGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEngineDefaultClusterParametersMessage$DBParameterGroupFamily":"<p>The name of the DB cluster parameter group family to return engine parameter information for.</p>",
+        "DescribeEngineDefaultClusterParametersMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultClusterParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEngineDefaultParametersMessage$DBParameterGroupFamily":"<p>The name of the DB parameter group family.</p>",
+        "DescribeEngineDefaultParametersMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribeEngineDefaultParameters</code> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeEventCategoriesMessage$SourceType":"<p>The type of source that is generating the events.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>",
+        "DescribeEventSubscriptionsMessage$SubscriptionName":"<p>The name of the RDS event notification subscription you want to describe.</p>",
+        "DescribeEventSubscriptionsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "DescribeEventsMessage$SourceIdentifier":"<p>The identifier of the event source for which events are returned. If not specified, then all sources are included in the response.</p> <p>Constraints:</p> <ul> <li> <p>If SourceIdentifier is supplied, SourceType must also be provided.</p> </li> <li> <p>If the source type is <code>DBInstance</code>, then a <code>DBInstanceIdentifier</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSecurityGroup</code>, a <code>DBSecurityGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBParameterGroup</code>, a <code>DBParameterGroupName</code> must be supplied.</p> </li> <li> <p>If the source type is <code>DBSnapshot</code>, a <code>DBSnapshotIdentifier</code> must be supplied.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul>",
+        "DescribeEventsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeEvents request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeOptionGroupOptionsMessage$EngineName":"<p>A required parameter. Options available for the given engine name are described.</p>",
+        "DescribeOptionGroupOptionsMessage$MajorEngineVersion":"<p>If specified, filters the results to include only options for the specified major engine version.</p>",
+        "DescribeOptionGroupOptionsMessage$Marker":"<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeOptionGroupsMessage$OptionGroupName":"<p>The name of the option group to describe. Cannot be supplied together with EngineName or MajorEngineVersion.</p>",
+        "DescribeOptionGroupsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeOptionGroups request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeOptionGroupsMessage$EngineName":"<p>Filters the list of option groups to only include groups associated with a specific database engine.</p>",
+        "DescribeOptionGroupsMessage$MajorEngineVersion":"<p>Filters the list of option groups to only include groups associated with a specific database engine version. If specified, then EngineName must also be specified.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$Engine":"<p>The name of the engine to retrieve DB instance options for.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$EngineVersion":"<p>The engine version filter value. Specify this parameter to show only the available offerings matching the specified engine version.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$DBInstanceClass":"<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$LicenseModel":"<p>The license model filter value. Specify this parameter to show only the available offerings matching the specified license model.</p>",
+        "DescribeOrderableDBInstanceOptionsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "DescribePendingMaintenanceActionsMessage$ResourceIdentifier":"<p>The ARN of a resource to return pending maintenance actions for.</p>",
+        "DescribePendingMaintenanceActionsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>",
+        "DescribeReservedDBInstancesMessage$ReservedDBInstanceId":"<p>The reserved DB instance identifier filter value. Specify this parameter to show only the reservation that matches the specified reservation ID.</p>",
+        "DescribeReservedDBInstancesMessage$ReservedDBInstancesOfferingId":"<p>The offering identifier filter value. Specify this parameter to show only purchased reservations matching the specified offering identifier.</p>",
+        "DescribeReservedDBInstancesMessage$DBInstanceClass":"<p>The DB instance class filter value. Specify this parameter to show only those reservations matching the specified DB instances class.</p>",
+        "DescribeReservedDBInstancesMessage$Duration":"<p>The duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
+        "DescribeReservedDBInstancesMessage$ProductDescription":"<p>The product description filter value. Specify this parameter to show only those reservations matching the specified product description.</p>",
+        "DescribeReservedDBInstancesMessage$OfferingType":"<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>",
+        "DescribeReservedDBInstancesMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeReservedDBInstancesOfferingsMessage$ReservedDBInstancesOfferingId":"<p>The offering identifier filter value. Specify this parameter to show only the available offering that matches the specified reservation identifier.</p> <p>Example: <code>438012d3-4052-4cc7-b2e3-8d3372e0e706</code> </p>",
+        "DescribeReservedDBInstancesOfferingsMessage$DBInstanceClass":"<p>The DB instance class filter value. Specify this parameter to show only the available offerings matching the specified DB instance class.</p>",
+        "DescribeReservedDBInstancesOfferingsMessage$Duration":"<p>Duration filter value, specified in years or seconds. Specify this parameter to show only reservations for this duration.</p> <p>Valid Values: <code>1 | 3 | 31536000 | 94608000</code> </p>",
+        "DescribeReservedDBInstancesOfferingsMessage$ProductDescription":"<p>Product description filter value. Specify this parameter to show only the available offerings that contain the specified product description.</p> <note> <p>The results show offerings that partially match the filter value.</p> </note>",
+        "DescribeReservedDBInstancesOfferingsMessage$OfferingType":"<p>The offering type filter value. Specify this parameter to show only the available offerings matching the specified offering type.</p> <p>Valid Values: <code>\"Partial Upfront\" | \"All Upfront\" | \"No Upfront\" </code> </p>",
+        "DescribeReservedDBInstancesOfferingsMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "DescribeSourceRegionsMessage$RegionName":"<p>The source AWS Region name. For example, <code>us-east-1</code>.</p> <p>Constraints:</p> <ul> <li> <p>Must specify a valid AWS Region name.</p> </li> </ul>",
+        "DescribeSourceRegionsMessage$Marker":"<p>An optional pagination token provided by a previous <a>DescribeSourceRegions</a> request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "DescribeValidDBInstanceModificationsMessage$DBInstanceIdentifier":"<p>The customer identifier or the ARN of your DB instance. </p>",
+        "DomainMembership$Domain":"<p>The identifier of the Active Directory Domain.</p>",
+        "DomainMembership$Status":"<p>The status of the DB instance's Active Directory Domain membership, such as joined, pending-join, failed etc).</p>",
+        "DomainMembership$FQDN":"<p>The fully qualified domain name of the Active Directory Domain.</p>",
+        "DomainMembership$IAMRoleName":"<p>The name of the IAM role to be used when making API calls to the Directory Service.</p>",
+        "DownloadDBLogFilePortionDetails$LogFileData":"<p>Entries from the specified log file.</p>",
+        "DownloadDBLogFilePortionDetails$Marker":"<p>A pagination token that can be used in a subsequent DownloadDBLogFilePortion request.</p>",
+        "DownloadDBLogFilePortionMessage$DBInstanceIdentifier":"<p>The customer-assigned name of the DB instance that contains the log files you want to list.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "DownloadDBLogFilePortionMessage$LogFileName":"<p>The name of the log file to be downloaded.</p>",
+        "DownloadDBLogFilePortionMessage$Marker":"<p>The pagination token provided in the previous request or \"0\". If the Marker parameter is specified the response includes only records beyond the marker until the end of the file or up to NumberOfLines.</p>",
+        "EC2SecurityGroup$Status":"<p>Provides the status of the EC2 security group. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>",
+        "EC2SecurityGroup$EC2SecurityGroupName":"<p>Specifies the name of the EC2 security group.</p>",
+        "EC2SecurityGroup$EC2SecurityGroupId":"<p>Specifies the id of the EC2 security group.</p>",
+        "EC2SecurityGroup$EC2SecurityGroupOwnerId":"<p> Specifies the AWS ID of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> field. </p>",
+        "Endpoint$Address":"<p>Specifies the DNS address of the DB instance.</p>",
+        "Endpoint$HostedZoneId":"<p>Specifies the ID that Amazon Route 53 assigns when you create a hosted zone.</p>",
+        "EngineDefaults$DBParameterGroupFamily":"<p>Specifies the name of the DB parameter group family that the engine default parameters apply to.</p>",
+        "EngineDefaults$Marker":"<p> An optional pagination token provided by a previous EngineDefaults request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "Event$SourceIdentifier":"<p>Provides the identifier for the source of the event.</p>",
+        "Event$Message":"<p>Provides the text of this event.</p>",
+        "Event$SourceArn":"<p>The Amazon Resource Name (ARN) for the event.</p>",
+        "EventCategoriesList$member":null,
+        "EventCategoriesMap$SourceType":"<p>The source type that the returned categories belong to</p>",
+        "EventSubscription$CustomerAwsId":"<p>The AWS customer account associated with the RDS event notification subscription.</p>",
+        "EventSubscription$CustSubscriptionId":"<p>The RDS event notification subscription Id.</p>",
+        "EventSubscription$SnsTopicArn":"<p>The topic ARN of the RDS event notification subscription.</p>",
+        "EventSubscription$Status":"<p>The status of the RDS event notification subscription.</p> <p>Constraints:</p> <p>Can be one of the following: creating | modifying | deleting | active | no-permission | topic-not-exist</p> <p>The status \"no-permission\" indicates that RDS no longer has permission to post to the SNS topic. The status \"topic-not-exist\" indicates that the topic was deleted after the subscription was created.</p>",
+        "EventSubscription$SubscriptionCreationTime":"<p>The time the RDS event notification subscription was created.</p>",
+        "EventSubscription$SourceType":"<p>The source type for the RDS event notification subscription.</p>",
+        "EventSubscription$EventSubscriptionArn":"<p>The Amazon Resource Name (ARN) for the event subscription.</p>",
+        "EventSubscriptionsMessage$Marker":"<p> An optional pagination token provided by a previous DescribeOrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "EventsMessage$Marker":"<p> An optional pagination token provided by a previous Events request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "FailoverDBClusterMessage$DBClusterIdentifier":"<p>A DB cluster identifier to force a failover for. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
+        "FailoverDBClusterMessage$TargetDBInstanceIdentifier":"<p>The name of the instance to promote to the primary instance.</p> <p>You must specify the instance identifier for an Aurora Replica in the DB cluster. For example, <code>mydbcluster-replica1</code>.</p>",
+        "Filter$Name":"<p>The name of the filter. Filter names are case-sensitive.</p>",
+        "FilterValueList$member":null,
+        "IPRange$Status":"<p>Specifies the status of the IP range. Status can be \"authorizing\", \"authorized\", \"revoking\", and \"revoked\".</p>",
+        "IPRange$CIDRIP":"<p>Specifies the IP range.</p>",
+        "KeyList$member":null,
+        "ListTagsForResourceMessage$ResourceName":"<p>The Amazon RDS resource with tags to be listed. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
+        "LogTypeList$member":null,
+        "ModifyDBClusterMessage$DBClusterIdentifier":"<p>The DB cluster identifier for the cluster being modified. This parameter is not case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
+        "ModifyDBClusterMessage$NewDBClusterIdentifier":"<p>The new DB cluster identifier for the DB cluster when renaming a DB cluster. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>The first character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-cluster2</code> </p>",
+        "ModifyDBClusterMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group to use for the DB cluster.</p>",
+        "ModifyDBClusterMessage$MasterUserPassword":"<p>The new password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
+        "ModifyDBClusterMessage$OptionGroupName":"<p>A value that indicates that the DB cluster should be associated with the specified option group. Changing this parameter doesn't result in an outage except in the following case, and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options can't be removed from an option group. The option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
+        "ModifyDBClusterMessage$PreferredBackupWindow":"<p>The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "ModifyDBClusterMessage$PreferredMaintenanceWindow":"<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
+        "ModifyDBClusterMessage$EngineVersion":"<p>The version number of the database engine to which you want to upgrade. Changing this parameter results in an outage. The change is applied during the next maintenance window unless the ApplyImmediately parameter is set to true.</p> <p>For a list of valid engine versions, see <a>CreateDBCluster</a>, or call <a>DescribeDBEngineVersions</a>.</p>",
+        "ModifyDBClusterParameterGroupMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group to modify.</p>",
+        "ModifyDBClusterSnapshotAttributeMessage$DBClusterSnapshotIdentifier":"<p>The identifier for the DB cluster snapshot to modify the attributes for.</p>",
+        "ModifyDBClusterSnapshotAttributeMessage$AttributeName":"<p>The name of the DB cluster snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB cluster snapshot, set this value to <code>restore</code>.</p>",
+        "ModifyDBInstanceMessage$DBInstanceIdentifier":"<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "ModifyDBInstanceMessage$DBInstanceClass":"<p>The new compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>If you modify the DB instance class, an outage occurs during the change. The change is applied during the next maintenance window, unless <code>ApplyImmediately</code> is specified as <code>true</code> for this request. </p> <p>Default: Uses existing setting</p>",
+        "ModifyDBInstanceMessage$DBSubnetGroupName":"<p>The new DB subnet group for the DB instance. You can use this parameter to move your DB instance to a different VPC. If your DB instance is not in a VPC, you can also use this parameter to move your DB instance into a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Non-VPC2VPC\">Updating the VPC for a DB Instance</a>. </p> <p>Changing the subnet group causes an outage during the change. The change is applied during the next maintenance window, unless you specify <code>true</code> for the <code>ApplyImmediately</code> parameter. </p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetGroup</code> </p>",
+        "ModifyDBInstanceMessage$MasterUserPassword":"<p>The new password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p> Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible. Between the time of the request and the completion of the request, the <code>MasterUserPassword</code> element exists in the <code>PendingModifiedValues</code> element of the operation response. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The password for the master user is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>. </p> <p>Default: Uses existing setting</p> <p> <b>MariaDB</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Microsoft SQL Server</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <p> <b>MySQL</b> </p> <p>Constraints: Must contain from 8 to 41 characters.</p> <p> <b>Oracle</b> </p> <p>Constraints: Must contain from 8 to 30 characters.</p> <p> <b>PostgreSQL</b> </p> <p>Constraints: Must contain from 8 to 128 characters.</p> <note> <p>Amazon RDS API actions never return the password, so this action provides a way to regain access to a primary instance user if the password is lost. This includes restoring privileges that might have been accidentally revoked. </p> </note>",
+        "ModifyDBInstanceMessage$DBParameterGroupName":"<p>The name of the DB parameter group to apply to the DB instance. Changing this setting doesn't result in an outage. The parameter group name itself is changed immediately, but the actual parameter changes are not applied until you reboot the instance without failover. The db instance will NOT be rebooted automatically and the parameter changes will NOT be applied during the next maintenance window.</p> <p>Default: Uses existing setting</p> <p>Constraints: The DB parameter group must be in the same DB parameter group family as this DB instance.</p>",
+        "ModifyDBInstanceMessage$PreferredBackupWindow":"<p> The daily time range during which automated backups are created if automated backups are enabled, as determined by the <code>BackupRetentionPeriod</code> parameter. Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible. </p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The daily time range for creating automated backups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>Must be in the format hh24:mi-hh24:mi</p> </li> <li> <p>Must be in Universal Time Coordinated (UTC)</p> </li> <li> <p>Must not conflict with the preferred maintenance window</p> </li> <li> <p>Must be at least 30 minutes</p> </li> </ul>",
+        "ModifyDBInstanceMessage$PreferredMaintenanceWindow":"<p>The weekly time range (in UTC) during which system maintenance can occur, which might result in an outage. Changing this parameter doesn't result in an outage, except in the following situation, and the change is asynchronously applied as soon as possible. If there are pending actions that cause a reboot, and the maintenance window is changed to include the current time, then changing this parameter will cause a reboot of the DB instance. If moving this window to the current time, there must be at least 30 minutes between the current time and end of the window to ensure pending changes are applied.</p> <p>Default: Uses existing setting</p> <p>Format: ddd:hh24:mi-ddd:hh24:mi</p> <p>Valid Days: Mon | Tue | Wed | Thu | Fri | Sat | Sun</p> <p>Constraints: Must be at least 30 minutes</p>",
+        "ModifyDBInstanceMessage$EngineVersion":"<p> The version number of the database engine to upgrade to. Changing this parameter results in an outage and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. </p> <p>For major version upgrades, if a nondefault DB parameter group is currently in use, a new DB parameter group in the DB parameter group family for the new engine version must be specified. The new DB parameter group can be the default for that DB parameter group family.</p> <p>For information about valid engine versions, see <a>CreateDBInstance</a>, or call <a>DescribeDBEngineVersions</a>.</p>",
+        "ModifyDBInstanceMessage$LicenseModel":"<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
+        "ModifyDBInstanceMessage$OptionGroupName":"<p> Indicates that the DB instance should be associated with the specified option group. Changing this parameter doesn't result in an outage except in the following case and the change is applied during the next maintenance window unless the <code>ApplyImmediately</code> parameter is set to <code>true</code> for this request. If the parameter change results in an option group that enables OEM, this change can cause a brief (sub-second) period during which new connections are rejected but existing connections are not interrupted. </p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
+        "ModifyDBInstanceMessage$NewDBInstanceIdentifier":"<p> The new DB instance identifier for the DB instance when renaming a DB instance. When you change the DB instance identifier, an instance reboot will occur immediately if you set <code>Apply Immediately</code> to true, or will occur during the next maintenance window if <code>Apply Immediately</code> to false. This value is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>The first character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
+        "ModifyDBInstanceMessage$StorageType":"<p>Specifies the storage type to be associated with the DB instance. </p> <p>If you specify Provisioned IOPS (<code>io1</code>), you must also include a value for the <code>Iops</code> parameter. </p> <p>If you choose to migrate your DB instance from using standard storage to using Provisioned IOPS, or from using Provisioned IOPS to using standard storage, the process can take time. The duration of the migration depends on several factors such as database load, storage size, storage type (standard or Provisioned IOPS), amount of IOPS provisioned (if any), and the number of prior scale storage operations. Typical migration times are under 24 hours, but the process can take up to several days in some cases. During the migration, the DB instance is available for use, but might experience performance degradation. While the migration takes place, nightly backups for the instance are suspended. No other Amazon RDS operations can take place for the instance, including modifying the instance, rebooting the instance, deleting the instance, creating a Read Replica for the instance, and creating a DB snapshot of the instance. </p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p>Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
+        "ModifyDBInstanceMessage$TdeCredentialArn":"<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
+        "ModifyDBInstanceMessage$TdeCredentialPassword":"<p>The password for the given ARN from the key store in order to access the device.</p>",
+        "ModifyDBInstanceMessage$CACertificateIdentifier":"<p>Indicates the certificate that needs to be associated with the instance.</p>",
+        "ModifyDBInstanceMessage$Domain":"<p>The Active Directory Domain to move the instance to. Specify <code>none</code> to remove the instance from its current domain. The domain must be created prior to this operation. Currently only a Microsoft SQL Server instance can be created in a Active Directory Domain. </p>",
+        "ModifyDBInstanceMessage$MonitoringRoleArn":"<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, go to <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole\">To create an IAM role for Amazon RDS Enhanced Monitoring</a>.</p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value.</p>",
+        "ModifyDBInstanceMessage$DomainIAMRoleName":"<p>The name of the IAM role to use when making API calls to the Directory Service.</p>",
+        "ModifyDBInstanceMessage$PerformanceInsightsKMSKeyId":"<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the KMS key alias for the KMS encryption key.</p>",
+        "ModifyDBParameterGroupMessage$DBParameterGroupName":"<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBParameterGroup.</p> </li> </ul>",
+        "ModifyDBSnapshotAttributeMessage$DBSnapshotIdentifier":"<p>The identifier for the DB snapshot to modify the attributes for.</p>",
+        "ModifyDBSnapshotAttributeMessage$AttributeName":"<p>The name of the DB snapshot attribute to modify.</p> <p>To manage authorization for other AWS accounts to copy or restore a manual DB snapshot, set this value to <code>restore</code>.</p>",
+        "ModifyDBSnapshotMessage$DBSnapshotIdentifier":"<p>The identifier of the DB snapshot to modify.</p>",
+        "ModifyDBSnapshotMessage$EngineVersion":"<p>The engine version to upgrade the DB snapshot to. </p> <p>The following are the database engines and engine versions that are available when you upgrade a DB snapshot. </p> <p> <b>MySQL</b> </p> <ul> <li> <p> <code>5.5.46</code> (supported for 5.1 DB snapshots)</p> </li> </ul> <p> <b>Oracle</b> </p> <ul> <li> <p> <code>12.1.0.2.v8</code> (supported for 12.1.0.1 DB snapshots)</p> </li> <li> <p> <code>11.2.0.4.v12</code> (supported for 11.2.0.2 DB snapshots)</p> </li> <li> <p> <code>11.2.0.4.v11</code> (supported for 11.2.0.3 DB snapshots)</p> </li> </ul>",
+        "ModifyDBSnapshotMessage$OptionGroupName":"<p>The option group to identify with the upgraded DB snapshot. </p> <p>You can specify this parameter when you upgrade an Oracle DB snapshot. The same option group considerations apply when upgrading a DB snapshot as when upgrading a DB instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Oracle.html#USER_UpgradeDBInstance.Oracle.OGPG.OG\">Option Group Considerations</a>. </p>",
+        "ModifyDBSubnetGroupMessage$DBSubnetGroupName":"<p>The name for the DB subnet group. This value is stored as a lowercase string. You can't modify the default subnet group. </p> <p>Constraints: Must match the name of an existing DBSubnetGroup. Must not be default.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "ModifyDBSubnetGroupMessage$DBSubnetGroupDescription":"<p>The description for the DB subnet group.</p>",
+        "ModifyEventSubscriptionMessage$SubscriptionName":"<p>The name of the RDS event notification subscription.</p>",
+        "ModifyEventSubscriptionMessage$SnsTopicArn":"<p>The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it.</p>",
+        "ModifyEventSubscriptionMessage$SourceType":"<p>The type of source that is generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned.</p> <p>Valid values: db-instance | db-parameter-group | db-security-group | db-snapshot</p>",
+        "ModifyOptionGroupMessage$OptionGroupName":"<p>The name of the option group to be modified.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
+        "Option$OptionName":"<p>The name of the option.</p>",
+        "Option$OptionDescription":"<p>The description of the option.</p>",
+        "Option$OptionVersion":"<p>The version of the option.</p>",
+        "OptionConfiguration$OptionName":"<p>The configuration of options to include in a group.</p>",
+        "OptionConfiguration$OptionVersion":"<p>The version for the option.</p>",
+        "OptionGroup$OptionGroupName":"<p>Specifies the name of the option group.</p>",
+        "OptionGroup$OptionGroupDescription":"<p>Provides a description of the option group.</p>",
+        "OptionGroup$EngineName":"<p>Indicates the name of the engine that this option group can be applied to.</p>",
+        "OptionGroup$MajorEngineVersion":"<p>Indicates the major engine version associated with this option group.</p>",
+        "OptionGroup$VpcId":"<p>If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>false</code>, this field is blank. If <b>AllowsVpcAndNonVpcInstanceMemberships</b> is <code>true</code> and this field is blank, then this option group can be applied to both VPC and non-VPC instances. If this field contains a value, then this option group can only be applied to instances that are in the VPC indicated by this field. </p>",
+        "OptionGroup$OptionGroupArn":"<p>The Amazon Resource Name (ARN) for the option group.</p>",
+        "OptionGroupMembership$OptionGroupName":"<p>The name of the option group that the instance belongs to.</p>",
+        "OptionGroupMembership$Status":"<p>The status of the DB instance's option group membership. Valid values are: <code>in-sync</code>, <code>pending-apply</code>, <code>pending-removal</code>, <code>pending-maintenance-apply</code>, <code>pending-maintenance-removal</code>, <code>applying</code>, <code>removing</code>, and <code>failed</code>. </p>",
+        "OptionGroupOption$Name":"<p>The name of the option.</p>",
+        "OptionGroupOption$Description":"<p>The description of the option.</p>",
+        "OptionGroupOption$EngineName":"<p>The name of the engine that this option can be applied to.</p>",
+        "OptionGroupOption$MajorEngineVersion":"<p>Indicates the major engine version that the option is available for.</p>",
+        "OptionGroupOption$MinimumRequiredMinorEngineVersion":"<p>The minimum required engine version for the option to be applied.</p>",
+        "OptionGroupOptionSetting$SettingName":"<p>The name of the option group option.</p>",
+        "OptionGroupOptionSetting$SettingDescription":"<p>The description of the option group option.</p>",
+        "OptionGroupOptionSetting$DefaultValue":"<p>The default value for the option group option.</p>",
+        "OptionGroupOptionSetting$ApplyType":"<p>The DB engine specific parameter type for the option group option.</p>",
+        "OptionGroupOptionSetting$AllowedValues":"<p>Indicates the acceptable values for the option group option.</p>",
+        "OptionGroupOptionsMessage$Marker":"<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>",
+        "OptionGroups$Marker":"<p>An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "OptionNamesList$member":null,
+        "OptionSetting$Name":"<p>The name of the option that has settings that you can set.</p>",
+        "OptionSetting$Value":"<p>The current value of the option setting.</p>",
+        "OptionSetting$DefaultValue":"<p>The default value of the option setting.</p>",
+        "OptionSetting$Description":"<p>The description of the option setting.</p>",
+        "OptionSetting$ApplyType":"<p>The DB engine specific parameter type.</p>",
+        "OptionSetting$DataType":"<p>The data type of the option setting.</p>",
+        "OptionSetting$AllowedValues":"<p>The allowed values of the option setting.</p>",
+        "OptionVersion$Version":"<p>The version of the option.</p>",
+        "OptionsConflictsWith$member":null,
+        "OptionsDependedOn$member":null,
+        "OrderableDBInstanceOption$Engine":"<p>The engine type of a DB instance.</p>",
+        "OrderableDBInstanceOption$EngineVersion":"<p>The engine version of a DB instance.</p>",
+        "OrderableDBInstanceOption$DBInstanceClass":"<p>The DB instance class for a DB instance.</p>",
+        "OrderableDBInstanceOption$LicenseModel":"<p>The license model for a DB instance.</p>",
+        "OrderableDBInstanceOption$StorageType":"<p>Indicates the storage type for a DB instance.</p>",
+        "OrderableDBInstanceOptionsMessage$Marker":"<p> An optional pagination token provided by a previous OrderableDBInstanceOptions request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code> . </p>",
+        "Parameter$ParameterName":"<p>Specifies the name of the parameter.</p>",
+        "Parameter$ParameterValue":"<p>Specifies the value of the parameter.</p>",
+        "Parameter$Description":"<p>Provides a description of the parameter.</p>",
+        "Parameter$Source":"<p>Indicates the source of the parameter value.</p>",
+        "Parameter$ApplyType":"<p>Specifies the engine specific parameters type.</p>",
+        "Parameter$DataType":"<p>Specifies the valid data type for the parameter.</p>",
+        "Parameter$AllowedValues":"<p>Specifies the valid range of values for the parameter.</p>",
+        "Parameter$MinimumEngineVersion":"<p>The earliest engine version to which the parameter can apply.</p>",
+        "PendingMaintenanceAction$Action":"<p>The type of pending maintenance action that is available for the resource.</p>",
+        "PendingMaintenanceAction$OptInStatus":"<p>Indicates the type of opt-in request that has been received for the resource.</p>",
+        "PendingMaintenanceAction$Description":"<p>A description providing more detail about the maintenance action.</p>",
+        "PendingMaintenanceActionsMessage$Marker":"<p> An optional pagination token provided by a previous <code>DescribePendingMaintenanceActions</code> request. If this parameter is specified, the response includes only records beyond the marker, up to a number of records specified by <code>MaxRecords</code>. </p>",
+        "PendingModifiedValues$DBInstanceClass":"<p> Contains the new <code>DBInstanceClass</code> for the DB instance that will be applied or is currently being applied. </p>",
+        "PendingModifiedValues$MasterUserPassword":"<p>Contains the pending or currently-in-progress change of the master credentials for the DB instance.</p>",
+        "PendingModifiedValues$EngineVersion":"<p>Indicates the database engine version.</p>",
+        "PendingModifiedValues$LicenseModel":"<p>The license model for the DB instance.</p> <p>Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
+        "PendingModifiedValues$DBInstanceIdentifier":"<p> Contains the new <code>DBInstanceIdentifier</code> for the DB instance that will be applied or is currently being applied. </p>",
+        "PendingModifiedValues$StorageType":"<p>Specifies the storage type to be associated with the DB instance.</p>",
+        "PendingModifiedValues$CACertificateIdentifier":"<p>Specifies the identifier of the CA certificate for the DB instance.</p>",
+        "PendingModifiedValues$DBSubnetGroupName":"<p>The new DB subnet group for the DB instance. </p>",
+        "ProcessorFeature$Name":"<p>The name of the processor feature. Valid names are <code>coreCount</code> and <code>threadsPerCore</code>.</p>",
+        "ProcessorFeature$Value":"<p>The value of a processor feature name.</p>",
+        "PromoteReadReplicaDBClusterMessage$DBClusterIdentifier":"<p>The identifier of the DB cluster Read Replica to promote. This parameter is not case-sensitive. </p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster Read Replica.</p> </li> </ul> <p>Example: <code>my-cluster-replica1</code> </p>",
+        "PromoteReadReplicaMessage$DBInstanceIdentifier":"<p>The DB instance identifier. This value is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing Read Replica DB instance.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
+        "PromoteReadReplicaMessage$PreferredBackupWindow":"<p> The daily time range during which automated backups are created if automated backups are enabled, using the <code>BackupRetentionPeriod</code> parameter. </p> <p> The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "PurchaseReservedDBInstancesOfferingMessage$ReservedDBInstancesOfferingId":"<p>The ID of the Reserved DB instance offering to purchase.</p> <p>Example: 438012d3-4052-4cc7-b2e3-8d3372e0e706</p>",
+        "PurchaseReservedDBInstancesOfferingMessage$ReservedDBInstanceId":"<p>Customer-specified identifier to track this reservation.</p> <p>Example: myreservationID</p>",
+        "ReadReplicaDBClusterIdentifierList$member":null,
+        "ReadReplicaDBInstanceIdentifierList$member":null,
+        "ReadReplicaIdentifierList$member":null,
+        "RebootDBInstanceMessage$DBInstanceIdentifier":"<p>The DB instance identifier. This parameter is stored as a lowercase string.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBInstance.</p> </li> </ul>",
+        "RecurringCharge$RecurringChargeFrequency":"<p>The frequency of the recurring charge.</p>",
+        "RemoveRoleFromDBClusterMessage$DBClusterIdentifier":"<p>The name of the DB cluster to disassociate the IAM role from.</p>",
+        "RemoveRoleFromDBClusterMessage$RoleArn":"<p>The Amazon Resource Name (ARN) of the IAM role to disassociate from the Aurora DB cluster, for example <code>arn:aws:iam::123456789012:role/AuroraAccessRole</code>.</p>",
+        "RemoveSourceIdentifierFromSubscriptionMessage$SubscriptionName":"<p>The name of the RDS event notification subscription you want to remove a source identifier from.</p>",
+        "RemoveSourceIdentifierFromSubscriptionMessage$SourceIdentifier":"<p> The source identifier to be removed from the subscription, such as the <b>DB instance identifier</b> for a DB instance or the name of a security group. </p>",
+        "RemoveTagsFromResourceMessage$ResourceName":"<p>The Amazon RDS resource that the tags are removed from. This value is an Amazon Resource Name (ARN). For information about creating an ARN, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing\"> Constructing an RDS Amazon Resource Name (ARN)</a>.</p>",
+        "ReservedDBInstance$ReservedDBInstanceId":"<p>The unique identifier for the reservation.</p>",
+        "ReservedDBInstance$ReservedDBInstancesOfferingId":"<p>The offering identifier.</p>",
+        "ReservedDBInstance$DBInstanceClass":"<p>The DB instance class for the reserved DB instance.</p>",
+        "ReservedDBInstance$CurrencyCode":"<p>The currency code for the reserved DB instance.</p>",
+        "ReservedDBInstance$ProductDescription":"<p>The description of the reserved DB instance.</p>",
+        "ReservedDBInstance$OfferingType":"<p>The offering type of this reserved DB instance.</p>",
+        "ReservedDBInstance$State":"<p>The state of the reserved DB instance.</p>",
+        "ReservedDBInstance$ReservedDBInstanceArn":"<p>The Amazon Resource Name (ARN) for the reserved DB instance.</p>",
+        "ReservedDBInstanceMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "ReservedDBInstancesOffering$ReservedDBInstancesOfferingId":"<p>The offering identifier.</p>",
+        "ReservedDBInstancesOffering$DBInstanceClass":"<p>The DB instance class for the reserved DB instance.</p>",
+        "ReservedDBInstancesOffering$CurrencyCode":"<p>The currency code for the reserved DB instance offering.</p>",
+        "ReservedDBInstancesOffering$ProductDescription":"<p>The database engine used by the offering.</p>",
+        "ReservedDBInstancesOffering$OfferingType":"<p>The offering type.</p>",
+        "ReservedDBInstancesOfferingMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "ResetDBClusterParameterGroupMessage$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group to reset.</p>",
+        "ResetDBParameterGroupMessage$DBParameterGroupName":"<p>The name of the DB parameter group.</p> <p>Constraints:</p> <ul> <li> <p>Must match the name of an existing DBParameterGroup.</p> </li> </ul>",
+        "ResourcePendingMaintenanceActions$ResourceIdentifier":"<p>The ARN of the resource that has pending maintenance actions.</p>",
+        "RestoreDBClusterFromS3Message$CharacterSetName":"<p>A value that indicates that the restored DB cluster should be associated with the specified CharacterSet.</p>",
+        "RestoreDBClusterFromS3Message$DatabaseName":"<p>The database name for the restored DB cluster.</p>",
+        "RestoreDBClusterFromS3Message$DBClusterIdentifier":"<p>The name of the DB cluster to create from the source data in the Amazon S3 bucket. This parameter is isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>my-cluster1</code> </p>",
+        "RestoreDBClusterFromS3Message$DBClusterParameterGroupName":"<p>The name of the DB cluster parameter group to associate with the restored DB cluster. If this argument is omitted, <code>default.aurora5.6</code> is used. </p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match the name of an existing DBClusterParameterGroup.</p> </li> </ul>",
+        "RestoreDBClusterFromS3Message$DBSubnetGroupName":"<p>A DB subnet group to associate with the restored DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup. </p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "RestoreDBClusterFromS3Message$Engine":"<p>The name of the database engine to be used for the restored DB cluster.</p> <p>Valid Values: <code>aurora</code>, <code>aurora-postgresql</code> </p>",
+        "RestoreDBClusterFromS3Message$EngineVersion":"<p>The version number of the database engine to use.</p> <p> <b>Aurora MySQL</b> </p> <p>Example: <code>5.6.10a</code> </p> <p> <b>Aurora PostgreSQL</b> </p> <p>Example: <code>9.6.3</code> </p>",
+        "RestoreDBClusterFromS3Message$MasterUsername":"<p>The name of the master user for the restored DB cluster.</p> <p>Constraints:</p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
+        "RestoreDBClusterFromS3Message$MasterUserPassword":"<p>The password for the master database user. This password can contain any printable ASCII character except \"/\", \"\"\", or \"@\".</p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
+        "RestoreDBClusterFromS3Message$OptionGroupName":"<p>A value that indicates that the restored DB cluster should be associated with the specified option group.</p> <p>Permanent options can't be removed from an option group. An option group can't be removed from a DB cluster once it is associated with a DB cluster.</p>",
+        "RestoreDBClusterFromS3Message$PreferredBackupWindow":"<p>The daily time range during which automated backups are created if automated backups are enabled using the <code>BackupRetentionPeriod</code> parameter. </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "RestoreDBClusterFromS3Message$PreferredMaintenanceWindow":"<p>The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).</p> <p>Format: <code>ddd:hh24:mi-ddd:hh24:mi</code> </p> <p>The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AdjustingTheMaintenanceWindow.html\"> Adjusting the Preferred Maintenance Window</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> <p>Constraints: Minimum 30-minute window.</p>",
+        "RestoreDBClusterFromS3Message$KmsKeyId":"<p>The AWS KMS key identifier for an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KM encryption key.</p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region.</p>",
+        "RestoreDBClusterFromS3Message$SourceEngine":"<p>The identifier for the database engine that was backed up to create the files stored in the Amazon S3 bucket. </p> <p>Valid values: <code>mysql</code> </p>",
+        "RestoreDBClusterFromS3Message$SourceEngineVersion":"<p>The version of the database that the backup files were created from.</p> <p>MySQL version 5.5 and 5.6 are supported. </p> <p>Example: <code>5.6.22</code> </p>",
+        "RestoreDBClusterFromS3Message$S3BucketName":"<p>The name of the Amazon S3 bucket that contains the data used to create the Amazon Aurora DB cluster.</p>",
+        "RestoreDBClusterFromS3Message$S3Prefix":"<p>The prefix for all of the file names that contain the data used to create the Amazon Aurora DB cluster. If you do not specify a <b>SourceS3Prefix</b> value, then the Amazon Aurora DB cluster is created by using all of the files in the Amazon S3 bucket.</p>",
+        "RestoreDBClusterFromS3Message$S3IngestionRoleArn":"<p>The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that authorizes Amazon RDS to access the Amazon S3 bucket on your behalf.</p>",
+        "RestoreDBClusterFromSnapshotMessage$DBClusterIdentifier":"<p>The name of the DB cluster to create from the DB snapshot or DB cluster snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
+        "RestoreDBClusterFromSnapshotMessage$SnapshotIdentifier":"<p>The identifier for the DB snapshot or DB cluster snapshot to restore from.</p> <p>You can use either the name or the Amazon Resource Name (ARN) to specify a DB cluster snapshot. However, you can use only the ARN to specify a DB snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing Snapshot.</p> </li> </ul>",
+        "RestoreDBClusterFromSnapshotMessage$Engine":"<p>The database engine to use for the new DB cluster.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p>",
+        "RestoreDBClusterFromSnapshotMessage$EngineVersion":"<p>The version of the database engine to use for the new DB cluster.</p>",
+        "RestoreDBClusterFromSnapshotMessage$DBSubnetGroupName":"<p>The name of the DB subnet group to use for the new DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "RestoreDBClusterFromSnapshotMessage$DatabaseName":"<p>The database name for the restored DB cluster.</p>",
+        "RestoreDBClusterFromSnapshotMessage$OptionGroupName":"<p>The name of the option group to use for the restored DB cluster.</p>",
+        "RestoreDBClusterFromSnapshotMessage$KmsKeyId":"<p>The AWS KMS key identifier to use when restoring an encrypted DB cluster from a DB snapshot or DB cluster snapshot.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB snapshot or DB cluster snapshot in <code>SnapshotIdentifier</code> is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the DB snapshot or DB cluster snapshot.</p> </li> <li> <p>If the DB snapshot or DB cluster snapshot in <code>SnapshotIdentifier</code> is not encrypted, then the restored DB cluster is not encrypted.</p> </li> </ul>",
+        "RestoreDBClusterToPointInTimeMessage$DBClusterIdentifier":"<p>The name of the new DB cluster to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "RestoreDBClusterToPointInTimeMessage$RestoreType":"<p>The type of restore to be performed. You can specify one of the following values:</p> <ul> <li> <p> <code>full-copy</code> - The new DB cluster is restored as a full copy of the source DB cluster.</p> </li> <li> <p> <code>copy-on-write</code> - The new DB cluster is restored as a clone of the source DB cluster.</p> </li> </ul> <p>Constraints: You can't specify <code>copy-on-write</code> if the engine version of the source DB cluster is earlier than 1.11.</p> <p>If you don't specify a <code>RestoreType</code> value, then the new DB cluster is restored as a full copy of the source DB cluster.</p>",
+        "RestoreDBClusterToPointInTimeMessage$SourceDBClusterIdentifier":"<p>The identifier of the source DB cluster from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBCluster.</p> </li> </ul>",
+        "RestoreDBClusterToPointInTimeMessage$DBSubnetGroupName":"<p>The DB subnet group name to use for the new DB cluster.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "RestoreDBClusterToPointInTimeMessage$OptionGroupName":"<p>The name of the option group for the new DB cluster.</p>",
+        "RestoreDBClusterToPointInTimeMessage$KmsKeyId":"<p>The AWS KMS key identifier to use when restoring an encrypted DB cluster from an encrypted DB cluster.</p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are restoring a DB cluster with the same AWS account that owns the KMS encryption key used to encrypt the new DB cluster, then you can use the KMS key alias instead of the ARN for the KMS encryption key.</p> <p>You can restore to a new DB cluster and encrypt the new DB cluster with a KMS key that is different than the KMS key used to encrypt the source DB cluster. The new DB cluster is encrypted with the KMS key identified by the <code>KmsKeyId</code> parameter.</p> <p>If you do not specify a value for the <code>KmsKeyId</code> parameter, then the following will occur:</p> <ul> <li> <p>If the DB cluster is encrypted, then the restored DB cluster is encrypted using the KMS key that was used to encrypt the source DB cluster.</p> </li> <li> <p>If the DB cluster is not encrypted, then the restored DB cluster is not encrypted.</p> </li> </ul> <p>If <code>DBClusterIdentifier</code> refers to a DB cluster that is not encrypted, then the restore request is rejected.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DBInstanceIdentifier":"<p>Name of the DB instance to create from the DB snapshot. This parameter isn't case-sensitive.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 numbers, letters, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul> <p>Example: <code>my-snapshot-id</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DBSnapshotIdentifier":"<p>The identifier for the DB snapshot to restore from.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DBSnapshot.</p> </li> <li> <p>If you are restoring from a shared manual DB snapshot, the <code>DBSnapshotIdentifier</code> must be the ARN of the shared DB snapshot.</p> </li> </ul>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DBInstanceClass":"<p>The compute and memory capacity of the Amazon RDS DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: The same DBInstanceClass as the original DB instance.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$AvailabilityZone":"<p>The EC2 Availability Zone that the DB instance is created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to <code>true</code>.</p> <p>Example: <code>us-east-1a</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DBSubnetGroupName":"<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$LicenseModel":"<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DBName":"<p>The database name for the restored DB instance.</p> <note> <p>This parameter doesn't apply to the MySQL, PostgreSQL, or MariaDB engines.</p> </note>",
+        "RestoreDBInstanceFromDBSnapshotMessage$Engine":"<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source. For example, you can restore a MariaDB 10.1 DB instance from a MySQL 5.6 snapshot.</p> <p>Valid Values:</p> <ul> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
+        "RestoreDBInstanceFromDBSnapshotMessage$OptionGroupName":"<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$StorageType":"<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$TdeCredentialArn":"<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$TdeCredentialPassword":"<p>The password for the given ARN from the key store in order to access the device.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$Domain":"<p>Specify the Active Directory Domain to restore the instance in.</p>",
+        "RestoreDBInstanceFromDBSnapshotMessage$DomainIAMRoleName":"<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
+        "RestoreDBInstanceFromS3Message$DBName":"<p>The name of the database to create when the DB instance is created. Follow the naming rules specified in <a>CreateDBInstance</a>. </p>",
+        "RestoreDBInstanceFromS3Message$DBInstanceIdentifier":"<p>The DB instance identifier. This parameter is stored as a lowercase string. </p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> </ul> <p>Example: <code>mydbinstance</code> </p>",
+        "RestoreDBInstanceFromS3Message$DBInstanceClass":"<p>The compute and memory capacity of the DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Importing from Amazon S3 is not supported on the db.t2.micro DB instance class. </p>",
+        "RestoreDBInstanceFromS3Message$Engine":"<p>The name of the database engine to be used for this instance. </p> <p>Valid Values: <code>mysql</code> </p>",
+        "RestoreDBInstanceFromS3Message$MasterUsername":"<p>The name for the master user. </p> <p>Constraints: </p> <ul> <li> <p>Must be 1 to 16 letters or numbers.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot be a reserved word for the chosen database engine.</p> </li> </ul>",
+        "RestoreDBInstanceFromS3Message$MasterUserPassword":"<p>The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\". </p> <p>Constraints: Must contain from 8 to 41 characters.</p>",
+        "RestoreDBInstanceFromS3Message$AvailabilityZone":"<p>The Availability Zone that the DB instance is created in. For information about AWS Regions and Availability Zones, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html\">Regions and Availability Zones</a>. </p> <p>Default: A random, system-chosen Availability Zone in the endpoint's AWS Region. </p> <p> Example: <code>us-east-1d</code> </p> <p>Constraint: The AvailabilityZone parameter can't be specified if the MultiAZ parameter is set to <code>true</code>. The specified Availability Zone must be in the same AWS Region as the current endpoint. </p>",
+        "RestoreDBInstanceFromS3Message$DBSubnetGroupName":"<p>A DB subnet group to associate with this DB instance.</p>",
+        "RestoreDBInstanceFromS3Message$PreferredMaintenanceWindow":"<p>The time range each week during which system maintenance can occur, in Universal Coordinated Time (UTC). For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#Concepts.DBMaintenance\">Amazon RDS Maintenance Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>ddd:hh24:mi-ddd:hh24:mi</code>.</p> </li> <li> <p>Valid Days: Mon, Tue, Wed, Thu, Fri, Sat, Sun.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred backup window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "RestoreDBInstanceFromS3Message$DBParameterGroupName":"<p>The name of the DB parameter group to associate with this DB instance. If this argument is omitted, the default parameter group for the specified engine is used. </p>",
+        "RestoreDBInstanceFromS3Message$PreferredBackupWindow":"<p>The time range each day during which automated backups are created if automated backups are enabled. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupWindow\">The Backup Window</a>. </p> <p>Constraints:</p> <ul> <li> <p>Must be in the format <code>hh24:mi-hh24:mi</code>.</p> </li> <li> <p>Must be in Universal Coordinated Time (UTC).</p> </li> <li> <p>Must not conflict with the preferred maintenance window.</p> </li> <li> <p>Must be at least 30 minutes.</p> </li> </ul>",
+        "RestoreDBInstanceFromS3Message$EngineVersion":"<p>The version number of the database engine to use. Choose the latest minor version of your database engine. For information about engine versions, see <a>CreateDBInstance</a>, or call <a>DescribeDBEngineVersions</a>. </p>",
+        "RestoreDBInstanceFromS3Message$LicenseModel":"<p>The license model for this DB instance. Use <code>general-public-license</code>. </p>",
+        "RestoreDBInstanceFromS3Message$OptionGroupName":"<p>The name of the option group to associate with this DB instance. If this argument is omitted, the default option group for the specified engine is used. </p>",
+        "RestoreDBInstanceFromS3Message$StorageType":"<p>Specifies the storage type to be associated with the DB instance. </p> <p>Valid values: <code>standard</code> | <code>gp2</code> | <code>io1</code> </p> <p>If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p>Default: <code>io1</code> if the <code>Iops</code> parameter is specified; otherwise <code>standard</code> </p>",
+        "RestoreDBInstanceFromS3Message$KmsKeyId":"<p>The AWS KMS key identifier for an encrypted DB instance. </p> <p>The KMS key identifier is the Amazon Resource Name (ARN) for the KMS encryption key. If you are creating a DB instance with the same AWS account that owns the KMS encryption key used to encrypt the new DB instance, then you can use the KMS key alias instead of the ARN for the KM encryption key. </p> <p>If the <code>StorageEncrypted</code> parameter is true, and you do not specify a value for the <code>KmsKeyId</code> parameter, then Amazon RDS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS Region. </p>",
+        "RestoreDBInstanceFromS3Message$MonitoringRoleArn":"<p>The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, <code>arn:aws:iam:123456789012:role/emaccess</code>. For information on creating a monitoring role, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling\">Setting Up and Enabling Enhanced Monitoring</a>. </p> <p>If <code>MonitoringInterval</code> is set to a value other than 0, then you must supply a <code>MonitoringRoleArn</code> value. </p>",
+        "RestoreDBInstanceFromS3Message$SourceEngine":"<p>The name of the engine of your source database. </p> <p>Valid Values: <code>mysql</code> </p>",
+        "RestoreDBInstanceFromS3Message$SourceEngineVersion":"<p>The engine version of your source database. </p> <p>Valid Values: <code>5.6</code> </p>",
+        "RestoreDBInstanceFromS3Message$S3BucketName":"<p>The name of your Amazon S3 bucket that contains your database backup file. </p>",
+        "RestoreDBInstanceFromS3Message$S3Prefix":"<p>The prefix of your Amazon S3 bucket. </p>",
+        "RestoreDBInstanceFromS3Message$S3IngestionRoleArn":"<p>An AWS Identity and Access Management (IAM) role to allow Amazon RDS to access your Amazon S3 bucket. </p>",
+        "RestoreDBInstanceFromS3Message$PerformanceInsightsKMSKeyId":"<p>The AWS KMS key identifier for encryption of Performance Insights data. The KMS key ID is the Amazon Resource Name (ARN), the KMS key identifier, or the KMS key alias for the KMS encryption key. </p>",
+        "RestoreDBInstanceToPointInTimeMessage$SourceDBInstanceIdentifier":"<p>The identifier of the source DB instance from which to restore.</p> <p>Constraints:</p> <ul> <li> <p>Must match the identifier of an existing DB instance.</p> </li> </ul>",
+        "RestoreDBInstanceToPointInTimeMessage$TargetDBInstanceIdentifier":"<p>The name of the new DB instance to be created.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 letters, numbers, or hyphens</p> </li> <li> <p>First character must be a letter</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens</p> </li> </ul>",
+        "RestoreDBInstanceToPointInTimeMessage$DBInstanceClass":"<p>The compute and memory capacity of the Amazon RDS DB instance, for example, <code>db.m4.large</code>. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes, and availability for your engine, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html\">DB Instance Class</a> in the <i>Amazon RDS User Guide.</i> </p> <p>Default: The same DBInstanceClass as the original DB instance.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$AvailabilityZone":"<p>The EC2 Availability Zone that the DB instance is created in.</p> <p>Default: A random, system-chosen Availability Zone.</p> <p>Constraint: You can't specify the AvailabilityZone parameter if the MultiAZ parameter is set to true.</p> <p>Example: <code>us-east-1a</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$DBSubnetGroupName":"<p>The DB subnet group name to use for the new instance.</p> <p>Constraints: If supplied, must match the name of an existing DBSubnetGroup.</p> <p>Example: <code>mySubnetgroup</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$LicenseModel":"<p>License model information for the restored DB instance.</p> <p>Default: Same as source.</p> <p> Valid values: <code>license-included</code> | <code>bring-your-own-license</code> | <code>general-public-license</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$DBName":"<p>The database name for the restored DB instance.</p> <note> <p>This parameter is not used for the MySQL or MariaDB engines.</p> </note>",
+        "RestoreDBInstanceToPointInTimeMessage$Engine":"<p>The database engine to use for the new instance.</p> <p>Default: The same as source</p> <p>Constraint: Must be compatible with the engine of the source</p> <p>Valid Values:</p> <ul> <li> <p> <code>mariadb</code> </p> </li> <li> <p> <code>mysql</code> </p> </li> <li> <p> <code>oracle-ee</code> </p> </li> <li> <p> <code>oracle-se2</code> </p> </li> <li> <p> <code>oracle-se1</code> </p> </li> <li> <p> <code>oracle-se</code> </p> </li> <li> <p> <code>postgres</code> </p> </li> <li> <p> <code>sqlserver-ee</code> </p> </li> <li> <p> <code>sqlserver-se</code> </p> </li> <li> <p> <code>sqlserver-ex</code> </p> </li> <li> <p> <code>sqlserver-web</code> </p> </li> </ul>",
+        "RestoreDBInstanceToPointInTimeMessage$OptionGroupName":"<p>The name of the option group to be used for the restored DB instance.</p> <p>Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group, and that option group can't be removed from a DB instance once it is associated with a DB instance</p>",
+        "RestoreDBInstanceToPointInTimeMessage$StorageType":"<p>Specifies the storage type to be associated with the DB instance.</p> <p> Valid values: <code>standard | gp2 | io1</code> </p> <p> If you specify <code>io1</code>, you must also include a value for the <code>Iops</code> parameter. </p> <p> Default: <code>io1</code> if the <code>Iops</code> parameter is specified, otherwise <code>standard</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$TdeCredentialArn":"<p>The ARN from the key store with which to associate the instance for TDE encryption.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$TdeCredentialPassword":"<p>The password for the given ARN from the key store in order to access the device.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$Domain":"<p>Specify the Active Directory Domain to restore the instance in.</p>",
+        "RestoreDBInstanceToPointInTimeMessage$DomainIAMRoleName":"<p>Specify the name of the IAM role to be used when making API calls to the Directory Service.</p>",
+        "RevokeDBSecurityGroupIngressMessage$DBSecurityGroupName":"<p>The name of the DB security group to revoke ingress from.</p>",
+        "RevokeDBSecurityGroupIngressMessage$CIDRIP":"<p> The IP range to revoke access from. Must be a valid CIDR range. If <code>CIDRIP</code> is specified, <code>EC2SecurityGroupName</code>, <code>EC2SecurityGroupId</code> and <code>EC2SecurityGroupOwnerId</code> can't be provided. </p>",
+        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupName":"<p> The name of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupId":"<p> The id of the EC2 security group to revoke access from. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "RevokeDBSecurityGroupIngressMessage$EC2SecurityGroupOwnerId":"<p> The AWS Account Number of the owner of the EC2 security group specified in the <code>EC2SecurityGroupName</code> parameter. The AWS Access Key ID is not an acceptable value. For VPC DB security groups, <code>EC2SecurityGroupId</code> must be provided. Otherwise, EC2SecurityGroupOwnerId and either <code>EC2SecurityGroupName</code> or <code>EC2SecurityGroupId</code> must be provided. </p>",
+        "SourceIdsList$member":null,
+        "SourceRegion$RegionName":"<p>The name of the source AWS Region.</p>",
+        "SourceRegion$Endpoint":"<p>The endpoint for the source AWS Region endpoint.</p>",
+        "SourceRegion$Status":"<p>The status of the source AWS Region.</p>",
+        "SourceRegionMessage$Marker":"<p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>",
+        "StartDBInstanceMessage$DBInstanceIdentifier":"<p> The user-supplied instance identifier. </p>",
+        "StopDBInstanceMessage$DBInstanceIdentifier":"<p> The user-supplied instance identifier. </p>",
+        "StopDBInstanceMessage$DBSnapshotIdentifier":"<p> The user-supplied instance identifier of the DB Snapshot created immediately before the DB instance is stopped. </p>",
+        "Subnet$SubnetIdentifier":"<p>Specifies the identifier of the subnet.</p>",
+        "Subnet$SubnetStatus":"<p>Specifies the status of the subnet.</p>",
+        "SubnetIdentifierList$member":null,
+        "Tag$Key":"<p>A key is the required name of the tag. The string value can be from 1 to 128 Unicode characters in length and can't be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
+        "Tag$Value":"<p>A value is the optional value of the tag. The string value can be from 1 to 256 Unicode characters in length and can't be prefixed with \"aws:\" or \"rds:\". The string can only contain only the set of Unicode letters, digits, white-space, '_', '.', '/', '=', '+', '-' (Java regex: \"^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-]*)$\").</p>",
+        "Timezone$TimezoneName":"<p>The name of the time zone.</p>",
+        "UpgradeTarget$Engine":"<p>The name of the upgrade target database engine.</p>",
+        "UpgradeTarget$EngineVersion":"<p>The version number of the upgrade target database engine.</p>",
+        "UpgradeTarget$Description":"<p>The version of the database engine that a DB instance can be upgraded to.</p>",
+        "ValidStorageOptions$StorageType":"<p>The valid storage types for your DB instance. For example, gp2, io1. </p>",
+        "VpcSecurityGroupIdList$member":null,
+        "VpcSecurityGroupMembership$VpcSecurityGroupId":"<p>The name of the VPC security group.</p>",
+        "VpcSecurityGroupMembership$Status":"<p>The status of the VPC security group.</p>"
+      }
+    },
+    "Subnet":{
+      "base":"<p> This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>",
+      "refs":{
+        "SubnetList$member":null
+      }
+    },
+    "SubnetAlreadyInUse":{
+      "base":"<p>The DB subnet is already in use in the Availability Zone.</p>",
+      "refs":{
+      }
+    },
+    "SubnetIdentifierList":{
+      "base":null,
+      "refs":{
+        "CreateDBSubnetGroupMessage$SubnetIds":"<p>The EC2 Subnet IDs for the DB subnet group.</p>",
+        "ModifyDBSubnetGroupMessage$SubnetIds":"<p>The EC2 subnet IDs for the DB subnet group.</p>"
+      }
+    },
+    "SubnetList":{
+      "base":null,
+      "refs":{
+        "DBSubnetGroup$Subnets":"<p> Contains a list of <a>Subnet</a> elements. </p>"
+      }
+    },
+    "SubscriptionAlreadyExistFault":{
+      "base":"<p>The supplied subscription name already exists.</p>",
+      "refs":{
+      }
+    },
+    "SubscriptionCategoryNotFoundFault":{
+      "base":"<p>The supplied category does not exist.</p>",
+      "refs":{
+      }
+    },
+    "SubscriptionNotFoundFault":{
+      "base":"<p>The subscription name does not exist.</p>",
+      "refs":{
+      }
+    },
+    "SupportedCharacterSetsList":{
+      "base":null,
+      "refs":{
+        "DBEngineVersion$SupportedCharacterSets":"<p> A list of the character sets supported by this engine for the <code>CharacterSetName</code> parameter of the <code>CreateDBInstance</code> action. </p>"
+      }
+    },
+    "SupportedTimezonesList":{
+      "base":null,
+      "refs":{
+        "DBEngineVersion$SupportedTimezones":"<p>A list of the time zones supported by this engine for the <code>Timezone</code> parameter of the <code>CreateDBInstance</code> action. </p>"
+      }
+    },
+    "TStamp":{
+      "base":null,
+      "refs":{
+        "BacktrackDBClusterMessage$BacktrackTo":"<p>The timestamp of the time to backtrack the DB cluster to, specified in ISO 8601 format. For more information about ISO 8601, see the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <note> <p>If the specified time is not a consistent time for the DB cluster, Aurora automatically chooses the nearest possible consistent time for the DB cluster.</p> </note> <p>Constraints:</p> <ul> <li> <p>Must contain a valid ISO 8601 timestamp.</p> </li> <li> <p>Cannot contain a timestamp set in the future.</p> </li> </ul> <p>Example: <code>2017-07-08T18:00Z</code> </p>",
+        "Certificate$ValidFrom":"<p>The starting date from which the certificate is valid.</p>",
+        "Certificate$ValidTill":"<p>The final date that the certificate continues to be valid.</p>",
+        "DBCluster$EarliestRestorableTime":"<p>The earliest time to which a database can be restored with point-in-time restore.</p>",
+        "DBCluster$LatestRestorableTime":"<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>",
+        "DBCluster$ClusterCreateTime":"<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>",
+        "DBCluster$EarliestBacktrackTime":"<p>The earliest time to which a DB cluster can be backtracked.</p>",
+        "DBClusterBacktrack$BacktrackTo":"<p>The timestamp of the time to which the DB cluster was backtracked.</p>",
+        "DBClusterBacktrack$BacktrackedFrom":"<p>The timestamp of the time from which the DB cluster was backtracked.</p>",
+        "DBClusterBacktrack$BacktrackRequestCreationTime":"<p>The timestamp of the time at which the backtrack was requested.</p>",
+        "DBClusterSnapshot$SnapshotCreateTime":"<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
+        "DBClusterSnapshot$ClusterCreateTime":"<p>Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).</p>",
+        "DBInstance$InstanceCreateTime":"<p>Provides the date and time the DB instance was created.</p>",
+        "DBInstance$LatestRestorableTime":"<p>Specifies the latest time to which a database can be restored with point-in-time restore.</p>",
+        "DBSnapshot$SnapshotCreateTime":"<p>Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
+        "DBSnapshot$InstanceCreateTime":"<p>Specifies the time when the snapshot was taken, in Universal Coordinated Time (UTC).</p>",
+        "DescribeEventsMessage$StartTime":"<p> The beginning of the time interval to retrieve events for, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>",
+        "DescribeEventsMessage$EndTime":"<p> The end of the time interval for which to retrieve events, specified in ISO 8601 format. For more information about ISO 8601, go to the <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO8601 Wikipedia page.</a> </p> <p>Example: 2009-07-08T18:00Z</p>",
+        "Event$Date":"<p>Specifies the date and time of the event.</p>",
+        "PendingMaintenanceAction$AutoAppliedAfterDate":"<p>The date of the maintenance window when the action is applied. The maintenance action is applied to the resource during its first maintenance window after this date. If this date is specified, any <code>next-maintenance</code> opt-in requests are ignored.</p>",
+        "PendingMaintenanceAction$ForcedApplyDate":"<p>The date when the maintenance action is automatically applied. The maintenance action is applied to the resource on this date regardless of the maintenance window for the resource. If this date is specified, any <code>immediate</code> opt-in requests are ignored.</p>",
+        "PendingMaintenanceAction$CurrentApplyDate":"<p>The effective date when the pending maintenance action is applied to the resource. This date takes into account opt-in requests received from the <a>ApplyPendingMaintenanceAction</a> API, the <code>AutoAppliedAfterDate</code>, and the <code>ForcedApplyDate</code>. This value is blank if an opt-in request has not been received and nothing has been specified as <code>AutoAppliedAfterDate</code> or <code>ForcedApplyDate</code>.</p>",
+        "ReservedDBInstance$StartTime":"<p>The time the reservation started.</p>",
+        "RestoreDBClusterToPointInTimeMessage$RestoreToTime":"<p>The date and time to restore the DB cluster to.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Must be specified if <code>UseLatestRestorableTime</code> parameter is not provided</p> </li> <li> <p>Cannot be specified if <code>UseLatestRestorableTime</code> parameter is true</p> </li> <li> <p>Cannot be specified if <code>RestoreType</code> parameter is <code>copy-on-write</code> </p> </li> </ul> <p>Example: <code>2015-03-07T23:45:00Z</code> </p>",
+        "RestoreDBInstanceToPointInTimeMessage$RestoreTime":"<p>The date and time to restore from.</p> <p>Valid Values: Value must be a time in Universal Coordinated Time (UTC) format</p> <p>Constraints:</p> <ul> <li> <p>Must be before the latest restorable time for the DB instance</p> </li> <li> <p>Cannot be specified if UseLatestRestorableTime parameter is true</p> </li> </ul> <p>Example: <code>2009-09-07T23:45:00Z</code> </p>"
+      }
+    },
+    "Tag":{
+      "base":"<p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>",
+      "refs":{
+        "TagList$member":null
+      }
+    },
+    "TagList":{
+      "base":"<p>A list of tags. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS Resources</a>. </p>",
+      "refs":{
+        "AddTagsToResourceMessage$Tags":"<p>The tags to be assigned to the Amazon RDS resource.</p>",
+        "CopyDBClusterParameterGroupMessage$Tags":null,
+        "CopyDBClusterSnapshotMessage$Tags":null,
+        "CopyDBParameterGroupMessage$Tags":null,
+        "CopyDBSnapshotMessage$Tags":null,
+        "CopyOptionGroupMessage$Tags":null,
+        "CreateDBClusterMessage$Tags":null,
+        "CreateDBClusterParameterGroupMessage$Tags":null,
+        "CreateDBClusterSnapshotMessage$Tags":"<p>The tags to be assigned to the DB cluster snapshot.</p>",
+        "CreateDBInstanceMessage$Tags":null,
+        "CreateDBInstanceReadReplicaMessage$Tags":null,
+        "CreateDBParameterGroupMessage$Tags":null,
+        "CreateDBSecurityGroupMessage$Tags":null,
+        "CreateDBSnapshotMessage$Tags":null,
+        "CreateDBSubnetGroupMessage$Tags":null,
+        "CreateEventSubscriptionMessage$Tags":null,
+        "CreateOptionGroupMessage$Tags":null,
+        "PurchaseReservedDBInstancesOfferingMessage$Tags":null,
+        "RestoreDBClusterFromS3Message$Tags":null,
+        "RestoreDBClusterFromSnapshotMessage$Tags":"<p>The tags to be assigned to the restored DB cluster.</p>",
+        "RestoreDBClusterToPointInTimeMessage$Tags":null,
+        "RestoreDBInstanceFromDBSnapshotMessage$Tags":null,
+        "RestoreDBInstanceFromS3Message$Tags":"<p>A list of tags to associate with this DB instance. For more information, see <a href=\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html\">Tagging Amazon RDS Resources</a>. </p>",
+        "RestoreDBInstanceToPointInTimeMessage$Tags":null,
+        "TagListMessage$TagList":"<p>List of tags returned by the ListTagsForResource operation.</p>"
+      }
+    },
+    "TagListMessage":{
+      "base":"<p/>",
+      "refs":{
+      }
+    },
+    "Timezone":{
+      "base":"<p>A time zone associated with a <a>DBInstance</a> or a <a>DBSnapshot</a>. This data type is an element in the response to the <a>DescribeDBInstances</a>, the <a>DescribeDBSnapshots</a>, and the <a>DescribeDBEngineVersions</a> actions. </p>",
+      "refs":{
+        "SupportedTimezonesList$member":null
+      }
+    },
+    "UpgradeTarget":{
+      "base":"<p>The version of the database engine that a DB instance can be upgraded to.</p>",
+      "refs":{
+        "ValidUpgradeTargetList$member":null
+      }
+    },
+    "ValidDBInstanceModificationsMessage":{
+      "base":"<p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. You can use this information when you call <a>ModifyDBInstance</a>. </p>",
+      "refs":{
+        "DescribeValidDBInstanceModificationsResult$ValidDBInstanceModificationsMessage":null
+      }
+    },
+    "ValidStorageOptions":{
+      "base":"<p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. </p>",
+      "refs":{
+        "ValidStorageOptionsList$member":null
+      }
+    },
+    "ValidStorageOptionsList":{
+      "base":null,
+      "refs":{
+        "ValidDBInstanceModificationsMessage$Storage":"<p>Valid storage options for your DB instance. </p>"
+      }
+    },
+    "ValidUpgradeTargetList":{
+      "base":null,
+      "refs":{
+        "DBEngineVersion$ValidUpgradeTarget":"<p>A list of engine versions that this database engine version can be upgraded to.</p>"
+      }
+    },
+    "VpcSecurityGroupIdList":{
+      "base":null,
+      "refs":{
+        "CreateDBClusterMessage$VpcSecurityGroupIds":"<p>A list of EC2 VPC security groups to associate with this DB cluster.</p>",
+        "CreateDBInstanceMessage$VpcSecurityGroupIds":"<p>A list of EC2 VPC security groups to associate with this DB instance.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>CreateDBCluster</a>.</p> <p>Default: The default EC2 VPC security group for the DB subnet group's VPC.</p>",
+        "ModifyDBClusterMessage$VpcSecurityGroupIds":"<p>A list of VPC security groups that the DB cluster will belong to.</p>",
+        "ModifyDBInstanceMessage$VpcSecurityGroupIds":"<p>A list of EC2 VPC security groups to authorize on this DB instance. This change is asynchronously applied as soon as possible.</p> <p> <b>Amazon Aurora</b> </p> <p>Not applicable. The associated list of EC2 VPC security groups is managed by the DB cluster. For more information, see <a>ModifyDBCluster</a>.</p> <p>Constraints:</p> <ul> <li> <p>If supplied, must match existing VpcSecurityGroupIds.</p> </li> </ul>",
+        "OptionConfiguration$VpcSecurityGroupMemberships":"<p>A list of VpcSecurityGroupMemebrship name strings used for this option.</p>",
+        "RestoreDBClusterFromS3Message$VpcSecurityGroupIds":"<p>A list of EC2 VPC security groups to associate with the restored DB cluster.</p>",
+        "RestoreDBClusterFromSnapshotMessage$VpcSecurityGroupIds":"<p>A list of VPC security groups that the new DB cluster will belong to.</p>",
+        "RestoreDBClusterToPointInTimeMessage$VpcSecurityGroupIds":"<p>A list of VPC security groups that the new DB cluster belongs to.</p>",
+        "RestoreDBInstanceFromS3Message$VpcSecurityGroupIds":"<p>A list of VPC security groups to associate with this DB instance. </p>"
+      }
+    },
+    "VpcSecurityGroupMembership":{
+      "base":"<p>This data type is used as a response element for queries on VPC security group membership.</p>",
+      "refs":{
+        "VpcSecurityGroupMembershipList$member":null
+      }
+    },
+    "VpcSecurityGroupMembershipList":{
+      "base":null,
+      "refs":{
+        "DBCluster$VpcSecurityGroups":"<p>Provides a list of VPC security groups that the DB cluster belongs to.</p>",
+        "DBInstance$VpcSecurityGroups":"<p>Provides a list of VPC security group elements that the DB instance belongs to.</p>",
+        "Option$VpcSecurityGroupMemberships":"<p>If the option requires access to a port, then this VPC security group allows access to the port.</p>"
       }
     }
   }

--- a/models/apis/rds/2014-10-31/examples-1.json
+++ b/models/apis/rds/2014-10-31/examples-1.json
@@ -1,1950 +1,1950 @@
 {
-  "version": "1.0",
-  "examples": {
-    "AddSourceIdentifierToSubscription": [
+  "version":"1.0",
+  "examples":{
+    "AddSourceIdentifierToSubscription":[
       {
-        "input": {
-          "SourceIdentifier": "mymysqlinstance",
-          "SubscriptionName": "mymysqleventsubscription"
+        "input":{
+          "SourceIdentifier":"mymysqlinstance",
+          "SubscriptionName":"mymysqleventsubscription"
         },
-        "output": {
-          "EventSubscription": {
+        "output":{
+          "EventSubscription":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example add a source identifier to an event notification subscription.",
-        "id": "add-source-identifier-to-subscription-93fb6a15-0a59-4577-a7b5-e12db9752c14",
-        "title": "To add a source identifier to an event notification subscription"
+        "description":"This example add a source identifier to an event notification subscription.",
+        "id":"add-source-identifier-to-subscription-93fb6a15-0a59-4577-a7b5-e12db9752c14",
+        "title":"To add a source identifier to an event notification subscription"
       }
     ],
-    "AddTagsToResource": [
+    "AddTagsToResource":[
       {
-        "input": {
-          "ResourceName": "arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup",
-          "Tags": [
+        "input":{
+          "ResourceName":"arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup",
+          "Tags":[
             {
-              "Key": "Staging",
-              "Value": "LocationDB"
+              "Key":"Staging",
+              "Value":"LocationDB"
             }
           ]
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example adds a tag to an option group.",
-        "id": "add-tags-to-resource-fa99ef50-228b-449d-b893-ca4d4e9768ab",
-        "title": "To add tags to a resource"
+        "description":"This example adds a tag to an option group.",
+        "id":"add-tags-to-resource-fa99ef50-228b-449d-b893-ca4d4e9768ab",
+        "title":"To add tags to a resource"
       }
     ],
-    "ApplyPendingMaintenanceAction": [
+    "ApplyPendingMaintenanceAction":[
       {
-        "input": {
-          "ApplyAction": "system-update",
-          "OptInType": "immediate",
-          "ResourceIdentifier": "arn:aws:rds:us-east-1:992648334831:db:mymysqlinstance"
+        "input":{
+          "ApplyAction":"system-update",
+          "OptInType":"immediate",
+          "ResourceIdentifier":"arn:aws:rds:us-east-1:992648334831:db:mymysqlinstance"
         },
-        "output": {
-          "ResourcePendingMaintenanceActions": {
+        "output":{
+          "ResourcePendingMaintenanceActions":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example immediately applies a pending system update to a DB instance.",
-        "id": "apply-pending-maintenance-action-2a026047-8bbb-47fc-b695-abad9f308c24",
-        "title": "To apply a pending maintenance action"
+        "description":"This example immediately applies a pending system update to a DB instance.",
+        "id":"apply-pending-maintenance-action-2a026047-8bbb-47fc-b695-abad9f308c24",
+        "title":"To apply a pending maintenance action"
       }
     ],
-    "AuthorizeDBSecurityGroupIngress": [
+    "AuthorizeDBSecurityGroupIngress":[
       {
-        "input": {
-          "CIDRIP": "203.0.113.5/32",
-          "DBSecurityGroupName": "mydbsecuritygroup"
+        "input":{
+          "CIDRIP":"203.0.113.5/32",
+          "DBSecurityGroupName":"mydbsecuritygroup"
         },
-        "output": {
-          "DBSecurityGroup": {
+        "output":{
+          "DBSecurityGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example authorizes access to the specified security group by the specified CIDR block.",
-        "id": "authorize-db-security-group-ingress-ebf9ab91-8912-4b07-a32e-ca150668164f",
-        "title": "To authorize DB security group integress"
+        "description":"This example authorizes access to the specified security group by the specified CIDR block.",
+        "id":"authorize-db-security-group-ingress-ebf9ab91-8912-4b07-a32e-ca150668164f",
+        "title":"To authorize DB security group integress"
       }
     ],
-    "CopyDBClusterParameterGroup": [
+    "CopyDBClusterParameterGroup":[
       {
-        "input": {
-          "SourceDBClusterParameterGroupIdentifier": "mydbclusterparametergroup",
-          "TargetDBClusterParameterGroupDescription": "My DB cluster parameter group copy",
-          "TargetDBClusterParameterGroupIdentifier": "mydbclusterparametergroup-copy"
+        "input":{
+          "SourceDBClusterParameterGroupIdentifier":"mydbclusterparametergroup",
+          "TargetDBClusterParameterGroupDescription":"My DB cluster parameter group copy",
+          "TargetDBClusterParameterGroupIdentifier":"mydbclusterparametergroup-copy"
         },
-        "output": {
-          "DBClusterParameterGroup": {
+        "output":{
+          "DBClusterParameterGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example copies a DB cluster parameter group.",
-        "id": "copy-db-cluster-parameter-group-6fefaffe-cde9-4dba-9f0b-d3f593572fe4",
-        "title": "To copy a DB cluster parameter group"
+        "description":"This example copies a DB cluster parameter group.",
+        "id":"copy-db-cluster-parameter-group-6fefaffe-cde9-4dba-9f0b-d3f593572fe4",
+        "title":"To copy a DB cluster parameter group"
       }
     ],
-    "CopyDBClusterSnapshot": [
+    "CopyDBClusterSnapshot":[
       {
-        "input": {
-          "SourceDBClusterSnapshotIdentifier": "rds:sample-cluster-2016-09-14-10-38",
-          "TargetDBClusterSnapshotIdentifier": "cluster-snapshot-copy-1"
+        "input":{
+          "SourceDBClusterSnapshotIdentifier":"rds:sample-cluster-2016-09-14-10-38",
+          "TargetDBClusterSnapshotIdentifier":"cluster-snapshot-copy-1"
         },
-        "output": {
-          "DBClusterSnapshot": {
+        "output":{
+          "DBClusterSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example copies an automated snapshot of a DB cluster to a new DB cluster snapshot.",
-        "id": "to-copy-a-db-cluster-snapshot-1473879770564",
-        "title": "To copy a DB cluster snapshot"
+        "description":"The following example copies an automated snapshot of a DB cluster to a new DB cluster snapshot.",
+        "id":"to-copy-a-db-cluster-snapshot-1473879770564",
+        "title":"To copy a DB cluster snapshot"
       }
     ],
-    "CopyDBParameterGroup": [
+    "CopyDBParameterGroup":[
       {
-        "input": {
-          "SourceDBParameterGroupIdentifier": "mymysqlparametergroup",
-          "TargetDBParameterGroupDescription": "My MySQL parameter group copy",
-          "TargetDBParameterGroupIdentifier": "mymysqlparametergroup-copy"
+        "input":{
+          "SourceDBParameterGroupIdentifier":"mymysqlparametergroup",
+          "TargetDBParameterGroupDescription":"My MySQL parameter group copy",
+          "TargetDBParameterGroupIdentifier":"mymysqlparametergroup-copy"
         },
-        "output": {
-          "DBParameterGroup": {
+        "output":{
+          "DBParameterGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example copies a DB parameter group.",
-        "id": "copy-db-parameter-group-610d4dba-2c87-467f-ae5d-edd7f8e47349",
-        "title": "To copy a DB parameter group"
+        "description":"This example copies a DB parameter group.",
+        "id":"copy-db-parameter-group-610d4dba-2c87-467f-ae5d-edd7f8e47349",
+        "title":"To copy a DB parameter group"
       }
     ],
-    "CopyDBSnapshot": [
+    "CopyDBSnapshot":[
       {
-        "input": {
-          "SourceDBSnapshotIdentifier": "mydbsnapshot",
-          "TargetDBSnapshotIdentifier": "mydbsnapshot-copy"
+        "input":{
+          "SourceDBSnapshotIdentifier":"mydbsnapshot",
+          "TargetDBSnapshotIdentifier":"mydbsnapshot-copy"
         },
-        "output": {
-          "DBSnapshot": {
+        "output":{
+          "DBSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example copies a DB snapshot.",
-        "id": "copy-db-snapshot-1b2f0210-bc67-415d-9822-6eecf447dc86",
-        "title": "To copy a DB snapshot"
+        "description":"This example copies a DB snapshot.",
+        "id":"copy-db-snapshot-1b2f0210-bc67-415d-9822-6eecf447dc86",
+        "title":"To copy a DB snapshot"
       }
     ],
-    "CopyOptionGroup": [
+    "CopyOptionGroup":[
       {
-        "input": {
-          "SourceOptionGroupIdentifier": "mymysqloptiongroup",
-          "TargetOptionGroupDescription": "My MySQL option group copy",
-          "TargetOptionGroupIdentifier": "mymysqloptiongroup-copy"
+        "input":{
+          "SourceOptionGroupIdentifier":"mymysqloptiongroup",
+          "TargetOptionGroupDescription":"My MySQL option group copy",
+          "TargetOptionGroupIdentifier":"mymysqloptiongroup-copy"
         },
-        "output": {
-          "OptionGroup": {
+        "output":{
+          "OptionGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example copies an option group.",
-        "id": "copy-option-group-8d5c01c3-8846-4e9c-a4b0-1b7237f7d0ec",
-        "title": "To copy an option group"
+        "description":"This example copies an option group.",
+        "id":"copy-option-group-8d5c01c3-8846-4e9c-a4b0-1b7237f7d0ec",
+        "title":"To copy an option group"
       }
     ],
-    "CreateDBCluster": [
+    "CreateDBCluster":[
       {
-        "input": {
-          "AvailabilityZones": [
+        "input":{
+          "AvailabilityZones":[
             "us-east-1a"
           ],
-          "BackupRetentionPeriod": 1,
-          "DBClusterIdentifier": "mydbcluster",
-          "DBClusterParameterGroupName": "mydbclusterparametergroup",
-          "DatabaseName": "myauroradb",
-          "Engine": "aurora",
-          "EngineVersion": "5.6.10a",
-          "MasterUserPassword": "mypassword",
-          "MasterUsername": "myuser",
-          "Port": 3306,
-          "StorageEncrypted": true
+          "BackupRetentionPeriod":1,
+          "DBClusterIdentifier":"mydbcluster",
+          "DBClusterParameterGroupName":"mydbclusterparametergroup",
+          "DatabaseName":"myauroradb",
+          "Engine":"aurora",
+          "EngineVersion":"5.6.10a",
+          "MasterUserPassword":"mypassword",
+          "MasterUsername":"myuser",
+          "Port":3306,
+          "StorageEncrypted":true
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB cluster.",
-        "id": "create-db-cluster-423b998d-eba9-40dd-8e19-96c5b6e5f31d",
-        "title": "To create a DB cluster"
+        "description":"This example creates a DB cluster.",
+        "id":"create-db-cluster-423b998d-eba9-40dd-8e19-96c5b6e5f31d",
+        "title":"To create a DB cluster"
       }
     ],
-    "CreateDBClusterParameterGroup": [
+    "CreateDBClusterParameterGroup":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup",
-          "DBParameterGroupFamily": "aurora5.6",
-          "Description": "My DB cluster parameter group"
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup",
+          "DBParameterGroupFamily":"aurora5.6",
+          "Description":"My DB cluster parameter group"
         },
-        "output": {
-          "DBClusterParameterGroup": {
+        "output":{
+          "DBClusterParameterGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB cluster parameter group.",
-        "id": "create-db-cluster-parameter-group-8eb1c3ae-1965-4262-afe3-ee134c4430b1",
-        "title": "To create a DB cluster parameter group"
+        "description":"This example creates a DB cluster parameter group.",
+        "id":"create-db-cluster-parameter-group-8eb1c3ae-1965-4262-afe3-ee134c4430b1",
+        "title":"To create a DB cluster parameter group"
       }
     ],
-    "CreateDBClusterSnapshot": [
+    "CreateDBClusterSnapshot":[
       {
-        "input": {
-          "DBClusterIdentifier": "mydbcluster",
-          "DBClusterSnapshotIdentifier": "mydbclustersnapshot"
+        "input":{
+          "DBClusterIdentifier":"mydbcluster",
+          "DBClusterSnapshotIdentifier":"mydbclustersnapshot"
         },
-        "output": {
-          "DBClusterSnapshot": {
+        "output":{
+          "DBClusterSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB cluster snapshot.",
-        "id": "create-db-cluster-snapshot-",
-        "title": "To create a DB cluster snapshot"
+        "description":"This example creates a DB cluster snapshot.",
+        "id":"create-db-cluster-snapshot-",
+        "title":"To create a DB cluster snapshot"
       }
     ],
-    "CreateDBInstance": [
+    "CreateDBInstance":[
       {
-        "input": {
-          "AllocatedStorage": 5,
-          "DBInstanceClass": "db.t2.micro",
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "Engine": "MySQL",
-          "MasterUserPassword": "MyPassword",
-          "MasterUsername": "MyUser"
+        "input":{
+          "AllocatedStorage":5,
+          "DBInstanceClass":"db.t2.micro",
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "Engine":"MySQL",
+          "MasterUserPassword":"MyPassword",
+          "MasterUsername":"MyUser"
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB instance.",
-        "id": "create-db-instance-57eb5d16-8bf8-4c84-9709-1700322b37b9",
-        "title": "To create a DB instance."
+        "description":"This example creates a DB instance.",
+        "id":"create-db-instance-57eb5d16-8bf8-4c84-9709-1700322b37b9",
+        "title":"To create a DB instance."
       }
     ],
-    "CreateDBInstanceReadReplica": [
+    "CreateDBInstanceReadReplica":[
       {
-        "input": {
-          "AvailabilityZone": "us-east-1a",
-          "CopyTagsToSnapshot": true,
-          "DBInstanceClass": "db.t2.micro",
-          "DBInstanceIdentifier": "mydbreadreplica",
-          "PubliclyAccessible": true,
-          "SourceDBInstanceIdentifier": "mymysqlinstance",
-          "StorageType": "gp2",
-          "Tags": [
+        "input":{
+          "AvailabilityZone":"us-east-1a",
+          "CopyTagsToSnapshot":true,
+          "DBInstanceClass":"db.t2.micro",
+          "DBInstanceIdentifier":"mydbreadreplica",
+          "PubliclyAccessible":true,
+          "SourceDBInstanceIdentifier":"mymysqlinstance",
+          "StorageType":"gp2",
+          "Tags":[
             {
-              "Key": "mydbreadreplicakey",
-              "Value": "mydbreadreplicavalue"
+              "Key":"mydbreadreplicakey",
+              "Value":"mydbreadreplicavalue"
             }
           ]
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB instance read replica.",
-        "id": "create-db-instance-read-replica-81b41cd5-2871-4dae-bc59-3e264449d5fe",
-        "title": "To create a DB instance read replica."
+        "description":"This example creates a DB instance read replica.",
+        "id":"create-db-instance-read-replica-81b41cd5-2871-4dae-bc59-3e264449d5fe",
+        "title":"To create a DB instance read replica."
       }
     ],
-    "CreateDBParameterGroup": [
+    "CreateDBParameterGroup":[
       {
-        "input": {
-          "DBParameterGroupFamily": "mysql5.6",
-          "DBParameterGroupName": "mymysqlparametergroup",
-          "Description": "My MySQL parameter group"
+        "input":{
+          "DBParameterGroupFamily":"mysql5.6",
+          "DBParameterGroupName":"mymysqlparametergroup",
+          "Description":"My MySQL parameter group"
         },
-        "output": {
-          "DBParameterGroup": {
+        "output":{
+          "DBParameterGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB parameter group.",
-        "id": "create-db-parameter-group-42afcc37-12e9-4b6a-a55c-b8a141246e87",
-        "title": "To create a DB parameter group."
+        "description":"This example creates a DB parameter group.",
+        "id":"create-db-parameter-group-42afcc37-12e9-4b6a-a55c-b8a141246e87",
+        "title":"To create a DB parameter group."
       }
     ],
-    "CreateDBSecurityGroup": [
+    "CreateDBSecurityGroup":[
       {
-        "input": {
-          "DBSecurityGroupDescription": "My DB security group",
-          "DBSecurityGroupName": "mydbsecuritygroup"
+        "input":{
+          "DBSecurityGroupDescription":"My DB security group",
+          "DBSecurityGroupName":"mydbsecuritygroup"
         },
-        "output": {
-          "DBSecurityGroup": {
+        "output":{
+          "DBSecurityGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB security group.",
-        "id": "create-db-security-group-41b6786a-539e-42a5-a645-a8bc3cf99353",
-        "title": "To create a DB security group."
+        "description":"This example creates a DB security group.",
+        "id":"create-db-security-group-41b6786a-539e-42a5-a645-a8bc3cf99353",
+        "title":"To create a DB security group."
       }
     ],
-    "CreateDBSnapshot": [
+    "CreateDBSnapshot":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "DBSnapshotIdentifier": "mydbsnapshot"
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "DBSnapshotIdentifier":"mydbsnapshot"
         },
-        "output": {
-          "DBSnapshot": {
+        "output":{
+          "DBSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB snapshot.",
-        "id": "create-db-snapshot-e10e0e2c-9ac4-426d-9b17-6b6a3e382ce2",
-        "title": "To create a DB snapshot."
+        "description":"This example creates a DB snapshot.",
+        "id":"create-db-snapshot-e10e0e2c-9ac4-426d-9b17-6b6a3e382ce2",
+        "title":"To create a DB snapshot."
       }
     ],
-    "CreateDBSubnetGroup": [
+    "CreateDBSubnetGroup":[
       {
-        "input": {
-          "DBSubnetGroupDescription": "My DB subnet group",
-          "DBSubnetGroupName": "mydbsubnetgroup",
-          "SubnetIds": [
+        "input":{
+          "DBSubnetGroupDescription":"My DB subnet group",
+          "DBSubnetGroupName":"mydbsubnetgroup",
+          "SubnetIds":[
             "subnet-1fab8a69",
             "subnet-d43a468c"
           ]
         },
-        "output": {
-          "DBSubnetGroup": {
+        "output":{
+          "DBSubnetGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates a DB subnet group.",
-        "id": "create-db-subnet-group-c3d162c2-0ec4-4955-ba89-18967615fdb8",
-        "title": "To create a DB subnet group."
+        "description":"This example creates a DB subnet group.",
+        "id":"create-db-subnet-group-c3d162c2-0ec4-4955-ba89-18967615fdb8",
+        "title":"To create a DB subnet group."
       }
     ],
-    "CreateEventSubscription": [
+    "CreateEventSubscription":[
       {
-        "input": {
-          "Enabled": true,
-          "EventCategories": [
+        "input":{
+          "Enabled":true,
+          "EventCategories":[
             "availability"
           ],
-          "SnsTopicArn": "arn:aws:sns:us-east-1:992648334831:MyDemoSNSTopic",
-          "SourceIds": [
+          "SnsTopicArn":"arn:aws:sns:us-east-1:992648334831:MyDemoSNSTopic",
+          "SourceIds":[
             "mymysqlinstance"
           ],
-          "SourceType": "db-instance",
-          "SubscriptionName": "mymysqleventsubscription"
+          "SourceType":"db-instance",
+          "SubscriptionName":"mymysqleventsubscription"
         },
-        "output": {
-          "EventSubscription": {
+        "output":{
+          "EventSubscription":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates an event notification subscription.",
-        "id": "create-event-subscription-00dd0ee6-0e0f-4a38-ae83-e5f2ded5f69a",
-        "title": "To create an event notification subscription"
+        "description":"This example creates an event notification subscription.",
+        "id":"create-event-subscription-00dd0ee6-0e0f-4a38-ae83-e5f2ded5f69a",
+        "title":"To create an event notification subscription"
       }
     ],
-    "CreateOptionGroup": [
+    "CreateOptionGroup":[
       {
-        "input": {
-          "EngineName": "MySQL",
-          "MajorEngineVersion": "5.6",
-          "OptionGroupDescription": "My MySQL 5.6 option group",
-          "OptionGroupName": "mymysqloptiongroup"
+        "input":{
+          "EngineName":"MySQL",
+          "MajorEngineVersion":"5.6",
+          "OptionGroupDescription":"My MySQL 5.6 option group",
+          "OptionGroupName":"mymysqloptiongroup"
         },
-        "output": {
-          "OptionGroup": {
+        "output":{
+          "OptionGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example creates an option group.",
-        "id": "create-option-group-a7708c87-1b79-4a5e-a762-21cf8fc62b78",
-        "title": "To create an option group"
+        "description":"This example creates an option group.",
+        "id":"create-option-group-a7708c87-1b79-4a5e-a762-21cf8fc62b78",
+        "title":"To create an option group"
       }
     ],
-    "DeleteDBCluster": [
+    "DeleteDBCluster":[
       {
-        "input": {
-          "DBClusterIdentifier": "mydbcluster",
-          "SkipFinalSnapshot": true
+        "input":{
+          "DBClusterIdentifier":"mydbcluster",
+          "SkipFinalSnapshot":true
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB cluster.",
-        "id": "delete-db-cluster-927fc2c8-6c67-4075-b1ba-75490be0f7d6",
-        "title": "To delete a DB cluster."
+        "description":"This example deletes the specified DB cluster.",
+        "id":"delete-db-cluster-927fc2c8-6c67-4075-b1ba-75490be0f7d6",
+        "title":"To delete a DB cluster."
       }
     ],
-    "DeleteDBClusterParameterGroup": [
+    "DeleteDBClusterParameterGroup":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup"
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup"
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB cluster parameter group.",
-        "id": "delete-db-cluster-parameter-group-364f5555-ba0a-4cc8-979c-e769098924fc",
-        "title": "To delete a DB cluster parameter group."
+        "description":"This example deletes the specified DB cluster parameter group.",
+        "id":"delete-db-cluster-parameter-group-364f5555-ba0a-4cc8-979c-e769098924fc",
+        "title":"To delete a DB cluster parameter group."
       }
     ],
-    "DeleteDBClusterSnapshot": [
+    "DeleteDBClusterSnapshot":[
       {
-        "input": {
-          "DBClusterSnapshotIdentifier": "mydbclustersnapshot"
+        "input":{
+          "DBClusterSnapshotIdentifier":"mydbclustersnapshot"
         },
-        "output": {
-          "DBClusterSnapshot": {
+        "output":{
+          "DBClusterSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB cluster snapshot.",
-        "id": "delete-db-cluster-snapshot-c67e0d95-670e-4fb5-af90-6d9a70a91b07",
-        "title": "To delete a DB cluster snapshot."
+        "description":"This example deletes the specified DB cluster snapshot.",
+        "id":"delete-db-cluster-snapshot-c67e0d95-670e-4fb5-af90-6d9a70a91b07",
+        "title":"To delete a DB cluster snapshot."
       }
     ],
-    "DeleteDBInstance": [
+    "DeleteDBInstance":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "SkipFinalSnapshot": true
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "SkipFinalSnapshot":true
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB instance.",
-        "id": "delete-db-instance-4412e650-949c-488a-b32a-7d3038ebccc4",
-        "title": "To delete a DB instance."
+        "description":"This example deletes the specified DB instance.",
+        "id":"delete-db-instance-4412e650-949c-488a-b32a-7d3038ebccc4",
+        "title":"To delete a DB instance."
       }
     ],
-    "DeleteDBParameterGroup": [
+    "DeleteDBParameterGroup":[
       {
-        "input": {
-          "DBParameterGroupName": "mydbparamgroup3"
+        "input":{
+          "DBParameterGroupName":"mydbparamgroup3"
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example deletes a DB parameter group.",
-        "id": "to-delete-a-db-parameter-group-1473888796509",
-        "title": "To delete a DB parameter group"
+        "description":"The following example deletes a DB parameter group.",
+        "id":"to-delete-a-db-parameter-group-1473888796509",
+        "title":"To delete a DB parameter group"
       }
     ],
-    "DeleteDBSecurityGroup": [
+    "DeleteDBSecurityGroup":[
       {
-        "input": {
-          "DBSecurityGroupName": "mysecgroup"
+        "input":{
+          "DBSecurityGroupName":"mysecgroup"
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example deletes a DB security group.",
-        "id": "to-delete-a-db-security-group-1473960141889",
-        "title": "To delete a DB security group"
+        "description":"The following example deletes a DB security group.",
+        "id":"to-delete-a-db-security-group-1473960141889",
+        "title":"To delete a DB security group"
       }
     ],
-    "DeleteDBSnapshot": [
+    "DeleteDBSnapshot":[
       {
-        "input": {
-          "DBSnapshotIdentifier": "mydbsnapshot"
+        "input":{
+          "DBSnapshotIdentifier":"mydbsnapshot"
         },
-        "output": {
-          "DBSnapshot": {
+        "output":{
+          "DBSnapshot":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB snapshot.",
-        "id": "delete-db-snapshot-505d6b4e-8ced-479c-856a-c460a33fe07b",
-        "title": "To delete a DB cluster snapshot."
+        "description":"This example deletes the specified DB snapshot.",
+        "id":"delete-db-snapshot-505d6b4e-8ced-479c-856a-c460a33fe07b",
+        "title":"To delete a DB cluster snapshot."
       }
     ],
-    "DeleteDBSubnetGroup": [
+    "DeleteDBSubnetGroup":[
       {
-        "input": {
-          "DBSubnetGroupName": "mydbsubnetgroup"
+        "input":{
+          "DBSubnetGroupName":"mydbsubnetgroup"
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB subnetgroup.",
-        "id": "delete-db-subnet-group-4ae00375-511e-443d-a01d-4b9f552244aa",
-        "title": "To delete a DB subnet group."
+        "description":"This example deletes the specified DB subnetgroup.",
+        "id":"delete-db-subnet-group-4ae00375-511e-443d-a01d-4b9f552244aa",
+        "title":"To delete a DB subnet group."
       }
     ],
-    "DeleteEventSubscription": [
+    "DeleteEventSubscription":[
       {
-        "input": {
-          "SubscriptionName": "myeventsubscription"
+        "input":{
+          "SubscriptionName":"myeventsubscription"
         },
-        "output": {
-          "EventSubscription": {
+        "output":{
+          "EventSubscription":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified DB event subscription.",
-        "id": "delete-db-event-subscription-d33567e3-1d5d-48ff-873f-0270453f4a75",
-        "title": "To delete a DB event subscription."
+        "description":"This example deletes the specified DB event subscription.",
+        "id":"delete-db-event-subscription-d33567e3-1d5d-48ff-873f-0270453f4a75",
+        "title":"To delete a DB event subscription."
       }
     ],
-    "DeleteOptionGroup": [
+    "DeleteOptionGroup":[
       {
-        "input": {
-          "OptionGroupName": "mydboptiongroup"
+        "input":{
+          "OptionGroupName":"mydboptiongroup"
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example deletes the specified option group.",
-        "id": "delete-db-option-group-578be2be-3095-431a-9ea4-9a3c3b0daef4",
-        "title": "To delete an option group."
+        "description":"This example deletes the specified option group.",
+        "id":"delete-db-option-group-578be2be-3095-431a-9ea4-9a3c3b0daef4",
+        "title":"To delete an option group."
       }
     ],
-    "DescribeAccountAttributes": [
+    "DescribeAccountAttributes":[
       {
-        "input": {
+        "input":{
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists account attributes.",
-        "id": "describe-account-attributes-683d3ff7-5524-421a-8da5-e88f1ea2222b",
-        "title": "To list account attributes"
+        "description":"This example lists account attributes.",
+        "id":"describe-account-attributes-683d3ff7-5524-421a-8da5-e88f1ea2222b",
+        "title":"To list account attributes"
       }
     ],
-    "DescribeCertificates": [
+    "DescribeCertificates":[
       {
-        "input": {
-          "CertificateIdentifier": "rds-ca-2015",
-          "MaxRecords": 20
+        "input":{
+          "CertificateIdentifier":"rds-ca-2015",
+          "MaxRecords":20
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists up to 20 certificates for the specified certificate identifier.",
-        "id": "describe-certificates-9d71a70d-7908-4444-b43f-321d842c62dc",
-        "title": "To list certificates"
+        "description":"This example lists up to 20 certificates for the specified certificate identifier.",
+        "id":"describe-certificates-9d71a70d-7908-4444-b43f-321d842c62dc",
+        "title":"To list certificates"
       }
     ],
-    "DescribeDBClusterParameterGroups": [
+    "DescribeDBClusterParameterGroups":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup"
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified DB cluster parameter group.",
-        "id": "describe-db-cluster-parameter-groups-cf9c6e66-664e-4f57-8e29-a9080abfc013",
-        "title": "To list DB cluster parameter group settings"
+        "description":"This example lists settings for the specified DB cluster parameter group.",
+        "id":"describe-db-cluster-parameter-groups-cf9c6e66-664e-4f57-8e29-a9080abfc013",
+        "title":"To list DB cluster parameter group settings"
       }
     ],
-    "DescribeDBClusterParameters": [
+    "DescribeDBClusterParameters":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup",
-          "Source": "system"
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup",
+          "Source":"system"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists system parameters for the specified DB cluster parameter group.",
-        "id": "describe-db-cluster-parameters-98043c28-e489-41a7-b118-bfd96dc779a1",
-        "title": "To list DB cluster parameters"
+        "description":"This example lists system parameters for the specified DB cluster parameter group.",
+        "id":"describe-db-cluster-parameters-98043c28-e489-41a7-b118-bfd96dc779a1",
+        "title":"To list DB cluster parameters"
       }
     ],
-    "DescribeDBClusterSnapshotAttributes": [
+    "DescribeDBClusterSnapshotAttributes":[
       {
-        "input": {
-          "DBClusterSnapshotIdentifier": "mydbclustersnapshot"
+        "input":{
+          "DBClusterSnapshotIdentifier":"mydbclustersnapshot"
         },
-        "output": {
-          "DBClusterSnapshotAttributesResult": {
+        "output":{
+          "DBClusterSnapshotAttributesResult":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists attributes for the specified DB cluster snapshot.",
-        "id": "describe-db-cluster-snapshot-attributes-6752ade3-0c7b-4b06-a8e4-b76bf4e2d3571",
-        "title": "To list DB cluster snapshot attributes"
+        "description":"This example lists attributes for the specified DB cluster snapshot.",
+        "id":"describe-db-cluster-snapshot-attributes-6752ade3-0c7b-4b06-a8e4-b76bf4e2d3571",
+        "title":"To list DB cluster snapshot attributes"
       }
     ],
-    "DescribeDBClusterSnapshots": [
+    "DescribeDBClusterSnapshots":[
       {
-        "input": {
-          "DBClusterSnapshotIdentifier": "mydbclustersnapshot",
-          "SnapshotType": "manual"
+        "input":{
+          "DBClusterSnapshotIdentifier":"mydbclustersnapshot",
+          "SnapshotType":"manual"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified, manually-created cluster snapshot.",
-        "id": "describe-db-cluster-snapshots-52f38af1-3431-4a51-9a6a-e6bb8c961b32",
-        "title": "To list DB cluster snapshots"
+        "description":"This example lists settings for the specified, manually-created cluster snapshot.",
+        "id":"describe-db-cluster-snapshots-52f38af1-3431-4a51-9a6a-e6bb8c961b32",
+        "title":"To list DB cluster snapshots"
       }
     ],
-    "DescribeDBClusters": [
+    "DescribeDBClusters":[
       {
-        "input": {
-          "DBClusterIdentifier": "mynewdbcluster"
+        "input":{
+          "DBClusterIdentifier":"mynewdbcluster"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified DB cluster.",
-        "id": "describe-db-clusters-7aae8861-cb95-4b3b-9042-f62df7698635",
-        "title": "To list DB clusters"
+        "description":"This example lists settings for the specified DB cluster.",
+        "id":"describe-db-clusters-7aae8861-cb95-4b3b-9042-f62df7698635",
+        "title":"To list DB clusters"
       }
     ],
-    "DescribeDBEngineVersions": [
+    "DescribeDBEngineVersions":[
       {
-        "input": {
-          "DBParameterGroupFamily": "mysql5.6",
-          "DefaultOnly": true,
-          "Engine": "mysql",
-          "EngineVersion": "5.6",
-          "ListSupportedCharacterSets": true
+        "input":{
+          "DBParameterGroupFamily":"mysql5.6",
+          "DefaultOnly":true,
+          "Engine":"mysql",
+          "EngineVersion":"5.6",
+          "ListSupportedCharacterSets":true
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified DB engine version.",
-        "id": "describe-db-engine-versions-8e698cf2-2162-425a-a854-111cdaceb52b",
-        "title": "To list DB engine version settings"
+        "description":"This example lists settings for the specified DB engine version.",
+        "id":"describe-db-engine-versions-8e698cf2-2162-425a-a854-111cdaceb52b",
+        "title":"To list DB engine version settings"
       }
     ],
-    "DescribeDBInstances": [
+    "DescribeDBInstances":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance"
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified DB instance.",
-        "id": "describe-db-instances-0e11a8c5-4ec3-4463-8cbf-f7254d04c4fc",
-        "title": "To list DB instance settings"
+        "description":"This example lists settings for the specified DB instance.",
+        "id":"describe-db-instances-0e11a8c5-4ec3-4463-8cbf-f7254d04c4fc",
+        "title":"To list DB instance settings"
       }
     ],
-    "DescribeDBLogFiles": [
+    "DescribeDBLogFiles":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "FileLastWritten": 1470873600000,
-          "FileSize": 0,
-          "FilenameContains": "error"
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "FileLastWritten":1470873600000,
+          "FileSize":0,
+          "FilenameContains":"error"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists matching log file names for the specified DB instance, file name pattern, last write date in POSIX time with milleseconds, and minimum file size.",
-        "id": "describe-db-log-files-5f002d8d-5c1d-44c2-b5f4-bd284c0f1285",
-        "title": "To list DB log file names"
+        "description":"This example lists matching log file names for the specified DB instance, file name pattern, last write date in POSIX time with milleseconds, and minimum file size.",
+        "id":"describe-db-log-files-5f002d8d-5c1d-44c2-b5f4-bd284c0f1285",
+        "title":"To list DB log file names"
       }
     ],
-    "DescribeDBParameterGroups": [
+    "DescribeDBParameterGroups":[
       {
-        "input": {
-          "DBParameterGroupName": "mymysqlparametergroup"
+        "input":{
+          "DBParameterGroupName":"mymysqlparametergroup"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information about the specified DB parameter group.",
-        "id": "describe-db-parameter-groups-",
-        "title": "To list information about DB parameter groups"
+        "description":"This example lists information about the specified DB parameter group.",
+        "id":"describe-db-parameter-groups-",
+        "title":"To list information about DB parameter groups"
       }
     ],
-    "DescribeDBParameters": [
+    "DescribeDBParameters":[
       {
-        "input": {
-          "DBParameterGroupName": "mymysqlparametergroup",
-          "MaxRecords": 20,
-          "Source": "system"
+        "input":{
+          "DBParameterGroupName":"mymysqlparametergroup",
+          "MaxRecords":20,
+          "Source":"system"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for up to the first 20 system parameters for the specified DB parameter group.",
-        "id": "describe-db-parameters-09db4201-ef4f-4d97-a4b5-d71c0715b901",
-        "title": "To list information about DB parameters"
+        "description":"This example lists information for up to the first 20 system parameters for the specified DB parameter group.",
+        "id":"describe-db-parameters-09db4201-ef4f-4d97-a4b5-d71c0715b901",
+        "title":"To list information about DB parameters"
       }
     ],
-    "DescribeDBSecurityGroups": [
+    "DescribeDBSecurityGroups":[
       {
-        "input": {
-          "DBSecurityGroupName": "mydbsecuritygroup"
+        "input":{
+          "DBSecurityGroupName":"mydbsecuritygroup"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists settings for the specified security group.",
-        "id": "describe-db-security-groups-66fe9ea1-17dd-4275-b82e-f771cee0c849",
-        "title": "To list DB security group settings"
+        "description":"This example lists settings for the specified security group.",
+        "id":"describe-db-security-groups-66fe9ea1-17dd-4275-b82e-f771cee0c849",
+        "title":"To list DB security group settings"
       }
     ],
-    "DescribeDBSnapshotAttributes": [
+    "DescribeDBSnapshotAttributes":[
       {
-        "input": {
-          "DBSnapshotIdentifier": "mydbsnapshot"
+        "input":{
+          "DBSnapshotIdentifier":"mydbsnapshot"
         },
-        "output": {
-          "DBSnapshotAttributesResult": {
+        "output":{
+          "DBSnapshotAttributesResult":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists attributes for the specified DB snapshot.",
-        "id": "describe-db-snapshot-attributes-1d4fb750-34f6-4e43-8b3d-b2751d796a95",
-        "title": "To list DB snapshot attributes"
+        "description":"This example lists attributes for the specified DB snapshot.",
+        "id":"describe-db-snapshot-attributes-1d4fb750-34f6-4e43-8b3d-b2751d796a95",
+        "title":"To list DB snapshot attributes"
       }
     ],
-    "DescribeDBSnapshots": [
+    "DescribeDBSnapshots":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "IncludePublic": false,
-          "IncludeShared": true,
-          "SnapshotType": "manual"
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "IncludePublic":false,
+          "IncludeShared":true,
+          "SnapshotType":"manual"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists all manually-created, shared snapshots for the specified DB instance.",
-        "id": "describe-db-snapshots-2c935989-a1ef-4c85-aea4-1d0f45f17f26",
-        "title": "To list DB snapshot attributes"
+        "description":"This example lists all manually-created, shared snapshots for the specified DB instance.",
+        "id":"describe-db-snapshots-2c935989-a1ef-4c85-aea4-1d0f45f17f26",
+        "title":"To list DB snapshot attributes"
       }
     ],
-    "DescribeDBSubnetGroups": [
+    "DescribeDBSubnetGroups":[
       {
-        "input": {
-          "DBSubnetGroupName": "mydbsubnetgroup"
+        "input":{
+          "DBSubnetGroupName":"mydbsubnetgroup"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information about the specified DB subnet group.",
-        "id": "describe-db-subnet-groups-1d97b340-682f-4dd6-9653-8ed72a8d1221",
-        "title": "To list information about DB subnet groups"
+        "description":"This example lists information about the specified DB subnet group.",
+        "id":"describe-db-subnet-groups-1d97b340-682f-4dd6-9653-8ed72a8d1221",
+        "title":"To list information about DB subnet groups"
       }
     ],
-    "DescribeEngineDefaultClusterParameters": [
+    "DescribeEngineDefaultClusterParameters":[
       {
-        "input": {
-          "DBParameterGroupFamily": "aurora5.6"
+        "input":{
+          "DBParameterGroupFamily":"aurora5.6"
         },
-        "output": {
-          "EngineDefaults": {
+        "output":{
+          "EngineDefaults":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists default parameters for the specified DB cluster engine.",
-        "id": "describe-engine-default-cluster-parameters-f130374a-7bee-434b-b51d-da20b6e000e0",
-        "title": "To list default parameters for a DB cluster engine"
+        "description":"This example lists default parameters for the specified DB cluster engine.",
+        "id":"describe-engine-default-cluster-parameters-f130374a-7bee-434b-b51d-da20b6e000e0",
+        "title":"To list default parameters for a DB cluster engine"
       }
     ],
-    "DescribeEngineDefaultParameters": [
+    "DescribeEngineDefaultParameters":[
       {
-        "input": {
-          "DBParameterGroupFamily": "mysql5.6"
+        "input":{
+          "DBParameterGroupFamily":"mysql5.6"
         },
-        "output": {
-          "EngineDefaults": {
+        "output":{
+          "EngineDefaults":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists default parameters for the specified DB engine.",
-        "id": "describe-engine-default-parameters-35d5108e-1d44-4fac-8aeb-04b8fdfface1",
-        "title": "To list default parameters for a DB engine"
+        "description":"This example lists default parameters for the specified DB engine.",
+        "id":"describe-engine-default-parameters-35d5108e-1d44-4fac-8aeb-04b8fdfface1",
+        "title":"To list default parameters for a DB engine"
       }
     ],
-    "DescribeEventCategories": [
+    "DescribeEventCategories":[
       {
-        "input": {
-          "SourceType": "db-instance"
+        "input":{
+          "SourceType":"db-instance"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists all DB instance event categories.",
-        "id": "describe-event-categories-97bd4c77-12da-4be6-b42f-edf77771428b",
-        "title": "To list event categories."
+        "description":"This example lists all DB instance event categories.",
+        "id":"describe-event-categories-97bd4c77-12da-4be6-b42f-edf77771428b",
+        "title":"To list event categories."
       }
     ],
-    "DescribeEventSubscriptions": [
+    "DescribeEventSubscriptions":[
       {
-        "input": {
-          "SubscriptionName": "mymysqleventsubscription"
+        "input":{
+          "SubscriptionName":"mymysqleventsubscription"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for the specified DB event notification subscription.",
-        "id": "describe-event-subscriptions-11184a82-e58a-4d0c-b558-f3a7489e0850",
-        "title": "To list information about DB event notification subscriptions"
+        "description":"This example lists information for the specified DB event notification subscription.",
+        "id":"describe-event-subscriptions-11184a82-e58a-4d0c-b558-f3a7489e0850",
+        "title":"To list information about DB event notification subscriptions"
       }
     ],
-    "DescribeEvents": [
+    "DescribeEvents":[
       {
-        "input": {
-          "Duration": 10080,
-          "EventCategories": [
+        "input":{
+          "Duration":10080,
+          "EventCategories":[
             "backup"
           ],
-          "SourceIdentifier": "mymysqlinstance",
-          "SourceType": "db-instance"
+          "SourceIdentifier":"mymysqlinstance",
+          "SourceType":"db-instance"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all backup-related events for the specified DB instance for the past 7 days (7 days * 24 hours * 60 minutes = 10,080 minutes).",
-        "id": "describe-events-3836e5ed-3913-4f76-8452-c77fcad5016b",
-        "title": "To list information about events"
+        "description":"This example lists information for all backup-related events for the specified DB instance for the past 7 days (7 days * 24 hours * 60 minutes = 10,080 minutes).",
+        "id":"describe-events-3836e5ed-3913-4f76-8452-c77fcad5016b",
+        "title":"To list information about events"
       }
     ],
-    "DescribeOptionGroupOptions": [
+    "DescribeOptionGroupOptions":[
       {
-        "input": {
-          "EngineName": "mysql",
-          "MajorEngineVersion": "5.6"
+        "input":{
+          "EngineName":"mysql",
+          "MajorEngineVersion":"5.6"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all option group options for the specified DB engine.",
-        "id": "describe-option-group-options-30d735a4-81f1-49e4-b3f2-5dc45d50c8ed",
-        "title": "To list information about DB option group options"
+        "description":"This example lists information for all option group options for the specified DB engine.",
+        "id":"describe-option-group-options-30d735a4-81f1-49e4-b3f2-5dc45d50c8ed",
+        "title":"To list information about DB option group options"
       }
     ],
-    "DescribeOptionGroups": [
+    "DescribeOptionGroups":[
       {
-        "input": {
-          "EngineName": "mysql",
-          "MajorEngineVersion": "5.6"
+        "input":{
+          "EngineName":"mysql",
+          "MajorEngineVersion":"5.6"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all option groups for the specified DB engine.",
-        "id": "describe-option-groups-4ef478a1-66d5-45f2-bec3-e608720418a4",
-        "title": "To list information about DB option groups"
+        "description":"This example lists information for all option groups for the specified DB engine.",
+        "id":"describe-option-groups-4ef478a1-66d5-45f2-bec3-e608720418a4",
+        "title":"To list information about DB option groups"
       }
     ],
-    "DescribeOrderableDBInstanceOptions": [
+    "DescribeOrderableDBInstanceOptions":[
       {
-        "input": {
-          "DBInstanceClass": "db.t2.micro",
-          "Engine": "mysql",
-          "EngineVersion": "5.6.27",
-          "LicenseModel": "general-public-license",
-          "Vpc": true
+        "input":{
+          "DBInstanceClass":"db.t2.micro",
+          "Engine":"mysql",
+          "EngineVersion":"5.6.27",
+          "LicenseModel":"general-public-license",
+          "Vpc":true
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all orderable DB instance options for the specified DB engine, engine version, DB instance class, license model, and VPC settings.",
-        "id": "describe-orderable-db-instance-options-7444d3ed-82eb-42b9-9ed9-896b8c27a782",
-        "title": "To list information about orderable DB instance options"
+        "description":"This example lists information for all orderable DB instance options for the specified DB engine, engine version, DB instance class, license model, and VPC settings.",
+        "id":"describe-orderable-db-instance-options-7444d3ed-82eb-42b9-9ed9-896b8c27a782",
+        "title":"To list information about orderable DB instance options"
       }
     ],
-    "DescribePendingMaintenanceActions": [
+    "DescribePendingMaintenanceActions":[
       {
-        "input": {
-          "ResourceIdentifier": "arn:aws:rds:us-east-1:992648334831:db:mymysqlinstance"
+        "input":{
+          "ResourceIdentifier":"arn:aws:rds:us-east-1:992648334831:db:mymysqlinstance"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all pending maintenance actions for the specified DB instance.",
-        "id": "describe-pending-maintenance-actions-e6021f7e-58ae-49cc-b874-11996176835c",
-        "title": "To list information about pending maintenance actions"
+        "description":"This example lists information for all pending maintenance actions for the specified DB instance.",
+        "id":"describe-pending-maintenance-actions-e6021f7e-58ae-49cc-b874-11996176835c",
+        "title":"To list information about pending maintenance actions"
       }
     ],
-    "DescribeReservedDBInstances": [
+    "DescribeReservedDBInstances":[
       {
-        "input": {
-          "DBInstanceClass": "db.t2.micro",
-          "Duration": "1y",
-          "MultiAZ": false,
-          "OfferingType": "No Upfront",
-          "ProductDescription": "mysql"
+        "input":{
+          "DBInstanceClass":"db.t2.micro",
+          "Duration":"1y",
+          "MultiAZ":false,
+          "OfferingType":"No Upfront",
+          "ProductDescription":"mysql"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all reserved DB instances for the specified DB instance class, duration, product, offering type, and availability zone settings.",
-        "id": "describe-reserved-db-instances-d45adaca-2e30-407c-a0f3-aa7b98bea17f",
-        "title": "To list information about reserved DB instances"
+        "description":"This example lists information for all reserved DB instances for the specified DB instance class, duration, product, offering type, and availability zone settings.",
+        "id":"describe-reserved-db-instances-d45adaca-2e30-407c-a0f3-aa7b98bea17f",
+        "title":"To list information about reserved DB instances"
       }
     ],
-    "DescribeReservedDBInstancesOfferings": [
+    "DescribeReservedDBInstancesOfferings":[
       {
-        "input": {
-          "DBInstanceClass": "db.t2.micro",
-          "Duration": "1y",
-          "MultiAZ": false,
-          "OfferingType": "No Upfront",
-          "ProductDescription": "mysql"
+        "input":{
+          "DBInstanceClass":"db.t2.micro",
+          "Duration":"1y",
+          "MultiAZ":false,
+          "OfferingType":"No Upfront",
+          "ProductDescription":"mysql"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for all reserved DB instance offerings for the specified DB instance class, duration, product, offering type, and availability zone settings.",
-        "id": "describe-reserved-db-instances-offerings-9de7d1fd-d6a6-4a72-84ae-b2ef58d47d8d",
-        "title": "To list information about reserved DB instance offerings"
+        "description":"This example lists information for all reserved DB instance offerings for the specified DB instance class, duration, product, offering type, and availability zone settings.",
+        "id":"describe-reserved-db-instances-offerings-9de7d1fd-d6a6-4a72-84ae-b2ef58d47d8d",
+        "title":"To list information about reserved DB instance offerings"
       }
     ],
-    "DescribeSourceRegions": [
+    "DescribeSourceRegions":[
       {
-        "input": {
+        "input":{
         },
-        "output": {
-          "SourceRegions": [
+        "output":{
+          "SourceRegions":[
             {
-              "Endpoint": "https://rds.ap-northeast-1.amazonaws.com",
-              "RegionName": "ap-northeast-1",
-              "Status": "available"
+              "Endpoint":"https://rds.ap-northeast-1.amazonaws.com",
+              "RegionName":"ap-northeast-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.ap-northeast-2.amazonaws.com",
-              "RegionName": "ap-northeast-2",
-              "Status": "available"
+              "Endpoint":"https://rds.ap-northeast-2.amazonaws.com",
+              "RegionName":"ap-northeast-2",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.ap-south-1.amazonaws.com",
-              "RegionName": "ap-south-1",
-              "Status": "available"
+              "Endpoint":"https://rds.ap-south-1.amazonaws.com",
+              "RegionName":"ap-south-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.ap-southeast-1.amazonaws.com",
-              "RegionName": "ap-southeast-1",
-              "Status": "available"
+              "Endpoint":"https://rds.ap-southeast-1.amazonaws.com",
+              "RegionName":"ap-southeast-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.ap-southeast-2.amazonaws.com",
-              "RegionName": "ap-southeast-2",
-              "Status": "available"
+              "Endpoint":"https://rds.ap-southeast-2.amazonaws.com",
+              "RegionName":"ap-southeast-2",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.eu-central-1.amazonaws.com",
-              "RegionName": "eu-central-1",
-              "Status": "available"
+              "Endpoint":"https://rds.eu-central-1.amazonaws.com",
+              "RegionName":"eu-central-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.eu-west-1.amazonaws.com",
-              "RegionName": "eu-west-1",
-              "Status": "available"
+              "Endpoint":"https://rds.eu-west-1.amazonaws.com",
+              "RegionName":"eu-west-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.sa-east-1.amazonaws.com",
-              "RegionName": "sa-east-1",
-              "Status": "available"
+              "Endpoint":"https://rds.sa-east-1.amazonaws.com",
+              "RegionName":"sa-east-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.us-west-1.amazonaws.com",
-              "RegionName": "us-west-1",
-              "Status": "available"
+              "Endpoint":"https://rds.us-west-1.amazonaws.com",
+              "RegionName":"us-west-1",
+              "Status":"available"
             },
             {
-              "Endpoint": "https://rds.us-west-2.amazonaws.com",
-              "RegionName": "us-west-2",
-              "Status": "available"
+              "Endpoint":"https://rds.us-west-2.amazonaws.com",
+              "RegionName":"us-west-2",
+              "Status":"available"
             }
           ]
         },
-        "comments": {
+        "comments":{
         },
-        "description": "To list the AWS regions where a Read Replica can be created.",
-        "id": "to-describe-source-regions-1473457722410",
-        "title": "To describe source regions"
+        "description":"To list the AWS regions where a Read Replica can be created.",
+        "id":"to-describe-source-regions-1473457722410",
+        "title":"To describe source regions"
       }
     ],
-    "DownloadDBLogFilePortion": [
+    "DownloadDBLogFilePortion":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "LogFileName": "mysqlUpgrade"
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "LogFileName":"mysqlUpgrade"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information for the specified log file for the specified DB instance.",
-        "id": "download-db-log-file-portion-54a82731-a441-4fc7-a010-8eccae6fa202",
-        "title": "To list information about DB log files"
+        "description":"This example lists information for the specified log file for the specified DB instance.",
+        "id":"download-db-log-file-portion-54a82731-a441-4fc7-a010-8eccae6fa202",
+        "title":"To list information about DB log files"
       }
     ],
-    "FailoverDBCluster": [
+    "FailoverDBCluster":[
       {
-        "input": {
-          "DBClusterIdentifier": "myaurorainstance-cluster",
-          "TargetDBInstanceIdentifier": "myaurorareplica"
+        "input":{
+          "DBClusterIdentifier":"myaurorainstance-cluster",
+          "TargetDBInstanceIdentifier":"myaurorareplica"
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example performs a failover for the specified DB cluster to the specified DB instance.",
-        "id": "failover-db-cluster-9e7f2f93-d98c-42c7-bb0e-d6c485c096d6",
-        "title": "To perform a failover for a DB cluster"
+        "description":"This example performs a failover for the specified DB cluster to the specified DB instance.",
+        "id":"failover-db-cluster-9e7f2f93-d98c-42c7-bb0e-d6c485c096d6",
+        "title":"To perform a failover for a DB cluster"
       }
     ],
-    "ListTagsForResource": [
+    "ListTagsForResource":[
       {
-        "input": {
-          "ResourceName": "arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup"
+        "input":{
+          "ResourceName":"arn:aws:rds:us-east-1:992648334831:og:mymysqloptiongroup"
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example lists information about all tags associated with the specified DB option group.",
-        "id": "list-tags-for-resource-8401f3c2-77cd-4f90-bfd5-b523f0adcc2f",
-        "title": "To list information about tags associated with a resource"
+        "description":"This example lists information about all tags associated with the specified DB option group.",
+        "id":"list-tags-for-resource-8401f3c2-77cd-4f90-bfd5-b523f0adcc2f",
+        "title":"To list information about tags associated with a resource"
       }
     ],
-    "ModifyDBCluster": [
+    "ModifyDBCluster":[
       {
-        "input": {
-          "ApplyImmediately": true,
-          "DBClusterIdentifier": "mydbcluster",
-          "MasterUserPassword": "mynewpassword",
-          "NewDBClusterIdentifier": "mynewdbcluster",
-          "PreferredBackupWindow": "04:00-04:30",
-          "PreferredMaintenanceWindow": "Tue:05:00-Tue:05:30"
+        "input":{
+          "ApplyImmediately":true,
+          "DBClusterIdentifier":"mydbcluster",
+          "MasterUserPassword":"mynewpassword",
+          "NewDBClusterIdentifier":"mynewdbcluster",
+          "PreferredBackupWindow":"04:00-04:30",
+          "PreferredMaintenanceWindow":"Tue:05:00-Tue:05:30"
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example changes the specified settings for the specified DB cluster.",
-        "id": "modify-db-cluster-a370ee1b-768d-450a-853b-707cb1ab663d",
-        "title": "To change DB cluster settings"
+        "description":"This example changes the specified settings for the specified DB cluster.",
+        "id":"modify-db-cluster-a370ee1b-768d-450a-853b-707cb1ab663d",
+        "title":"To change DB cluster settings"
       }
     ],
-    "ModifyDBClusterParameterGroup": [
+    "ModifyDBClusterParameterGroup":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup",
-          "Parameters": [
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup",
+          "Parameters":[
             {
-              "ApplyMethod": "immediate",
-              "ParameterName": "time_zone",
-              "ParameterValue": "America/Phoenix"
+              "ApplyMethod":"immediate",
+              "ParameterName":"time_zone",
+              "ParameterValue":"America/Phoenix"
             }
           ]
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example immediately changes the specified setting for the specified DB cluster parameter group.",
-        "id": "modify-db-cluster-parameter-group-f9156bc9-082a-442e-8d12-239542c1a113",
-        "title": "To change DB cluster parameter group settings"
+        "description":"This example immediately changes the specified setting for the specified DB cluster parameter group.",
+        "id":"modify-db-cluster-parameter-group-f9156bc9-082a-442e-8d12-239542c1a113",
+        "title":"To change DB cluster parameter group settings"
       }
     ],
-    "ModifyDBClusterSnapshotAttribute": [
+    "ModifyDBClusterSnapshotAttribute":[
       {
-        "input": {
-          "AttributeName": "restore",
-          "DBClusterSnapshotIdentifier": "manual-cluster-snapshot1",
-          "ValuesToAdd": [
+        "input":{
+          "AttributeName":"restore",
+          "DBClusterSnapshotIdentifier":"manual-cluster-snapshot1",
+          "ValuesToAdd":[
             "123451234512",
             "123456789012"
           ],
-          "ValuesToRemove": [
+          "ValuesToRemove":[
             "all"
           ]
         },
-        "output": {
-          "DBClusterSnapshotAttributesResult": {
+        "output":{
+          "DBClusterSnapshotAttributesResult":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example gives two AWS accounts access to a manual DB cluster snapshot and ensures that the DB cluster snapshot is private by removing the value \"all\".",
-        "id": "to-add-or-remove-access-to-a-manual-db-cluster-snapshot-1473889426431",
-        "title": "To add or remove access to a manual DB cluster snapshot"
+        "description":"The following example gives two AWS accounts access to a manual DB cluster snapshot and ensures that the DB cluster snapshot is private by removing the value \"all\".",
+        "id":"to-add-or-remove-access-to-a-manual-db-cluster-snapshot-1473889426431",
+        "title":"To add or remove access to a manual DB cluster snapshot"
       }
     ],
-    "ModifyDBInstance": [
+    "ModifyDBInstance":[
       {
-        "input": {
-          "AllocatedStorage": 10,
-          "ApplyImmediately": true,
-          "BackupRetentionPeriod": 1,
-          "DBInstanceClass": "db.t2.small",
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "MasterUserPassword": "mynewpassword",
-          "PreferredBackupWindow": "04:00-04:30",
-          "PreferredMaintenanceWindow": "Tue:05:00-Tue:05:30"
+        "input":{
+          "AllocatedStorage":10,
+          "ApplyImmediately":true,
+          "BackupRetentionPeriod":1,
+          "DBInstanceClass":"db.t2.small",
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "MasterUserPassword":"mynewpassword",
+          "PreferredBackupWindow":"04:00-04:30",
+          "PreferredMaintenanceWindow":"Tue:05:00-Tue:05:30"
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example immediately changes the specified settings for the specified DB instance.",
-        "id": "modify-db-instance-6979a368-6254-467b-8a8d-61103f4fcde9",
-        "title": "To change DB instance settings"
+        "description":"This example immediately changes the specified settings for the specified DB instance.",
+        "id":"modify-db-instance-6979a368-6254-467b-8a8d-61103f4fcde9",
+        "title":"To change DB instance settings"
       }
     ],
-    "ModifyDBParameterGroup": [
+    "ModifyDBParameterGroup":[
       {
-        "input": {
-          "DBParameterGroupName": "mymysqlparametergroup",
-          "Parameters": [
+        "input":{
+          "DBParameterGroupName":"mymysqlparametergroup",
+          "Parameters":[
             {
-              "ApplyMethod": "immediate",
-              "ParameterName": "time_zone",
-              "ParameterValue": "America/Phoenix"
+              "ApplyMethod":"immediate",
+              "ParameterName":"time_zone",
+              "ParameterValue":"America/Phoenix"
             }
           ]
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example immediately changes the specified setting for the specified DB parameter group.",
-        "id": "modify-db-parameter-group-f3a4e52a-68e4-4b88-b559-f912d34c457a",
-        "title": "To change DB parameter group settings"
+        "description":"This example immediately changes the specified setting for the specified DB parameter group.",
+        "id":"modify-db-parameter-group-f3a4e52a-68e4-4b88-b559-f912d34c457a",
+        "title":"To change DB parameter group settings"
       }
     ],
-    "ModifyDBSnapshotAttribute": [
+    "ModifyDBSnapshotAttribute":[
       {
-        "input": {
-          "AttributeName": "restore",
-          "DBSnapshotIdentifier": "mydbsnapshot",
-          "ValuesToAdd": [
+        "input":{
+          "AttributeName":"restore",
+          "DBSnapshotIdentifier":"mydbsnapshot",
+          "ValuesToAdd":[
             "all"
           ]
         },
-        "output": {
-          "DBSnapshotAttributesResult": {
+        "output":{
+          "DBSnapshotAttributesResult":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example adds the specified attribute for the specified DB snapshot.",
-        "id": "modify-db-snapshot-attribute-2e66f120-2b21-4a7c-890b-4474da88bde6",
-        "title": "To change DB snapshot attributes"
+        "description":"This example adds the specified attribute for the specified DB snapshot.",
+        "id":"modify-db-snapshot-attribute-2e66f120-2b21-4a7c-890b-4474da88bde6",
+        "title":"To change DB snapshot attributes"
       }
     ],
-    "ModifyDBSubnetGroup": [
+    "ModifyDBSubnetGroup":[
       {
-        "input": {
-          "DBSubnetGroupName": "mydbsubnetgroup",
-          "SubnetIds": [
+        "input":{
+          "DBSubnetGroupName":"mydbsubnetgroup",
+          "SubnetIds":[
             "subnet-70e1975a",
             "subnet-747a5c49"
           ]
         },
-        "output": {
-          "DBSubnetGroup": {
+        "output":{
+          "DBSubnetGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example changes the specified setting for the specified DB subnet group.",
-        "id": "modify-db-subnet-group-e34a97d9-8fe6-4239-a4ed-ad6e73a956b0",
-        "title": "To change DB subnet group settings"
+        "description":"This example changes the specified setting for the specified DB subnet group.",
+        "id":"modify-db-subnet-group-e34a97d9-8fe6-4239-a4ed-ad6e73a956b0",
+        "title":"To change DB subnet group settings"
       }
     ],
-    "ModifyEventSubscription": [
+    "ModifyEventSubscription":[
       {
-        "input": {
-          "Enabled": true,
-          "EventCategories": [
+        "input":{
+          "Enabled":true,
+          "EventCategories":[
             "deletion",
             "low storage"
           ],
-          "SourceType": "db-instance",
-          "SubscriptionName": "mymysqleventsubscription"
+          "SourceType":"db-instance",
+          "SubscriptionName":"mymysqleventsubscription"
         },
-        "output": {
-          "EventSubscription": {
+        "output":{
+          "EventSubscription":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example changes the specified setting for the specified event notification subscription.",
-        "id": "modify-event-subscription-405ac869-1f02-42cd-b8f4-6950a435f30e",
-        "title": "To change event notification subscription settings"
+        "description":"This example changes the specified setting for the specified event notification subscription.",
+        "id":"modify-event-subscription-405ac869-1f02-42cd-b8f4-6950a435f30e",
+        "title":"To change event notification subscription settings"
       }
     ],
-    "ModifyOptionGroup": [
+    "ModifyOptionGroup":[
       {
-        "input": {
-          "ApplyImmediately": true,
-          "OptionGroupName": "myawsuser-og02",
-          "OptionsToInclude": [
+        "input":{
+          "ApplyImmediately":true,
+          "OptionGroupName":"myawsuser-og02",
+          "OptionsToInclude":[
             {
-              "DBSecurityGroupMemberships": [
+              "DBSecurityGroupMemberships":[
                 "default"
               ],
-              "OptionName": "MEMCACHED"
+              "OptionName":"MEMCACHED"
             }
           ]
         },
-        "output": {
-          "OptionGroup": {
+        "output":{
+          "OptionGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example adds an option to an option group.",
-        "id": "to-modify-an-option-group-1473890247875",
-        "title": "To modify an option group"
+        "description":"The following example adds an option to an option group.",
+        "id":"to-modify-an-option-group-1473890247875",
+        "title":"To modify an option group"
       }
     ],
-    "PromoteReadReplica": [
+    "PromoteReadReplica":[
       {
-        "input": {
-          "BackupRetentionPeriod": 1,
-          "DBInstanceIdentifier": "mydbreadreplica",
-          "PreferredBackupWindow": "03:30-04:00"
+        "input":{
+          "BackupRetentionPeriod":1,
+          "DBInstanceIdentifier":"mydbreadreplica",
+          "PreferredBackupWindow":"03:30-04:00"
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example promotes the specified read replica and sets its backup retention period and preferred backup window.",
-        "id": "promote-read-replica-cc580039-c55d-4035-838a-def4a1ae4181",
-        "title": "To promote a read replica"
+        "description":"This example promotes the specified read replica and sets its backup retention period and preferred backup window.",
+        "id":"promote-read-replica-cc580039-c55d-4035-838a-def4a1ae4181",
+        "title":"To promote a read replica"
       }
     ],
-    "PurchaseReservedDBInstancesOffering": [
+    "PurchaseReservedDBInstancesOffering":[
       {
-        "input": {
-          "ReservedDBInstanceId": "myreservationid",
-          "ReservedDBInstancesOfferingId": "fb29428a-646d-4390-850e-5fe89926e727"
+        "input":{
+          "ReservedDBInstanceId":"myreservationid",
+          "ReservedDBInstancesOfferingId":"fb29428a-646d-4390-850e-5fe89926e727"
         },
-        "output": {
-          "ReservedDBInstance": {
+        "output":{
+          "ReservedDBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example purchases a reserved DB instance offering that matches the specified settings.",
-        "id": "purchase-reserved-db-instances-offfering-f423c736-8413-429b-ba13-850fd4fa4dcd",
-        "title": "To purchase a reserved DB instance offering"
+        "description":"This example purchases a reserved DB instance offering that matches the specified settings.",
+        "id":"purchase-reserved-db-instances-offfering-f423c736-8413-429b-ba13-850fd4fa4dcd",
+        "title":"To purchase a reserved DB instance offering"
       }
     ],
-    "RebootDBInstance": [
+    "RebootDBInstance":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mymysqlinstance",
-          "ForceFailover": false
+        "input":{
+          "DBInstanceIdentifier":"mymysqlinstance",
+          "ForceFailover":false
         },
-        "output": {
-          "DBInstance": {
+        "output":{
+          "DBInstance":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example reboots the specified DB instance without forcing a failover.",
-        "id": "reboot-db-instance-b9ce8a0a-2920-451d-a1f3-01d288aa7366",
-        "title": "To reboot a DB instance"
+        "description":"This example reboots the specified DB instance without forcing a failover.",
+        "id":"reboot-db-instance-b9ce8a0a-2920-451d-a1f3-01d288aa7366",
+        "title":"To reboot a DB instance"
       }
     ],
-    "RemoveSourceIdentifierFromSubscription": [
+    "RemoveSourceIdentifierFromSubscription":[
       {
-        "input": {
-          "SourceIdentifier": "mymysqlinstance",
-          "SubscriptionName": "myeventsubscription"
+        "input":{
+          "SourceIdentifier":"mymysqlinstance",
+          "SubscriptionName":"myeventsubscription"
         },
-        "output": {
-          "EventSubscription": {
+        "output":{
+          "EventSubscription":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example removes the specified source identifier from the specified DB event subscription.",
-        "id": "remove-source-identifier-from-subscription-30d25493-c19d-4cf7-b4e5-68371d0d8770",
-        "title": "To remove a source identifier from a DB event subscription"
+        "description":"This example removes the specified source identifier from the specified DB event subscription.",
+        "id":"remove-source-identifier-from-subscription-30d25493-c19d-4cf7-b4e5-68371d0d8770",
+        "title":"To remove a source identifier from a DB event subscription"
       }
     ],
-    "RemoveTagsFromResource": [
+    "RemoveTagsFromResource":[
       {
-        "input": {
-          "ResourceName": "arn:aws:rds:us-east-1:992648334831:og:mydboptiongroup",
-          "TagKeys": [
+        "input":{
+          "ResourceName":"arn:aws:rds:us-east-1:992648334831:og:mydboptiongroup",
+          "TagKeys":[
             "MyKey"
           ]
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example removes the specified tag associated with the specified DB option group.",
-        "id": "remove-tags-from-resource-49f00574-38f6-4d01-ac89-d3c668449ce3",
-        "title": "To remove tags from a resource"
+        "description":"This example removes the specified tag associated with the specified DB option group.",
+        "id":"remove-tags-from-resource-49f00574-38f6-4d01-ac89-d3c668449ce3",
+        "title":"To remove tags from a resource"
       }
     ],
-    "ResetDBClusterParameterGroup": [
+    "ResetDBClusterParameterGroup":[
       {
-        "input": {
-          "DBClusterParameterGroupName": "mydbclusterparametergroup",
-          "ResetAllParameters": true
+        "input":{
+          "DBClusterParameterGroupName":"mydbclusterparametergroup",
+          "ResetAllParameters":true
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example resets all parameters for the specified DB cluster parameter group to their default values.",
-        "id": "reset-db-cluster-parameter-group-b04aeaf7-7f73-49e1-9bb4-857573ea3ee4",
-        "title": "To reset the values of a DB cluster parameter group"
+        "description":"This example resets all parameters for the specified DB cluster parameter group to their default values.",
+        "id":"reset-db-cluster-parameter-group-b04aeaf7-7f73-49e1-9bb4-857573ea3ee4",
+        "title":"To reset the values of a DB cluster parameter group"
       }
     ],
-    "ResetDBParameterGroup": [
+    "ResetDBParameterGroup":[
       {
-        "input": {
-          "DBParameterGroupName": "mydbparametergroup",
-          "ResetAllParameters": true
+        "input":{
+          "DBParameterGroupName":"mydbparametergroup",
+          "ResetAllParameters":true
         },
-        "output": {
+        "output":{
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example resets all parameters for the specified DB parameter group to their default values.",
-        "id": "reset-db-parameter-group-ed2ed723-de0d-4824-8af5-3c65fa130abf",
-        "title": "To reset the values of a DB parameter group"
+        "description":"This example resets all parameters for the specified DB parameter group to their default values.",
+        "id":"reset-db-parameter-group-ed2ed723-de0d-4824-8af5-3c65fa130abf",
+        "title":"To reset the values of a DB parameter group"
       }
     ],
-    "RestoreDBClusterFromSnapshot": [
+    "RestoreDBClusterFromSnapshot":[
       {
-        "input": {
-          "DBClusterIdentifier": "restored-cluster1",
-          "Engine": "aurora",
-          "SnapshotIdentifier": "sample-cluster-snapshot1"
+        "input":{
+          "DBClusterIdentifier":"restored-cluster1",
+          "Engine":"aurora",
+          "SnapshotIdentifier":"sample-cluster-snapshot1"
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example restores an Amazon Aurora DB cluster from a DB cluster snapshot.",
-        "id": "to-restore-an-amazon-aurora-db-cluster-from-a-db-cluster-snapshot-1473958144325",
-        "title": "To restore an Amazon Aurora DB cluster from a DB cluster snapshot"
+        "description":"The following example restores an Amazon Aurora DB cluster from a DB cluster snapshot.",
+        "id":"to-restore-an-amazon-aurora-db-cluster-from-a-db-cluster-snapshot-1473958144325",
+        "title":"To restore an Amazon Aurora DB cluster from a DB cluster snapshot"
       }
     ],
-    "RestoreDBClusterToPointInTime": [
+    "RestoreDBClusterToPointInTime":[
       {
-        "input": {
-          "DBClusterIdentifier": "sample-restored-cluster1",
-          "RestoreToTime": "2016-09-13T18:45:00Z",
-          "SourceDBClusterIdentifier": "sample-cluster1"
+        "input":{
+          "DBClusterIdentifier":"sample-restored-cluster1",
+          "RestoreToTime":"2016-09-13T18:45:00Z",
+          "SourceDBClusterIdentifier":"sample-cluster1"
         },
-        "output": {
-          "DBCluster": {
+        "output":{
+          "DBCluster":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example restores a DB cluster to a new DB cluster at a point in time from the source DB cluster.",
-        "id": "to-restore-a-db-cluster-to-a-point-in-time-1473962082214",
-        "title": "To restore a DB cluster to a point in time."
+        "description":"The following example restores a DB cluster to a new DB cluster at a point in time from the source DB cluster.",
+        "id":"to-restore-a-db-cluster-to-a-point-in-time-1473962082214",
+        "title":"To restore a DB cluster to a point in time."
       }
     ],
-    "RestoreDBInstanceFromDBSnapshot": [
+    "RestoreDBInstanceFromDBSnapshot":[
       {
-        "input": {
-          "DBInstanceIdentifier": "mysqldb-restored",
-          "DBSnapshotIdentifier": "rds:mysqldb-2014-04-22-08-15"
+        "input":{
+          "DBInstanceIdentifier":"mysqldb-restored",
+          "DBSnapshotIdentifier":"rds:mysqldb-2014-04-22-08-15"
         },
-        "output": {
-          "DBInstance": {
-            "AllocatedStorage": 200,
-            "AutoMinorVersionUpgrade": true,
-            "AvailabilityZone": "us-west-2b",
-            "BackupRetentionPeriod": 7,
-            "CACertificateIdentifier": "rds-ca-2015",
-            "CopyTagsToSnapshot": false,
-            "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:mysqldb-restored",
-            "DBInstanceClass": "db.t2.small",
-            "DBInstanceIdentifier": "mysqldb-restored",
-            "DBInstanceStatus": "available",
-            "DBName": "sample",
-            "DBParameterGroups": [
+        "output":{
+          "DBInstance":{
+            "AllocatedStorage":200,
+            "AutoMinorVersionUpgrade":true,
+            "AvailabilityZone":"us-west-2b",
+            "BackupRetentionPeriod":7,
+            "CACertificateIdentifier":"rds-ca-2015",
+            "CopyTagsToSnapshot":false,
+            "DBInstanceArn":"arn:aws:rds:us-west-2:123456789012:db:mysqldb-restored",
+            "DBInstanceClass":"db.t2.small",
+            "DBInstanceIdentifier":"mysqldb-restored",
+            "DBInstanceStatus":"available",
+            "DBName":"sample",
+            "DBParameterGroups":[
               {
-                "DBParameterGroupName": "default.mysql5.6",
-                "ParameterApplyStatus": "in-sync"
+                "DBParameterGroupName":"default.mysql5.6",
+                "ParameterApplyStatus":"in-sync"
               }
             ],
-            "DBSecurityGroups": [
+            "DBSecurityGroups":[
 
             ],
-            "DBSubnetGroup": {
-              "DBSubnetGroupDescription": "default",
-              "DBSubnetGroupName": "default",
-              "SubnetGroupStatus": "Complete",
-              "Subnets": [
+            "DBSubnetGroup":{
+              "DBSubnetGroupDescription":"default",
+              "DBSubnetGroupName":"default",
+              "SubnetGroupStatus":"Complete",
+              "Subnets":[
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2a"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2a"
                   },
-                  "SubnetIdentifier": "subnet-77e8db03",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-77e8db03",
+                  "SubnetStatus":"Active"
                 },
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2b"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2b"
                   },
-                  "SubnetIdentifier": "subnet-c39989a1",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-c39989a1",
+                  "SubnetStatus":"Active"
                 },
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2c"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2c"
                   },
-                  "SubnetIdentifier": "subnet-4b267b0d",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-4b267b0d",
+                  "SubnetStatus":"Active"
                 }
               ],
-              "VpcId": "vpc-c1c5b3a3"
+              "VpcId":"vpc-c1c5b3a3"
             },
-            "DbInstancePort": 0,
-            "DbiResourceId": "db-VNZUCCBTEDC4WR7THXNJO72HVQ",
-            "DomainMemberships": [
+            "DbInstancePort":0,
+            "DbiResourceId":"db-VNZUCCBTEDC4WR7THXNJO72HVQ",
+            "DomainMemberships":[
 
             ],
-            "Engine": "mysql",
-            "EngineVersion": "5.6.27",
-            "LicenseModel": "general-public-license",
-            "MasterUsername": "mymasteruser",
-            "MonitoringInterval": 0,
-            "MultiAZ": false,
-            "OptionGroupMemberships": [
+            "Engine":"mysql",
+            "EngineVersion":"5.6.27",
+            "LicenseModel":"general-public-license",
+            "MasterUsername":"mymasteruser",
+            "MonitoringInterval":0,
+            "MultiAZ":false,
+            "OptionGroupMemberships":[
               {
-                "OptionGroupName": "default:mysql-5-6",
-                "Status": "in-sync"
+                "OptionGroupName":"default:mysql-5-6",
+                "Status":"in-sync"
               }
             ],
-            "PendingModifiedValues": {
+            "PendingModifiedValues":{
             },
-            "PreferredBackupWindow": "12:58-13:28",
-            "PreferredMaintenanceWindow": "tue:10:16-tue:10:46",
-            "PubliclyAccessible": true,
-            "ReadReplicaDBInstanceIdentifiers": [
+            "PreferredBackupWindow":"12:58-13:28",
+            "PreferredMaintenanceWindow":"tue:10:16-tue:10:46",
+            "PubliclyAccessible":true,
+            "ReadReplicaDBInstanceIdentifiers":[
 
             ],
-            "StorageEncrypted": false,
-            "StorageType": "gp2",
-            "VpcSecurityGroups": [
+            "StorageEncrypted":false,
+            "StorageType":"gp2",
+            "VpcSecurityGroups":[
               {
-                "Status": "active",
-                "VpcSecurityGroupId": "sg-e5e5b0d2"
+                "Status":"active",
+                "VpcSecurityGroupId":"sg-e5e5b0d2"
               }
             ]
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example restores a DB instance from a DB snapshot.",
-        "id": "to-restore-a-db-instance-from-a-db-snapshot-1473961657311",
-        "title": "To restore a DB instance from a DB snapshot."
+        "description":"The following example restores a DB instance from a DB snapshot.",
+        "id":"to-restore-a-db-instance-from-a-db-snapshot-1473961657311",
+        "title":"To restore a DB instance from a DB snapshot."
       }
     ],
-    "RestoreDBInstanceToPointInTime": [
+    "RestoreDBInstanceToPointInTime":[
       {
-        "input": {
-          "RestoreTime": "2016-09-13T18:45:00Z",
-          "SourceDBInstanceIdentifier": "mysql-sample",
-          "TargetDBInstanceIdentifier": "mysql-sample-restored"
+        "input":{
+          "RestoreTime":"2016-09-13T18:45:00Z",
+          "SourceDBInstanceIdentifier":"mysql-sample",
+          "TargetDBInstanceIdentifier":"mysql-sample-restored"
         },
-        "output": {
-          "DBInstance": {
-            "AllocatedStorage": 200,
-            "AutoMinorVersionUpgrade": true,
-            "AvailabilityZone": "us-west-2b",
-            "BackupRetentionPeriod": 7,
-            "CACertificateIdentifier": "rds-ca-2015",
-            "CopyTagsToSnapshot": false,
-            "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:mysql-sample-restored",
-            "DBInstanceClass": "db.t2.small",
-            "DBInstanceIdentifier": "mysql-sample-restored",
-            "DBInstanceStatus": "available",
-            "DBName": "sample",
-            "DBParameterGroups": [
+        "output":{
+          "DBInstance":{
+            "AllocatedStorage":200,
+            "AutoMinorVersionUpgrade":true,
+            "AvailabilityZone":"us-west-2b",
+            "BackupRetentionPeriod":7,
+            "CACertificateIdentifier":"rds-ca-2015",
+            "CopyTagsToSnapshot":false,
+            "DBInstanceArn":"arn:aws:rds:us-west-2:123456789012:db:mysql-sample-restored",
+            "DBInstanceClass":"db.t2.small",
+            "DBInstanceIdentifier":"mysql-sample-restored",
+            "DBInstanceStatus":"available",
+            "DBName":"sample",
+            "DBParameterGroups":[
               {
-                "DBParameterGroupName": "default.mysql5.6",
-                "ParameterApplyStatus": "in-sync"
+                "DBParameterGroupName":"default.mysql5.6",
+                "ParameterApplyStatus":"in-sync"
               }
             ],
-            "DBSecurityGroups": [
+            "DBSecurityGroups":[
 
             ],
-            "DBSubnetGroup": {
-              "DBSubnetGroupDescription": "default",
-              "DBSubnetGroupName": "default",
-              "SubnetGroupStatus": "Complete",
-              "Subnets": [
+            "DBSubnetGroup":{
+              "DBSubnetGroupDescription":"default",
+              "DBSubnetGroupName":"default",
+              "SubnetGroupStatus":"Complete",
+              "Subnets":[
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2a"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2a"
                   },
-                  "SubnetIdentifier": "subnet-77e8db03",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-77e8db03",
+                  "SubnetStatus":"Active"
                 },
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2b"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2b"
                   },
-                  "SubnetIdentifier": "subnet-c39989a1",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-c39989a1",
+                  "SubnetStatus":"Active"
                 },
                 {
-                  "SubnetAvailabilityZone": {
-                    "Name": "us-west-2c"
+                  "SubnetAvailabilityZone":{
+                    "Name":"us-west-2c"
                   },
-                  "SubnetIdentifier": "subnet-4b267b0d",
-                  "SubnetStatus": "Active"
+                  "SubnetIdentifier":"subnet-4b267b0d",
+                  "SubnetStatus":"Active"
                 }
               ],
-              "VpcId": "vpc-c1c5b3a3"
+              "VpcId":"vpc-c1c5b3a3"
             },
-            "DbInstancePort": 0,
-            "DbiResourceId": "db-VNZUCCBTEDC4WR7THXNJO72HVQ",
-            "DomainMemberships": [
+            "DbInstancePort":0,
+            "DbiResourceId":"db-VNZUCCBTEDC4WR7THXNJO72HVQ",
+            "DomainMemberships":[
 
             ],
-            "Engine": "mysql",
-            "EngineVersion": "5.6.27",
-            "LicenseModel": "general-public-license",
-            "MasterUsername": "mymasteruser",
-            "MonitoringInterval": 0,
-            "MultiAZ": false,
-            "OptionGroupMemberships": [
+            "Engine":"mysql",
+            "EngineVersion":"5.6.27",
+            "LicenseModel":"general-public-license",
+            "MasterUsername":"mymasteruser",
+            "MonitoringInterval":0,
+            "MultiAZ":false,
+            "OptionGroupMemberships":[
               {
-                "OptionGroupName": "default:mysql-5-6",
-                "Status": "in-sync"
+                "OptionGroupName":"default:mysql-5-6",
+                "Status":"in-sync"
               }
             ],
-            "PendingModifiedValues": {
+            "PendingModifiedValues":{
             },
-            "PreferredBackupWindow": "12:58-13:28",
-            "PreferredMaintenanceWindow": "tue:10:16-tue:10:46",
-            "PubliclyAccessible": true,
-            "ReadReplicaDBInstanceIdentifiers": [
+            "PreferredBackupWindow":"12:58-13:28",
+            "PreferredMaintenanceWindow":"tue:10:16-tue:10:46",
+            "PubliclyAccessible":true,
+            "ReadReplicaDBInstanceIdentifiers":[
 
             ],
-            "StorageEncrypted": false,
-            "StorageType": "gp2",
-            "VpcSecurityGroups": [
+            "StorageEncrypted":false,
+            "StorageType":"gp2",
+            "VpcSecurityGroups":[
               {
-                "Status": "active",
-                "VpcSecurityGroupId": "sg-e5e5b0d2"
+                "Status":"active",
+                "VpcSecurityGroupId":"sg-e5e5b0d2"
               }
             ]
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "The following example restores a DB instance to a new DB instance at a point in time from the source DB instance.",
-        "id": "to-restore-a-db-instance-to-a-point-in-time-1473962652154",
-        "title": "To restore a DB instance to a point in time."
+        "description":"The following example restores a DB instance to a new DB instance at a point in time from the source DB instance.",
+        "id":"to-restore-a-db-instance-to-a-point-in-time-1473962652154",
+        "title":"To restore a DB instance to a point in time."
       }
     ],
-    "RevokeDBSecurityGroupIngress": [
+    "RevokeDBSecurityGroupIngress":[
       {
-        "input": {
-          "CIDRIP": "203.0.113.5/32",
-          "DBSecurityGroupName": "mydbsecuritygroup"
+        "input":{
+          "CIDRIP":"203.0.113.5/32",
+          "DBSecurityGroupName":"mydbsecuritygroup"
         },
-        "output": {
-          "DBSecurityGroup": {
+        "output":{
+          "DBSecurityGroup":{
           }
         },
-        "comments": {
-          "input": {
+        "comments":{
+          "input":{
           },
-          "output": {
+          "output":{
           }
         },
-        "description": "This example revokes ingress for the specified CIDR block associated with the specified DB security group.",
-        "id": "revoke-db-security-group-ingress-ce5b2c1c-bd4e-4809-b04a-6d78ec448813",
-        "title": "To revoke ingress for a DB security group"
+        "description":"This example revokes ingress for the specified CIDR block associated with the specified DB security group.",
+        "id":"revoke-db-security-group-ingress-ce5b2c1c-bd4e-4809-b04a-6d78ec448813",
+        "title":"To revoke ingress for a DB security group"
       }
     ]
   }

--- a/service/acmpca/acmpcaiface/interface.go
+++ b/service/acmpca/acmpcaiface/interface.go
@@ -108,6 +108,10 @@ type ACMPCAAPI interface {
 	ListTagsWithContext(aws.Context, *acmpca.ListTagsInput, ...request.Option) (*acmpca.ListTagsOutput, error)
 	ListTagsRequest(*acmpca.ListTagsInput) (*request.Request, *acmpca.ListTagsOutput)
 
+	RestoreCertificateAuthority(*acmpca.RestoreCertificateAuthorityInput) (*acmpca.RestoreCertificateAuthorityOutput, error)
+	RestoreCertificateAuthorityWithContext(aws.Context, *acmpca.RestoreCertificateAuthorityInput, ...request.Option) (*acmpca.RestoreCertificateAuthorityOutput, error)
+	RestoreCertificateAuthorityRequest(*acmpca.RestoreCertificateAuthorityInput) (*request.Request, *acmpca.RestoreCertificateAuthorityOutput)
+
 	RevokeCertificate(*acmpca.RevokeCertificateInput) (*acmpca.RevokeCertificateOutput, error)
 	RevokeCertificateWithContext(aws.Context, *acmpca.RevokeCertificateInput, ...request.Option) (*acmpca.RevokeCertificateOutput, error)
 	RevokeCertificateRequest(*acmpca.RevokeCertificateInput) (*request.Request, *acmpca.RevokeCertificateOutput)

--- a/service/acmpca/doc.go
+++ b/service/acmpca/doc.go
@@ -4,9 +4,9 @@
 // requests to AWS Certificate Manager Private Certificate Authority.
 //
 // You can use the ACM PCA API to create a private certificate authority (CA).
-// You must first call the CreateCertificateAuthority function. If successful,
-// the function returns an Amazon Resource Name (ARN) for your private CA. Use
-// this ARN as input to the GetCertificateAuthorityCsr function to retrieve
+// You must first call the CreateCertificateAuthority operation. If successful,
+// the operation returns an Amazon Resource Name (ARN) for your private CA.
+// Use this ARN as input to the GetCertificateAuthorityCsr operation to retrieve
 // the certificate signing request (CSR) for your private CA certificate. Sign
 // the CSR using the root or an intermediate CA in your on-premises PKI hierarchy,
 // and call the ImportCertificateAuthorityCertificate to import your signed
@@ -15,8 +15,8 @@
 // Use your private CA to issue and revoke certificates. These are private certificates
 // that identify and secure client computers, servers, applications, services,
 // devices, and users over SSLS/TLS connections within your organization. Call
-// the IssueCertificate function to issue a certificate. Call the RevokeCertificate
-// function to revoke a certificate.
+// the IssueCertificate operation to issue a certificate. Call the RevokeCertificate
+// operation to revoke a certificate.
 //
 // Certificates issued by your private CA can be trusted only within your organization,
 // not publicly.
@@ -24,13 +24,13 @@
 // Your private CA can optionally create a certificate revocation list (CRL)
 // to track the certificates you revoke. To create a CRL, you must specify a
 // RevocationConfiguration object when you call the CreateCertificateAuthority
-// function. ACM PCA writes the CRL to an S3 bucket that you specify. You must
+// operation. ACM PCA writes the CRL to an S3 bucket that you specify. You must
 // specify a bucket policy that grants ACM PCA write permission.
 //
 // You can also call the CreateCertificateAuthorityAuditReport to create an
 // optional audit report that lists every time the CA private key is used. The
 // private key is used for signing when the IssueCertificate or RevokeCertificate
-// function is called.
+// operation is called.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/acm-pca-2017-08-22 for more information on this service.
 //

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -552,6 +552,98 @@ func (c *MediaLive) DeleteInputSecurityGroupWithContext(ctx aws.Context, input *
 	return out, req.Send()
 }
 
+const opDeleteReservation = "DeleteReservation"
+
+// DeleteReservationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteReservation operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteReservation for more information on using the DeleteReservation
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteReservationRequest method.
+//    req, resp := client.DeleteReservationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteReservation
+func (c *MediaLive) DeleteReservationRequest(input *DeleteReservationInput) (req *request.Request, output *DeleteReservationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteReservation,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/prod/reservations/{reservationId}",
+	}
+
+	if input == nil {
+		input = &DeleteReservationInput{}
+	}
+
+	output = &DeleteReservationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteReservation API operation for AWS Elemental MediaLive.
+//
+// Delete an expired reservation.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation DeleteReservation for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DeleteReservation
+func (c *MediaLive) DeleteReservation(input *DeleteReservationInput) (*DeleteReservationOutput, error) {
+	req, out := c.DeleteReservationRequest(input)
+	return out, req.Send()
+}
+
+// DeleteReservationWithContext is the same as DeleteReservation with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteReservation for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) DeleteReservationWithContext(ctx aws.Context, input *DeleteReservationInput, opts ...request.Option) (*DeleteReservationOutput, error) {
+	req, out := c.DeleteReservationRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeChannel = "DescribeChannel"
 
 // DescribeChannelRequest generates a "aws/request.Request" representing the
@@ -817,6 +909,186 @@ func (c *MediaLive) DescribeInputSecurityGroup(input *DescribeInputSecurityGroup
 // for more information on using Contexts.
 func (c *MediaLive) DescribeInputSecurityGroupWithContext(ctx aws.Context, input *DescribeInputSecurityGroupInput, opts ...request.Option) (*DescribeInputSecurityGroupOutput, error) {
 	req, out := c.DescribeInputSecurityGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeOffering = "DescribeOffering"
+
+// DescribeOfferingRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeOffering operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeOffering for more information on using the DescribeOffering
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeOfferingRequest method.
+//    req, resp := client.DescribeOfferingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeOffering
+func (c *MediaLive) DescribeOfferingRequest(input *DescribeOfferingInput) (req *request.Request, output *DescribeOfferingOutput) {
+	op := &request.Operation{
+		Name:       opDescribeOffering,
+		HTTPMethod: "GET",
+		HTTPPath:   "/prod/offerings/{offeringId}",
+	}
+
+	if input == nil {
+		input = &DescribeOfferingInput{}
+	}
+
+	output = &DescribeOfferingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeOffering API operation for AWS Elemental MediaLive.
+//
+// Get details for an offering.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation DescribeOffering for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeOffering
+func (c *MediaLive) DescribeOffering(input *DescribeOfferingInput) (*DescribeOfferingOutput, error) {
+	req, out := c.DescribeOfferingRequest(input)
+	return out, req.Send()
+}
+
+// DescribeOfferingWithContext is the same as DescribeOffering with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeOffering for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) DescribeOfferingWithContext(ctx aws.Context, input *DescribeOfferingInput, opts ...request.Option) (*DescribeOfferingOutput, error) {
+	req, out := c.DescribeOfferingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeReservation = "DescribeReservation"
+
+// DescribeReservationRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeReservation operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeReservation for more information on using the DescribeReservation
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeReservationRequest method.
+//    req, resp := client.DescribeReservationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeReservation
+func (c *MediaLive) DescribeReservationRequest(input *DescribeReservationInput) (req *request.Request, output *DescribeReservationOutput) {
+	op := &request.Operation{
+		Name:       opDescribeReservation,
+		HTTPMethod: "GET",
+		HTTPPath:   "/prod/reservations/{reservationId}",
+	}
+
+	if input == nil {
+		input = &DescribeReservationInput{}
+	}
+
+	output = &DescribeReservationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeReservation API operation for AWS Elemental MediaLive.
+//
+// Get details for a reservation.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation DescribeReservation for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/DescribeReservation
+func (c *MediaLive) DescribeReservation(input *DescribeReservationInput) (*DescribeReservationOutput, error) {
+	req, out := c.DescribeReservationRequest(input)
+	return out, req.Send()
+}
+
+// DescribeReservationWithContext is the same as DescribeReservation with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeReservation for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) DescribeReservationWithContext(ctx aws.Context, input *DescribeReservationInput, opts ...request.Option) (*DescribeReservationOutput, error) {
+	req, out := c.DescribeReservationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1252,6 +1524,386 @@ func (c *MediaLive) ListInputsPagesWithContext(ctx aws.Context, input *ListInput
 		cont = fn(p.Page().(*ListInputsOutput), !p.HasNextPage())
 	}
 	return p.Err()
+}
+
+const opListOfferings = "ListOfferings"
+
+// ListOfferingsRequest generates a "aws/request.Request" representing the
+// client's request for the ListOfferings operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListOfferings for more information on using the ListOfferings
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListOfferingsRequest method.
+//    req, resp := client.ListOfferingsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListOfferings
+func (c *MediaLive) ListOfferingsRequest(input *ListOfferingsInput) (req *request.Request, output *ListOfferingsOutput) {
+	op := &request.Operation{
+		Name:       opListOfferings,
+		HTTPMethod: "GET",
+		HTTPPath:   "/prod/offerings",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListOfferingsInput{}
+	}
+
+	output = &ListOfferingsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListOfferings API operation for AWS Elemental MediaLive.
+//
+// List offerings available for purchase.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation ListOfferings for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListOfferings
+func (c *MediaLive) ListOfferings(input *ListOfferingsInput) (*ListOfferingsOutput, error) {
+	req, out := c.ListOfferingsRequest(input)
+	return out, req.Send()
+}
+
+// ListOfferingsWithContext is the same as ListOfferings with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListOfferings for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) ListOfferingsWithContext(ctx aws.Context, input *ListOfferingsInput, opts ...request.Option) (*ListOfferingsOutput, error) {
+	req, out := c.ListOfferingsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListOfferingsPages iterates over the pages of a ListOfferings operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListOfferings method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListOfferings operation.
+//    pageNum := 0
+//    err := client.ListOfferingsPages(params,
+//        func(page *ListOfferingsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *MediaLive) ListOfferingsPages(input *ListOfferingsInput, fn func(*ListOfferingsOutput, bool) bool) error {
+	return c.ListOfferingsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListOfferingsPagesWithContext same as ListOfferingsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) ListOfferingsPagesWithContext(ctx aws.Context, input *ListOfferingsInput, fn func(*ListOfferingsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListOfferingsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListOfferingsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListOfferingsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opListReservations = "ListReservations"
+
+// ListReservationsRequest generates a "aws/request.Request" representing the
+// client's request for the ListReservations operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListReservations for more information on using the ListReservations
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListReservationsRequest method.
+//    req, resp := client.ListReservationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListReservations
+func (c *MediaLive) ListReservationsRequest(input *ListReservationsInput) (req *request.Request, output *ListReservationsOutput) {
+	op := &request.Operation{
+		Name:       opListReservations,
+		HTTPMethod: "GET",
+		HTTPPath:   "/prod/reservations",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListReservationsInput{}
+	}
+
+	output = &ListReservationsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListReservations API operation for AWS Elemental MediaLive.
+//
+// List purchased reservations.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation ListReservations for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/ListReservations
+func (c *MediaLive) ListReservations(input *ListReservationsInput) (*ListReservationsOutput, error) {
+	req, out := c.ListReservationsRequest(input)
+	return out, req.Send()
+}
+
+// ListReservationsWithContext is the same as ListReservations with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListReservations for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) ListReservationsWithContext(ctx aws.Context, input *ListReservationsInput, opts ...request.Option) (*ListReservationsOutput, error) {
+	req, out := c.ListReservationsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListReservationsPages iterates over the pages of a ListReservations operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListReservations method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListReservations operation.
+//    pageNum := 0
+//    err := client.ListReservationsPages(params,
+//        func(page *ListReservationsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *MediaLive) ListReservationsPages(input *ListReservationsInput, fn func(*ListReservationsOutput, bool) bool) error {
+	return c.ListReservationsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListReservationsPagesWithContext same as ListReservationsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) ListReservationsPagesWithContext(ctx aws.Context, input *ListReservationsInput, fn func(*ListReservationsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListReservationsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListReservationsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListReservationsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opPurchaseOffering = "PurchaseOffering"
+
+// PurchaseOfferingRequest generates a "aws/request.Request" representing the
+// client's request for the PurchaseOffering operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PurchaseOffering for more information on using the PurchaseOffering
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PurchaseOfferingRequest method.
+//    req, resp := client.PurchaseOfferingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/PurchaseOffering
+func (c *MediaLive) PurchaseOfferingRequest(input *PurchaseOfferingInput) (req *request.Request, output *PurchaseOfferingOutput) {
+	op := &request.Operation{
+		Name:       opPurchaseOffering,
+		HTTPMethod: "POST",
+		HTTPPath:   "/prod/offerings/{offeringId}/purchase",
+	}
+
+	if input == nil {
+		input = &PurchaseOfferingInput{}
+	}
+
+	output = &PurchaseOfferingOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PurchaseOffering API operation for AWS Elemental MediaLive.
+//
+// Purchase an offering and create a reservation.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaLive's
+// API operation PurchaseOffering for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeBadGatewayException "BadGatewayException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeGatewayTimeoutException "GatewayTimeoutException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/medialive-2017-10-14/PurchaseOffering
+func (c *MediaLive) PurchaseOffering(input *PurchaseOfferingInput) (*PurchaseOfferingOutput, error) {
+	req, out := c.PurchaseOfferingRequest(input)
+	return out, req.Send()
+}
+
+// PurchaseOfferingWithContext is the same as PurchaseOffering with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PurchaseOffering for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaLive) PurchaseOfferingWithContext(ctx aws.Context, input *PurchaseOfferingInput, opts ...request.Option) (*PurchaseOfferingOutput, error) {
+	req, out := c.PurchaseOfferingRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opStartChannel = "StartChannel"
@@ -4366,6 +5018,196 @@ func (s DeleteInputSecurityGroupOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteReservationInput struct {
+	_ struct{} `type:"structure"`
+
+	// ReservationId is a required field
+	ReservationId *string `location:"uri" locationName:"reservationId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteReservationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReservationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteReservationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteReservationInput"}
+	if s.ReservationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *DeleteReservationInput) SetReservationId(v string) *DeleteReservationInput {
+	s.ReservationId = &v
+	return s
+}
+
+type DeleteReservationOutput struct {
+	_ struct{} `type:"structure"`
+
+	Arn *string `locationName:"arn" type:"string"`
+
+	Count *int64 `locationName:"count" type:"integer"`
+
+	CurrencyCode *string `locationName:"currencyCode" type:"string"`
+
+	Duration *int64 `locationName:"duration" type:"integer"`
+
+	// Units for duration, e.g. 'MONTHS'
+	DurationUnits *string `locationName:"durationUnits" type:"string" enum:"OfferingDurationUnits"`
+
+	End *string `locationName:"end" type:"string"`
+
+	FixedPrice *float64 `locationName:"fixedPrice" type:"double"`
+
+	Name *string `locationName:"name" type:"string"`
+
+	OfferingDescription *string `locationName:"offeringDescription" type:"string"`
+
+	OfferingId *string `locationName:"offeringId" type:"string"`
+
+	// Offering type, e.g. 'NO_UPFRONT'
+	OfferingType *string `locationName:"offeringType" type:"string" enum:"OfferingType"`
+
+	Region *string `locationName:"region" type:"string"`
+
+	ReservationId *string `locationName:"reservationId" type:"string"`
+
+	// Resource configuration (codec, resolution, bitrate, ...)
+	ResourceSpecification *ReservationResourceSpecification `locationName:"resourceSpecification" type:"structure"`
+
+	Start *string `locationName:"start" type:"string"`
+
+	// Current reservation state
+	State *string `locationName:"state" type:"string" enum:"ReservationState"`
+
+	UsagePrice *float64 `locationName:"usagePrice" type:"double"`
+}
+
+// String returns the string representation
+func (s DeleteReservationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReservationOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *DeleteReservationOutput) SetArn(v string) *DeleteReservationOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *DeleteReservationOutput) SetCount(v int64) *DeleteReservationOutput {
+	s.Count = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *DeleteReservationOutput) SetCurrencyCode(v string) *DeleteReservationOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DeleteReservationOutput) SetDuration(v int64) *DeleteReservationOutput {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationUnits sets the DurationUnits field's value.
+func (s *DeleteReservationOutput) SetDurationUnits(v string) *DeleteReservationOutput {
+	s.DurationUnits = &v
+	return s
+}
+
+// SetEnd sets the End field's value.
+func (s *DeleteReservationOutput) SetEnd(v string) *DeleteReservationOutput {
+	s.End = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *DeleteReservationOutput) SetFixedPrice(v float64) *DeleteReservationOutput {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteReservationOutput) SetName(v string) *DeleteReservationOutput {
+	s.Name = &v
+	return s
+}
+
+// SetOfferingDescription sets the OfferingDescription field's value.
+func (s *DeleteReservationOutput) SetOfferingDescription(v string) *DeleteReservationOutput {
+	s.OfferingDescription = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *DeleteReservationOutput) SetOfferingId(v string) *DeleteReservationOutput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DeleteReservationOutput) SetOfferingType(v string) *DeleteReservationOutput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *DeleteReservationOutput) SetRegion(v string) *DeleteReservationOutput {
+	s.Region = &v
+	return s
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *DeleteReservationOutput) SetReservationId(v string) *DeleteReservationOutput {
+	s.ReservationId = &v
+	return s
+}
+
+// SetResourceSpecification sets the ResourceSpecification field's value.
+func (s *DeleteReservationOutput) SetResourceSpecification(v *ReservationResourceSpecification) *DeleteReservationOutput {
+	s.ResourceSpecification = v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *DeleteReservationOutput) SetStart(v string) *DeleteReservationOutput {
+	s.Start = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DeleteReservationOutput) SetState(v string) *DeleteReservationOutput {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *DeleteReservationOutput) SetUsagePrice(v float64) *DeleteReservationOutput {
+	s.UsagePrice = &v
+	return s
+}
+
 type DescribeChannelInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4721,6 +5563,337 @@ func (s *DescribeInputSecurityGroupOutput) SetState(v string) *DescribeInputSecu
 // SetWhitelistRules sets the WhitelistRules field's value.
 func (s *DescribeInputSecurityGroupOutput) SetWhitelistRules(v []*InputWhitelistRule) *DescribeInputSecurityGroupOutput {
 	s.WhitelistRules = v
+	return s
+}
+
+type DescribeOfferingInput struct {
+	_ struct{} `type:"structure"`
+
+	// OfferingId is a required field
+	OfferingId *string `location:"uri" locationName:"offeringId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeOfferingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOfferingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeOfferingInput"}
+	if s.OfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("OfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *DescribeOfferingInput) SetOfferingId(v string) *DescribeOfferingInput {
+	s.OfferingId = &v
+	return s
+}
+
+type DescribeOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
+	Arn *string `locationName:"arn" type:"string"`
+
+	CurrencyCode *string `locationName:"currencyCode" type:"string"`
+
+	Duration *int64 `locationName:"duration" type:"integer"`
+
+	// Units for duration, e.g. 'MONTHS'
+	DurationUnits *string `locationName:"durationUnits" type:"string" enum:"OfferingDurationUnits"`
+
+	FixedPrice *float64 `locationName:"fixedPrice" type:"double"`
+
+	OfferingDescription *string `locationName:"offeringDescription" type:"string"`
+
+	OfferingId *string `locationName:"offeringId" type:"string"`
+
+	// Offering type, e.g. 'NO_UPFRONT'
+	OfferingType *string `locationName:"offeringType" type:"string" enum:"OfferingType"`
+
+	Region *string `locationName:"region" type:"string"`
+
+	// Resource configuration (codec, resolution, bitrate, ...)
+	ResourceSpecification *ReservationResourceSpecification `locationName:"resourceSpecification" type:"structure"`
+
+	UsagePrice *float64 `locationName:"usagePrice" type:"double"`
+}
+
+// String returns the string representation
+func (s DescribeOfferingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOfferingOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *DescribeOfferingOutput) SetArn(v string) *DescribeOfferingOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *DescribeOfferingOutput) SetCurrencyCode(v string) *DescribeOfferingOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeOfferingOutput) SetDuration(v int64) *DescribeOfferingOutput {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationUnits sets the DurationUnits field's value.
+func (s *DescribeOfferingOutput) SetDurationUnits(v string) *DescribeOfferingOutput {
+	s.DurationUnits = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *DescribeOfferingOutput) SetFixedPrice(v float64) *DescribeOfferingOutput {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetOfferingDescription sets the OfferingDescription field's value.
+func (s *DescribeOfferingOutput) SetOfferingDescription(v string) *DescribeOfferingOutput {
+	s.OfferingDescription = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *DescribeOfferingOutput) SetOfferingId(v string) *DescribeOfferingOutput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeOfferingOutput) SetOfferingType(v string) *DescribeOfferingOutput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *DescribeOfferingOutput) SetRegion(v string) *DescribeOfferingOutput {
+	s.Region = &v
+	return s
+}
+
+// SetResourceSpecification sets the ResourceSpecification field's value.
+func (s *DescribeOfferingOutput) SetResourceSpecification(v *ReservationResourceSpecification) *DescribeOfferingOutput {
+	s.ResourceSpecification = v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *DescribeOfferingOutput) SetUsagePrice(v float64) *DescribeOfferingOutput {
+	s.UsagePrice = &v
+	return s
+}
+
+type DescribeReservationInput struct {
+	_ struct{} `type:"structure"`
+
+	// ReservationId is a required field
+	ReservationId *string `location:"uri" locationName:"reservationId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeReservationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeReservationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeReservationInput"}
+	if s.ReservationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReservationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *DescribeReservationInput) SetReservationId(v string) *DescribeReservationInput {
+	s.ReservationId = &v
+	return s
+}
+
+type DescribeReservationOutput struct {
+	_ struct{} `type:"structure"`
+
+	Arn *string `locationName:"arn" type:"string"`
+
+	Count *int64 `locationName:"count" type:"integer"`
+
+	CurrencyCode *string `locationName:"currencyCode" type:"string"`
+
+	Duration *int64 `locationName:"duration" type:"integer"`
+
+	// Units for duration, e.g. 'MONTHS'
+	DurationUnits *string `locationName:"durationUnits" type:"string" enum:"OfferingDurationUnits"`
+
+	End *string `locationName:"end" type:"string"`
+
+	FixedPrice *float64 `locationName:"fixedPrice" type:"double"`
+
+	Name *string `locationName:"name" type:"string"`
+
+	OfferingDescription *string `locationName:"offeringDescription" type:"string"`
+
+	OfferingId *string `locationName:"offeringId" type:"string"`
+
+	// Offering type, e.g. 'NO_UPFRONT'
+	OfferingType *string `locationName:"offeringType" type:"string" enum:"OfferingType"`
+
+	Region *string `locationName:"region" type:"string"`
+
+	ReservationId *string `locationName:"reservationId" type:"string"`
+
+	// Resource configuration (codec, resolution, bitrate, ...)
+	ResourceSpecification *ReservationResourceSpecification `locationName:"resourceSpecification" type:"structure"`
+
+	Start *string `locationName:"start" type:"string"`
+
+	// Current reservation state
+	State *string `locationName:"state" type:"string" enum:"ReservationState"`
+
+	UsagePrice *float64 `locationName:"usagePrice" type:"double"`
+}
+
+// String returns the string representation
+func (s DescribeReservationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservationOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *DescribeReservationOutput) SetArn(v string) *DescribeReservationOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *DescribeReservationOutput) SetCount(v int64) *DescribeReservationOutput {
+	s.Count = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *DescribeReservationOutput) SetCurrencyCode(v string) *DescribeReservationOutput {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *DescribeReservationOutput) SetDuration(v int64) *DescribeReservationOutput {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationUnits sets the DurationUnits field's value.
+func (s *DescribeReservationOutput) SetDurationUnits(v string) *DescribeReservationOutput {
+	s.DurationUnits = &v
+	return s
+}
+
+// SetEnd sets the End field's value.
+func (s *DescribeReservationOutput) SetEnd(v string) *DescribeReservationOutput {
+	s.End = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *DescribeReservationOutput) SetFixedPrice(v float64) *DescribeReservationOutput {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeReservationOutput) SetName(v string) *DescribeReservationOutput {
+	s.Name = &v
+	return s
+}
+
+// SetOfferingDescription sets the OfferingDescription field's value.
+func (s *DescribeReservationOutput) SetOfferingDescription(v string) *DescribeReservationOutput {
+	s.OfferingDescription = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *DescribeReservationOutput) SetOfferingId(v string) *DescribeReservationOutput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *DescribeReservationOutput) SetOfferingType(v string) *DescribeReservationOutput {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *DescribeReservationOutput) SetRegion(v string) *DescribeReservationOutput {
+	s.Region = &v
+	return s
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *DescribeReservationOutput) SetReservationId(v string) *DescribeReservationOutput {
+	s.ReservationId = &v
+	return s
+}
+
+// SetResourceSpecification sets the ResourceSpecification field's value.
+func (s *DescribeReservationOutput) SetResourceSpecification(v *ReservationResourceSpecification) *DescribeReservationOutput {
+	s.ResourceSpecification = v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *DescribeReservationOutput) SetStart(v string) *DescribeReservationOutput {
+	s.Start = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeReservationOutput) SetState(v string) *DescribeReservationOutput {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *DescribeReservationOutput) SetUsagePrice(v float64) *DescribeReservationOutput {
+	s.UsagePrice = &v
 	return s
 }
 
@@ -8164,6 +9337,272 @@ func (s *ListInputsOutput) SetNextToken(v string) *ListInputsOutput {
 	return s
 }
 
+type ListOfferingsInput struct {
+	_ struct{} `type:"structure"`
+
+	ChannelConfiguration *string `location:"querystring" locationName:"channelConfiguration" type:"string"`
+
+	Codec *string `location:"querystring" locationName:"codec" type:"string"`
+
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	MaximumBitrate *string `location:"querystring" locationName:"maximumBitrate" type:"string"`
+
+	MaximumFramerate *string `location:"querystring" locationName:"maximumFramerate" type:"string"`
+
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	Resolution *string `location:"querystring" locationName:"resolution" type:"string"`
+
+	ResourceType *string `location:"querystring" locationName:"resourceType" type:"string"`
+
+	SpecialFeature *string `location:"querystring" locationName:"specialFeature" type:"string"`
+
+	VideoQuality *string `location:"querystring" locationName:"videoQuality" type:"string"`
+}
+
+// String returns the string representation
+func (s ListOfferingsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListOfferingsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListOfferingsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListOfferingsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetChannelConfiguration sets the ChannelConfiguration field's value.
+func (s *ListOfferingsInput) SetChannelConfiguration(v string) *ListOfferingsInput {
+	s.ChannelConfiguration = &v
+	return s
+}
+
+// SetCodec sets the Codec field's value.
+func (s *ListOfferingsInput) SetCodec(v string) *ListOfferingsInput {
+	s.Codec = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListOfferingsInput) SetMaxResults(v int64) *ListOfferingsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetMaximumBitrate sets the MaximumBitrate field's value.
+func (s *ListOfferingsInput) SetMaximumBitrate(v string) *ListOfferingsInput {
+	s.MaximumBitrate = &v
+	return s
+}
+
+// SetMaximumFramerate sets the MaximumFramerate field's value.
+func (s *ListOfferingsInput) SetMaximumFramerate(v string) *ListOfferingsInput {
+	s.MaximumFramerate = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingsInput) SetNextToken(v string) *ListOfferingsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *ListOfferingsInput) SetResolution(v string) *ListOfferingsInput {
+	s.Resolution = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListOfferingsInput) SetResourceType(v string) *ListOfferingsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSpecialFeature sets the SpecialFeature field's value.
+func (s *ListOfferingsInput) SetSpecialFeature(v string) *ListOfferingsInput {
+	s.SpecialFeature = &v
+	return s
+}
+
+// SetVideoQuality sets the VideoQuality field's value.
+func (s *ListOfferingsInput) SetVideoQuality(v string) *ListOfferingsInput {
+	s.VideoQuality = &v
+	return s
+}
+
+type ListOfferingsOutput struct {
+	_ struct{} `type:"structure"`
+
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	Offerings []*Offering `locationName:"offerings" type:"list"`
+}
+
+// String returns the string representation
+func (s ListOfferingsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListOfferingsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListOfferingsOutput) SetNextToken(v string) *ListOfferingsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetOfferings sets the Offerings field's value.
+func (s *ListOfferingsOutput) SetOfferings(v []*Offering) *ListOfferingsOutput {
+	s.Offerings = v
+	return s
+}
+
+type ListReservationsInput struct {
+	_ struct{} `type:"structure"`
+
+	Codec *string `location:"querystring" locationName:"codec" type:"string"`
+
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	MaximumBitrate *string `location:"querystring" locationName:"maximumBitrate" type:"string"`
+
+	MaximumFramerate *string `location:"querystring" locationName:"maximumFramerate" type:"string"`
+
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+
+	Resolution *string `location:"querystring" locationName:"resolution" type:"string"`
+
+	ResourceType *string `location:"querystring" locationName:"resourceType" type:"string"`
+
+	SpecialFeature *string `location:"querystring" locationName:"specialFeature" type:"string"`
+
+	VideoQuality *string `location:"querystring" locationName:"videoQuality" type:"string"`
+}
+
+// String returns the string representation
+func (s ListReservationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListReservationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListReservationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListReservationsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCodec sets the Codec field's value.
+func (s *ListReservationsInput) SetCodec(v string) *ListReservationsInput {
+	s.Codec = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListReservationsInput) SetMaxResults(v int64) *ListReservationsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetMaximumBitrate sets the MaximumBitrate field's value.
+func (s *ListReservationsInput) SetMaximumBitrate(v string) *ListReservationsInput {
+	s.MaximumBitrate = &v
+	return s
+}
+
+// SetMaximumFramerate sets the MaximumFramerate field's value.
+func (s *ListReservationsInput) SetMaximumFramerate(v string) *ListReservationsInput {
+	s.MaximumFramerate = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListReservationsInput) SetNextToken(v string) *ListReservationsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *ListReservationsInput) SetResolution(v string) *ListReservationsInput {
+	s.Resolution = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ListReservationsInput) SetResourceType(v string) *ListReservationsInput {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSpecialFeature sets the SpecialFeature field's value.
+func (s *ListReservationsInput) SetSpecialFeature(v string) *ListReservationsInput {
+	s.SpecialFeature = &v
+	return s
+}
+
+// SetVideoQuality sets the VideoQuality field's value.
+func (s *ListReservationsInput) SetVideoQuality(v string) *ListReservationsInput {
+	s.VideoQuality = &v
+	return s
+}
+
+type ListReservationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	NextToken *string `locationName:"nextToken" type:"string"`
+
+	Reservations []*Reservation `locationName:"reservations" type:"list"`
+}
+
+// String returns the string representation
+func (s ListReservationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListReservationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListReservationsOutput) SetNextToken(v string) *ListReservationsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetReservations sets the Reservations field's value.
+func (s *ListReservationsOutput) SetReservations(v []*Reservation) *ListReservationsOutput {
+	s.Reservations = v
+	return s
+}
+
 type M2tsSettings struct {
 	_ struct{} `type:"structure"`
 
@@ -9212,6 +10651,121 @@ func (s *NetworkInputSettings) SetServerValidation(v string) *NetworkInputSettin
 	return s
 }
 
+// Reserved resources available for purchase
+type Offering struct {
+	_ struct{} `type:"structure"`
+
+	// Unique offering ARN, e.g. 'arn:aws:medialive:us-west-2:123456789012:offering:87654321'
+	Arn *string `locationName:"arn" type:"string"`
+
+	// Currency code for usagePrice and fixedPrice in ISO-4217 format, e.g. 'USD'
+	CurrencyCode *string `locationName:"currencyCode" type:"string"`
+
+	// Lease duration, e.g. '12'
+	Duration *int64 `locationName:"duration" type:"integer"`
+
+	// Units for duration, e.g. 'MONTHS'
+	DurationUnits *string `locationName:"durationUnits" type:"string" enum:"OfferingDurationUnits"`
+
+	// One-time charge for each reserved resource, e.g. '0.0' for a NO_UPFRONT offering
+	FixedPrice *float64 `locationName:"fixedPrice" type:"double"`
+
+	// Offering description, e.g. 'HD AVC output at 10-20 Mbps, 30 fps, and standard
+	// VQ in US West (Oregon)'
+	OfferingDescription *string `locationName:"offeringDescription" type:"string"`
+
+	// Unique offering ID, e.g. '87654321'
+	OfferingId *string `locationName:"offeringId" type:"string"`
+
+	// Offering type, e.g. 'NO_UPFRONT'
+	OfferingType *string `locationName:"offeringType" type:"string" enum:"OfferingType"`
+
+	// AWS region, e.g. 'us-west-2'
+	Region *string `locationName:"region" type:"string"`
+
+	// Resource configuration details
+	ResourceSpecification *ReservationResourceSpecification `locationName:"resourceSpecification" type:"structure"`
+
+	// Recurring usage charge for each reserved resource, e.g. '157.0'
+	UsagePrice *float64 `locationName:"usagePrice" type:"double"`
+}
+
+// String returns the string representation
+func (s Offering) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Offering) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Offering) SetArn(v string) *Offering {
+	s.Arn = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *Offering) SetCurrencyCode(v string) *Offering {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *Offering) SetDuration(v int64) *Offering {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationUnits sets the DurationUnits field's value.
+func (s *Offering) SetDurationUnits(v string) *Offering {
+	s.DurationUnits = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *Offering) SetFixedPrice(v float64) *Offering {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetOfferingDescription sets the OfferingDescription field's value.
+func (s *Offering) SetOfferingDescription(v string) *Offering {
+	s.OfferingDescription = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *Offering) SetOfferingId(v string) *Offering {
+	s.OfferingId = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *Offering) SetOfferingType(v string) *Offering {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Offering) SetRegion(v string) *Offering {
+	s.Region = &v
+	return s
+}
+
+// SetResourceSpecification sets the ResourceSpecification field's value.
+func (s *Offering) SetResourceSpecification(v *ReservationResourceSpecification) *Offering {
+	s.ResourceSpecification = v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *Offering) SetUsagePrice(v float64) *Offering {
+	s.UsagePrice = &v
+	return s
+}
+
 // Output settings. There can be multiple outputs within a group.
 type Output struct {
 	_ struct{} `type:"structure"`
@@ -9659,6 +11213,92 @@ func (s PassThroughSettings) GoString() string {
 	return s.String()
 }
 
+type PurchaseOfferingInput struct {
+	_ struct{} `type:"structure"`
+
+	Count *int64 `locationName:"count" min:"1" type:"integer"`
+
+	Name *string `locationName:"name" type:"string"`
+
+	// OfferingId is a required field
+	OfferingId *string `location:"uri" locationName:"offeringId" type:"string" required:"true"`
+
+	RequestId *string `locationName:"requestId" type:"string" idempotencyToken:"true"`
+}
+
+// String returns the string representation
+func (s PurchaseOfferingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseOfferingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseOfferingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseOfferingInput"}
+	if s.Count != nil && *s.Count < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("Count", 1))
+	}
+	if s.OfferingId == nil {
+		invalidParams.Add(request.NewErrParamRequired("OfferingId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCount sets the Count field's value.
+func (s *PurchaseOfferingInput) SetCount(v int64) *PurchaseOfferingInput {
+	s.Count = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PurchaseOfferingInput) SetName(v string) *PurchaseOfferingInput {
+	s.Name = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *PurchaseOfferingInput) SetOfferingId(v string) *PurchaseOfferingInput {
+	s.OfferingId = &v
+	return s
+}
+
+// SetRequestId sets the RequestId field's value.
+func (s *PurchaseOfferingInput) SetRequestId(v string) *PurchaseOfferingInput {
+	s.RequestId = &v
+	return s
+}
+
+type PurchaseOfferingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Reserved resources available to use
+	Reservation *Reservation `locationName:"reservation" type:"structure"`
+}
+
+// String returns the string representation
+func (s PurchaseOfferingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseOfferingOutput) GoString() string {
+	return s.String()
+}
+
+// SetReservation sets the Reservation field's value.
+func (s *PurchaseOfferingOutput) SetReservation(v *Reservation) *PurchaseOfferingOutput {
+	s.Reservation = v
+	return s
+}
+
 type RemixSettings struct {
 	_ struct{} `type:"structure"`
 
@@ -9728,6 +11368,253 @@ func (s *RemixSettings) SetChannelsIn(v int64) *RemixSettings {
 // SetChannelsOut sets the ChannelsOut field's value.
 func (s *RemixSettings) SetChannelsOut(v int64) *RemixSettings {
 	s.ChannelsOut = &v
+	return s
+}
+
+// Reserved resources available to use
+type Reservation struct {
+	_ struct{} `type:"structure"`
+
+	// Unique reservation ARN, e.g. 'arn:aws:medialive:us-west-2:123456789012:reservation:1234567'
+	Arn *string `locationName:"arn" type:"string"`
+
+	// Number of reserved resources
+	Count *int64 `locationName:"count" type:"integer"`
+
+	// Currency code for usagePrice and fixedPrice in ISO-4217 format, e.g. 'USD'
+	CurrencyCode *string `locationName:"currencyCode" type:"string"`
+
+	// Lease duration, e.g. '12'
+	Duration *int64 `locationName:"duration" type:"integer"`
+
+	// Units for duration, e.g. 'MONTHS'
+	DurationUnits *string `locationName:"durationUnits" type:"string" enum:"OfferingDurationUnits"`
+
+	// Reservation UTC end date and time in ISO-8601 format, e.g. '2019-03-01T00:00:00'
+	End *string `locationName:"end" type:"string"`
+
+	// One-time charge for each reserved resource, e.g. '0.0' for a NO_UPFRONT offering
+	FixedPrice *float64 `locationName:"fixedPrice" type:"double"`
+
+	// User specified reservation name
+	Name *string `locationName:"name" type:"string"`
+
+	// Offering description, e.g. 'HD AVC output at 10-20 Mbps, 30 fps, and standard
+	// VQ in US West (Oregon)'
+	OfferingDescription *string `locationName:"offeringDescription" type:"string"`
+
+	// Unique offering ID, e.g. '87654321'
+	OfferingId *string `locationName:"offeringId" type:"string"`
+
+	// Offering type, e.g. 'NO_UPFRONT'
+	OfferingType *string `locationName:"offeringType" type:"string" enum:"OfferingType"`
+
+	// AWS region, e.g. 'us-west-2'
+	Region *string `locationName:"region" type:"string"`
+
+	// Unique reservation ID, e.g. '1234567'
+	ReservationId *string `locationName:"reservationId" type:"string"`
+
+	// Resource configuration details
+	ResourceSpecification *ReservationResourceSpecification `locationName:"resourceSpecification" type:"structure"`
+
+	// Reservation UTC start date and time in ISO-8601 format, e.g. '2018-03-01T00:00:00'
+	Start *string `locationName:"start" type:"string"`
+
+	// Current state of reservation, e.g. 'ACTIVE'
+	State *string `locationName:"state" type:"string" enum:"ReservationState"`
+
+	// Recurring usage charge for each reserved resource, e.g. '157.0'
+	UsagePrice *float64 `locationName:"usagePrice" type:"double"`
+}
+
+// String returns the string representation
+func (s Reservation) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Reservation) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Reservation) SetArn(v string) *Reservation {
+	s.Arn = &v
+	return s
+}
+
+// SetCount sets the Count field's value.
+func (s *Reservation) SetCount(v int64) *Reservation {
+	s.Count = &v
+	return s
+}
+
+// SetCurrencyCode sets the CurrencyCode field's value.
+func (s *Reservation) SetCurrencyCode(v string) *Reservation {
+	s.CurrencyCode = &v
+	return s
+}
+
+// SetDuration sets the Duration field's value.
+func (s *Reservation) SetDuration(v int64) *Reservation {
+	s.Duration = &v
+	return s
+}
+
+// SetDurationUnits sets the DurationUnits field's value.
+func (s *Reservation) SetDurationUnits(v string) *Reservation {
+	s.DurationUnits = &v
+	return s
+}
+
+// SetEnd sets the End field's value.
+func (s *Reservation) SetEnd(v string) *Reservation {
+	s.End = &v
+	return s
+}
+
+// SetFixedPrice sets the FixedPrice field's value.
+func (s *Reservation) SetFixedPrice(v float64) *Reservation {
+	s.FixedPrice = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Reservation) SetName(v string) *Reservation {
+	s.Name = &v
+	return s
+}
+
+// SetOfferingDescription sets the OfferingDescription field's value.
+func (s *Reservation) SetOfferingDescription(v string) *Reservation {
+	s.OfferingDescription = &v
+	return s
+}
+
+// SetOfferingId sets the OfferingId field's value.
+func (s *Reservation) SetOfferingId(v string) *Reservation {
+	s.OfferingId = &v
+	return s
+}
+
+// SetOfferingType sets the OfferingType field's value.
+func (s *Reservation) SetOfferingType(v string) *Reservation {
+	s.OfferingType = &v
+	return s
+}
+
+// SetRegion sets the Region field's value.
+func (s *Reservation) SetRegion(v string) *Reservation {
+	s.Region = &v
+	return s
+}
+
+// SetReservationId sets the ReservationId field's value.
+func (s *Reservation) SetReservationId(v string) *Reservation {
+	s.ReservationId = &v
+	return s
+}
+
+// SetResourceSpecification sets the ResourceSpecification field's value.
+func (s *Reservation) SetResourceSpecification(v *ReservationResourceSpecification) *Reservation {
+	s.ResourceSpecification = v
+	return s
+}
+
+// SetStart sets the Start field's value.
+func (s *Reservation) SetStart(v string) *Reservation {
+	s.Start = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Reservation) SetState(v string) *Reservation {
+	s.State = &v
+	return s
+}
+
+// SetUsagePrice sets the UsagePrice field's value.
+func (s *Reservation) SetUsagePrice(v float64) *Reservation {
+	s.UsagePrice = &v
+	return s
+}
+
+// Resource configuration (codec, resolution, bitrate, ...)
+type ReservationResourceSpecification struct {
+	_ struct{} `type:"structure"`
+
+	// Codec, e.g. 'AVC'
+	Codec *string `locationName:"codec" type:"string" enum:"ReservationCodec"`
+
+	// Maximum bitrate, e.g. 'MAX_20_MBPS'
+	MaximumBitrate *string `locationName:"maximumBitrate" type:"string" enum:"ReservationMaximumBitrate"`
+
+	// Maximum framerate, e.g. 'MAX_30_FPS' (Outputs only)
+	MaximumFramerate *string `locationName:"maximumFramerate" type:"string" enum:"ReservationMaximumFramerate"`
+
+	// Resolution, e.g. 'HD'
+	Resolution *string `locationName:"resolution" type:"string" enum:"ReservationResolution"`
+
+	// Resource type, 'INPUT', 'OUTPUT', or 'CHANNEL'
+	ResourceType *string `locationName:"resourceType" type:"string" enum:"ReservationResourceType"`
+
+	// Special feature, e.g. 'AUDIO_NORMALIZATION' (Channels only)
+	SpecialFeature *string `locationName:"specialFeature" type:"string" enum:"ReservationSpecialFeature"`
+
+	// Video quality, e.g. 'STANDARD' (Outputs only)
+	VideoQuality *string `locationName:"videoQuality" type:"string" enum:"ReservationVideoQuality"`
+}
+
+// String returns the string representation
+func (s ReservationResourceSpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ReservationResourceSpecification) GoString() string {
+	return s.String()
+}
+
+// SetCodec sets the Codec field's value.
+func (s *ReservationResourceSpecification) SetCodec(v string) *ReservationResourceSpecification {
+	s.Codec = &v
+	return s
+}
+
+// SetMaximumBitrate sets the MaximumBitrate field's value.
+func (s *ReservationResourceSpecification) SetMaximumBitrate(v string) *ReservationResourceSpecification {
+	s.MaximumBitrate = &v
+	return s
+}
+
+// SetMaximumFramerate sets the MaximumFramerate field's value.
+func (s *ReservationResourceSpecification) SetMaximumFramerate(v string) *ReservationResourceSpecification {
+	s.MaximumFramerate = &v
+	return s
+}
+
+// SetResolution sets the Resolution field's value.
+func (s *ReservationResourceSpecification) SetResolution(v string) *ReservationResourceSpecification {
+	s.Resolution = &v
+	return s
+}
+
+// SetResourceType sets the ResourceType field's value.
+func (s *ReservationResourceSpecification) SetResourceType(v string) *ReservationResourceSpecification {
+	s.ResourceType = &v
+	return s
+}
+
+// SetSpecialFeature sets the SpecialFeature field's value.
+func (s *ReservationResourceSpecification) SetSpecialFeature(v string) *ReservationResourceSpecification {
+	s.SpecialFeature = &v
+	return s
+}
+
+// SetVideoQuality sets the VideoQuality field's value.
+func (s *ReservationResourceSpecification) SetVideoQuality(v string) *ReservationResourceSpecification {
+	s.VideoQuality = &v
 	return s
 }
 
@@ -12885,6 +14772,115 @@ const (
 
 	// NetworkInputServerValidationCheckCryptographyOnly is a NetworkInputServerValidation enum value
 	NetworkInputServerValidationCheckCryptographyOnly = "CHECK_CRYPTOGRAPHY_ONLY"
+)
+
+// Units for duration, e.g. 'MONTHS'
+const (
+	// OfferingDurationUnitsMonths is a OfferingDurationUnits enum value
+	OfferingDurationUnitsMonths = "MONTHS"
+)
+
+// Offering type, e.g. 'NO_UPFRONT'
+const (
+	// OfferingTypeNoUpfront is a OfferingType enum value
+	OfferingTypeNoUpfront = "NO_UPFRONT"
+)
+
+// Codec, 'MPEG2', 'AVC', 'HEVC', or 'AUDIO'
+const (
+	// ReservationCodecMpeg2 is a ReservationCodec enum value
+	ReservationCodecMpeg2 = "MPEG2"
+
+	// ReservationCodecAvc is a ReservationCodec enum value
+	ReservationCodecAvc = "AVC"
+
+	// ReservationCodecHevc is a ReservationCodec enum value
+	ReservationCodecHevc = "HEVC"
+
+	// ReservationCodecAudio is a ReservationCodec enum value
+	ReservationCodecAudio = "AUDIO"
+)
+
+// Maximum bitrate in megabits per second
+const (
+	// ReservationMaximumBitrateMax10Mbps is a ReservationMaximumBitrate enum value
+	ReservationMaximumBitrateMax10Mbps = "MAX_10_MBPS"
+
+	// ReservationMaximumBitrateMax20Mbps is a ReservationMaximumBitrate enum value
+	ReservationMaximumBitrateMax20Mbps = "MAX_20_MBPS"
+
+	// ReservationMaximumBitrateMax50Mbps is a ReservationMaximumBitrate enum value
+	ReservationMaximumBitrateMax50Mbps = "MAX_50_MBPS"
+)
+
+// Maximum framerate in frames per second (Outputs only)
+const (
+	// ReservationMaximumFramerateMax30Fps is a ReservationMaximumFramerate enum value
+	ReservationMaximumFramerateMax30Fps = "MAX_30_FPS"
+
+	// ReservationMaximumFramerateMax60Fps is a ReservationMaximumFramerate enum value
+	ReservationMaximumFramerateMax60Fps = "MAX_60_FPS"
+)
+
+// Resolution based on lines of vertical resolution; SD is less than 720 lines,
+// HD is 720 to 1080 lines, UHD is greater than 1080 lines
+const (
+	// ReservationResolutionSd is a ReservationResolution enum value
+	ReservationResolutionSd = "SD"
+
+	// ReservationResolutionHd is a ReservationResolution enum value
+	ReservationResolutionHd = "HD"
+
+	// ReservationResolutionUhd is a ReservationResolution enum value
+	ReservationResolutionUhd = "UHD"
+)
+
+// Resource type, 'INPUT', 'OUTPUT', or 'CHANNEL'
+const (
+	// ReservationResourceTypeInput is a ReservationResourceType enum value
+	ReservationResourceTypeInput = "INPUT"
+
+	// ReservationResourceTypeOutput is a ReservationResourceType enum value
+	ReservationResourceTypeOutput = "OUTPUT"
+
+	// ReservationResourceTypeChannel is a ReservationResourceType enum value
+	ReservationResourceTypeChannel = "CHANNEL"
+)
+
+// Special features, 'ADVANCED_AUDIO' or 'AUDIO_NORMALIZATION'
+const (
+	// ReservationSpecialFeatureAdvancedAudio is a ReservationSpecialFeature enum value
+	ReservationSpecialFeatureAdvancedAudio = "ADVANCED_AUDIO"
+
+	// ReservationSpecialFeatureAudioNormalization is a ReservationSpecialFeature enum value
+	ReservationSpecialFeatureAudioNormalization = "AUDIO_NORMALIZATION"
+)
+
+// Current reservation state
+const (
+	// ReservationStateActive is a ReservationState enum value
+	ReservationStateActive = "ACTIVE"
+
+	// ReservationStateExpired is a ReservationState enum value
+	ReservationStateExpired = "EXPIRED"
+
+	// ReservationStateCanceled is a ReservationState enum value
+	ReservationStateCanceled = "CANCELED"
+
+	// ReservationStateDeleted is a ReservationState enum value
+	ReservationStateDeleted = "DELETED"
+)
+
+// Video quality, e.g. 'STANDARD' (Outputs only)
+const (
+	// ReservationVideoQualityStandard is a ReservationVideoQuality enum value
+	ReservationVideoQualityStandard = "STANDARD"
+
+	// ReservationVideoQualityEnhanced is a ReservationVideoQuality enum value
+	ReservationVideoQualityEnhanced = "ENHANCED"
+
+	// ReservationVideoQualityPremium is a ReservationVideoQuality enum value
+	ReservationVideoQualityPremium = "PREMIUM"
 )
 
 const (

--- a/service/medialive/medialiveiface/interface.go
+++ b/service/medialive/medialiveiface/interface.go
@@ -84,6 +84,10 @@ type MediaLiveAPI interface {
 	DeleteInputSecurityGroupWithContext(aws.Context, *medialive.DeleteInputSecurityGroupInput, ...request.Option) (*medialive.DeleteInputSecurityGroupOutput, error)
 	DeleteInputSecurityGroupRequest(*medialive.DeleteInputSecurityGroupInput) (*request.Request, *medialive.DeleteInputSecurityGroupOutput)
 
+	DeleteReservation(*medialive.DeleteReservationInput) (*medialive.DeleteReservationOutput, error)
+	DeleteReservationWithContext(aws.Context, *medialive.DeleteReservationInput, ...request.Option) (*medialive.DeleteReservationOutput, error)
+	DeleteReservationRequest(*medialive.DeleteReservationInput) (*request.Request, *medialive.DeleteReservationOutput)
+
 	DescribeChannel(*medialive.DescribeChannelInput) (*medialive.DescribeChannelOutput, error)
 	DescribeChannelWithContext(aws.Context, *medialive.DescribeChannelInput, ...request.Option) (*medialive.DescribeChannelOutput, error)
 	DescribeChannelRequest(*medialive.DescribeChannelInput) (*request.Request, *medialive.DescribeChannelOutput)
@@ -95,6 +99,14 @@ type MediaLiveAPI interface {
 	DescribeInputSecurityGroup(*medialive.DescribeInputSecurityGroupInput) (*medialive.DescribeInputSecurityGroupOutput, error)
 	DescribeInputSecurityGroupWithContext(aws.Context, *medialive.DescribeInputSecurityGroupInput, ...request.Option) (*medialive.DescribeInputSecurityGroupOutput, error)
 	DescribeInputSecurityGroupRequest(*medialive.DescribeInputSecurityGroupInput) (*request.Request, *medialive.DescribeInputSecurityGroupOutput)
+
+	DescribeOffering(*medialive.DescribeOfferingInput) (*medialive.DescribeOfferingOutput, error)
+	DescribeOfferingWithContext(aws.Context, *medialive.DescribeOfferingInput, ...request.Option) (*medialive.DescribeOfferingOutput, error)
+	DescribeOfferingRequest(*medialive.DescribeOfferingInput) (*request.Request, *medialive.DescribeOfferingOutput)
+
+	DescribeReservation(*medialive.DescribeReservationInput) (*medialive.DescribeReservationOutput, error)
+	DescribeReservationWithContext(aws.Context, *medialive.DescribeReservationInput, ...request.Option) (*medialive.DescribeReservationOutput, error)
+	DescribeReservationRequest(*medialive.DescribeReservationInput) (*request.Request, *medialive.DescribeReservationOutput)
 
 	ListChannels(*medialive.ListChannelsInput) (*medialive.ListChannelsOutput, error)
 	ListChannelsWithContext(aws.Context, *medialive.ListChannelsInput, ...request.Option) (*medialive.ListChannelsOutput, error)
@@ -116,6 +128,24 @@ type MediaLiveAPI interface {
 
 	ListInputsPages(*medialive.ListInputsInput, func(*medialive.ListInputsOutput, bool) bool) error
 	ListInputsPagesWithContext(aws.Context, *medialive.ListInputsInput, func(*medialive.ListInputsOutput, bool) bool, ...request.Option) error
+
+	ListOfferings(*medialive.ListOfferingsInput) (*medialive.ListOfferingsOutput, error)
+	ListOfferingsWithContext(aws.Context, *medialive.ListOfferingsInput, ...request.Option) (*medialive.ListOfferingsOutput, error)
+	ListOfferingsRequest(*medialive.ListOfferingsInput) (*request.Request, *medialive.ListOfferingsOutput)
+
+	ListOfferingsPages(*medialive.ListOfferingsInput, func(*medialive.ListOfferingsOutput, bool) bool) error
+	ListOfferingsPagesWithContext(aws.Context, *medialive.ListOfferingsInput, func(*medialive.ListOfferingsOutput, bool) bool, ...request.Option) error
+
+	ListReservations(*medialive.ListReservationsInput) (*medialive.ListReservationsOutput, error)
+	ListReservationsWithContext(aws.Context, *medialive.ListReservationsInput, ...request.Option) (*medialive.ListReservationsOutput, error)
+	ListReservationsRequest(*medialive.ListReservationsInput) (*request.Request, *medialive.ListReservationsOutput)
+
+	ListReservationsPages(*medialive.ListReservationsInput, func(*medialive.ListReservationsOutput, bool) bool) error
+	ListReservationsPagesWithContext(aws.Context, *medialive.ListReservationsInput, func(*medialive.ListReservationsOutput, bool) bool, ...request.Option) error
+
+	PurchaseOffering(*medialive.PurchaseOfferingInput) (*medialive.PurchaseOfferingOutput, error)
+	PurchaseOfferingWithContext(aws.Context, *medialive.PurchaseOfferingInput, ...request.Option) (*medialive.PurchaseOfferingOutput, error)
+	PurchaseOfferingRequest(*medialive.PurchaseOfferingInput) (*request.Request, *medialive.PurchaseOfferingOutput)
 
 	StartChannel(*medialive.StartChannelInput) (*medialive.StartChannelOutput, error)
 	StartChannelWithContext(aws.Context, *medialive.StartChannelInput, ...request.Option) (*medialive.StartChannelOutput, error)

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -8861,6 +8861,10 @@ func (c *RDS) RestoreDBClusterFromSnapshotRequest(input *RestoreDBClusterFromSna
 //   * ErrCodeKMSKeyNotAccessibleFault "KMSKeyNotAccessibleFault"
 //   An error occurred accessing an AWS KMS key.
 //
+//   * ErrCodeDBClusterParameterGroupNotFoundFault "DBClusterParameterGroupNotFound"
+//   DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter
+//   group.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBClusterFromSnapshot
 func (c *RDS) RestoreDBClusterFromSnapshot(input *RestoreDBClusterFromSnapshotInput) (*RestoreDBClusterFromSnapshotOutput, error) {
 	req, out := c.RestoreDBClusterFromSnapshotRequest(input)
@@ -9004,6 +9008,10 @@ func (c *RDS) RestoreDBClusterToPointInTimeRequest(input *RestoreDBClusterToPoin
 //   * ErrCodeStorageQuotaExceededFault "StorageQuotaExceeded"
 //   The request would result in the user exceeding the allowed amount of storage
 //   available across all DB instances.
+//
+//   * ErrCodeDBClusterParameterGroupNotFoundFault "DBClusterParameterGroupNotFound"
+//   DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter
+//   group.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBClusterToPointInTime
 func (c *RDS) RestoreDBClusterToPointInTime(input *RestoreDBClusterToPointInTimeInput) (*RestoreDBClusterToPointInTimeOutput, error) {
@@ -9164,6 +9172,9 @@ func (c *RDS) RestoreDBInstanceFromDBSnapshotRequest(input *RestoreDBInstanceFro
 //
 //   * ErrCodeDomainNotFoundFault "DomainNotFoundFault"
 //   Domain doesn't refer to an existing Active Directory domain.
+//
+//   * ErrCodeDBParameterGroupNotFoundFault "DBParameterGroupNotFound"
+//   DBParameterGroupName doesn't refer to an existing DB parameter group.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBInstanceFromDBSnapshot
 func (c *RDS) RestoreDBInstanceFromDBSnapshot(input *RestoreDBInstanceFromDBSnapshotInput) (*RestoreDBInstanceFromDBSnapshotOutput, error) {
@@ -9461,6 +9472,9 @@ func (c *RDS) RestoreDBInstanceToPointInTimeRequest(input *RestoreDBInstanceToPo
 //
 //   * ErrCodeDomainNotFoundFault "DomainNotFoundFault"
 //   Domain doesn't refer to an existing Active Directory domain.
+//
+//   * ErrCodeDBParameterGroupNotFoundFault "DBParameterGroupNotFound"
+//   DBParameterGroupName doesn't refer to an existing DB parameter group.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBInstanceToPointInTime
 func (c *RDS) RestoreDBInstanceToPointInTime(input *RestoreDBInstanceToPointInTimeInput) (*RestoreDBInstanceToPointInTimeOutput, error) {
@@ -12682,6 +12696,10 @@ type CreateDBInstanceInput struct {
 	// KMS key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
+	// The amount of time, in days, to retain Performance Insights data. Valid values
+	// are 7 or 731 (2 years).
+	PerformanceInsightsRetentionPeriod *int64 `type:"integer"`
+
 	// The port number on which the database accepts connections.
 	//
 	// MySQL
@@ -13052,6 +13070,12 @@ func (s *CreateDBInstanceInput) SetPerformanceInsightsKMSKeyId(v string) *Create
 	return s
 }
 
+// SetPerformanceInsightsRetentionPeriod sets the PerformanceInsightsRetentionPeriod field's value.
+func (s *CreateDBInstanceInput) SetPerformanceInsightsRetentionPeriod(v int64) *CreateDBInstanceInput {
+	s.PerformanceInsightsRetentionPeriod = &v
+	return s
+}
+
 // SetPort sets the Port field's value.
 func (s *CreateDBInstanceInput) SetPort(v int64) *CreateDBInstanceInput {
 	s.Port = &v
@@ -13300,6 +13324,10 @@ type CreateDBInstanceReadReplicaInput struct {
 	// KMS key ID is the Amazon Resource Name (ARN), KMS key identifier, or the
 	// KMS key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
+
+	// The amount of time, in days, to retain Performance Insights data. Valid values
+	// are 7 or 731 (2 years).
+	PerformanceInsightsRetentionPeriod *int64 `type:"integer"`
 
 	// The port number that the DB instance uses for connections.
 	//
@@ -13551,6 +13579,12 @@ func (s *CreateDBInstanceReadReplicaInput) SetPerformanceInsightsKMSKeyId(v stri
 	return s
 }
 
+// SetPerformanceInsightsRetentionPeriod sets the PerformanceInsightsRetentionPeriod field's value.
+func (s *CreateDBInstanceReadReplicaInput) SetPerformanceInsightsRetentionPeriod(v int64) *CreateDBInstanceReadReplicaInput {
+	s.PerformanceInsightsRetentionPeriod = &v
+	return s
+}
+
 // SetPort sets the Port field's value.
 func (s *CreateDBInstanceReadReplicaInput) SetPort(v int64) *CreateDBInstanceReadReplicaInput {
 	s.Port = &v
@@ -13637,6 +13671,13 @@ type CreateDBParameterGroupInput struct {
 	// with one and only one DB parameter group family, and can be applied only
 	// to a DB instance running a database engine and engine version compatible
 	// with that DB parameter group family.
+	//
+	// To list all of the available parameter group families, use the following
+	// command:
+	//
+	// aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"
+	//
+	// The output contains duplicates.
 	//
 	// DBParameterGroupFamily is a required field
 	DBParameterGroupFamily *string `type:"string" required:"true"`
@@ -15540,6 +15581,10 @@ type DBInstance struct {
 	// KMS key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
+	// The amount of time, in days, to retain Performance Insights data. Valid values
+	// are 7 or 731 (2 years).
+	PerformanceInsightsRetentionPeriod *int64 `type:"integer"`
+
 	// Specifies the daily time range during which automated backups are created
 	// if automated backups are enabled, as determined by the BackupRetentionPeriod.
 	PreferredBackupWindow *string `type:"string"`
@@ -15850,6 +15895,12 @@ func (s *DBInstance) SetPerformanceInsightsEnabled(v bool) *DBInstance {
 // SetPerformanceInsightsKMSKeyId sets the PerformanceInsightsKMSKeyId field's value.
 func (s *DBInstance) SetPerformanceInsightsKMSKeyId(v string) *DBInstance {
 	s.PerformanceInsightsKMSKeyId = &v
+	return s
+}
+
+// SetPerformanceInsightsRetentionPeriod sets the PerformanceInsightsRetentionPeriod field's value.
+func (s *DBInstance) SetPerformanceInsightsRetentionPeriod(v int64) *DBInstance {
+	s.PerformanceInsightsRetentionPeriod = &v
 	return s
 }
 
@@ -22929,6 +22980,10 @@ type ModifyDBInstanceInput struct {
 	// KMS key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
+	// The amount of time, in days, to retain Performance Insights data. Valid values
+	// are 7 or 731 (2 years).
+	PerformanceInsightsRetentionPeriod *int64 `type:"integer"`
+
 	// The daily time range during which automated backups are created if automated
 	// backups are enabled, as determined by the BackupRetentionPeriod parameter.
 	// Changing this parameter doesn't result in an outage and the change is asynchronously
@@ -23233,6 +23288,12 @@ func (s *ModifyDBInstanceInput) SetOptionGroupName(v string) *ModifyDBInstanceIn
 // SetPerformanceInsightsKMSKeyId sets the PerformanceInsightsKMSKeyId field's value.
 func (s *ModifyDBInstanceInput) SetPerformanceInsightsKMSKeyId(v string) *ModifyDBInstanceInput {
 	s.PerformanceInsightsKMSKeyId = &v
+	return s
+}
+
+// SetPerformanceInsightsRetentionPeriod sets the PerformanceInsightsRetentionPeriod field's value.
+func (s *ModifyDBInstanceInput) SetPerformanceInsightsRetentionPeriod(v int64) *ModifyDBInstanceInput {
+	s.PerformanceInsightsRetentionPeriod = &v
 	return s
 }
 
@@ -27917,6 +27978,10 @@ type RestoreDBInstanceFromS3Input struct {
 	// the KMS key alias for the KMS encryption key.
 	PerformanceInsightsKMSKeyId *string `type:"string"`
 
+	// The amount of time, in days, to retain Performance Insights data. Valid values
+	// are 7 or 731 (2 years).
+	PerformanceInsightsRetentionPeriod *int64 `type:"integer"`
+
 	// The port number on which the database accepts connections.
 	//
 	// Type: Integer
@@ -28211,6 +28276,12 @@ func (s *RestoreDBInstanceFromS3Input) SetOptionGroupName(v string) *RestoreDBIn
 // SetPerformanceInsightsKMSKeyId sets the PerformanceInsightsKMSKeyId field's value.
 func (s *RestoreDBInstanceFromS3Input) SetPerformanceInsightsKMSKeyId(v string) *RestoreDBInstanceFromS3Input {
 	s.PerformanceInsightsKMSKeyId = &v
+	return s
+}
+
+// SetPerformanceInsightsRetentionPeriod sets the PerformanceInsightsRetentionPeriod field's value.
+func (s *RestoreDBInstanceFromS3Input) SetPerformanceInsightsRetentionPeriod(v int64) *RestoreDBInstanceFromS3Input {
+	s.PerformanceInsightsRetentionPeriod = &v
 	return s
 }
 

--- a/service/rds/examples_test.go
+++ b/service/rds/examples_test.go
@@ -2803,6 +2803,8 @@ func ExampleRDS_RestoreDBClusterFromSnapshot_shared00() {
 				fmt.Println(rds.ErrCodeOptionGroupNotFoundFault, aerr.Error())
 			case rds.ErrCodeKMSKeyNotAccessibleFault:
 				fmt.Println(rds.ErrCodeKMSKeyNotAccessibleFault, aerr.Error())
+			case rds.ErrCodeDBClusterParameterGroupNotFoundFault:
+				fmt.Println(rds.ErrCodeDBClusterParameterGroupNotFoundFault, aerr.Error())
 			default:
 				fmt.Println(aerr.Error())
 			}
@@ -2865,6 +2867,8 @@ func ExampleRDS_RestoreDBClusterToPointInTime_shared00() {
 				fmt.Println(rds.ErrCodeOptionGroupNotFoundFault, aerr.Error())
 			case rds.ErrCodeStorageQuotaExceededFault:
 				fmt.Println(rds.ErrCodeStorageQuotaExceededFault, aerr.Error())
+			case rds.ErrCodeDBClusterParameterGroupNotFoundFault:
+				fmt.Println(rds.ErrCodeDBClusterParameterGroupNotFoundFault, aerr.Error())
 			default:
 				fmt.Println(aerr.Error())
 			}
@@ -2929,6 +2933,8 @@ func ExampleRDS_RestoreDBInstanceFromDBSnapshot_shared00() {
 				fmt.Println(rds.ErrCodeDBSecurityGroupNotFoundFault, aerr.Error())
 			case rds.ErrCodeDomainNotFoundFault:
 				fmt.Println(rds.ErrCodeDomainNotFoundFault, aerr.Error())
+			case rds.ErrCodeDBParameterGroupNotFoundFault:
+				fmt.Println(rds.ErrCodeDBParameterGroupNotFoundFault, aerr.Error())
 			default:
 				fmt.Println(aerr.Error())
 			}
@@ -2997,6 +3003,8 @@ func ExampleRDS_RestoreDBInstanceToPointInTime_shared00() {
 				fmt.Println(rds.ErrCodeDBSecurityGroupNotFoundFault, aerr.Error())
 			case rds.ErrCodeDomainNotFoundFault:
 				fmt.Println(rds.ErrCodeDomainNotFoundFault, aerr.Error())
+			case rds.ErrCodeDBParameterGroupNotFoundFault:
+				fmt.Println(rds.ErrCodeDBParameterGroupNotFoundFault, aerr.Error())
 			default:
 				fmt.Println(aerr.Error())
 			}


### PR DESCRIPTION
Release v1.14.10 (2018-06-20)
===

### Service Client Updates
* `service/acm-pca`: Updates service API, documentation, paginators, and examples
* `service/medialive`: Updates service API, documentation, and paginators
  * AWS Elemental MediaLive now makes Reserved Outputs and Inputs available through the AWS Management Console and API. You can reserve outputs and inputs with a 12 month commitment in exchange for discounted hourly rates. Pricing is available at https://aws.amazon.com/medialive/pricing/
* `service/rds`: Updates service API, documentation, and examples
  * This release adds a new parameter to specify the retention period for Performance Insights data for RDS instances. You can either choose 7 days (default) or 731 days. For more information, see Amazon RDS Documentation.

### SDK Enhancements
* `service/s3`: Update SelectObjectContent doc example to be on the API not nested type. ([#1991](https://github.com/aws/aws-sdk-go/pull/1991))

### SDK Bugs
* `aws/client`: Fix HTTP debug log EventStream payloads ([#2000](https://github.com/aws/aws-sdk-go/pull/2000))
  * Fixes the SDK's HTTP client debug logging to not log the HTTP response body for EventStreams. This prevents the SDK from buffering a very large amount of data to be logged at once. The aws.LogDebugWithEventStreamBody should be used to log the event stream events.
  * Fixes a bug in the SDK's response logger which will buffer the response body's content if LogDebug is enabled but LogDebugWithHTTPBody is not.
