### PR TITLE
aws/credentials/ec2rolecreds: Avoid unneccesary redirect

### DIFF
--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -125,7 +124,7 @@ type ec2RoleCredRespBody struct {
 	Message string
 }
 
-const iamSecurityCredsPath = "/iam/security-credentials/"
+const iamSecurityCredsPath = "iam/security-credentials/"
 
 // requestCredList requests a list of credentials from the EC2 service.
 // If there are no credentials, or there is an error making or receiving the request
@@ -153,7 +152,7 @@ func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 // If the credentials cannot be found, or there is an error reading the response
 // and error will be returned.
 func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCredRespBody, error) {
-	resp, err := client.GetMetadata(path.Join(iamSecurityCredsPath, credsName))
+	resp, err := client.GetMetadata(iamSecurityCredsPath + credsName)
 	if err != nil {
 		return ec2RoleCredRespBody{},
 			awserr.New("EC2RoleRequestError",

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -125,7 +125,7 @@ type ec2RoleCredRespBody struct {
 	Message string
 }
 
-const iamSecurityCredsPath = "/iam/security-credentials"
+const iamSecurityCredsPath = "/iam/security-credentials/"
 
 // requestCredList requests a list of credentials from the EC2 service.
 // If there are no credentials, or there is an error making or receiving the request

--- a/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
@@ -34,7 +34,7 @@ const credsFailRespTmpl = `{
 
 func initTestServer(expireOn string, failAssume bool) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/latest/meta-data/iam/security-credentials" {
+		if r.URL.Path == "/latest/meta-data/iam/security-credentials/" {
 			fmt.Fprintln(w, "RoleName")
 		} else if r.URL.Path == "/latest/meta-data/iam/security-credentials/RoleName" {
 			if failAssume {

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 	"strings"
 	"time"
 
@@ -19,7 +18,7 @@ func (c *EC2Metadata) GetMetadata(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "meta-data", p),
+		HTTPPath:   "/meta-data/" + p,
 	}
 
 	output := &metadataOutput{}
@@ -35,7 +34,7 @@ func (c *EC2Metadata) GetUserData() (string, error) {
 	op := &request.Operation{
 		Name:       "GetUserData",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "user-data"),
+		HTTPPath:   "/user-data",
 	}
 
 	output := &metadataOutput{}
@@ -56,7 +55,7 @@ func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetDynamicData",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "dynamic", p),
+		HTTPPath:   "/dynamic/" + p,
 	}
 
 	output := &metadataOutput{}


### PR DESCRIPTION
This seems to have started on cb515e2df76b5f5a77cd1c3b49f932cbb6873eb5. Since the http library follows redirects by default, no one has noticed. The only reason I noticed is because I have [a project](https://github.com/stefansundin/vagrant-ec2-metadata) which didn't work with aws-sdk-go because of this disparity.

This makes aws-sdk-go consistent with the other SDKs.
- https://github.com/boto/boto/blob/315b76e01e65fb742cbc14170e5207d648bc649a/boto/provider.py#L390-L392
- https://github.com/aws/aws-sdk-ruby/blob/5fe5795e8910bb667996dfc75e4f16b7e69e3980/gems/aws-sdk-core/lib/aws-sdk-core/instance_profile_credentials.rb#L92

You can try this on an EC2 instance:
```
$ curl -v 169.254.169.254/latest/meta-data/iam/security-credentials
* Hostname was NOT found in DNS cache
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/meta-data/iam/security-credentials HTTP/1.1
> User-Agent: curl/7.35.0
> Host: 169.254.169.254
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 301 Moved Permanently
< Location: http://169.254.169.254/latest/meta-data/iam/security-credentials/
< Content-Length: 0
< Connection: close
< Date: Wed, 20 Jun 2018 19:17:26 GMT
< Server: EC2ws
<
* Closing connection 0
```

Anyway, it should make things a tiny bit faster, which is always nice.