### PR TITLE
Add support for credential_source = Ec2InstanceMetadata in config

### DIFF
--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -110,6 +110,17 @@ func TestLoadSharedConfig(t *testing.T) {
 		},
 		{
 			Filenames: []string{testConfigOtherFilename, testConfigFilename},
+			Profile:   "assume_role_ec2_instance_metadata",
+			Expected: sharedConfig{
+				AssumeRole: assumeRoleConfig{
+					RoleARN:          "assume_role_ec2_instance_metadata_role_arn",
+					CredentialSource: "Ec2InstanceMetadata",
+				},
+				AssumeRoleSource: &sharedConfig{},
+			},
+		},
+		{
+			Filenames: []string{testConfigOtherFilename, testConfigFilename},
 			Profile:   "assume_role_wo_creds",
 			Expected: sharedConfig{
 				AssumeRole: assumeRoleConfig{

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -1,5 +1,5 @@
 [default]
-s3 = 
+s3 =
   unsupported_key=123
   other_unsupported=abc
 
@@ -63,3 +63,7 @@ aws_secret_access_key = assume_role_w_creds_secret
 [assume_role_wo_creds]
 role_arn = assume_role_wo_creds_role_arn
 source_profile = assume_role_wo_creds
+
+[assume_role_ec2_instance_metadata]
+role_arn = assume_role_ec2_instance_metadata_role_arn
+credential_source = Ec2InstanceMetadata


### PR DESCRIPTION
Addresses https://github.com/aws/aws-sdk-go/issues/1901, at least partially.

This PR makes it possible to use a profile configured with `credential_source = Ec2InstanceMetadata`.

I'm not experienced with Go, so I'd appreciate feedback on how to write a test for this change. As `defaults.RemoteCredProvider` already has tests of its own, I think it would be ideal to have a test in session/shared_config_test.go which stubs out `RemoteCredProvider`. How does one do that? Thanks.