### PR TITLE
Add ability to correct clock skew

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -223,6 +223,9 @@ type Config struct {
 	//    	Key: aws.String("//foo//bar//moo"),
 	//    })
 	DisableRestProtocolURICleaning *bool
+
+	// Enable clock skew correction for all API requests
+	ClockSkew *time.Duration
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -134,6 +134,11 @@ func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 	}
 	r.SetBufferBody([]byte{})
 
+	if cfg.ClockSkew != nil {
+		r.AttemptTime = r.AttemptTime.Add(*cfg.ClockSkew)
+		r.Time = r.Time.Add(*cfg.ClockSkew)
+	}
+
 	return r
 }
 
@@ -464,6 +469,9 @@ func (r *Request) Send() error {
 
 	for {
 		r.AttemptTime = time.Now()
+		if cfg.ClockSkew != nil {
+			r.AttemptTime = r.AttemptTime.Add(*cfg.ClockSkew)
+		}
 		if aws.BoolValue(r.Retryable) {
 			if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {
 				r.Config.Logger.Log(fmt.Sprintf("DEBUG: Retrying Request %s/%s, attempt %d",

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -469,8 +469,8 @@ func (r *Request) Send() error {
 
 	for {
 		r.AttemptTime = time.Now()
-		if cfg.ClockSkew != nil {
-			r.AttemptTime = r.AttemptTime.Add(*cfg.ClockSkew)
+		if r.Config.ClockSkew != nil {
+			r.AttemptTime = r.AttemptTime.Add(*r.Config.ClockSkew)
 		}
 		if aws.BoolValue(r.Retryable) {
 			if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {


### PR DESCRIPTION
Currently when AWS code runs on machine that we don't have full control and it has incorrectly set local-time, for every API cann we need to use *Request api like `kinesis.PutRecordsRequest` and then set time corrected from NTP on `req` struct to avoid `InvalidSignature` error.

This is mentioned in issue #423

Here's a proposal for fix
