### PR TITLE
private/model/api: Add tests for empty response event stream API codegen

### DIFF
--- a/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
@@ -21,6 +21,15 @@
       },
       "input":{"shape":"GetEventStreamRequest"},
       "output":{"shape":"GetEventStreamResponse"}
+    },
+    "EmptyStream":{
+      "name":"EmptyStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"EmptyStreamRequest"},
+      "output":{"shape":"EmptyStreamResponse"}
     }
   },
   "shapes":{
@@ -56,6 +65,22 @@
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
+      },
+      "eventstream":true
+    },
+    "EmptyStreamRequest":{
+      "type":"structure",
+      "members":{}
+    },
+    "EmptyStreamResponse":{
+      "type":"structure",
+      "members":{
+        "EventStream":{"shape":"EmptyEventStream"}
+      }
+    },
+    "EmptyEventStream":{
+      "type":"structure",
+      "members":{
       },
       "eventstream":true
     },

--- a/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
@@ -63,6 +63,7 @@
         "ExplicitPayload":{"shape":"ExplicitPayloadEvent"},
         "PayloadOnly":{"shape":"PayloadOnlyEvent"},
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
+        "PayloadOnlyString":{"shape":"PayloadOnlyStringEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
       },
@@ -176,6 +177,16 @@
       },
       "event":true
     },
+	"PayloadOnlyStringEvent":{
+      "type":"structure",
+      "members":{
+        "StringPayload":{
+          "shape":"String",
+          "eventpayload":true
+        }
+      },
+      "event":true
+	},
     "EmptyEvent": {
       "type":"structure",
       "members":{},

--- a/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
@@ -21,6 +21,15 @@
       },
       "input":{"shape":"GetEventStreamRequest"},
       "output":{"shape":"GetEventStreamResponse"}
+    },
+    "EmptyStream":{
+      "name":"EmptyStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"EmptyStreamRequest"},
+      "output":{"shape":"EmptyStreamResponse"}
     }
   },
   "shapes":{
@@ -56,6 +65,22 @@
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
+      },
+      "eventstream":true
+    },
+    "EmptyStreamRequest":{
+      "type":"structure",
+      "members":{}
+    },
+    "EmptyStreamResponse":{
+      "type":"structure",
+      "members":{
+        "EventStream":{"shape":"EmptyEventStream"}
+      }
+    },
+    "EmptyEventStream":{
+      "type":"structure",
+      "members":{
       },
       "eventstream":true
     },

--- a/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
@@ -63,6 +63,7 @@
         "ExplicitPayload":{"shape":"ExplicitPayloadEvent"},
         "PayloadOnly":{"shape":"PayloadOnlyEvent"},
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
+        "PayloadOnlyString":{"shape":"PayloadOnlyStringEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
       },
@@ -176,6 +177,16 @@
       },
       "event":true
     },
+	"PayloadOnlyStringEvent":{
+      "type":"structure",
+      "members":{
+        "StringPayload":{
+          "shape":"String",
+          "eventpayload":true
+        }
+      },
+      "event":true
+	},
     "EmptyEvent": {
       "type":"structure",
       "members":{},

--- a/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
@@ -21,6 +21,15 @@
       },
       "input":{"shape":"GetEventStreamRequest"},
       "output":{"shape":"GetEventStreamResponse"}
+    },
+    "EmptyStream":{
+      "name":"EmptyStream",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"EmptyStreamRequest"},
+      "output":{"shape":"EmptyStreamResponse"}
     }
   },
   "shapes":{
@@ -56,6 +65,22 @@
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
+      },
+      "eventstream":true
+    },
+    "EmptyStreamRequest":{
+      "type":"structure",
+      "members":{}
+    },
+    "EmptyStreamResponse":{
+      "type":"structure",
+      "members":{
+        "EventStream":{"shape":"EmptyEventStream"}
+      }
+    },
+    "EmptyEventStream":{
+      "type":"structure",
+      "members":{
       },
       "eventstream":true
     },

--- a/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
@@ -63,6 +63,7 @@
         "ExplicitPayload":{"shape":"ExplicitPayloadEvent"},
         "PayloadOnly":{"shape":"PayloadOnlyEvent"},
         "PayloadOnlyBlob":{"shape":"PayloadOnlyBlobEvent"},
+        "PayloadOnlyString":{"shape":"PayloadOnlyStringEvent"},
         "Empty":{"shape":"EmptyEvent"},
         "Exception":{"shape":"ExceptionEvent"}
       },
@@ -176,6 +177,16 @@
       },
       "event":true
     },
+	"PayloadOnlyStringEvent":{
+      "type":"structure",
+      "members":{
+        "StringPayload":{
+          "shape":"String",
+          "eventpayload":true
+        }
+      },
+      "event":true
+	},
     "EmptyEvent": {
       "type":"structure",
       "members":{},

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -22,6 +22,81 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restjson"
 )
 
+const opEmptyStream = "EmptyStream"
+
+// EmptyStreamRequest generates a "aws/request.Request" representing the
+// client's request for the EmptyStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See EmptyStream for more information on using the EmptyStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the EmptyStreamRequest method.
+//    req, resp := client.EmptyStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RESTJSONService-0000-00-00/EmptyStream
+func (c *RESTJSONService) EmptyStreamRequest(input *EmptyStreamInput) (req *request.Request, output *EmptyStreamOutput) {
+	op := &request.Operation{
+		Name:       opEmptyStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &EmptyStreamInput{}
+	}
+
+	output = &EmptyStreamOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
+	req.Handlers.Unmarshal.Swap(restjson.UnmarshalHandler.Name, rest.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBack(output.runEventStreamLoop)
+	return
+}
+
+// EmptyStream API operation for REST JSON Service.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for REST JSON Service's
+// API operation EmptyStream for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RESTJSONService-0000-00-00/EmptyStream
+func (c *RESTJSONService) EmptyStream(input *EmptyStreamInput) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	return out, req.Send()
+}
+
+// EmptyStreamWithContext is the same as EmptyStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See EmptyStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *RESTJSONService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamInput, opts ...request.Option) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetEventStream = "GetEventStream"
 
 // GetEventStreamRequest generates a "aws/request.Request" representing the
@@ -121,6 +196,248 @@ func (s *EmptyEvent) UnmarshalEvent(
 	msg eventstream.Message,
 ) error {
 	return nil
+}
+
+// EmptyStreamEventStream provides handling of EventStreams for
+// the EmptyStream API.
+//
+// Use this type to receive EmptyEventStream events. The events
+// can be read from the Events channel member.
+//
+// The events that can be received are:
+//
+type EmptyStreamEventStream struct {
+	// Reader is the EventStream reader for the EmptyEventStream
+	// events. This value is automatically set by the SDK when the API call is made
+	// Use this member when unit testing your code with the SDK to mock out the
+	// EventStream Reader.
+	//
+	// Must not be nil.
+	Reader EmptyStreamEventStreamReader
+
+	// StreamCloser is the io.Closer for the EventStream connection. For HTTP
+	// EventStream this is the response Body. The stream will be closed when
+	// the Close method of the EventStream is called.
+	StreamCloser io.Closer
+}
+
+// Close closes the EventStream. This will also cause the Events channel to be
+// closed. You can use the closing of the Events channel to terminate your
+// application's read from the API's EventStream.
+//
+// Will close the underlying EventStream reader. For EventStream over HTTP
+// connection this will also close the HTTP connection.
+//
+// Close must be called when done using the EventStream API. Not calling Close
+// may result in resource leaks.
+func (es *EmptyStreamEventStream) Close() (err error) {
+	es.Reader.Close()
+	return es.Err()
+}
+
+// Err returns any error that occurred while reading EventStream Events from
+// the service API's response. Returns nil if there were no errors.
+func (es *EmptyStreamEventStream) Err() error {
+	if err := es.Reader.Err(); err != nil {
+		return err
+	}
+	es.StreamCloser.Close()
+
+	return nil
+}
+
+// Events returns a channel to read EventStream Events from the
+// EmptyStream API.
+//
+// These events are:
+//
+func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return es.Reader.Events()
+}
+
+// EmptyEventStreamEvent groups together all EventStream
+// events read from the EmptyStream API.
+//
+// These events are:
+//
+type EmptyEventStreamEvent interface {
+	eventEmptyEventStream()
+}
+
+// EmptyStreamEventStreamReader provides the interface for reading EventStream
+// Events from the EmptyStream API. The
+// default implementation for this interface will be EmptyStreamEventStream.
+//
+// The reader's Close method must allow multiple concurrent calls.
+//
+// These events are:
+//
+type EmptyStreamEventStreamReader interface {
+	// Returns a channel of events as they are read from the event stream.
+	Events() <-chan EmptyEventStreamEvent
+
+	// Close will close the underlying event stream reader. For event stream over
+	// HTTP this will also close the HTTP connection.
+	Close() error
+
+	// Returns any error that has occured while reading from the event stream.
+	Err() error
+}
+
+type readEmptyStreamEventStream struct {
+	eventReader *eventstreamapi.EventReader
+	stream      chan EmptyEventStreamEvent
+	errVal      atomic.Value
+
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newReadEmptyStreamEventStream(
+	reader io.ReadCloser,
+	unmarshalers request.HandlerList,
+	logger aws.Logger,
+	logLevel aws.LogLevelType,
+) *readEmptyStreamEventStream {
+	r := &readEmptyStreamEventStream{
+		stream: make(chan EmptyEventStreamEvent),
+		done:   make(chan struct{}),
+	}
+
+	r.eventReader = eventstreamapi.NewEventReader(
+		reader,
+		protocol.HandlerPayloadUnmarshal{
+			Unmarshalers: unmarshalers,
+		},
+		r.unmarshalerForEventType,
+	)
+	r.eventReader.UseLogger(logger, logLevel)
+
+	return r
+}
+
+// Close will close the underlying event stream reader. For EventStream over
+// HTTP this will also close the HTTP connection.
+func (r *readEmptyStreamEventStream) Close() error {
+	r.closeOnce.Do(r.safeClose)
+
+	return r.Err()
+}
+
+func (r *readEmptyStreamEventStream) safeClose() {
+	close(r.done)
+	err := r.eventReader.Close()
+	if err != nil {
+		r.errVal.Store(err)
+	}
+}
+
+func (r *readEmptyStreamEventStream) Err() error {
+	if v := r.errVal.Load(); v != nil {
+		return v.(error)
+	}
+
+	return nil
+}
+
+func (r *readEmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return r.stream
+}
+
+func (r *readEmptyStreamEventStream) readEventStream() {
+	defer close(r.stream)
+
+	for {
+		event, err := r.eventReader.ReadEvent()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			select {
+			case <-r.done:
+				// If closed already ignore the error
+				return
+			default:
+			}
+			r.errVal.Store(err)
+			return
+		}
+
+		select {
+		case r.stream <- event.(EmptyEventStreamEvent):
+		case <-r.done:
+			return
+		}
+	}
+}
+
+func (r *readEmptyStreamEventStream) unmarshalerForEventType(
+	eventType string,
+) (eventstreamapi.Unmarshaler, error) {
+	switch eventType {
+	default:
+		return nil, awserr.New(
+			request.ErrCodeSerialization,
+			fmt.Sprintf("unknown event type name, %s, for EmptyStreamEventStream", eventType),
+			nil,
+		)
+	}
+}
+
+type EmptyStreamInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamInput) GoString() string {
+	return s.String()
+}
+
+type EmptyStreamOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Use EventStream to use the API's stream.
+	EventStream *EmptyStreamEventStream `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventStream sets the EventStream field's value.
+func (s *EmptyStreamOutput) SetEventStream(v *EmptyStreamEventStream) *EmptyStreamOutput {
+	s.EventStream = v
+	return s
+}
+
+func (s *EmptyStreamOutput) runEventStreamLoop(r *request.Request) {
+	if r.Error != nil {
+		return
+	}
+	reader := newReadEmptyStreamEventStream(
+		r.HTTPResponse.Body,
+		r.Handlers.UnmarshalStream,
+		r.Config.Logger,
+		r.Config.LogLevel.Value(),
+	)
+	go reader.readEventStream()
+
+	eventStream := &EmptyStreamEventStream{
+		StreamCloser: r.HTTPResponse.Body,
+		Reader:       reader,
+	}
+	s.EventStream = eventStream
 }
 
 type ExceptionEvent struct {

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -571,6 +571,7 @@ func (s *ExplicitPayloadEvent) UnmarshalEvent(
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStream struct {
 	// Reader is the EventStream reader for the EventStream
 	// events. This value is automatically set by the SDK when the API call is made
@@ -622,6 +623,7 @@ func (es *GetEventStreamEventStream) Err() error {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 	return es.Reader.Events()
 }
@@ -637,6 +639,7 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type EventStreamEvent interface {
 	eventEventStream()
 }
@@ -655,6 +658,7 @@ type EventStreamEvent interface {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EventStreamEvent
@@ -775,6 +779,9 @@ func (r *readGetEventStreamEventStream) unmarshalerForEventType(
 
 	case "PayloadOnlyBlob":
 		return &PayloadOnlyBlobEvent{}, nil
+
+	case "PayloadOnlyString":
+		return &PayloadOnlyStringEvent{}, nil
 
 	case "Exception":
 		return &ExceptionEvent{}, nil
@@ -1156,5 +1163,40 @@ func (s *PayloadOnlyEvent) UnmarshalEvent(
 	); err != nil {
 		return err
 	}
+	return nil
+}
+
+type PayloadOnlyStringEvent struct {
+	_ struct{} `type:"structure" payload:"StringPayload"`
+
+	StringPayload *string `locationName:"StringPayload" type:"string"`
+}
+
+// String returns the string representation
+func (s PayloadOnlyStringEvent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PayloadOnlyStringEvent) GoString() string {
+	return s.String()
+}
+
+// SetStringPayload sets the StringPayload field's value.
+func (s *PayloadOnlyStringEvent) SetStringPayload(v string) *PayloadOnlyStringEvent {
+	s.StringPayload = &v
+	return s
+}
+
+// The PayloadOnlyStringEvent is and event in the EventStream group of events.
+func (s *PayloadOnlyStringEvent) eventEventStream() {}
+
+// UnmarshalEvent unmarshals the EventStream Message into the PayloadOnlyStringEvent value.
+// This method is only used internally within the SDK's EventStream handling.
+func (s *PayloadOnlyStringEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	s.StringPayload = aws.String(string(msg.Payload))
 	return nil
 }

--- a/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -307,6 +307,9 @@ func mockGetEventStreamReadEvents() (
 		&PayloadOnlyBlobEvent{
 			BlobPayload: []byte("blob value goes here"),
 		},
+		&PayloadOnlyStringEvent{
+			StringPayload: aws.String("string value goes here"),
+		},
 	}
 
 	var marshalers request.HandlerList
@@ -418,6 +421,16 @@ func mockGetEventStreamReadEvents() (
 				},
 			},
 			Payload: expectEvents[5].(*PayloadOnlyBlobEvent).BlobPayload,
+		},
+		{
+			Headers: eventstream.Headers{
+				eventstreamtest.EventMessageTypeHeader,
+				{
+					Name:  eventstreamapi.EventTypeHeader,
+					Value: eventstream.StringValue("PayloadOnlyString"),
+				},
+			},
+			Payload: []byte(*expectEvents[6].(*PayloadOnlyStringEvent).StringPayload),
 		},
 	}
 

--- a/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -27,6 +27,136 @@ import (
 var _ time.Time
 var _ awserr.Error
 
+func TestEmptyStream_Read(t *testing.T) {
+	expectEvents, eventMsgs := mockEmptyStreamReadEvents()
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.EventStream.Close()
+
+	var i int
+	for event := range resp.EventStream.Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.EventStream.Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
+func TestEmptyStream_ReadClose(t *testing.T) {
+	_, eventMsgs := mockEmptyStreamReadEvents()
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+
+	resp.EventStream.Close()
+	<-resp.EventStream.Events()
+
+	if err := resp.EventStream.Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
+func BenchmarkEmptyStream_Read(b *testing.B) {
+	_, eventMsgs := mockEmptyStreamReadEvents()
+	var buf bytes.Buffer
+	encoder := eventstream.NewEncoder(&buf)
+	for _, msg := range eventMsgs {
+		if err := encoder.Encode(msg); err != nil {
+			b.Fatalf("failed to encode message, %v", err)
+		}
+	}
+	stream := &loopReader{source: bytes.NewReader(buf.Bytes())}
+
+	sess := unit.Session
+	svc := New(sess, &aws.Config{
+		Endpoint:               aws.String("https://example.com"),
+		DisableParamValidation: aws.Bool(true),
+	})
+	svc.Handlers.Send.Swap(corehandlers.SendHandler.Name,
+		request.NamedHandler{Name: "mockSend",
+			Fn: func(r *request.Request) {
+				r.HTTPResponse = &http.Response{
+					Status:     "200 OK",
+					StatusCode: 200,
+					Header:     http.Header{},
+					Body:       ioutil.NopCloser(stream),
+				}
+			},
+		},
+	)
+
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		b.Fatalf("failed to create request, %v", err)
+	}
+	defer resp.EventStream.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err = resp.EventStream.Err(); err != nil {
+			b.Fatalf("expect no error, got %v", err)
+		}
+		event := <-resp.EventStream.Events()
+		if event == nil {
+			b.Fatalf("expect event, got nil, %v, %d", resp.EventStream.Err(), i)
+		}
+	}
+}
+
+func mockEmptyStreamReadEvents() (
+	[]EmptyEventStreamEvent,
+	[]eventstream.Message,
+) {
+	expectEvents := []EmptyEventStreamEvent{}
+
+	var marshalers request.HandlerList
+	marshalers.PushBackNamed(restjson.BuildHandler)
+	payloadMarshaler := protocol.HandlerPayloadMarshal{
+		Marshalers: marshalers,
+	}
+	_ = payloadMarshaler
+
+	eventMsgs := []eventstream.Message{}
+
+	return expectEvents, eventMsgs
+}
+
 func TestGetEventStream_Read(t *testing.T) {
 	expectEvents, eventMsgs := mockGetEventStreamReadEvents()
 	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
@@ -184,6 +314,7 @@ func mockGetEventStreamReadEvents() (
 	payloadMarshaler := protocol.HandlerPayloadMarshal{
 		Marshalers: marshalers,
 	}
+	_ = payloadMarshaler
 
 	eventMsgs := []eventstream.Message{
 		{

--- a/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restjsonservice/eventstream_test.go
@@ -291,7 +291,7 @@ func mockGetEventStreamReadEvents() (
 			LongVal:    aws.Int64(1234),
 			ShortVal:   aws.Int64(12),
 			StringVal:  aws.String("string value goes here"),
-			TimeVal:    aws.Time(time.Unix(1396594860, 0)),
+			TimeVal:    aws.Time(time.Unix(1396594860, 0).UTC()),
 		},
 		&ImplicitPayloadEvent{
 			ByteVal:    aws.Int64(1),

--- a/private/model/api/codegentest/service/restjsonservice/restjsonserviceiface/interface.go
+++ b/private/model/api/codegentest/service/restjsonservice/restjsonserviceiface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // REST JSON Service.
 //    func myFunc(svc restjsonserviceiface.RESTJSONServiceAPI) bool {
-//        // Make svc.GetEventStream request
+//        // Make svc.EmptyStream request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockRESTJSONServiceClient struct {
 //        restjsonserviceiface.RESTJSONServiceAPI
 //    }
-//    func (m *mockRESTJSONServiceClient) GetEventStream(input *restjsonservice.GetEventStreamInput) (*restjsonservice.GetEventStreamOutput, error) {
+//    func (m *mockRESTJSONServiceClient) EmptyStream(input *restjsonservice.EmptyStreamInput) (*restjsonservice.EmptyStreamOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,10 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type RESTJSONServiceAPI interface {
+	EmptyStream(*restjsonservice.EmptyStreamInput) (*restjsonservice.EmptyStreamOutput, error)
+	EmptyStreamWithContext(aws.Context, *restjsonservice.EmptyStreamInput, ...request.Option) (*restjsonservice.EmptyStreamOutput, error)
+	EmptyStreamRequest(*restjsonservice.EmptyStreamInput) (*request.Request, *restjsonservice.EmptyStreamOutput)
+
 	GetEventStream(*restjsonservice.GetEventStreamInput) (*restjsonservice.GetEventStreamOutput, error)
 	GetEventStreamWithContext(aws.Context, *restjsonservice.GetEventStreamInput, ...request.Option) (*restjsonservice.GetEventStreamOutput, error)
 	GetEventStreamRequest(*restjsonservice.GetEventStreamInput) (*request.Request, *restjsonservice.GetEventStreamOutput)

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -22,6 +22,81 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
+const opEmptyStream = "EmptyStream"
+
+// EmptyStreamRequest generates a "aws/request.Request" representing the
+// client's request for the EmptyStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See EmptyStream for more information on using the EmptyStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the EmptyStreamRequest method.
+//    req, resp := client.EmptyStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RESTXMLService-0000-00-00/EmptyStream
+func (c *RESTXMLService) EmptyStreamRequest(input *EmptyStreamInput) (req *request.Request, output *EmptyStreamOutput) {
+	op := &request.Operation{
+		Name:       opEmptyStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &EmptyStreamInput{}
+	}
+
+	output = &EmptyStreamOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, rest.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBack(output.runEventStreamLoop)
+	return
+}
+
+// EmptyStream API operation for REST XML Service.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for REST XML Service's
+// API operation EmptyStream for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RESTXMLService-0000-00-00/EmptyStream
+func (c *RESTXMLService) EmptyStream(input *EmptyStreamInput) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	return out, req.Send()
+}
+
+// EmptyStreamWithContext is the same as EmptyStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See EmptyStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *RESTXMLService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamInput, opts ...request.Option) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetEventStream = "GetEventStream"
 
 // GetEventStreamRequest generates a "aws/request.Request" representing the
@@ -121,6 +196,248 @@ func (s *EmptyEvent) UnmarshalEvent(
 	msg eventstream.Message,
 ) error {
 	return nil
+}
+
+// EmptyStreamEventStream provides handling of EventStreams for
+// the EmptyStream API.
+//
+// Use this type to receive EmptyEventStream events. The events
+// can be read from the Events channel member.
+//
+// The events that can be received are:
+//
+type EmptyStreamEventStream struct {
+	// Reader is the EventStream reader for the EmptyEventStream
+	// events. This value is automatically set by the SDK when the API call is made
+	// Use this member when unit testing your code with the SDK to mock out the
+	// EventStream Reader.
+	//
+	// Must not be nil.
+	Reader EmptyStreamEventStreamReader
+
+	// StreamCloser is the io.Closer for the EventStream connection. For HTTP
+	// EventStream this is the response Body. The stream will be closed when
+	// the Close method of the EventStream is called.
+	StreamCloser io.Closer
+}
+
+// Close closes the EventStream. This will also cause the Events channel to be
+// closed. You can use the closing of the Events channel to terminate your
+// application's read from the API's EventStream.
+//
+// Will close the underlying EventStream reader. For EventStream over HTTP
+// connection this will also close the HTTP connection.
+//
+// Close must be called when done using the EventStream API. Not calling Close
+// may result in resource leaks.
+func (es *EmptyStreamEventStream) Close() (err error) {
+	es.Reader.Close()
+	return es.Err()
+}
+
+// Err returns any error that occurred while reading EventStream Events from
+// the service API's response. Returns nil if there were no errors.
+func (es *EmptyStreamEventStream) Err() error {
+	if err := es.Reader.Err(); err != nil {
+		return err
+	}
+	es.StreamCloser.Close()
+
+	return nil
+}
+
+// Events returns a channel to read EventStream Events from the
+// EmptyStream API.
+//
+// These events are:
+//
+func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return es.Reader.Events()
+}
+
+// EmptyEventStreamEvent groups together all EventStream
+// events read from the EmptyStream API.
+//
+// These events are:
+//
+type EmptyEventStreamEvent interface {
+	eventEmptyEventStream()
+}
+
+// EmptyStreamEventStreamReader provides the interface for reading EventStream
+// Events from the EmptyStream API. The
+// default implementation for this interface will be EmptyStreamEventStream.
+//
+// The reader's Close method must allow multiple concurrent calls.
+//
+// These events are:
+//
+type EmptyStreamEventStreamReader interface {
+	// Returns a channel of events as they are read from the event stream.
+	Events() <-chan EmptyEventStreamEvent
+
+	// Close will close the underlying event stream reader. For event stream over
+	// HTTP this will also close the HTTP connection.
+	Close() error
+
+	// Returns any error that has occured while reading from the event stream.
+	Err() error
+}
+
+type readEmptyStreamEventStream struct {
+	eventReader *eventstreamapi.EventReader
+	stream      chan EmptyEventStreamEvent
+	errVal      atomic.Value
+
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newReadEmptyStreamEventStream(
+	reader io.ReadCloser,
+	unmarshalers request.HandlerList,
+	logger aws.Logger,
+	logLevel aws.LogLevelType,
+) *readEmptyStreamEventStream {
+	r := &readEmptyStreamEventStream{
+		stream: make(chan EmptyEventStreamEvent),
+		done:   make(chan struct{}),
+	}
+
+	r.eventReader = eventstreamapi.NewEventReader(
+		reader,
+		protocol.HandlerPayloadUnmarshal{
+			Unmarshalers: unmarshalers,
+		},
+		r.unmarshalerForEventType,
+	)
+	r.eventReader.UseLogger(logger, logLevel)
+
+	return r
+}
+
+// Close will close the underlying event stream reader. For EventStream over
+// HTTP this will also close the HTTP connection.
+func (r *readEmptyStreamEventStream) Close() error {
+	r.closeOnce.Do(r.safeClose)
+
+	return r.Err()
+}
+
+func (r *readEmptyStreamEventStream) safeClose() {
+	close(r.done)
+	err := r.eventReader.Close()
+	if err != nil {
+		r.errVal.Store(err)
+	}
+}
+
+func (r *readEmptyStreamEventStream) Err() error {
+	if v := r.errVal.Load(); v != nil {
+		return v.(error)
+	}
+
+	return nil
+}
+
+func (r *readEmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return r.stream
+}
+
+func (r *readEmptyStreamEventStream) readEventStream() {
+	defer close(r.stream)
+
+	for {
+		event, err := r.eventReader.ReadEvent()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			select {
+			case <-r.done:
+				// If closed already ignore the error
+				return
+			default:
+			}
+			r.errVal.Store(err)
+			return
+		}
+
+		select {
+		case r.stream <- event.(EmptyEventStreamEvent):
+		case <-r.done:
+			return
+		}
+	}
+}
+
+func (r *readEmptyStreamEventStream) unmarshalerForEventType(
+	eventType string,
+) (eventstreamapi.Unmarshaler, error) {
+	switch eventType {
+	default:
+		return nil, awserr.New(
+			request.ErrCodeSerialization,
+			fmt.Sprintf("unknown event type name, %s, for EmptyStreamEventStream", eventType),
+			nil,
+		)
+	}
+}
+
+type EmptyStreamInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamInput) GoString() string {
+	return s.String()
+}
+
+type EmptyStreamOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Use EventStream to use the API's stream.
+	EventStream *EmptyStreamEventStream `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventStream sets the EventStream field's value.
+func (s *EmptyStreamOutput) SetEventStream(v *EmptyStreamEventStream) *EmptyStreamOutput {
+	s.EventStream = v
+	return s
+}
+
+func (s *EmptyStreamOutput) runEventStreamLoop(r *request.Request) {
+	if r.Error != nil {
+		return
+	}
+	reader := newReadEmptyStreamEventStream(
+		r.HTTPResponse.Body,
+		r.Handlers.UnmarshalStream,
+		r.Config.Logger,
+		r.Config.LogLevel.Value(),
+	)
+	go reader.readEventStream()
+
+	eventStream := &EmptyStreamEventStream{
+		StreamCloser: r.HTTPResponse.Body,
+		Reader:       reader,
+	}
+	s.EventStream = eventStream
 }
 
 type ExceptionEvent struct {

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -571,6 +571,7 @@ func (s *ExplicitPayloadEvent) UnmarshalEvent(
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStream struct {
 	// Reader is the EventStream reader for the EventStream
 	// events. This value is automatically set by the SDK when the API call is made
@@ -622,6 +623,7 @@ func (es *GetEventStreamEventStream) Err() error {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 	return es.Reader.Events()
 }
@@ -637,6 +639,7 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type EventStreamEvent interface {
 	eventEventStream()
 }
@@ -655,6 +658,7 @@ type EventStreamEvent interface {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EventStreamEvent
@@ -775,6 +779,9 @@ func (r *readGetEventStreamEventStream) unmarshalerForEventType(
 
 	case "PayloadOnlyBlob":
 		return &PayloadOnlyBlobEvent{}, nil
+
+	case "PayloadOnlyString":
+		return &PayloadOnlyStringEvent{}, nil
 
 	case "Exception":
 		return &ExceptionEvent{}, nil
@@ -1156,5 +1163,40 @@ func (s *PayloadOnlyEvent) UnmarshalEvent(
 	); err != nil {
 		return err
 	}
+	return nil
+}
+
+type PayloadOnlyStringEvent struct {
+	_ struct{} `locationName:"PayloadOnlyStringEvent" type:"structure" payload:"StringPayload"`
+
+	StringPayload *string `locationName:"StringPayload" type:"string"`
+}
+
+// String returns the string representation
+func (s PayloadOnlyStringEvent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PayloadOnlyStringEvent) GoString() string {
+	return s.String()
+}
+
+// SetStringPayload sets the StringPayload field's value.
+func (s *PayloadOnlyStringEvent) SetStringPayload(v string) *PayloadOnlyStringEvent {
+	s.StringPayload = &v
+	return s
+}
+
+// The PayloadOnlyStringEvent is and event in the EventStream group of events.
+func (s *PayloadOnlyStringEvent) eventEventStream() {}
+
+// UnmarshalEvent unmarshals the EventStream Message into the PayloadOnlyStringEvent value.
+// This method is only used internally within the SDK's EventStream handling.
+func (s *PayloadOnlyStringEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	s.StringPayload = aws.String(string(msg.Payload))
 	return nil
 }

--- a/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
@@ -27,6 +27,136 @@ import (
 var _ time.Time
 var _ awserr.Error
 
+func TestEmptyStream_Read(t *testing.T) {
+	expectEvents, eventMsgs := mockEmptyStreamReadEvents()
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+	defer resp.EventStream.Close()
+
+	var i int
+	for event := range resp.EventStream.Events() {
+		if event == nil {
+			t.Errorf("%d, expect event, got nil", i)
+		}
+		if e, a := expectEvents[i], event; !reflect.DeepEqual(e, a) {
+			t.Errorf("%d, expect %T %v, got %T %v", i, e, e, a, a)
+		}
+		i++
+	}
+
+	if err := resp.EventStream.Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
+func TestEmptyStream_ReadClose(t *testing.T) {
+	_, eventMsgs := mockEmptyStreamReadEvents()
+	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
+		eventstreamtest.ServeEventStream{
+			T:      t,
+			Events: eventMsgs,
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expect no error, %v", err)
+	}
+	defer cleanupFn()
+
+	svc := New(sess)
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		t.Fatalf("expect no error got, %v", err)
+	}
+
+	resp.EventStream.Close()
+	<-resp.EventStream.Events()
+
+	if err := resp.EventStream.Err(); err != nil {
+		t.Errorf("expect no error, %v", err)
+	}
+}
+
+func BenchmarkEmptyStream_Read(b *testing.B) {
+	_, eventMsgs := mockEmptyStreamReadEvents()
+	var buf bytes.Buffer
+	encoder := eventstream.NewEncoder(&buf)
+	for _, msg := range eventMsgs {
+		if err := encoder.Encode(msg); err != nil {
+			b.Fatalf("failed to encode message, %v", err)
+		}
+	}
+	stream := &loopReader{source: bytes.NewReader(buf.Bytes())}
+
+	sess := unit.Session
+	svc := New(sess, &aws.Config{
+		Endpoint:               aws.String("https://example.com"),
+		DisableParamValidation: aws.Bool(true),
+	})
+	svc.Handlers.Send.Swap(corehandlers.SendHandler.Name,
+		request.NamedHandler{Name: "mockSend",
+			Fn: func(r *request.Request) {
+				r.HTTPResponse = &http.Response{
+					Status:     "200 OK",
+					StatusCode: 200,
+					Header:     http.Header{},
+					Body:       ioutil.NopCloser(stream),
+				}
+			},
+		},
+	)
+
+	resp, err := svc.EmptyStream(nil)
+	if err != nil {
+		b.Fatalf("failed to create request, %v", err)
+	}
+	defer resp.EventStream.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err = resp.EventStream.Err(); err != nil {
+			b.Fatalf("expect no error, got %v", err)
+		}
+		event := <-resp.EventStream.Events()
+		if event == nil {
+			b.Fatalf("expect event, got nil, %v, %d", resp.EventStream.Err(), i)
+		}
+	}
+}
+
+func mockEmptyStreamReadEvents() (
+	[]EmptyEventStreamEvent,
+	[]eventstream.Message,
+) {
+	expectEvents := []EmptyEventStreamEvent{}
+
+	var marshalers request.HandlerList
+	marshalers.PushBackNamed(restxml.BuildHandler)
+	payloadMarshaler := protocol.HandlerPayloadMarshal{
+		Marshalers: marshalers,
+	}
+	_ = payloadMarshaler
+
+	eventMsgs := []eventstream.Message{}
+
+	return expectEvents, eventMsgs
+}
+
 func TestGetEventStream_Read(t *testing.T) {
 	expectEvents, eventMsgs := mockGetEventStreamReadEvents()
 	sess, cleanupFn, err := eventstreamtest.SetupEventStreamSession(t,
@@ -184,6 +314,7 @@ func mockGetEventStreamReadEvents() (
 	payloadMarshaler := protocol.HandlerPayloadMarshal{
 		Marshalers: marshalers,
 	}
+	_ = payloadMarshaler
 
 	eventMsgs := []eventstream.Message{
 		{

--- a/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
@@ -307,6 +307,9 @@ func mockGetEventStreamReadEvents() (
 		&PayloadOnlyBlobEvent{
 			BlobPayload: []byte("blob value goes here"),
 		},
+		&PayloadOnlyStringEvent{
+			StringPayload: aws.String("string value goes here"),
+		},
 	}
 
 	var marshalers request.HandlerList
@@ -418,6 +421,16 @@ func mockGetEventStreamReadEvents() (
 				},
 			},
 			Payload: expectEvents[5].(*PayloadOnlyBlobEvent).BlobPayload,
+		},
+		{
+			Headers: eventstream.Headers{
+				eventstreamtest.EventMessageTypeHeader,
+				{
+					Name:  eventstreamapi.EventTypeHeader,
+					Value: eventstream.StringValue("PayloadOnlyString"),
+				},
+			},
+			Payload: []byte(*expectEvents[6].(*PayloadOnlyStringEvent).StringPayload),
 		},
 	}
 

--- a/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/restxmlservice/eventstream_test.go
@@ -291,7 +291,7 @@ func mockGetEventStreamReadEvents() (
 			LongVal:    aws.Int64(1234),
 			ShortVal:   aws.Int64(12),
 			StringVal:  aws.String("string value goes here"),
-			TimeVal:    aws.Time(time.Unix(1396594860, 0)),
+			TimeVal:    aws.Time(time.Unix(1396594860, 0).UTC()),
 		},
 		&ImplicitPayloadEvent{
 			ByteVal:    aws.Int64(1),

--- a/private/model/api/codegentest/service/restxmlservice/restxmlserviceiface/interface.go
+++ b/private/model/api/codegentest/service/restxmlservice/restxmlserviceiface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // REST XML Service.
 //    func myFunc(svc restxmlserviceiface.RESTXMLServiceAPI) bool {
-//        // Make svc.GetEventStream request
+//        // Make svc.EmptyStream request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockRESTXMLServiceClient struct {
 //        restxmlserviceiface.RESTXMLServiceAPI
 //    }
-//    func (m *mockRESTXMLServiceClient) GetEventStream(input *restxmlservice.GetEventStreamInput) (*restxmlservice.GetEventStreamOutput, error) {
+//    func (m *mockRESTXMLServiceClient) EmptyStream(input *restxmlservice.EmptyStreamInput) (*restxmlservice.EmptyStreamOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,10 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type RESTXMLServiceAPI interface {
+	EmptyStream(*restxmlservice.EmptyStreamInput) (*restxmlservice.EmptyStreamOutput, error)
+	EmptyStreamWithContext(aws.Context, *restxmlservice.EmptyStreamInput, ...request.Option) (*restxmlservice.EmptyStreamOutput, error)
+	EmptyStreamRequest(*restxmlservice.EmptyStreamInput) (*request.Request, *restxmlservice.EmptyStreamOutput)
+
 	GetEventStream(*restxmlservice.GetEventStreamInput) (*restxmlservice.GetEventStreamOutput, error)
 	GetEventStreamWithContext(aws.Context, *restxmlservice.GetEventStreamInput, ...request.Option) (*restxmlservice.GetEventStreamOutput, error)
 	GetEventStreamRequest(*restxmlservice.GetEventStreamInput) (*request.Request, *restxmlservice.GetEventStreamOutput)

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -620,6 +620,7 @@ func (s *ExplicitPayloadEvent) UnmarshalEvent(
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStream struct {
 	// Reader is the EventStream reader for the EventStream
 	// events. This value is automatically set by the SDK when the API call is made
@@ -671,6 +672,7 @@ func (es *GetEventStreamEventStream) Err() error {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 	return es.Reader.Events()
 }
@@ -686,6 +688,7 @@ func (es *GetEventStreamEventStream) Events() <-chan EventStreamEvent {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type EventStreamEvent interface {
 	eventEventStream()
 }
@@ -704,6 +707,7 @@ type EventStreamEvent interface {
 //     * ImplicitPayloadEvent
 //     * PayloadOnlyEvent
 //     * PayloadOnlyBlobEvent
+//     * PayloadOnlyStringEvent
 type GetEventStreamEventStreamReader interface {
 	// Returns a channel of events as they are read from the event stream.
 	Events() <-chan EventStreamEvent
@@ -831,6 +835,9 @@ func (r *readGetEventStreamEventStream) unmarshalerForEventType(
 
 	case "PayloadOnlyBlob":
 		return &PayloadOnlyBlobEvent{}, nil
+
+	case "PayloadOnlyString":
+		return &PayloadOnlyStringEvent{}, nil
 
 	case "Exception":
 		return &ExceptionEvent{}, nil
@@ -1253,5 +1260,40 @@ func (s *PayloadOnlyEvent) UnmarshalEvent(
 	); err != nil {
 		return err
 	}
+	return nil
+}
+
+type PayloadOnlyStringEvent struct {
+	_ struct{} `type:"structure" payload:"StringPayload"`
+
+	StringPayload *string `locationName:"StringPayload" type:"string"`
+}
+
+// String returns the string representation
+func (s PayloadOnlyStringEvent) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PayloadOnlyStringEvent) GoString() string {
+	return s.String()
+}
+
+// SetStringPayload sets the StringPayload field's value.
+func (s *PayloadOnlyStringEvent) SetStringPayload(v string) *PayloadOnlyStringEvent {
+	s.StringPayload = &v
+	return s
+}
+
+// The PayloadOnlyStringEvent is and event in the EventStream group of events.
+func (s *PayloadOnlyStringEvent) eventEventStream() {}
+
+// UnmarshalEvent unmarshals the EventStream Message into the PayloadOnlyStringEvent value.
+// This method is only used internally within the SDK's EventStream handling.
+func (s *PayloadOnlyStringEvent) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	s.StringPayload = aws.String(string(msg.Payload))
 	return nil
 }

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -22,6 +22,82 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 )
 
+const opEmptyStream = "EmptyStream"
+
+// EmptyStreamRequest generates a "aws/request.Request" representing the
+// client's request for the EmptyStream operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See EmptyStream for more information on using the EmptyStream
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the EmptyStreamRequest method.
+//    req, resp := client.EmptyStreamRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RPCService-0000-00-00/EmptyStream
+func (c *RPCService) EmptyStreamRequest(input *EmptyStreamInput) (req *request.Request, output *EmptyStreamOutput) {
+	op := &request.Operation{
+		Name:       opEmptyStream,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &EmptyStreamInput{}
+	}
+
+	output = &EmptyStreamOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Send.Swap(client.LogHTTPResponseHandler.Name, client.LogHTTPResponseHeaderHandler)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, rest.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBack(output.runEventStreamLoop)
+	req.Handlers.Unmarshal.PushBack(output.unmarshalInitialResponse)
+	return
+}
+
+// EmptyStream API operation for RPC Service.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for RPC Service's
+// API operation EmptyStream for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/RPCService-0000-00-00/EmptyStream
+func (c *RPCService) EmptyStream(input *EmptyStreamInput) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	return out, req.Send()
+}
+
+// EmptyStreamWithContext is the same as EmptyStream with the addition of
+// the ability to pass a context and additional request options.
+//
+// See EmptyStream for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *RPCService) EmptyStreamWithContext(ctx aws.Context, input *EmptyStreamInput, opts ...request.Option) (*EmptyStreamOutput, error) {
+	req, out := c.EmptyStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetEventStream = "GetEventStream"
 
 // GetEventStreamRequest generates a "aws/request.Request" representing the
@@ -121,6 +197,295 @@ func (s *EmptyEvent) UnmarshalEvent(
 	payloadUnmarshaler protocol.PayloadUnmarshaler,
 	msg eventstream.Message,
 ) error {
+	return nil
+}
+
+// EmptyStreamEventStream provides handling of EventStreams for
+// the EmptyStream API.
+//
+// Use this type to receive EmptyEventStream events. The events
+// can be read from the Events channel member.
+//
+// The events that can be received are:
+//
+type EmptyStreamEventStream struct {
+	// Reader is the EventStream reader for the EmptyEventStream
+	// events. This value is automatically set by the SDK when the API call is made
+	// Use this member when unit testing your code with the SDK to mock out the
+	// EventStream Reader.
+	//
+	// Must not be nil.
+	Reader EmptyStreamEventStreamReader
+
+	// StreamCloser is the io.Closer for the EventStream connection. For HTTP
+	// EventStream this is the response Body. The stream will be closed when
+	// the Close method of the EventStream is called.
+	StreamCloser io.Closer
+}
+
+// Close closes the EventStream. This will also cause the Events channel to be
+// closed. You can use the closing of the Events channel to terminate your
+// application's read from the API's EventStream.
+//
+// Will close the underlying EventStream reader. For EventStream over HTTP
+// connection this will also close the HTTP connection.
+//
+// Close must be called when done using the EventStream API. Not calling Close
+// may result in resource leaks.
+func (es *EmptyStreamEventStream) Close() (err error) {
+	es.Reader.Close()
+	return es.Err()
+}
+
+// Err returns any error that occurred while reading EventStream Events from
+// the service API's response. Returns nil if there were no errors.
+func (es *EmptyStreamEventStream) Err() error {
+	if err := es.Reader.Err(); err != nil {
+		return err
+	}
+	es.StreamCloser.Close()
+
+	return nil
+}
+
+// Events returns a channel to read EventStream Events from the
+// EmptyStream API.
+//
+// These events are:
+//
+func (es *EmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return es.Reader.Events()
+}
+
+// EmptyEventStreamEvent groups together all EventStream
+// events read from the EmptyStream API.
+//
+// These events are:
+//
+type EmptyEventStreamEvent interface {
+	eventEmptyEventStream()
+}
+
+// EmptyStreamEventStreamReader provides the interface for reading EventStream
+// Events from the EmptyStream API. The
+// default implementation for this interface will be EmptyStreamEventStream.
+//
+// The reader's Close method must allow multiple concurrent calls.
+//
+// These events are:
+//
+type EmptyStreamEventStreamReader interface {
+	// Returns a channel of events as they are read from the event stream.
+	Events() <-chan EmptyEventStreamEvent
+
+	// Close will close the underlying event stream reader. For event stream over
+	// HTTP this will also close the HTTP connection.
+	Close() error
+
+	// Returns any error that has occured while reading from the event stream.
+	Err() error
+}
+
+type readEmptyStreamEventStream struct {
+	eventReader *eventstreamapi.EventReader
+	stream      chan EmptyEventStreamEvent
+	errVal      atomic.Value
+
+	done      chan struct{}
+	closeOnce sync.Once
+
+	initResp eventstreamapi.Unmarshaler
+}
+
+func newReadEmptyStreamEventStream(
+	reader io.ReadCloser,
+	unmarshalers request.HandlerList,
+	logger aws.Logger,
+	logLevel aws.LogLevelType,
+	initResp eventstreamapi.Unmarshaler,
+) *readEmptyStreamEventStream {
+	r := &readEmptyStreamEventStream{
+		stream:   make(chan EmptyEventStreamEvent),
+		done:     make(chan struct{}),
+		initResp: initResp,
+	}
+
+	r.eventReader = eventstreamapi.NewEventReader(
+		reader,
+		protocol.HandlerPayloadUnmarshal{
+			Unmarshalers: unmarshalers,
+		},
+		r.unmarshalerForEventType,
+	)
+	r.eventReader.UseLogger(logger, logLevel)
+
+	return r
+}
+
+// Close will close the underlying event stream reader. For EventStream over
+// HTTP this will also close the HTTP connection.
+func (r *readEmptyStreamEventStream) Close() error {
+	r.closeOnce.Do(r.safeClose)
+
+	return r.Err()
+}
+
+func (r *readEmptyStreamEventStream) safeClose() {
+	close(r.done)
+	err := r.eventReader.Close()
+	if err != nil {
+		r.errVal.Store(err)
+	}
+}
+
+func (r *readEmptyStreamEventStream) Err() error {
+	if v := r.errVal.Load(); v != nil {
+		return v.(error)
+	}
+
+	return nil
+}
+
+func (r *readEmptyStreamEventStream) Events() <-chan EmptyEventStreamEvent {
+	return r.stream
+}
+
+func (r *readEmptyStreamEventStream) readEventStream() {
+	defer close(r.stream)
+
+	for {
+		event, err := r.eventReader.ReadEvent()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			select {
+			case <-r.done:
+				// If closed already ignore the error
+				return
+			default:
+			}
+			r.errVal.Store(err)
+			return
+		}
+
+		select {
+		case r.stream <- event.(EmptyEventStreamEvent):
+		case <-r.done:
+			return
+		}
+	}
+}
+
+func (r *readEmptyStreamEventStream) unmarshalerForEventType(
+	eventType string,
+) (eventstreamapi.Unmarshaler, error) {
+	switch eventType {
+	case "initial-response":
+		return r.initResp, nil
+	default:
+		return nil, awserr.New(
+			request.ErrCodeSerialization,
+			fmt.Sprintf("unknown event type name, %s, for EmptyStreamEventStream", eventType),
+			nil,
+		)
+	}
+}
+
+type EmptyStreamInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamInput) GoString() string {
+	return s.String()
+}
+
+type EmptyStreamOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Use EventStream to use the API's stream.
+	EventStream *EmptyStreamEventStream `type:"structure"`
+}
+
+// String returns the string representation
+func (s EmptyStreamOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EmptyStreamOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventStream sets the EventStream field's value.
+func (s *EmptyStreamOutput) SetEventStream(v *EmptyStreamEventStream) *EmptyStreamOutput {
+	s.EventStream = v
+	return s
+}
+
+func (s *EmptyStreamOutput) runEventStreamLoop(r *request.Request) {
+	if r.Error != nil {
+		return
+	}
+	reader := newReadEmptyStreamEventStream(
+		r.HTTPResponse.Body,
+		r.Handlers.UnmarshalStream,
+		r.Config.Logger,
+		r.Config.LogLevel.Value(),
+		s,
+	)
+	go reader.readEventStream()
+
+	eventStream := &EmptyStreamEventStream{
+		StreamCloser: r.HTTPResponse.Body,
+		Reader:       reader,
+	}
+	s.EventStream = eventStream
+}
+
+func (s *EmptyStreamOutput) unmarshalInitialResponse(r *request.Request) {
+	// Wait for the initial response event, which must be the first event to be
+	// received from the API.
+	select {
+	case event, ok := <-s.EventStream.Events():
+		if !ok {
+			return
+		}
+		es := s.EventStream
+		v, ok := event.(*EmptyStreamOutput)
+		if !ok || v == nil {
+			r.Error = awserr.New(
+				request.ErrCodeSerialization,
+				fmt.Sprintf("invalid event, %T, expect *SubscribeToShardOutput, %v", event, v),
+				nil,
+			)
+			return
+		}
+		*s = *v
+		s.EventStream = es
+	}
+}
+
+// The EmptyStreamOutput is and event in the EmptyEventStream group of events.
+func (s *EmptyStreamOutput) eventEmptyEventStream() {}
+
+// UnmarshalEvent unmarshals the EventStream Message into the EmptyStreamOutput value.
+// This method is only used internally within the SDK's EventStream handling.
+func (s *EmptyStreamOutput) UnmarshalEvent(
+	payloadUnmarshaler protocol.PayloadUnmarshaler,
+	msg eventstream.Message,
+) error {
+	if err := payloadUnmarshaler.UnmarshalPayload(
+		bytes.NewReader(msg.Payload), s,
+	); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -317,7 +317,7 @@ func mockGetEventStreamReadEvents() (
 			LongVal:    aws.Int64(1234),
 			ShortVal:   aws.Int64(12),
 			StringVal:  aws.String("string value goes here"),
-			TimeVal:    aws.Time(time.Unix(1396594860, 0)),
+			TimeVal:    aws.Time(time.Unix(1396594860, 0).UTC()),
 		},
 		&ImplicitPayloadEvent{
 			ByteVal:    aws.Int64(1),

--- a/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -333,6 +333,9 @@ func mockGetEventStreamReadEvents() (
 		&PayloadOnlyBlobEvent{
 			BlobPayload: []byte("blob value goes here"),
 		},
+		&PayloadOnlyStringEvent{
+			StringPayload: aws.String("string value goes here"),
+		},
 	}
 
 	var marshalers request.HandlerList
@@ -454,6 +457,16 @@ func mockGetEventStreamReadEvents() (
 				},
 			},
 			Payload: expectEvents[6].(*PayloadOnlyBlobEvent).BlobPayload,
+		},
+		{
+			Headers: eventstream.Headers{
+				eventstreamtest.EventMessageTypeHeader,
+				{
+					Name:  eventstreamapi.EventTypeHeader,
+					Value: eventstream.StringValue("PayloadOnlyString"),
+				},
+			},
+			Payload: []byte(*expectEvents[7].(*PayloadOnlyStringEvent).StringPayload),
 		},
 	}
 

--- a/private/model/api/codegentest/service/rpcservice/rpcserviceiface/interface.go
+++ b/private/model/api/codegentest/service/rpcservice/rpcserviceiface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // RPC Service.
 //    func myFunc(svc rpcserviceiface.RPCServiceAPI) bool {
-//        // Make svc.GetEventStream request
+//        // Make svc.EmptyStream request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockRPCServiceClient struct {
 //        rpcserviceiface.RPCServiceAPI
 //    }
-//    func (m *mockRPCServiceClient) GetEventStream(input *rpcservice.GetEventStreamInput) (*rpcservice.GetEventStreamOutput, error) {
+//    func (m *mockRPCServiceClient) EmptyStream(input *rpcservice.EmptyStreamInput) (*rpcservice.EmptyStreamOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,10 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type RPCServiceAPI interface {
+	EmptyStream(*rpcservice.EmptyStreamInput) (*rpcservice.EmptyStreamOutput, error)
+	EmptyStreamWithContext(aws.Context, *rpcservice.EmptyStreamInput, ...request.Option) (*rpcservice.EmptyStreamOutput, error)
+	EmptyStreamRequest(*rpcservice.EmptyStreamInput) (*request.Request, *rpcservice.EmptyStreamOutput)
+
 	GetEventStream(*rpcservice.GetEventStreamInput) (*rpcservice.GetEventStreamOutput, error)
 	GetEventStreamWithContext(aws.Context, *rpcservice.GetEventStreamInput, ...request.Option) (*rpcservice.GetEventStreamOutput, error)
 	GetEventStreamRequest(*rpcservice.GetEventStreamInput) (*request.Request, *rpcservice.GetEventStreamOutput)

--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -746,7 +746,7 @@ func valueForType(s *Shape, visited []string) string {
 	case "double":
 		return `aws.Float64(123.45)`
 	case "timestamp":
-		return `aws.Time(time.Unix(1396594860, 0))`
+		return `aws.Time(time.Unix(1396594860, 0).UTC())`
 	case "structure":
 		w := bytes.NewBuffer(nil)
 		fmt.Fprintf(w, "&%s{\n", s.ShapeName)

--- a/private/protocol/eventstream/header_value.go
+++ b/private/protocol/eventstream/header_value.go
@@ -464,7 +464,7 @@ func (v *TimestampValue) decode(r io.Reader) error {
 func timeFromEpochMilli(t int64) time.Time {
 	secs := t / 1e3
 	msec := t % 1e3
-	return time.Unix(secs, msec*int64(time.Millisecond))
+	return time.Unix(secs, msec*int64(time.Millisecond)).UTC()
 }
 
 // An UUIDValue provides eventstream encoding, and representation of a UUID

--- a/service/s3/eventstream_test.go
+++ b/service/s3/eventstream_test.go
@@ -170,6 +170,7 @@ func mockSelectObjectContentReadEvents() (
 	payloadMarshaler := protocol.HandlerPayloadMarshal{
 		Marshalers: marshalers,
 	}
+	_ = payloadMarshaler
 
 	eventMsgs := []eventstream.Message{
 		{


### PR DESCRIPTION
Fixes eventstream generated tests for APIs without any response members. Adds additional empty response modeled APIs to codegentests covering this case.