### PR TITLE
Improve s3manager.BatchDelete

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -195,8 +195,8 @@ func (iter *DeleteListIterator) DeleteObject() BatchDeleteObject {
 // BatchDelete will use the s3 package's service client to perform a batch
 // delete.
 type BatchDelete struct {
-	Client    s3iface.S3API
-	BatchSize int
+	client    s3iface.S3API
+	batchSize int
 }
 
 // NewBatchDeleteWithClient will return a new delete client that can delete a batched amount of
@@ -221,8 +221,8 @@ type BatchDelete struct {
 //	}
 func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete)) *BatchDelete {
 	svc := &BatchDelete{
-		Client:    client,
-		BatchSize: DefaultBatchSize,
+		client:    client,
+		batchSize: DefaultBatchSize,
 	}
 
 	for _, opt := range options {
@@ -319,7 +319,7 @@ func (d *BatchDelete) Delete(ctx aws.Context, iter BatchDeleteIterator) error {
 			objects = append(objects, o)
 		}
 
-		if len(input.Delete.Objects) == d.BatchSize || !parity {
+		if len(input.Delete.Objects) == d.batchSize || !parity {
 			if err := deleteBatch(ctx, d, input, objects); err != nil {
 				errs = append(errs, err...)
 			}
@@ -370,7 +370,7 @@ const (
 func deleteBatch(ctx aws.Context, d *BatchDelete, input *s3.DeleteObjectsInput, objects []BatchDeleteObject) []Error {
 	errs := []Error{}
 
-	if result, err := d.Client.DeleteObjectsWithContext(ctx, input); err != nil {
+	if result, err := d.client.DeleteObjectsWithContext(ctx, input); err != nil {
 		for i := 0; i < len(input.Delete.Objects); i++ {
 			errs = append(errs, newError(err, input.Bucket, input.Delete.Objects[i].Key))
 		}

--- a/service/s3/s3manager/batch_1_7_test.go
+++ b/service/s3/s3manager/batch_1_7_test.go
@@ -97,8 +97,8 @@ func TestBatchDeleteContext(t *testing.T) {
 		}
 
 		batcher := BatchDelete{
-			Client:    svc,
-			BatchSize: c.size,
+			client:    svc,
+			batchSize: c.size,
 		}
 
 		err := batcher.Delete(ctx, &DeleteObjectsIterator{Objects: c.objects})

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -294,8 +294,8 @@ func TestBatchDelete(t *testing.T) {
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL)}
 	for i, c := range cases {
 		batcher := BatchDelete{
-			Client:    svc,
-			BatchSize: c.size,
+			client:    svc,
+			batchSize: c.size,
 		}
 
 		if err := batcher.Delete(aws.BackgroundContext(), &DeleteObjectsIterator{Objects: c.objects}); err != nil {
@@ -374,8 +374,8 @@ func TestBatchDeleteError(t *testing.T) {
 	}
 	for _, c := range cases {
 		batcher := BatchDelete{
-			Client:    svc,
-			BatchSize: c.size,
+			client:    svc,
+			batchSize: c.size,
 		}
 
 		err := batcher.Delete(aws.BackgroundContext(), &DeleteObjectsIterator{Objects: c.objects})
@@ -492,8 +492,8 @@ func TestBatchDeleteList(t *testing.T) {
 
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL), objects: objects}
 	batcher := BatchDelete{
-		Client:    svc,
-		BatchSize: 1,
+		client:    svc,
+		batchSize: 1,
 	}
 
 	input := &s3.ListObjectsInput{
@@ -546,7 +546,7 @@ func TestBatchDeleteList_EmptyListObjects(t *testing.T) {
 
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL)}
 	batcher := BatchDelete{
-		Client: svc,
+		client: svc,
 	}
 
 	input := &s3.ListObjectsInput{


### PR DESCRIPTION
It seems the `Client` and `BatchSize` fields inside `BatchDelete` struct don't need to be public.

This will prevent users from creating `BatchDelete` objects other than using `NewBatchDeleteWithClient`.