### PR TITLE
private/model/api: Fix EventStream Exception message codegen

### DIFF
--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -482,7 +482,7 @@ func (s ExceptionEvent) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent) Message() string {
-	return ""
+	return *s.Message_
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -482,7 +482,7 @@ func (s ExceptionEvent) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent) Message() string {
-	return ""
+	return *s.Message_
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -531,7 +531,7 @@ func (s ExceptionEvent) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent) Message() string {
-	return ""
+	return *s.Message_
 }
 
 // OrigErr always returns nil, satisfies awserr.Error interface.

--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -667,8 +667,8 @@ func (s {{ $.ShapeName }}) Code() string {
 
 // Message returns the exception's message.
 func (s {{ $.ShapeName }}) Message() string {
-	{{- if index $.MemberRefs "Message" }}
-		return *s.Message
+	{{- if index $.MemberRefs "Message_" }}
+		return *s.Message_
 	{{- else }}
 		return ""
 	{{ end -}}


### PR DESCRIPTION
Fixes the EventStream's exception message member not being code
generated into the Message method.