### PR TITLE
Avoid using provider side interface for s3 packages.

### DIFF
--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 // WrapEntry is builder that return a proper key decrypter and error
@@ -16,6 +15,10 @@ type WrapEntry func(Envelope) (CipherDataDecrypter, error)
 
 // CEKEntry is a builder thatn returns a proper content decrypter and error
 type CEKEntry func(CipherData) (ContentCipher, error)
+
+type getObjectRequester interface {
+	GetObjectRequest(*s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput)
+}
 
 // DecryptionClient is an S3 crypto client. The decryption client
 // will handle all get object requests from Amazon S3.
@@ -26,7 +29,7 @@ type CEKEntry func(CipherData) (ContentCipher, error)
 //	* AES/GCM
 //	* AES/CBC
 type DecryptionClient struct {
-	S3Client s3iface.S3API
+	S3Client getObjectRequester
 	// LoadStrategy is used to load the metadata either from the metadata of the object
 	// or from a separate file in s3.
 	//

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -9,19 +9,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/sdkio"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 // DefaultMinFileSize is used to check whether we want to write to a temp file
 // or store the data in memory.
 const DefaultMinFileSize = 1024 * 512 * 5
 
+type putObjectRequester interface {
+	PutObjectRequest(*s3.PutObjectInput) (*request.Request, *s3.PutObjectOutput)
+}
+
 // EncryptionClient is an S3 crypto client. By default the SDK will use Authentication mode which
 // will use KMS for key wrapping and AES GCM for content encryption.
 // AES GCM will load all data into memory. However, the rest of the content algorithms
 // do not load the entire contents into memory.
 type EncryptionClient struct {
-	S3Client             s3iface.S3API
+	S3Client             putObjectRequester
 	ContentCipherBuilder ContentCipherBuilder
 	// SaveStrategy will dictate where the envelope is saved.
 	//

--- a/service/s3/s3manager/bucket_region.go
+++ b/service/s3/s3manager/bucket_region.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 // GetBucketRegion will attempt to get the region for a bucket using the
@@ -46,12 +45,16 @@ func GetBucketRegion(ctx aws.Context, c client.ConfigProvider, bucket, regionHin
 
 const bucketRegionHeader = "X-Amz-Bucket-Region"
 
+type headBucketRequester interface {
+	HeadBucketRequest(*s3.HeadBucketInput) (*request.Request, *s3.HeadBucketOutput)
+}
+
 // GetBucketRegionWithClient is the same as GetBucketRegion with the exception
 // that it takes a S3 service client instead of a Session. The regionHint is
 // derived from the region the S3 service client was created in.
 //
 // See GetBucketRegion for more information.
-func GetBucketRegionWithClient(ctx aws.Context, svc s3iface.S3API, bucket string, opts ...request.Option) (string, error) {
+func GetBucketRegionWithClient(ctx aws.Context, svc headBucketRequester, bucket string, opts ...request.Option) (string, error) {
 	req, _ := svc.HeadBucketRequest(&s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	})


### PR DESCRIPTION
This will bring the benefits that if adding more functions into `s3iface`, all customer side code and tests won't break.

From https://github.com/golang/go/wiki/CodeReviewComments#interfaces

> Go interfaces generally belong in the package that uses values of the interface type, not the package that implements those values. The implementing package should return concrete (usually pointer or struct) types: that way, new methods can be added to implementations without requiring extensive refactoring.