### PR TITLE
fix typos

### DIFF
--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -125,7 +125,7 @@ func (c *DecryptionClient) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOut
 //
 // GetObjectWithContext is the same as GetObject with the additional support for
 // Context input parameters. The Context must not be nil. A nil Context will
-// cause a panic. Use the Context to add deadlining, timeouts, ect. In the future
+// cause a panic. Use the Context to add deadlining, timeouts, etc. In the future
 // this may create sub-contexts for individual underlying requests.
 func (c *DecryptionClient) GetObjectWithContext(ctx aws.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
 	req, out := c.GetObjectRequest(input)

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -136,7 +136,7 @@ func (c *EncryptionClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOut
 //
 // PutObjectWithContext is the same as PutObject with the additional support for
 // Context input parameters. The Context must not be nil. A nil Context will
-// cause a panic. Use the Context to add deadlining, timeouts, ect. In the future
+// cause a panic. Use the Context to add deadlining, timeouts, etc. In the future
 // this may create sub-contexts for individual underlying requests.
 func (c *EncryptionClient) PutObjectWithContext(ctx aws.Context, input *s3.PutObjectInput, opts ...request.Option) (*s3.PutObjectOutput, error) {
 	req, out := c.PutObjectRequest(input)

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -147,7 +147,7 @@ func (d Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ..
 //
 // DownloadWithContext is the same as Download with the additional support for
 // Context input parameters. The Context must not be nil. A nil Context will
-// cause a panic. Use the Context to add deadlining, timeouts, ect. The
+// cause a panic. Use the Context to add deadlining, timeouts, etc. The
 // DownloadWithContext may create sub-contexts for individual underlying
 // requests.
 //

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -357,7 +357,7 @@ func (u Uploader) Upload(input *UploadInput, options ...func(*Uploader)) (*Uploa
 //
 // UploadWithContext is the same as Upload with the additional support for
 // Context input parameters. The Context must not be nil. A nil Context will
-// cause a panic. Use the context to add deadlining, timeouts, ect. The
+// cause a panic. Use the context to add deadlining, timeouts, etc. The
 // UploadWithContext may create sub-contexts for individual underlying requests.
 //
 // Additional functional options can be provided to configure the individual


### PR DESCRIPTION
`s/, ect./, etc./g`