### PR TITLE
v1.14.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Release v1.14.20 (2018-07-05)
+===
+
+### Service Client Updates
+* `service/pinpoint`: Updates service API and documentation
+  * This release of the Amazon Pinpoint SDK adds the ability to create complex segments and validate phone numbers for SMS messages. It also adds the ability to get or delete endpoints based on user IDs, remove attributes from endpoints, and list the defined channels for an app.
+* `service/sagemaker`: Updates service API and documentation
+  * Amazon SageMaker NotebookInstances supports 'Updating' as a NotebookInstanceStatus.  In addition, DescribeEndpointOutput now includes Docker repository digest of deployed Model images.
+
 Release v1.14.19 (2018-07-03)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.19"
+const SDKVersion = "1.14.20"

--- a/models/apis/pinpoint/2016-12-01/api-2.json
+++ b/models/apis/pinpoint/2016-12-01/api-2.json
@@ -4,6 +4,7 @@
     "endpointPrefix" : "pinpoint",
     "signingName" : "mobiletargeting",
     "serviceFullName" : "Amazon Pinpoint",
+    "serviceId" : "Pinpoint",
     "protocol" : "rest-json",
     "jsonVersion" : "1.1",
     "uid" : "pinpoint-2016-12-01",
@@ -64,7 +65,7 @@
         "shape" : "TooManyRequestsException"
       } ]
     },
-      "CreateExportJob" : {
+    "CreateExportJob" : {
       "name" : "CreateExportJob",
       "http" : {
         "method" : "POST",
@@ -523,6 +524,33 @@
         "shape" : "TooManyRequestsException"
       } ]
     },
+    "DeleteUserEndpoints" : {
+      "name" : "DeleteUserEndpoints",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v1/apps/{application-id}/users/{user-id}",
+        "responseCode" : 202
+      },
+      "input" : {
+        "shape" : "DeleteUserEndpointsRequest"
+      },
+      "output" : {
+        "shape" : "DeleteUserEndpointsResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      }, {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "MethodNotAllowedException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
     "GetAdmChannel" : {
       "name" : "GetAdmChannel",
       "http" : {
@@ -886,6 +914,33 @@
       },
       "output" : {
         "shape" : "GetCampaignsResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      }, {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "MethodNotAllowedException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetChannels" : {
+      "name" : "GetChannels",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/apps/{application-id}/channels",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetChannelsRequest"
+      },
+      "output" : {
+        "shape" : "GetChannelsResponse"
       },
       "errors" : [ {
         "shape" : "BadRequestException"
@@ -1306,6 +1361,60 @@
         "shape" : "TooManyRequestsException"
       } ]
     },
+    "GetUserEndpoints" : {
+      "name" : "GetUserEndpoints",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v1/apps/{application-id}/users/{user-id}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetUserEndpointsRequest"
+      },
+      "output" : {
+        "shape" : "GetUserEndpointsResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      }, {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "MethodNotAllowedException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "PhoneNumberValidate" : {
+      "name" : "PhoneNumberValidate",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v1/phone/number/validate",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "PhoneNumberValidateRequest"
+      },
+      "output" : {
+        "shape" : "PhoneNumberValidateResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      }, {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "MethodNotAllowedException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
     "PutEventStream" : {
       "name" : "PutEventStream",
       "http" : {
@@ -1318,6 +1427,33 @@
       },
       "output" : {
         "shape" : "PutEventStreamResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "InternalServerErrorException"
+      }, {
+        "shape" : "ForbiddenException"
+      }, {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "MethodNotAllowedException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "RemoveAttributes" : {
+      "name" : "RemoveAttributes",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v1/apps/{application-id}/attributes/{attribute-type}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "RemoveAttributesRequest"
+      },
+      "output" : {
+        "shape" : "RemoveAttributesResponse"
       },
       "errors" : [ {
         "shape" : "BadRequestException"
@@ -1779,7 +1915,8 @@
         "Enabled" : {
           "shape" : "__boolean"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ADMChannelResponse" : {
       "type" : "structure",
@@ -1814,7 +1951,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ADMMessage" : {
       "type" : "structure",
@@ -1896,7 +2034,8 @@
         "TokenKeyId" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSChannelResponse" : {
       "type" : "structure",
@@ -1937,7 +2076,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSMessage" : {
       "type" : "structure",
@@ -2022,7 +2162,8 @@
         "TokenKeyId" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSSandboxChannelResponse" : {
       "type" : "structure",
@@ -2063,7 +2204,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSVoipChannelRequest" : {
       "type" : "structure",
@@ -2092,7 +2234,8 @@
         "TokenKeyId" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSVoipChannelResponse" : {
       "type" : "structure",
@@ -2133,7 +2276,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSVoipSandboxChannelRequest" : {
       "type" : "structure",
@@ -2162,7 +2306,8 @@
         "TokenKeyId" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "APNSVoipSandboxChannelResponse" : {
       "type" : "structure",
@@ -2203,7 +2348,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "Action" : {
       "type" : "string",
@@ -2215,7 +2361,8 @@
         "Item" : {
           "shape" : "ListOfActivityResponse"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ActivityResponse" : {
       "type" : "structure",
@@ -2259,7 +2406,8 @@
         "TreatmentId" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "AddressConfiguration" : {
       "type" : "structure",
@@ -2293,7 +2441,8 @@
         "Name" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ApplicationSettingsResource" : {
       "type" : "structure",
@@ -2313,7 +2462,8 @@
         "QuietTime" : {
           "shape" : "QuietTime"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ApplicationsResponse" : {
       "type" : "structure",
@@ -2335,11 +2485,27 @@
         "Values" : {
           "shape" : "ListOf__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "AttributeType" : {
       "type" : "string",
       "enum" : [ "INCLUSIVE", "EXCLUSIVE" ]
+    },
+    "AttributesResource" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string"
+        },
+        "AttributeType" : {
+          "shape" : "__string"
+        },
+        "Attributes" : {
+          "shape" : "ListOf__string"
+        }
+      },
+      "required" : [ ]
     },
     "BadRequestException" : {
       "type" : "structure",
@@ -2368,7 +2534,8 @@
         "SecretKey" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "BaiduChannelResponse" : {
       "type" : "structure",
@@ -2406,7 +2573,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "BaiduMessage" : {
       "type" : "structure",
@@ -2444,6 +2612,9 @@
         "Substitutions" : {
           "shape" : "MapOfListOf__string"
         },
+        "TimeToLive" : {
+          "shape" : "__integer"
+        },
         "Title" : {
           "shape" : "__string"
         },
@@ -2467,7 +2638,8 @@
         "Title" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "CampaignHook" : {
       "type" : "structure",
@@ -2563,7 +2735,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "CampaignSmsMessage" : {
       "type" : "structure",
@@ -2589,7 +2762,7 @@
     },
     "CampaignStatus" : {
       "type" : "string",
-      "enum" : [ "SCHEDULED", "EXECUTING", "PENDING_NEXT_RUN", "COMPLETED", "PAUSED" ]
+      "enum" : [ "SCHEDULED", "EXECUTING", "PENDING_NEXT_RUN", "COMPLETED", "PAUSED", "DELETED" ]
     },
     "CampaignsResponse" : {
       "type" : "structure",
@@ -2600,11 +2773,53 @@
         "NextToken" : {
           "shape" : "__string"
         }
+      },
+      "required" : [ ]
+    },
+    "ChannelResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string"
+        },
+        "CreationDate" : {
+          "shape" : "__string"
+        },
+        "Enabled" : {
+          "shape" : "__boolean"
+        },
+        "HasCredential" : {
+          "shape" : "__boolean"
+        },
+        "Id" : {
+          "shape" : "__string"
+        },
+        "IsArchived" : {
+          "shape" : "__boolean"
+        },
+        "LastModifiedBy" : {
+          "shape" : "__string"
+        },
+        "LastModifiedDate" : {
+          "shape" : "__string"
+        },
+        "Version" : {
+          "shape" : "__integer"
+        }
       }
     },
     "ChannelType" : {
       "type" : "string",
       "enum" : [ "GCM", "APNS", "APNS_SANDBOX", "APNS_VOIP", "APNS_VOIP_SANDBOX", "ADM", "SMS", "EMAIL", "BAIDU", "CUSTOM" ]
+    },
+    "ChannelsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Channels" : {
+          "shape" : "MapOfChannelResponse"
+        }
+      },
+      "required" : [ ]
     },
     "CreateAppRequest" : {
       "type" : "structure",
@@ -2632,7 +2847,8 @@
         "Name" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "CreateCampaignRequest" : {
       "type" : "structure",
@@ -3080,6 +3296,32 @@
       "required" : [ "SMSChannelResponse" ],
       "payload" : "SMSChannelResponse"
     },
+    "DeleteUserEndpointsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "application-id"
+        },
+        "UserId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "user-id"
+        }
+      },
+      "required" : [ "ApplicationId", "UserId" ]
+    },
+    "DeleteUserEndpointsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "EndpointsResponse" : {
+          "shape" : "EndpointsResponse"
+        }
+      },
+      "required" : [ "EndpointsResponse" ],
+      "payload" : "EndpointsResponse"
+    },
     "DeliveryStatus" : {
       "type" : "string",
       "enum" : [ "SUCCESSFUL", "THROTTLED", "TEMPORARY_FAILURE", "PERMANENT_FAILURE", "UNKNOWN_FAILURE", "OPT_OUT", "DUPLICATE" ]
@@ -3112,7 +3354,8 @@
         "SMSMessage" : {
           "shape" : "SMSMessage"
         }
-      }
+      },
+      "required" : [ ]
     },
     "Duration" : {
       "type" : "string",
@@ -3133,7 +3376,8 @@
         "RoleArn" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "EmailChannelResponse" : {
       "type" : "structure",
@@ -3168,6 +3412,9 @@
         "LastModifiedDate" : {
           "shape" : "__string"
         },
+        "MessagesPerSecond" : {
+          "shape" : "__integer"
+        },
         "Platform" : {
           "shape" : "__string"
         },
@@ -3177,7 +3424,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "EndpointBatchItem" : {
       "type" : "structure",
@@ -3226,7 +3474,8 @@
         "Item" : {
           "shape" : "ListOfEndpointBatchItem"
         }
-      }
+      },
+      "required" : [ ]
     },
     "EndpointDemographic" : {
       "type" : "structure",
@@ -3289,6 +3538,9 @@
         "DeliveryStatus" : {
           "shape" : "DeliveryStatus"
         },
+        "MessageId" : {
+          "shape" : "__string"
+        },
         "StatusCode" : {
           "shape" : "__integer"
         },
@@ -3298,7 +3550,8 @@
         "UpdatedToken" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "EndpointRequest" : {
       "type" : "structure",
@@ -3419,6 +3672,15 @@
         }
       }
     },
+    "EndpointsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Item" : {
+          "shape" : "ListOfEndpointResponse"
+        }
+      },
+      "required" : [ ]
+    },
     "EventStream" : {
       "type" : "structure",
       "members" : {
@@ -3440,7 +3702,8 @@
         "RoleArn" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ExportJobRequest" : {
       "type" : "structure",
@@ -3453,6 +3716,9 @@
         },
         "SegmentId" : {
           "shape" : "__string"
+        },
+        "SegmentVersion" : {
+          "shape" : "__integer"
         }
       },
       "required" : [ ]
@@ -3468,6 +3734,9 @@
         },
         "SegmentId" : {
           "shape" : "__string"
+        },
+        "SegmentVersion" : {
+          "shape" : "__integer"
         }
       },
       "required" : [ ]
@@ -3561,7 +3830,8 @@
         "Enabled" : {
           "shape" : "__boolean"
         }
-      }
+      },
+      "required" : [ ]
     },
     "GCMChannelResponse" : {
       "type" : "structure",
@@ -3599,7 +3869,8 @@
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "GCMMessage" : {
       "type" : "structure",
@@ -3656,6 +3927,30 @@
           "shape" : "__string"
         }
       }
+    },
+    "GPSCoordinates" : {
+      "type" : "structure",
+      "members" : {
+        "Latitude" : {
+          "shape" : "__double"
+        },
+        "Longitude" : {
+          "shape" : "__double"
+        }
+      },
+      "required" : [ ]
+    },
+    "GPSPointDimension" : {
+      "type" : "structure",
+      "members" : {
+        "Coordinates" : {
+          "shape" : "GPSCoordinates"
+        },
+        "RangeInKilometers" : {
+          "shape" : "__double"
+        }
+      },
+      "required" : [ ]
     },
     "GetAdmChannelRequest" : {
       "type" : "structure",
@@ -4009,6 +4304,27 @@
       },
       "required" : [ "CampaignsResponse" ],
       "payload" : "CampaignsResponse"
+    },
+    "GetChannelsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "application-id"
+        }
+      },
+      "required" : [ "ApplicationId" ]
+    },
+    "GetChannelsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ChannelsResponse" : {
+          "shape" : "ChannelsResponse"
+        }
+      },
+      "required" : [ "ChannelsResponse" ],
+      "payload" : "ChannelsResponse"
     },
     "GetEmailChannelRequest" : {
       "type" : "structure",
@@ -4430,6 +4746,32 @@
       "required" : [ "SMSChannelResponse" ],
       "payload" : "SMSChannelResponse"
     },
+    "GetUserEndpointsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "application-id"
+        },
+        "UserId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "user-id"
+        }
+      },
+      "required" : [ "ApplicationId", "UserId" ]
+    },
+    "GetUserEndpointsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "EndpointsResponse" : {
+          "shape" : "EndpointsResponse"
+        }
+      },
+      "required" : [ "EndpointsResponse" ],
+      "payload" : "EndpointsResponse"
+    },
     "ImportJobRequest" : {
       "type" : "structure",
       "members" : {
@@ -4457,7 +4799,8 @@
         "SegmentName" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ImportJobResource" : {
       "type" : "structure",
@@ -4486,7 +4829,8 @@
         "SegmentName" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ImportJobResponse" : {
       "type" : "structure",
@@ -4530,7 +4874,8 @@
         "Type" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "ImportJobsResponse" : {
       "type" : "structure",
@@ -4541,7 +4886,12 @@
         "NextToken" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
+    },
+    "Include" : {
+      "type" : "string",
+      "enum" : [ "ALL", "ANY", "NONE" ]
     },
     "InternalServerErrorException" : {
       "type" : "structure",
@@ -4561,156 +4911,6 @@
     "JobStatus" : {
       "type" : "string",
       "enum" : [ "CREATED", "INITIALIZING", "PROCESSING", "COMPLETING", "COMPLETED", "FAILING", "FAILED" ]
-    },
-    "ListOfActivityResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ActivityResponse"
-      }
-    },
-    "ListOfApplicationResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ApplicationResponse"
-      }
-    },
-    "ListOfCampaignResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "CampaignResponse"
-      }
-    },
-    "ListOfEndpointBatchItem" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "EndpointBatchItem"
-      }
-    },
-    "ListOfExportJobResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ExportJobResponse"
-      }
-    },
-    "ListOfImportJobResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "ImportJobResponse"
-      }
-    },
-    "ListOfSegmentResponse" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "SegmentResponse"
-      }
-    },
-    "ListOfTreatmentResource" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "TreatmentResource"
-      }
-    },
-    "ListOfWriteTreatmentResource" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "WriteTreatmentResource"
-      }
-    },
-    "ListOf__string" : {
-      "type" : "list",
-      "member" : {
-        "shape" : "__string"
-      }
-    },
-    "MapOfAddressConfiguration" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "AddressConfiguration"
-      }
-    },
-    "MapOfAttributeDimension" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "AttributeDimension"
-      }
-    },
-    "MapOfEndpointMessageResult" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "EndpointMessageResult"
-      }
-    },
-    "MapOfEndpointSendConfiguration" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "EndpointSendConfiguration"
-      }
-    },
-    "MapOfListOf__string" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "ListOf__string"
-      }
-    },
-    "MapOfMapOfEndpointMessageResult" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "MapOfEndpointMessageResult"
-      }
-    },
-    "MapOfMessageResult" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "MessageResult"
-      }
-    },
-    "MapOf__double" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__double"
-      }
-    },
-    "MapOf__integer" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__integer"
-      }
-    },
-    "MapOf__string" : {
-      "type" : "map",
-      "key" : {
-        "shape" : "__string"
-      },
-      "value" : {
-        "shape" : "__string"
-      }
     },
     "Message" : {
       "type" : "structure",
@@ -4742,13 +4942,17 @@
         "SilentPush" : {
           "shape" : "__boolean"
         },
+        "TimeToLive" : {
+          "shape" : "__integer"
+        },
         "Title" : {
           "shape" : "__string"
         },
         "Url" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "MessageBody" : {
       "type" : "structure",
@@ -4802,7 +5006,8 @@
         "MessageConfiguration" : {
           "shape" : "DirectMessageConfiguration"
         }
-      }
+      },
+      "required" : [ ]
     },
     "MessageResponse" : {
       "type" : "structure",
@@ -4819,13 +5024,17 @@
         "Result" : {
           "shape" : "MapOfMessageResult"
         }
-      }
+      },
+      "required" : [ ]
     },
     "MessageResult" : {
       "type" : "structure",
       "members" : {
         "DeliveryStatus" : {
           "shape" : "DeliveryStatus"
+        },
+        "MessageId" : {
+          "shape" : "__string"
         },
         "StatusCode" : {
           "shape" : "__integer"
@@ -4836,7 +5045,8 @@
         "UpdatedToken" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "MessageType" : {
       "type" : "string",
@@ -4857,6 +5067,17 @@
         "httpStatusCode" : 405
       }
     },
+    "MetricDimension" : {
+      "type" : "structure",
+      "members" : {
+        "ComparisonOperator" : {
+          "shape" : "__string"
+        },
+        "Value" : {
+          "shape" : "__double"
+        }
+      }
+    },
     "Mode" : {
       "type" : "string",
       "enum" : [ "DELIVERY", "FILTER" ]
@@ -4875,6 +5096,84 @@
       "error" : {
         "httpStatusCode" : 404
       }
+    },
+    "NumberValidateRequest" : {
+      "type" : "structure",
+      "members" : {
+        "IsoCountryCode" : {
+          "shape" : "__string"
+        },
+        "PhoneNumber" : {
+          "shape" : "__string"
+        }
+      }
+    },
+    "NumberValidateResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Carrier" : {
+          "shape" : "__string"
+        },
+        "City" : {
+          "shape" : "__string"
+        },
+        "CleansedPhoneNumberE164" : {
+          "shape" : "__string"
+        },
+        "CleansedPhoneNumberNational" : {
+          "shape" : "__string"
+        },
+        "Country" : {
+          "shape" : "__string"
+        },
+        "CountryCodeIso2" : {
+          "shape" : "__string"
+        },
+        "CountryCodeNumeric" : {
+          "shape" : "__string"
+        },
+        "County" : {
+          "shape" : "__string"
+        },
+        "OriginalCountryCodeIso2" : {
+          "shape" : "__string"
+        },
+        "OriginalPhoneNumber" : {
+          "shape" : "__string"
+        },
+        "PhoneType" : {
+          "shape" : "__string"
+        },
+        "PhoneTypeCode" : {
+          "shape" : "__integer"
+        },
+        "Timezone" : {
+          "shape" : "__string"
+        },
+        "ZipCode" : {
+          "shape" : "__string"
+        }
+      }
+    },
+    "PhoneNumberValidateRequest" : {
+      "type" : "structure",
+      "members" : {
+        "NumberValidateRequest" : {
+          "shape" : "NumberValidateRequest"
+        }
+      },
+      "required" : [ "NumberValidateRequest" ],
+      "payload" : "NumberValidateRequest"
+    },
+    "PhoneNumberValidateResponse" : {
+      "type" : "structure",
+      "members" : {
+        "NumberValidateResponse" : {
+          "shape" : "NumberValidateResponse"
+        }
+      },
+      "required" : [ "NumberValidateResponse" ],
+      "payload" : "NumberValidateResponse"
     },
     "PutEventStreamRequest" : {
       "type" : "structure",
@@ -4921,11 +5220,42 @@
         "RecencyType" : {
           "shape" : "RecencyType"
         }
-      }
+      },
+      "required" : [ ]
     },
     "RecencyType" : {
       "type" : "string",
       "enum" : [ "ACTIVE", "INACTIVE" ]
+    },
+    "RemoveAttributesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApplicationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "application-id"
+        },
+        "AttributeType" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "attribute-type"
+        },
+        "UpdateAttributesRequest" : {
+          "shape" : "UpdateAttributesRequest"
+        }
+      },
+      "required" : [ "AttributeType", "ApplicationId", "UpdateAttributesRequest" ],
+      "payload" : "UpdateAttributesRequest"
+    },
+    "RemoveAttributesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AttributesResource" : {
+          "shape" : "AttributesResource"
+        }
+      },
+      "required" : [ "AttributesResource" ],
+      "payload" : "AttributesResource"
     },
     "SMSChannelRequest" : {
       "type" : "structure",
@@ -4939,7 +5269,8 @@
         "ShortCode" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SMSChannelResponse" : {
       "type" : "structure",
@@ -4971,21 +5302,31 @@
         "Platform" : {
           "shape" : "__string"
         },
+        "PromotionalMessagesPerSecond" : {
+          "shape" : "__integer"
+        },
         "SenderId" : {
           "shape" : "__string"
         },
         "ShortCode" : {
           "shape" : "__string"
         },
+        "TransactionalMessagesPerSecond" : {
+          "shape" : "__integer"
+        },
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SMSMessage" : {
       "type" : "structure",
       "members" : {
         "Body" : {
+          "shape" : "__string"
+        },
+        "Keyword" : {
           "shape" : "__string"
         },
         "MessageType" : {
@@ -5023,7 +5364,8 @@
         "Timezone" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SegmentBehaviors" : {
       "type" : "structure",
@@ -5071,10 +5413,43 @@
         "Location" : {
           "shape" : "SegmentLocation"
         },
+        "Metrics" : {
+          "shape" : "MapOfMetricDimension"
+        },
         "UserAttributes" : {
           "shape" : "MapOfAttributeDimension"
         }
       }
+    },
+    "SegmentGroup" : {
+      "type" : "structure",
+      "members" : {
+        "Dimensions" : {
+          "shape" : "ListOfSegmentDimensions"
+        },
+        "SourceSegments" : {
+          "shape" : "ListOfSegmentReference"
+        },
+        "SourceType" : {
+          "shape" : "SourceType"
+        },
+        "Type" : {
+          "shape" : "Type"
+        }
+      },
+      "required" : [ ]
+    },
+    "SegmentGroupList" : {
+      "type" : "structure",
+      "members" : {
+        "Groups" : {
+          "shape" : "ListOfSegmentGroup"
+        },
+        "Include" : {
+          "shape" : "Include"
+        }
+      },
+      "required" : [ ]
     },
     "SegmentImportResource" : {
       "type" : "structure",
@@ -5097,13 +5472,28 @@
         "Size" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SegmentLocation" : {
       "type" : "structure",
       "members" : {
         "Country" : {
           "shape" : "SetDimension"
+        },
+        "GPSPoint" : {
+          "shape" : "GPSPointDimension"
+        }
+      }
+    },
+    "SegmentReference" : {
+      "type" : "structure",
+      "members" : {
+        "Id" : {
+          "shape" : "__string"
+        },
+        "Version" : {
+          "shape" : "__integer"
         }
       }
     },
@@ -5131,13 +5521,17 @@
         "Name" : {
           "shape" : "__string"
         },
+        "SegmentGroups" : {
+          "shape" : "SegmentGroupList"
+        },
         "SegmentType" : {
           "shape" : "SegmentType"
         },
         "Version" : {
           "shape" : "__integer"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SegmentType" : {
       "type" : "string",
@@ -5152,7 +5546,8 @@
         "NextToken" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SendMessagesRequest" : {
       "type" : "structure",
@@ -5191,7 +5586,8 @@
         "Users" : {
           "shape" : "MapOfEndpointSendConfiguration"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SendUsersMessageResponse" : {
       "type" : "structure",
@@ -5205,7 +5601,8 @@
         "Result" : {
           "shape" : "MapOfMapOfEndpointMessageResult"
         }
-      }
+      },
+      "required" : [ ]
     },
     "SendUsersMessagesRequest" : {
       "type" : "structure",
@@ -5241,7 +5638,12 @@
         "Values" : {
           "shape" : "ListOf__string"
         }
-      }
+      },
+      "required" : [ ]
+    },
+    "SourceType" : {
+      "type" : "string",
+      "enum" : [ "ALL", "ANY" ]
     },
     "TooManyRequestsException" : {
       "type" : "structure",
@@ -5282,7 +5684,12 @@
         "TreatmentName" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
+    },
+    "Type" : {
+      "type" : "string",
+      "enum" : [ "ALL", "ANY", "NONE" ]
     },
     "UpdateAdmChannelRequest" : {
       "type" : "structure",
@@ -5433,6 +5840,14 @@
       },
       "required" : [ "ApplicationSettingsResource" ],
       "payload" : "ApplicationSettingsResource"
+    },
+    "UpdateAttributesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "Blacklist" : {
+          "shape" : "ListOf__string"
+        }
+      }
     },
     "UpdateBaiduChannelRequest" : {
       "type" : "structure",
@@ -5655,6 +6070,9 @@
         "CampaignHook" : {
           "shape" : "CampaignHook"
         },
+        "CloudWatchMetricsEnabled" : {
+          "shape" : "__boolean"
+        },
         "Limits" : {
           "shape" : "CampaignLimits"
         },
@@ -5716,7 +6134,8 @@
         "RoleArn" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "WriteSegmentRequest" : {
       "type" : "structure",
@@ -5726,8 +6145,12 @@
         },
         "Name" : {
           "shape" : "__string"
+        },
+        "SegmentGroups" : {
+          "shape" : "SegmentGroupList"
         }
-      }
+      },
+      "required" : [ ]
     },
     "WriteTreatmentResource" : {
       "type" : "structure",
@@ -5747,7 +6170,8 @@
         "TreatmentName" : {
           "shape" : "__string"
         }
-      }
+      },
+      "required" : [ ]
     },
     "__boolean" : {
       "type" : "boolean"
@@ -5758,11 +6182,211 @@
     "__integer" : {
       "type" : "integer"
     },
+    "ListOfActivityResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ActivityResponse"
+      }
+    },
+    "ListOfApplicationResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ApplicationResponse"
+      }
+    },
+    "ListOfCampaignResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "CampaignResponse"
+      }
+    },
+    "ListOfEndpointBatchItem" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "EndpointBatchItem"
+      }
+    },
+    "ListOfEndpointResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "EndpointResponse"
+      }
+    },
+    "ListOfExportJobResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ExportJobResponse"
+      }
+    },
+    "ListOfImportJobResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ImportJobResponse"
+      }
+    },
+    "ListOfSegmentDimensions" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "SegmentDimensions"
+      }
+    },
+    "ListOfSegmentGroup" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "SegmentGroup"
+      }
+    },
+    "ListOfSegmentReference" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "SegmentReference"
+      }
+    },
+    "ListOfSegmentResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "SegmentResponse"
+      }
+    },
+    "ListOfTreatmentResource" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "TreatmentResource"
+      }
+    },
+    "ListOfWriteTreatmentResource" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "WriteTreatmentResource"
+      }
+    },
+    "ListOf__string" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "__long" : {
+      "type" : "long"
+    },
+    "MapOfAddressConfiguration" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "AddressConfiguration"
+      }
+    },
+    "MapOfAttributeDimension" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "AttributeDimension"
+      }
+    },
+    "MapOfChannelResponse" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "ChannelResponse"
+      }
+    },
+    "MapOfEndpointMessageResult" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "EndpointMessageResult"
+      }
+    },
+    "MapOfEndpointSendConfiguration" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "EndpointSendConfiguration"
+      }
+    },
+    "MapOfMessageResult" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "MessageResult"
+      }
+    },
+    "MapOfMetricDimension" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "MetricDimension"
+      }
+    },
+    "MapOf__double" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__double"
+      }
+    },
+    "MapOf__integer" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__integer"
+      }
+    },
+    "MapOfListOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "ListOf__string"
+      }
+    },
+    "MapOfMapOfEndpointMessageResult" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "MapOfEndpointMessageResult"
+      }
+    },
+    "MapOf__string" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "__string"
+      }
+    },
     "__string" : {
       "type" : "string"
     },
-    "__timestamp" : {
-      "type" : "timestamp"
+    "__timestampIso8601" : {
+      "type" : "timestamp",
+      "timestampFormat" : "iso8601"
+    },
+    "__timestampUnix" : {
+      "type" : "timestamp",
+      "timestampFormat" : "unixTimestamp"
     }
   }
 }

--- a/models/apis/pinpoint/2016-12-01/docs-2.json
+++ b/models/apis/pinpoint/2016-12-01/docs-2.json
@@ -7,23 +7,24 @@
     "CreateExportJob" : "Creates an export job.",
     "CreateImportJob" : "Creates or updates an import job.",
     "CreateSegment" : "Used to create or update a segment.",
-    "DeleteAdmChannel" : "Delete an ADM channel",
+    "DeleteAdmChannel" : "Delete an ADM channel.",
     "DeleteApnsChannel" : "Deletes the APNs channel for an app.",
-    "DeleteApnsSandboxChannel" : "Delete an APNS sandbox channel",
+    "DeleteApnsSandboxChannel" : "Delete an APNS sandbox channel.",
     "DeleteApnsVoipChannel" : "Delete an APNS VoIP channel",
     "DeleteApnsVoipSandboxChannel" : "Delete an APNS VoIP sandbox channel",
     "DeleteApp" : "Deletes an app.",
     "DeleteBaiduChannel" : "Delete a BAIDU GCM channel",
     "DeleteCampaign" : "Deletes a campaign.",
-    "DeleteEmailChannel" : "Delete an email channel",
+    "DeleteEmailChannel" : "Delete an email channel.",
     "DeleteEndpoint" : "Deletes an endpoint.",
     "DeleteEventStream" : "Deletes the event stream for an app.",
     "DeleteGcmChannel" : "Deletes the GCM channel for an app.",
     "DeleteSegment" : "Deletes a segment.",
-    "DeleteSmsChannel" : "Delete an SMS channel",
-    "GetAdmChannel" : "Get an ADM channel",
+    "DeleteSmsChannel" : "Delete an SMS channel.",
+    "DeleteUserEndpoints" : "Deletes endpoints associated with an user id.",
+    "GetAdmChannel" : "Get an ADM channel.",
     "GetApnsChannel" : "Returns information about the APNs channel for an app.",
-    "GetApnsSandboxChannel" : "Get an APNS sandbox channel",
+    "GetApnsSandboxChannel" : "Get an APNS sandbox channel.",
     "GetApnsVoipChannel" : "Get an APNS VoIP channel",
     "GetApnsVoipSandboxChannel" : "Get an APNS VoIPSandbox channel",
     "GetApp" : "Returns information about an app.",
@@ -35,7 +36,8 @@
     "GetCampaignVersion" : "Returns information about a specific version of a campaign.",
     "GetCampaignVersions" : "Returns information about your campaign versions.",
     "GetCampaigns" : "Returns information about your campaigns.",
-    "GetEmailChannel" : "Get an email channel",
+    "GetChannels" : "Get all channels.",
+    "GetEmailChannel" : "Get an email channel.",
     "GetEndpoint" : "Returns information about an endpoint.",
     "GetEventStream" : "Returns the event stream for an app.",
     "GetExportJob" : "Returns information about an export job.",
@@ -49,24 +51,27 @@
     "GetSegmentVersion" : "Returns information about a segment version.",
     "GetSegmentVersions" : "Returns information about your segment versions.",
     "GetSegments" : "Used to get information about your segments.",
-    "GetSmsChannel" : "Get an SMS channel",
+    "GetSmsChannel" : "Get an SMS channel.",
+    "GetUserEndpoints" : "Returns information about the endpoints associated with an user id.",
+    "PhoneNumberValidate" : "Returns information about the specified phone number.",
     "PutEventStream" : "Use to create or update the event stream for an app.",
-    "SendMessages" : "Send a batch of messages",
-    "SendUsersMessages" : "Send a batch of messages to users",
-    "UpdateAdmChannel" : "Update an ADM channel",
+    "RemoveAttributes" : "Used to remove the attributes for an app",
+    "SendMessages" : "Use this resource to send a direct message, which is a one time message that you send to a limited audience without creating a campaign. \n\nYou can send the message to up to 100 recipients. You cannot use the message to engage a segment. When you send the message, Amazon Pinpoint delivers it immediately, and you cannot schedule the delivery. To engage a user segment, and to schedule the message delivery, create a campaign instead of sending a direct message.\n\nYou can send a direct message as a push notification to your mobile app or as an SMS message to SMS-enabled devices.",
+    "SendUsersMessages" : "Use this resource to message a list of users. Amazon Pinpoint sends the message to all of the endpoints that are associated with each user.\n\nA user represents an individual who is assigned a unique user ID, and this ID is assigned to one or more endpoints. For example, if an individual uses your app on multiple devices, your app could assign that person's user ID to the endpoint for each device.\n\nWith the users-messages resource, you specify the message recipients as user IDs. For each user ID, Amazon Pinpoint delivers the message to all of the user's endpoints. Within the body of your request, you can specify a default message, and you can tailor your message for different channels, including those for mobile push and SMS.\n\nWith this resource, you send a direct message, which is a one time message that you send to a limited audience without creating a campaign. You can send the message to up to 100 users per request. You cannot use the message to engage a segment. When you send the message, Amazon Pinpoint delivers it immediately, and you cannot schedule the delivery. To engage a user segment, and to schedule the message delivery, create a campaign instead of using the users-messages resource.",
+    "UpdateAdmChannel" : "Update an ADM channel.",
     "UpdateApnsChannel" : "Use to update the APNs channel for an app.",
-    "UpdateApnsSandboxChannel" : "Update an APNS sandbox channel",
+    "UpdateApnsSandboxChannel" : "Update an APNS sandbox channel.",
     "UpdateApnsVoipChannel" : "Update an APNS VoIP channel",
     "UpdateApnsVoipSandboxChannel" : "Update an APNS VoIP sandbox channel",
     "UpdateApplicationSettings" : "Used to update the settings for an app.",
     "UpdateBaiduChannel" : "Update a BAIDU GCM channel",
     "UpdateCampaign" : "Use to update a campaign.",
-    "UpdateEmailChannel" : "Update an email channel",
-    "UpdateEndpoint" : "Use to update an endpoint.",
+    "UpdateEmailChannel" : "Update an email channel.",
+    "UpdateEndpoint" : "Creates or updates an endpoint.",
     "UpdateEndpointsBatch" : "Use to update a batch of endpoints.",
     "UpdateGcmChannel" : "Use to update the GCM channel for an app.",
     "UpdateSegment" : "Use to update a segment.",
-    "UpdateSmsChannel" : "Update an SMS channel"
+    "UpdateSmsChannel" : "Update an SMS channel."
   },
   "shapes" : {
     "ADMChannelRequest" : {
@@ -139,19 +144,19 @@
     "ActivityResponse" : {
       "base" : "Activity definition",
       "refs" : {
-        "ActivitiesResponse$Item" : "List of campaign activities"
+        "ListOfActivityResponse$member" : null
       }
     },
     "AddressConfiguration" : {
       "base" : "Address configuration.",
       "refs" : {
-        "MessageRequest$Addresses" : "A map of destination addresses, with the address as the key(Email address, phone number or push token) and the Address Configuration as the value."
+        "MapOfAddressConfiguration$member" : null
       }
     },
     "ApplicationResponse" : {
       "base" : "Application Response.",
       "refs" : {
-        "ApplicationsResponse$Item" : "List of applications returned in this page."
+        "ListOfApplicationResponse$member" : null
       }
     },
     "ApplicationSettingsResource" : {
@@ -165,8 +170,7 @@
     "AttributeDimension" : {
       "base" : "Custom attibute dimension",
       "refs" : {
-        "SegmentDimensions$Attributes" : "Custom segment attributes.",
-        "SegmentDimensions$UserAttributes" : "Custom segment user attributes."
+        "MapOfAttributeDimension$member" : null
       }
     },
     "AttributeType" : {
@@ -175,8 +179,12 @@
         "AttributeDimension$AttributeType" : "The type of dimension:\nINCLUSIVE - Endpoints that match the criteria are included in the segment.\nEXCLUSIVE - Endpoints that match the criteria are excluded from the segment."
       }
     },
+    "AttributesResource" : {
+      "base" : "Attributes.",
+      "refs" : { }
+    },
     "BadRequestException" : {
-      "base" : null,
+      "base" : "Simple message object.",
       "refs" : { }
     },
     "BaiduChannelRequest" : {
@@ -200,7 +208,7 @@
       }
     },
     "CampaignHook" : {
-      "base" : null,
+      "base" : "Campaign hook information.",
       "refs" : {
         "ApplicationSettingsResource$CampaignHook" : "Default campaign hook.",
         "CampaignResponse$Hook" : "Campaign hook information.",
@@ -220,7 +228,7 @@
     "CampaignResponse" : {
       "base" : "Campaign definition",
       "refs" : {
-        "CampaignsResponse$Item" : "A list of campaigns."
+        "ListOfCampaignResponse$member" : null
       }
     },
     "CampaignSmsMessage" : {
@@ -247,6 +255,12 @@
       "base" : "List of available campaigns.",
       "refs" : { }
     },
+    "ChannelResponse" : {
+      "base" : "Base definition for channel response.",
+      "refs" : {
+        "MapOfChannelResponse$member" : null
+      }
+    },
     "ChannelType" : {
       "base" : null,
       "refs" : {
@@ -255,6 +269,10 @@
         "EndpointRequest$ChannelType" : "The channel type.\n\nValid values: GCM | APNS | APNS_SANDBOX | APNS_VOIP | APNS_VOIP_SANDBOX | ADM | SMS | EMAIL | BAIDU",
         "EndpointResponse$ChannelType" : "The channel type.\n\nValid values: GCM | APNS | APNS_SANDBOX | APNS_VOIP | APNS_VOIP_SANDBOX | ADM | SMS | EMAIL | BAIDU"
       }
+    },
+    "ChannelsResponse" : {
+      "base" : "Get channels definition",
+      "refs" : { }
     },
     "CreateApplicationRequest" : {
       "base" : "Application Request.",
@@ -286,10 +304,10 @@
       }
     },
     "DirectMessageConfiguration" : {
-      "base" : "The message configuration.",
+      "base" : "Message definitions for the default message and any messages that are tailored for specific channels.",
       "refs" : {
         "MessageRequest$MessageConfiguration" : "Message configuration.",
-        "SendUsersMessageRequest$MessageConfiguration" : "Message configuration."
+        "SendUsersMessageRequest$MessageConfiguration" : "Message definitions for the default message and any messages that are tailored for specific channels."
       }
     },
     "Duration" : {
@@ -309,7 +327,7 @@
     "EndpointBatchItem" : {
       "base" : "Endpoint update request",
       "refs" : {
-        "EndpointBatchRequest$Item" : "List of items to update. Maximum 100 items"
+        "ListOfEndpointBatchItem$member" : null
       }
     },
     "EndpointBatchRequest" : {
@@ -335,8 +353,7 @@
     "EndpointMessageResult" : {
       "base" : "The result from sending a message to an endpoint.",
       "refs" : {
-        "MessageResponse$EndpointResult" : "A map containing a multi part response for each address, with the endpointId as the key and the result as the value.",
-        "SendUsersMessageResponse$Result" : "A map containing of UserId to Map of EndpointId to Endpoint Message Result."
+        "MapOfEndpointMessageResult$member" : null
       }
     },
     "EndpointRequest" : {
@@ -345,13 +362,14 @@
     },
     "EndpointResponse" : {
       "base" : "Endpoint response",
-      "refs" : { }
+      "refs" : {
+        "ListOfEndpointResponse$member" : null
+      }
     },
     "EndpointSendConfiguration" : {
       "base" : "Endpoint send configuration.",
       "refs" : {
-        "MessageRequest$Endpoints" : "A map of destination addresses, with the address as the key(Email address, phone number or push token) and the Address Configuration as the value.",
-        "SendUsersMessageRequest$Users" : "A map of destination endpoints, with the EndpointId as the key Endpoint Message Configuration as the value."
+        "MapOfEndpointSendConfiguration$member" : null
       }
     },
     "EndpointUser" : {
@@ -362,24 +380,28 @@
         "EndpointResponse$User" : "Custom user-specific attributes that your app reports to Amazon Pinpoint."
       }
     },
+    "EndpointsResponse" : {
+      "base" : "List of endpoints",
+      "refs" : { }
+    },
     "EventStream" : {
       "base" : "Model for an event publishing subscription export.",
       "refs" : { }
     },
     "ExportJobRequest" : {
-      "base" : null,
+      "base" : "Export job request.",
       "refs" : { }
     },
     "ExportJobResource" : {
-      "base" : null,
+      "base" : "Export job resource.",
       "refs" : {
         "ExportJobResponse$Definition" : "The export job settings."
       }
     },
     "ExportJobResponse" : {
-      "base" : null,
+      "base" : "Export job response.",
       "refs" : {
-        "ExportJobsResponse$Item" : "A list of export jobs for the application."
+        "ListOfExportJobResponse$member" : null
       }
     },
     "ExportJobsResponse" : {
@@ -387,7 +409,7 @@
       "refs" : { }
     },
     "ForbiddenException" : {
-      "base" : null,
+      "base" : "Simple message object.",
       "refs" : { }
     },
     "Format" : {
@@ -418,119 +440,57 @@
         "DirectMessageConfiguration$GCMMessage" : "The message to GCM channels. Overrides the default push notification message."
       }
     },
+    "GPSCoordinates" : {
+      "base" : "GPS coordinates",
+      "refs" : {
+        "GPSPointDimension$Coordinates" : "Coordinate to measure distance from."
+      }
+    },
+    "GPSPointDimension" : {
+      "base" : "GPS point location dimension",
+      "refs" : {
+        "SegmentLocation$GPSPoint" : "The GPS Point dimension."
+      }
+    },
     "ImportJobRequest" : {
-      "base" : null,
+      "base" : "Import job request.",
       "refs" : { }
     },
     "ImportJobResource" : {
-      "base" : null,
+      "base" : "Import job resource",
       "refs" : {
         "ImportJobResponse$Definition" : "The import job settings."
       }
     },
     "ImportJobResponse" : {
-      "base" : null,
+      "base" : "Import job response.",
       "refs" : {
-        "ImportJobsResponse$Item" : "A list of import jobs for the application."
+        "ListOfImportJobResponse$member" : null
       }
     },
     "ImportJobsResponse" : {
       "base" : "Import job list.",
       "refs" : { }
     },
-    "InternalServerErrorException" : {
+    "Include" : {
       "base" : null,
+      "refs" : {
+        "SegmentGroupList$Include" : "How should the groups be applied for the result"
+      }
+    },
+    "InternalServerErrorException" : {
+      "base" : "Simple message object.",
       "refs" : { }
     },
     "JobStatus" : {
       "base" : null,
       "refs" : {
-        "ExportJobResponse$JobStatus" : "The status of the export job.\nValid values: CREATED, INITIALIZING, PROCESSING, COMPLETING, COMPLETED, FAILING, FAILED\n\nThe job status is FAILED if one or more pieces failed.",
+        "ExportJobResponse$JobStatus" : "The status of the job.\nValid values: CREATED, INITIALIZING, PROCESSING, COMPLETING, COMPLETED, FAILING, FAILED\n\nThe job status is FAILED if one or more pieces failed.",
         "ImportJobResponse$JobStatus" : "The status of the import job.\nValid values: CREATED, INITIALIZING, PROCESSING, COMPLETING, COMPLETED, FAILING, FAILED\n\nThe job status is FAILED if one or more pieces failed to import."
       }
     },
-    "ListOfActivityResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfApplicationResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfCampaignResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfEndpointBatchItem" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfExportJobResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfImportJobResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfSegmentResponse" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfTreatmentResource" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOfWriteTreatmentResource" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "ListOf__string" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfAddressConfiguration" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfAttributeDimension" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfEndpointMessageResult" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfEndpointSendConfiguration" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfListOf__string" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfMapOfEndpointMessageResult" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOfMessageResult" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOf__double" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOf__integer" : {
-      "base" : null,
-      "refs" : { }
-    },
-    "MapOf__string" : {
-      "base" : null,
-      "refs" : { }
-    },
     "Message" : {
-      "base" : null,
+      "base" : "Message to send",
       "refs" : {
         "MessageConfiguration$ADMMessage" : "The message that the campaign delivers to ADM channels. Overrides the default message.",
         "MessageConfiguration$APNSMessage" : "The message that the campaign delivers to APNS channels. Overrides the default message.",
@@ -563,7 +523,7 @@
     "MessageResult" : {
       "base" : "The result from sending a message to an address.",
       "refs" : {
-        "MessageResponse$Result" : "A map containing a multi part response for each address, with the address as the key(Email address, phone number or push token) and the result as the value."
+        "MapOfMessageResult$member" : null
       }
     },
     "MessageType" : {
@@ -574,8 +534,14 @@
       }
     },
     "MethodNotAllowedException" : {
-      "base" : null,
+      "base" : "Simple message object.",
       "refs" : { }
+    },
+    "MetricDimension" : {
+      "base" : "Custom metric dimension",
+      "refs" : {
+        "MapOfMetricDimension$member" : null
+      }
     },
     "Mode" : {
       "base" : null,
@@ -584,7 +550,15 @@
       }
     },
     "NotFoundException" : {
-      "base" : null,
+      "base" : "Simple message object.",
+      "refs" : { }
+    },
+    "NumberValidateRequest" : {
+      "base" : "Phone Number Information request.",
+      "refs" : { }
+    },
+    "NumberValidateResponse" : {
+      "base" : "Phone Number Information response.",
       "refs" : { }
     },
     "QuietTime" : {
@@ -646,7 +620,21 @@
       "base" : "Segment dimensions",
       "refs" : {
         "SegmentResponse$Dimensions" : "The segment dimensions attributes.",
-        "WriteSegmentRequest$Dimensions" : "The segment dimensions attributes."
+        "WriteSegmentRequest$Dimensions" : "The segment dimensions attributes.",
+        "ListOfSegmentDimensions$member" : null
+      }
+    },
+    "SegmentGroup" : {
+      "base" : "Segment group definition.",
+      "refs" : {
+        "ListOfSegmentGroup$member" : null
+      }
+    },
+    "SegmentGroupList" : {
+      "base" : "Segment group definition.",
+      "refs" : {
+        "SegmentResponse$SegmentGroups" : "Segment definition groups. We currently only support one. If specified Dimensions must be empty.",
+        "WriteSegmentRequest$SegmentGroups" : "Segment definition groups. We currently only support one. If specified Dimensions must be empty."
       }
     },
     "SegmentImportResource" : {
@@ -661,10 +649,16 @@
         "SegmentDimensions$Location" : "The segment location attributes."
       }
     },
+    "SegmentReference" : {
+      "base" : "Segment reference.",
+      "refs" : {
+        "ListOfSegmentReference$member" : null
+      }
+    },
     "SegmentResponse" : {
       "base" : "Segment definition.",
       "refs" : {
-        "SegmentsResponse$Item" : "The list of segments."
+        "ListOfSegmentResponse$member" : null
       }
     },
     "SegmentType" : {
@@ -697,15 +691,31 @@
         "SegmentLocation$Country" : "The country filter according to ISO 3166-1 Alpha-2 codes."
       }
     },
-    "TooManyRequestsException" : {
+    "SourceType" : {
       "base" : null,
+      "refs" : {
+        "SegmentGroup$SourceType" : "Include or exclude the source."
+      }
+    },
+    "TooManyRequestsException" : {
+      "base" : "Simple message object.",
       "refs" : { }
     },
     "TreatmentResource" : {
       "base" : "Treatment resource",
       "refs" : {
-        "CampaignResponse$AdditionalTreatments" : "Treatments that are defined in addition to the default treatment."
+        "ListOfTreatmentResource$member" : null
       }
+    },
+    "Type" : {
+      "base" : null,
+      "refs" : {
+        "SegmentGroup$Type" : "How should the dimensions be applied for the result"
+      }
+    },
+    "UpdateAttributesRequest" : {
+      "base" : "Update attributes request",
+      "refs" : { }
     },
     "WriteApplicationSettingsRequest" : {
       "base" : "Creating application setting request",
@@ -726,7 +736,7 @@
     "WriteTreatmentResource" : {
       "base" : "Used to create a campaign treatment.",
       "refs" : {
-        "WriteCampaignRequest$AdditionalTreatments" : "Treatments that are defined in addition to the default treatment."
+        "ListOfWriteTreatmentResource$member" : null
       }
     },
     "__boolean" : {
@@ -734,44 +744,47 @@
       "refs" : {
         "ADMChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "ADMChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "ADMChannelResponse$HasCredential" : "Indicates whether the channel is configured with ADM credentials. Amazon Pinpoint uses your credentials to authenticate push notifications with ADM. Provide your credentials by setting the ClientId and ClientSecret attributes.",
+        "ADMChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "ADMChannelResponse$IsArchived" : "Is this channel archived",
         "ADMMessage$SilentPush" : "Indicates if the message should display on the users device. Silent pushes can be used for Remote Configuration and Phone Home use cases.",
         "APNSChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "APNSChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "APNSChannelResponse$HasCredential" : "Indicates whether the channel is configured with APNs credentials. Amazon Pinpoint uses your credentials to authenticate push notifications with APNs. To use APNs token authentication, set the BundleId, TeamId, TokenKey, and TokenKeyId attributes. To use certificate authentication, set the Certificate and PrivateKey attributes.",
+        "APNSChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "APNSChannelResponse$HasTokenKey" : "Indicates whether the channel is configured with a key for APNs token authentication. Provide a token key by setting the TokenKey attribute.",
         "APNSChannelResponse$IsArchived" : "Is this channel archived",
         "APNSMessage$SilentPush" : "Indicates if the message should display on the users device. Silent pushes can be used for Remote Configuration and Phone Home use cases.",
         "APNSSandboxChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "APNSSandboxChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "APNSSandboxChannelResponse$HasCredential" : "Indicates whether the channel is configured with APNs credentials. Amazon Pinpoint uses your credentials to authenticate push notifications with APNs. To use APNs token authentication, set the BundleId, TeamId, TokenKey, and TokenKeyId attributes. To use certificate authentication, set the Certificate and PrivateKey attributes.",
+        "APNSSandboxChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "APNSSandboxChannelResponse$HasTokenKey" : "Indicates whether the channel is configured with a key for APNs token authentication. Provide a token key by setting the TokenKey attribute.",
         "APNSSandboxChannelResponse$IsArchived" : "Is this channel archived",
         "APNSVoipChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "APNSVoipChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "APNSVoipChannelResponse$HasCredential" : "If the channel is registered with a credential for authentication.",
+        "APNSVoipChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "APNSVoipChannelResponse$HasTokenKey" : "If the channel is registered with a token key for authentication.",
         "APNSVoipChannelResponse$IsArchived" : "Is this channel archived",
         "APNSVoipSandboxChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "APNSVoipSandboxChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "APNSVoipSandboxChannelResponse$HasCredential" : "If the channel is registered with a credential for authentication.",
+        "APNSVoipSandboxChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "APNSVoipSandboxChannelResponse$HasTokenKey" : "If the channel is registered with a token key for authentication.",
         "APNSVoipSandboxChannelResponse$IsArchived" : "Is this channel archived",
         "BaiduChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "BaiduChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "BaiduChannelResponse$HasCredential" : "Indicates whether the channel is configured with Baidu Cloud Push credentials. Amazon Pinpoint uses your credentials to authenticate push notifications with Baidu Cloud Push. Provide your credentials by setting the ApiKey and SecretKey attributes.",
+        "BaiduChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "BaiduChannelResponse$IsArchived" : "Is this channel archived",
         "BaiduMessage$SilentPush" : "Indicates if the message should display on the users device. Silent pushes can be used for Remote Configuration and Phone Home use cases.",
         "CampaignResponse$IsPaused" : "Indicates whether the campaign is paused. A paused campaign does not send messages unless you resume it by setting IsPaused to false.",
+        "ChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
+        "ChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
+        "ChannelResponse$IsArchived" : "Is this channel archived",
         "DefaultPushNotificationMessage$SilentPush" : "Indicates if the message should display on the users device. Silent pushes can be used for Remote Configuration and Phone Home use cases.",
         "EmailChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "EmailChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "EmailChannelResponse$HasCredential" : "If the channel is registered with a credential for authentication.",
+        "EmailChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "EmailChannelResponse$IsArchived" : "Is this channel archived",
         "GCMChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "GCMChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "GCMChannelResponse$HasCredential" : "Indicates whether the channel is configured with FCM or GCM credentials. Amazon Pinpoint uses your credentials to authenticate push notifications with FCM or GCM. Provide your credentials by setting the ApiKey attribute.",
+        "GCMChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "GCMChannelResponse$IsArchived" : "Is this channel archived",
         "GCMMessage$SilentPush" : "Indicates if the message should display on the users device. Silent pushes can be used for Remote Configuration and Phone Home use cases.",
         "ImportJobRequest$DefineSegment" : "Sets whether the endpoints create a segment when they are imported.",
@@ -781,20 +794,23 @@
         "Message$SilentPush" : "Indicates if the message should display on the users device.\n\nSilent pushes can be used for Remote Configuration and Phone Home use cases. ",
         "SMSChannelRequest$Enabled" : "If the channel is enabled for sending messages.",
         "SMSChannelResponse$Enabled" : "If the channel is enabled for sending messages.",
-        "SMSChannelResponse$HasCredential" : "If the channel is registered with a credential for authentication.",
+        "SMSChannelResponse$HasCredential" : "Not used. Retained for backwards compatibility.",
         "SMSChannelResponse$IsArchived" : "Is this channel archived",
         "Schedule$IsLocalTime" : "Indicates whether the campaign schedule takes effect according to each user's local time.",
+        "WriteApplicationSettingsRequest$CloudWatchMetricsEnabled" : "The CloudWatchMetrics settings for the app.",
         "WriteCampaignRequest$IsPaused" : "Indicates whether the campaign is paused. A paused campaign does not send messages unless you resume it by setting IsPaused to false."
       }
     },
     "__double" : {
       "base" : null,
       "refs" : {
-        "EndpointBatchItem$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint.",
         "EndpointLocation$Latitude" : "The latitude of the endpoint location. Rounded to one decimal (Roughly corresponding to a mile).",
         "EndpointLocation$Longitude" : "The longitude of the endpoint location. Rounded to one decimal (Roughly corresponding to a mile).",
-        "EndpointRequest$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint.",
-        "EndpointResponse$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint."
+        "GPSCoordinates$Latitude" : "Latitude",
+        "GPSCoordinates$Longitude" : "Longitude",
+        "GPSPointDimension$RangeInKilometers" : "Range in kilometers from the coordinate.",
+        "MetricDimension$Value" : "Value to be compared.",
+        "MapOf__double$member" : null
       }
     },
     "__integer" : {
@@ -812,6 +828,7 @@
         "ActivityResponse$TimezonesTotalCount" : "The total number of unique timezones present in the segment.",
         "ActivityResponse$TotalEndpointCount" : "The total number of endpoints to which the campaign attempts to deliver messages.",
         "BaiduChannelResponse$Version" : "Version of channel",
+        "BaiduMessage$TimeToLive" : "This parameter specifies how long (in seconds) the message should be kept in Baidu storage if the device is offline. The and the default value and the maximum time to live supported is 7 days (604800 seconds)",
         "CampaignLimits$Daily" : "The maximum number of messages that the campaign can send daily.",
         "CampaignLimits$MaximumDuration" : "The length of time (in seconds) that the campaign can run before it ends and message deliveries stop. This duration begins at the scheduled start time for the campaign. The minimum value is 60.",
         "CampaignLimits$MessagesPerSecond" : "The number of messages that the campaign can send per second. The minimum value is 50, and the maximum is 20000.",
@@ -819,8 +836,12 @@
         "CampaignResponse$HoldoutPercent" : "The allocated percentage of end users who will not receive messages from this campaign.",
         "CampaignResponse$SegmentVersion" : "The version of the segment to which the campaign sends messages.",
         "CampaignResponse$Version" : "The campaign version number.",
+        "ChannelResponse$Version" : "Version of channel",
+        "EmailChannelResponse$MessagesPerSecond" : "Messages per second that can be sent",
         "EmailChannelResponse$Version" : "Version of channel",
         "EndpointMessageResult$StatusCode" : "Downstream service status code.",
+        "ExportJobRequest$SegmentVersion" : "The version of the segment to export if specified.",
+        "ExportJobResource$SegmentVersion" : "The version of the segment to export if specified.",
         "ExportJobResponse$CompletedPieces" : "The number of pieces that have successfully completed as of the time of the request.",
         "ExportJobResponse$FailedPieces" : "The number of pieces that failed to be processed as of the time of the request.",
         "ExportJobResponse$TotalFailures" : "The number of endpoints that were not processed; for example, because of syntax errors.",
@@ -833,340 +854,548 @@
         "ImportJobResponse$TotalFailures" : "The number of endpoints that failed to import; for example, because of syntax errors.",
         "ImportJobResponse$TotalPieces" : "The total number of pieces that must be imported to finish the job. Each piece is an approximately equal portion of the endpoints to import.",
         "ImportJobResponse$TotalProcessed" : "The number of endpoints that were processed by the import job.",
+        "Message$TimeToLive" : "This parameter specifies how long (in seconds) the message should be kept if the service is unable to deliver the notification the first time. If the value is 0, it treats the notification as if it expires immediately and does not store the notification or attempt to redeliver it. This value is converted to the expiration field when sent to the service. It only applies to APNs and GCM",
         "MessageResult$StatusCode" : "Downstream service status code.",
+        "NumberValidateResponse$PhoneTypeCode" : "The phone type as an integer. Possible values include 0 (MOBILE), 1 (LANDLINE), 2 (VOIP), 3 (INVALID), and 4 (OTHER).",
+        "SMSChannelResponse$PromotionalMessagesPerSecond" : "Promotional messages per second that can be sent",
+        "SMSChannelResponse$TransactionalMessagesPerSecond" : "Transactional messages per second that can be sent",
         "SMSChannelResponse$Version" : "Version of channel",
-        "SegmentImportResource$ChannelCounts" : "Channel type counts",
         "SegmentImportResource$Size" : "The number of endpoints that were successfully imported to create this segment.",
+        "SegmentReference$Version" : "If specified contains a specific version of the segment included.",
         "SegmentResponse$Version" : "The segment version number.",
         "TreatmentResource$SizePercent" : "The allocated percentage of users for this treatment.",
         "WriteCampaignRequest$HoldoutPercent" : "The allocated percentage of end users who will not receive messages from this campaign.",
         "WriteCampaignRequest$SegmentVersion" : "The version of the segment to which the campaign sends messages.",
-        "WriteTreatmentResource$SizePercent" : "The allocated percentage of users for this treatment."
+        "WriteTreatmentResource$SizePercent" : "The allocated percentage of users for this treatment.",
+        "MapOf__integer$member" : null
+      }
+    },
+    "ListOfActivityResponse" : {
+      "base" : null,
+      "refs" : {
+        "ActivitiesResponse$Item" : "List of campaign activities"
+      }
+    },
+    "ListOfApplicationResponse" : {
+      "base" : null,
+      "refs" : {
+        "ApplicationsResponse$Item" : "List of applications returned in this page."
+      }
+    },
+    "ListOfCampaignResponse" : {
+      "base" : null,
+      "refs" : {
+        "CampaignsResponse$Item" : "A list of campaigns."
+      }
+    },
+    "ListOfEndpointBatchItem" : {
+      "base" : null,
+      "refs" : {
+        "EndpointBatchRequest$Item" : "List of items to update. Maximum 100 items"
+      }
+    },
+    "ListOfEndpointResponse" : {
+      "base" : null,
+      "refs" : {
+        "EndpointsResponse$Item" : "The list of endpoints."
+      }
+    },
+    "ListOfExportJobResponse" : {
+      "base" : null,
+      "refs" : {
+        "ExportJobsResponse$Item" : "A list of export jobs for the application."
+      }
+    },
+    "ListOfImportJobResponse" : {
+      "base" : null,
+      "refs" : {
+        "ImportJobsResponse$Item" : "A list of import jobs for the application."
+      }
+    },
+    "ListOfSegmentDimensions" : {
+      "base" : null,
+      "refs" : {
+        "SegmentGroup$Dimensions" : "List of dimensions to include or exclude."
+      }
+    },
+    "ListOfSegmentGroup" : {
+      "base" : null,
+      "refs" : {
+        "SegmentGroupList$Groups" : "List of dimension groups to evaluate."
+      }
+    },
+    "ListOfSegmentReference" : {
+      "base" : null,
+      "refs" : {
+        "SegmentGroup$SourceSegments" : "Segments that define the source of this segment. Currently a maximum of 1 import segment is supported."
+      }
+    },
+    "ListOfSegmentResponse" : {
+      "base" : null,
+      "refs" : {
+        "SegmentsResponse$Item" : "The list of segments."
+      }
+    },
+    "ListOfTreatmentResource" : {
+      "base" : null,
+      "refs" : {
+        "CampaignResponse$AdditionalTreatments" : "Treatments that are defined in addition to the default treatment."
+      }
+    },
+    "ListOfWriteTreatmentResource" : {
+      "base" : null,
+      "refs" : {
+        "WriteCampaignRequest$AdditionalTreatments" : "Treatments that are defined in addition to the default treatment."
+      }
+    },
+    "ListOf__string" : {
+      "base" : null,
+      "refs" : {
+        "AttributeDimension$Values" : "The criteria values for the segment dimension. Endpoints with matching attribute values are included or excluded from the segment, depending on the setting for Type.",
+        "AttributesResource$Attributes" : "The attributes for the application.",
+        "ExportJobResponse$Failures" : "Provides up to 100 of the first failed entries for the job, if any exist.",
+        "ImportJobResponse$Failures" : "Provides up to 100 of the first failed entries for the job, if any exist.",
+        "SetDimension$Values" : "The criteria values for the segment dimension. Endpoints with matching attribute values are included or excluded from the segment, depending on the setting for Type.",
+        "UpdateAttributesRequest$Blacklist" : "The GLOB wildcard for removing the attributes in the application",
+        "MapOfListOf__string$member" : null
+      }
+    },
+    "MapOfAddressConfiguration" : {
+      "base" : null,
+      "refs" : {
+        "MessageRequest$Addresses" : "A map of key-value pairs, where each key is an address and each value is an AddressConfiguration object. An address can be a push notification token, a phone number, or an email address."
+      }
+    },
+    "MapOfAttributeDimension" : {
+      "base" : null,
+      "refs" : {
+        "SegmentDimensions$Attributes" : "Custom segment attributes.",
+        "SegmentDimensions$UserAttributes" : "Custom segment user attributes."
+      }
+    },
+    "MapOfChannelResponse" : {
+      "base" : null,
+      "refs" : {
+        "ChannelsResponse$Channels" : "A map of channels, with the ChannelType as the key and the Channel as the value."
+      }
+    },
+    "MapOfEndpointMessageResult" : {
+      "base" : null,
+      "refs" : {
+        "MessageResponse$EndpointResult" : "A map containing a multi part response for each address, with the endpointId as the key and the result as the value.",
+        "MapOfMapOfEndpointMessageResult$member" : null
+      }
+    },
+    "MapOfEndpointSendConfiguration" : {
+      "base" : null,
+      "refs" : {
+        "MessageRequest$Endpoints" : "A map of key-value pairs, where each key is an endpoint ID and each value is an EndpointSendConfiguration object. Within an EndpointSendConfiguration object, you can tailor the message for an endpoint by specifying message overrides or substitutions.",
+        "SendUsersMessageRequest$Users" : "A map that associates user IDs with EndpointSendConfiguration objects. Within an EndpointSendConfiguration object, you can tailor the message for a user by specifying message overrides or substitutions."
+      }
+    },
+    "MapOfMessageResult" : {
+      "base" : null,
+      "refs" : {
+        "MessageResponse$Result" : "A map containing a multi part response for each address, with the address as the key(Email address, phone number or push token) and the result as the value."
+      }
+    },
+    "MapOfMetricDimension" : {
+      "base" : null,
+      "refs" : {
+        "SegmentDimensions$Metrics" : "Custom segment metrics."
+      }
+    },
+    "MapOf__double" : {
+      "base" : null,
+      "refs" : {
+        "EndpointBatchItem$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint.",
+        "EndpointRequest$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint.",
+        "EndpointResponse$Metrics" : "Custom metrics that your app reports to Amazon Pinpoint."
+      }
+    },
+    "MapOf__integer" : {
+      "base" : null,
+      "refs" : {
+        "SegmentImportResource$ChannelCounts" : "Channel type counts"
+      }
+    },
+    "MapOfListOf__string" : {
+      "base" : null,
+      "refs" : {
+        "ADMMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "APNSMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "AddressConfiguration$Substitutions" : "A map of substitution values for the message to be merged with the DefaultMessage's substitutions. Substitutions on this map take precedence over the all other substitutions.",
+        "BaiduMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "DefaultMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "DefaultPushNotificationMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "EndpointBatchItem$Attributes" : "Custom attributes that describe the endpoint by associating a name with an array of values. For example, an attribute named \"interests\" might have the values [\"science\", \"politics\", \"travel\"]. You can use these attributes as selection criteria when you create a segment of users to engage with a messaging campaign.\n\nThe following characters are not recommended in attribute names: # : ? \\ /. The Amazon Pinpoint console does not display attributes that include these characters in the name. This limitation does not apply to attribute values.",
+        "EndpointRequest$Attributes" : "Custom attributes that describe the endpoint by associating a name with an array of values. For example, an attribute named \"interests\" might have the values [\"science\", \"politics\", \"travel\"]. You can use these attributes as selection criteria when you create a segment of users to engage with a messaging campaign.\n\nThe following characters are not recommended in attribute names: # : ? \\ /. The Amazon Pinpoint console does not display attributes that include these characters in the name. This limitation does not apply to attribute values.",
+        "EndpointResponse$Attributes" : "Custom attributes that describe the endpoint by associating a name with an array of values. For example, an attribute named \"interests\" might have the values [\"science\", \"politics\", \"travel\"]. You can use these attributes as selection criteria when you create a segment of users to engage with a messaging campaign.\n\nThe following characters are not recommended in attribute names: # : ? \\ /. The Amazon Pinpoint console does not display attributes that include these characters in the name. This limitation does not apply to attribute values.",
+        "EndpointSendConfiguration$Substitutions" : "A map of substitution values for the message to be merged with the DefaultMessage's substitutions. Substitutions on this map take precedence over the all other substitutions.",
+        "EndpointUser$UserAttributes" : "Custom attributes that describe an end user by associating a name with an array of values. For example, an attribute named \"interests\" might have the values [\"science\", \"politics\", \"travel\"]. You can use these attributes as selection criteria when you create a segment of users to engage with a messaging campaign.\n\nThe following characters are not recommended in attribute names: # : ? \\ /. The Amazon Pinpoint console does not display attributes that include these characters in the name. This limitation does not apply to attribute values.",
+        "GCMMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions.",
+        "SMSMessage$Substitutions" : "Default message substitutions. Can be overridden by individual address substitutions."
+      }
+    },
+    "MapOfMapOfEndpointMessageResult" : {
+      "base" : null,
+      "refs" : {
+        "SendUsersMessageResponse$Result" : "An object that shows the endpoints that were messaged for each user. The object provides a list of user IDs. For each user ID, it provides the endpoint IDs that were messaged. For each endpoint ID, it provides an EndpointMessageResult object."
+      }
+    },
+    "MapOf__string" : {
+      "base" : null,
+      "refs" : {
+        "ADMMessage$Data" : "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
+        "APNSMessage$Data" : "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
+        "AddressConfiguration$Context" : "A map of custom attributes to attributes to be attached to the message for this address. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
+        "BaiduMessage$Data" : "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
+        "DefaultPushNotificationMessage$Data" : "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
+        "EndpointSendConfiguration$Context" : "A map of custom attributes to attributes to be attached to the message for this address. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
+        "GCMMessage$Data" : "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
+        "MessageRequest$Context" : "A map of custom attributes to attributes to be attached to the message. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
+        "SendUsersMessageRequest$Context" : "A map of custom attribute-value pairs. Amazon Pinpoint adds these attributes to the data.pinpoint object in the body of the push notification payload. Amazon Pinpoint also provides these attributes in the events that it generates for users-messages deliveries."
       }
     },
     "__string" : {
       "base" : null,
       "refs" : {
-        "ADMChannelRequest$ClientId": "Client ID as gotten from Amazon",
-        "ADMChannelRequest$ClientSecret": "Client secret as gotten from Amazon",
-        "ADMChannelResponse$ApplicationId": "The ID of the application to which the channel applies.",
-        "ADMChannelResponse$CreationDate": "When was this segment created",
-        "ADMChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "ADMChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "ADMChannelResponse$LastModifiedDate": "Last date this was updated",
-        "ADMChannelResponse$Platform": "Platform type. Will be \"ADM\"",
-        "ADMMessage$Body": "The message body of the notification, the email body or the text message.",
-        "ADMMessage$ConsolidationKey": "Optional. Arbitrary string used to indicate multiple messages are logically the same and that ADM is allowed to drop previously enqueued messages in favor of this one.",
-        "ADMMessage$Data": "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
-        "ADMMessage$ExpiresAfter": "Optional. Number of seconds ADM should retain the message if the device is offline",
-        "ADMMessage$IconReference": "The icon image name of the asset saved in your application.",
-        "ADMMessage$ImageIconUrl": "The URL that points to an image used as the large icon to the notification content view.",
-        "ADMMessage$ImageUrl": "The URL that points to an image used in the push notification.",
-        "ADMMessage$MD5": "Optional. Base-64-encoded MD5 checksum of the data parameter. Used to verify data integrity",
-        "ADMMessage$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "ADMMessage$SmallImageIconUrl": "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
-        "ADMMessage$Sound": "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
-        "ADMMessage$Title": "The message title that displays above the message on the user's device.",
-        "ADMMessage$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "APNSChannelRequest$BundleId": "The bundle id used for APNs Tokens.",
-        "APNSChannelRequest$Certificate": "The distribution certificate from Apple.",
-        "APNSChannelRequest$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSChannelRequest$PrivateKey": "The certificate private key.",
-        "APNSChannelRequest$TeamId": "The team id used for APNs Tokens.",
-        "APNSChannelRequest$TokenKey": "The token key used for APNs Tokens.",
-        "APNSChannelRequest$TokenKeyId": "The token key used for APNs Tokens.",
-        "APNSChannelResponse$ApplicationId": "The ID of the application to which the channel applies.",
-        "APNSChannelResponse$CreationDate": "When was this segment created",
-        "APNSChannelResponse$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSChannelResponse$Id": "Channel ID. Not used. Present only for backwards compatibility.",
-        "APNSChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "APNSChannelResponse$LastModifiedDate": "Last date this was updated",
-        "APNSChannelResponse$Platform": "The platform type. Will be APNS.",
-        "APNSMessage$Body": "The message body of the notification, the email body or the text message.",
-        "APNSMessage$Category": "Provide this key with a string value that represents the notification's type. This value corresponds to the value in the identifier property of one of your app's registered categories.",
-        "APNSMessage$CollapseId": "An ID that, if assigned to multiple messages, causes APNs to coalesce the messages into a single push notification instead of delivering each message individually. The value must not exceed 64 bytes. Amazon Pinpoint uses this value to set the apns-collapse-id request header when it sends the message to APNs.",
-        "APNSMessage$Data": "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
-        "APNSMessage$MediaUrl": "The URL that points to a video used in the push notification.",
-        "APNSMessage$PreferredAuthenticationMethod": "The preferred authentication method, either \"CERTIFICATE\" or \"TOKEN\"",
-        "APNSMessage$Priority": "The message priority. Amazon Pinpoint uses this value to set the apns-priority request header when it sends the message to APNs. Accepts the following values:\n\n\"5\" - Low priority. Messages might be delayed, delivered in groups, and throttled.\n\n\"10\" - High priority. Messages are sent immediately. High priority messages must cause an alert, sound, or badge on the receiving device.\n\nThe default value is \"10\".\n\nThe equivalent values for FCM or GCM messages are \"normal\" and \"high\". Amazon Pinpoint accepts these values for APNs messages and converts them.\n\nFor more information about the apns-priority parameter, see Communicating with APNs in the APNs Local and Remote Notification Programming Guide.",
-        "APNSMessage$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "APNSMessage$Sound": "Include this key when you want the system to play a sound. The value of this key is the name of a sound file in your app's main bundle or in the Library/Sounds folder of your app's data container. If the sound file cannot be found, or if you specify defaultfor the value, the system plays the default alert sound.",
-        "APNSMessage$ThreadId": "Provide this key with a string value that represents the app-specific identifier for grouping notifications. If you provide a Notification Content app extension, you can use this value to group your notifications together.",
-        "APNSMessage$Title": "The message title that displays above the message on the user's device.",
-        "APNSMessage$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "APNSSandboxChannelRequest$BundleId": "The bundle id used for APNs Tokens.",
-        "APNSSandboxChannelRequest$Certificate": "The distribution certificate from Apple.",
-        "APNSSandboxChannelRequest$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSSandboxChannelRequest$PrivateKey": "The certificate private key.",
-        "APNSSandboxChannelRequest$TeamId": "The team id used for APNs Tokens.",
-        "APNSSandboxChannelRequest$TokenKey": "The token key used for APNs Tokens.",
-        "APNSSandboxChannelRequest$TokenKeyId": "The token key used for APNs Tokens.",
-        "APNSSandboxChannelResponse$ApplicationId": "The ID of the application to which the channel applies.",
-        "APNSSandboxChannelResponse$CreationDate": "When was this segment created",
-        "APNSSandboxChannelResponse$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSSandboxChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "APNSSandboxChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "APNSSandboxChannelResponse$LastModifiedDate": "Last date this was updated",
-        "APNSSandboxChannelResponse$Platform": "The platform type. Will be APNS_SANDBOX.",
-        "APNSVoipChannelRequest$BundleId": "The bundle id used for APNs Tokens.",
-        "APNSVoipChannelRequest$Certificate": "The distribution certificate from Apple.",
-        "APNSVoipChannelRequest$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSVoipChannelRequest$PrivateKey": "The certificate private key.",
-        "APNSVoipChannelRequest$TeamId": "The team id used for APNs Tokens.",
-        "APNSVoipChannelRequest$TokenKey": "The token key used for APNs Tokens.",
-        "APNSVoipChannelRequest$TokenKeyId": "The token key used for APNs Tokens.",
-        "APNSVoipChannelResponse$ApplicationId": "Application id",
-        "APNSVoipChannelResponse$CreationDate": "When was this segment created",
-        "APNSVoipChannelResponse$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSVoipChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "APNSVoipChannelResponse$LastModifiedBy": "Who made the last change",
-        "APNSVoipChannelResponse$LastModifiedDate": "Last date this was updated",
-        "APNSVoipChannelResponse$Platform": "The platform type. Will be APNS.",
-        "APNSVoipSandboxChannelRequest$BundleId": "The bundle id used for APNs Tokens.",
-        "APNSVoipSandboxChannelRequest$Certificate": "The distribution certificate from Apple.",
-        "APNSVoipSandboxChannelRequest$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSVoipSandboxChannelRequest$PrivateKey": "The certificate private key.",
-        "APNSVoipSandboxChannelRequest$TeamId": "The team id used for APNs Tokens.",
-        "APNSVoipSandboxChannelRequest$TokenKey": "The token key used for APNs Tokens.",
-        "APNSVoipSandboxChannelRequest$TokenKeyId": "The token key used for APNs Tokens.",
-        "APNSVoipSandboxChannelResponse$ApplicationId": "Application id",
-        "APNSVoipSandboxChannelResponse$CreationDate": "When was this segment created",
-        "APNSVoipSandboxChannelResponse$DefaultAuthenticationMethod": "The default authentication method used for APNs.",
-        "APNSVoipSandboxChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "APNSVoipSandboxChannelResponse$LastModifiedBy": "Who made the last change",
-        "APNSVoipSandboxChannelResponse$LastModifiedDate": "Last date this was updated",
-        "APNSVoipSandboxChannelResponse$Platform": "The platform type. Will be APNS.",
-        "ActivityResponse$ApplicationId": "The ID of the application to which the campaign applies.",
-        "ActivityResponse$CampaignId": "The ID of the campaign to which the activity applies.",
-        "ActivityResponse$End": "The actual time the activity was marked CANCELLED or COMPLETED. Provided in ISO 8601 format.",
-        "ActivityResponse$Id": "The unique activity ID.",
-        "ActivityResponse$Result": "Indicates whether the activity succeeded.\n\nValid values: SUCCESS, FAIL",
-        "ActivityResponse$ScheduledStart": "The scheduled start time for the activity in ISO 8601 format.",
-        "ActivityResponse$Start": "The actual start time of the activity in ISO 8601 format.",
-        "ActivityResponse$State": "The state of the activity.\n\nValid values: PENDING, INITIALIZING, RUNNING, PAUSED, CANCELLED, COMPLETED",
-        "ActivityResponse$TreatmentId": "The ID of a variation of the campaign used for A/B testing.",
-        "AddressConfiguration$BodyOverride": "Body override. If specified will override default body.",
-        "AddressConfiguration$Context": "A map of custom attributes to attributes to be attached to the message for this address. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
-        "AddressConfiguration$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "AddressConfiguration$TitleOverride": "Title override. If specified will override default title if applicable.",
-        "ApplicationResponse$Id": "The unique application ID.",
-        "ApplicationResponse$Name": "The display name of the application.",
-        "ApplicationSettingsResource$ApplicationId": "The unique ID for the application.",
-        "ApplicationSettingsResource$LastModifiedDate": "The date that the settings were last updated in ISO 8601 format.",
-        "ApplicationsResponse$NextToken": "The string that you use in a subsequent request to get the next page of results in a paginated response.",
-        "BaiduChannelRequest$ApiKey": "Platform credential API key from Baidu.",
-        "BaiduChannelRequest$SecretKey": "Platform credential Secret key from Baidu.",
-        "BaiduChannelResponse$ApplicationId": "Application id",
-        "BaiduChannelResponse$CreationDate": "When was this segment created",
-        "BaiduChannelResponse$Credential": "The Baidu API key from Baidu.",
-        "BaiduChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "BaiduChannelResponse$LastModifiedBy": "Who made the last change",
-        "BaiduChannelResponse$LastModifiedDate": "Last date this was updated",
-        "BaiduChannelResponse$Platform": "The platform type. Will be BAIDU",
-        "BaiduMessage$Body": "The message body of the notification, the email body or the text message.",
-        "BaiduMessage$Data": "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
-        "BaiduMessage$IconReference": "The icon image name of the asset saved in your application.",
-        "BaiduMessage$ImageIconUrl": "The URL that points to an image used as the large icon to the notification content view.",
-        "BaiduMessage$ImageUrl": "The URL that points to an image used in the push notification.",
-        "BaiduMessage$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "BaiduMessage$SmallImageIconUrl": "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
-        "BaiduMessage$Sound": "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
-        "BaiduMessage$Title": "The message title that displays above the message on the user's device.",
-        "BaiduMessage$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "CampaignEmailMessage$Body": "The email text body.",
-        "CampaignEmailMessage$FromAddress": "The email address used to send the email from. Defaults to use FromAddress specified in the Email Channel.",
-        "CampaignEmailMessage$HtmlBody": "The email html body.",
-        "CampaignEmailMessage$Title": "The email title (Or subject).",
-        "CampaignHook$LambdaFunctionName": "Lambda function name or arn to be called for delivery",
-        "CampaignHook$WebUrl": "Web URL to call for hook. If the URL has authentication specified it will be added as authentication to the request",
-        "CampaignResponse$ApplicationId": "The ID of the application to which the campaign applies.",
-        "CampaignResponse$CreationDate": "The date the campaign was created in ISO 8601 format.",
-        "CampaignResponse$Description": "A description of the campaign.",
-        "CampaignResponse$Id": "The unique campaign ID.",
-        "CampaignResponse$LastModifiedDate": "The date the campaign was last updated in ISO 8601 format.\t",
-        "CampaignResponse$Name": "The custom name of the campaign.",
-        "CampaignResponse$SegmentId": "The ID of the segment to which the campaign sends messages.",
-        "CampaignResponse$TreatmentDescription": "A custom description for the treatment.",
-        "CampaignResponse$TreatmentName": "The custom name of a variation of the campaign used for A/B testing.",
-        "CampaignSmsMessage$Body": "The SMS text body.",
-        "CampaignSmsMessage$SenderId": "Sender ID of sent message.",
-        "CampaignsResponse$NextToken": "The string that you use in a subsequent request to get the next page of results in a paginated response.",
-        "CreateApplicationRequest$Name": "The display name of the application. Used in the Amazon Pinpoint console.",
-        "DefaultMessage$Body": "The message body of the notification, the email body or the text message.",
-        "DefaultPushNotificationMessage$Body": "The message body of the notification, the email body or the text message.",
-        "DefaultPushNotificationMessage$Data": "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
-        "DefaultPushNotificationMessage$Title": "The message title that displays above the message on the user's device.",
-        "DefaultPushNotificationMessage$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "EmailChannelRequest$FromAddress": "The email address used to send emails from.",
-        "EmailChannelRequest$Identity": "The ARN of an identity verified with SES.",
-        "EmailChannelRequest$RoleArn": "The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service",
-        "EmailChannelResponse$ApplicationId": "The unique ID of the application to which the email channel belongs.",
-        "EmailChannelResponse$CreationDate": "The date that the settings were last updated in ISO 8601 format.",
-        "EmailChannelResponse$FromAddress": "The email address used to send emails from.",
-        "EmailChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "EmailChannelResponse$Identity": "The ARN of an identity verified with SES.",
-        "EmailChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "EmailChannelResponse$LastModifiedDate": "Last date this was updated",
-        "EmailChannelResponse$Platform": "Platform type. Will be \"EMAIL\"",
-        "EmailChannelResponse$RoleArn": "The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service",
-        "EndpointBatchItem$Address": "The address or token of the endpoint as provided by your push provider (e.g. DeviceToken or RegistrationId).",
-        "EndpointBatchItem$EffectiveDate": "The last time the endpoint was updated. Provided in ISO 8601 format.",
-        "EndpointBatchItem$EndpointStatus": "The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE if a delivery fails. Will be set to ACTIVE if the address is updated.",
-        "EndpointBatchItem$Id": "The unique Id for the Endpoint in the batch.",
-        "EndpointBatchItem$OptOut": "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
-        "EndpointBatchItem$RequestId": "The unique ID for the most recent request to update the endpoint.",
-        "EndpointDemographic$AppVersion": "The version of the application associated with the endpoint.",
-        "EndpointDemographic$Locale": "The endpoint locale in the following format: The ISO 639-1 alpha-2 code, followed by an underscore, followed by an ISO 3166-1 alpha-2 value.\n",
-        "EndpointDemographic$Make": "The endpoint make, such as such as Apple or Samsung.",
-        "EndpointDemographic$Model": "The endpoint model, such as iPhone.",
-        "EndpointDemographic$ModelVersion": "The endpoint model version.",
-        "EndpointDemographic$Platform": "The endpoint platform, such as ios or android.",
-        "EndpointDemographic$PlatformVersion": "The endpoint platform version.",
-        "EndpointDemographic$Timezone": "The timezone of the endpoint. Specified as a tz database value, such as Americas/Los_Angeles.",
-        "EndpointLocation$City": "The city where the endpoint is located.",
-        "EndpointLocation$Country": "Country according to ISO 3166-1 Alpha-2 codes. For example, US.",
-        "EndpointLocation$PostalCode": "The postal code or zip code of the endpoint.",
-        "EndpointLocation$Region": "The region of the endpoint location. For example, corresponds to a state in US.",
-        "EndpointMessageResult$Address": "Address that endpoint message was delivered to.",
-        "EndpointMessageResult$StatusMessage": "Status message for message delivery.",
-        "EndpointMessageResult$UpdatedToken": "If token was updated as part of delivery. (This is GCM Specific)",
-        "EndpointRequest$Address": "The address or token of the endpoint as provided by your push provider (e.g. DeviceToken or RegistrationId).",
-        "EndpointRequest$EffectiveDate": "The last time the endpoint was updated. Provided in ISO 8601 format.",
-        "EndpointRequest$EndpointStatus": "The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE if a delivery fails. Will be set to ACTIVE if the address is updated.",
-        "EndpointRequest$OptOut": "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
-        "EndpointRequest$RequestId": "The unique ID for the most recent request to update the endpoint.",
-        "EndpointResponse$Address": "The address or token of the endpoint as provided by your push provider (e.g. DeviceToken or RegistrationId).",
-        "EndpointResponse$ApplicationId": "The ID of the application associated with the endpoint.",
-        "EndpointResponse$CohortId": "A number from 0 - 99 that represents the cohort the endpoint is assigned to. Endpoints are grouped into cohorts randomly, and each cohort contains approximately 1 percent of the endpoints for an app. Amazon Pinpoint assigns cohorts to the holdout or treatment allocations for a campaign.",
-        "EndpointResponse$CreationDate": "The last time the endpoint was created. Provided in ISO 8601 format.",
-        "EndpointResponse$EffectiveDate": "The last time the endpoint was updated. Provided in ISO 8601 format.",
-        "EndpointResponse$EndpointStatus": "The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE if a delivery fails. Will be set to ACTIVE if the address is updated.",
-        "EndpointResponse$Id": "The unique ID that you assigned to the endpoint. The ID should be a globally unique identifier (GUID) to ensure that it is unique compared to all other endpoints for the application.",
-        "EndpointResponse$OptOut": "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
-        "EndpointResponse$RequestId": "The unique ID for the most recent request to update the endpoint.",
-        "EndpointSendConfiguration$BodyOverride": "Body override. If specified will override default body.",
-        "EndpointSendConfiguration$Context": "A map of custom attributes to attributes to be attached to the message for this address. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
-        "EndpointSendConfiguration$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "EndpointSendConfiguration$TitleOverride": "Title override. If specified will override default title if applicable.",
-        "EndpointUser$UserId": "The unique ID of the user.",
-        "EventStream$ApplicationId": "The ID of the application from which events should be published.",
-        "EventStream$DestinationStreamArn": "The Amazon Resource Name (ARN) of the Amazon Kinesis stream or Firehose delivery stream to which you want to publish events.\n Firehose ARN: arn:aws:firehose:REGION:ACCOUNT_ID:deliverystream/STREAM_NAME\n Kinesis ARN: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME",
-        "EventStream$ExternalId": "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
-        "EventStream$LastModifiedDate": "The date the event stream was last updated in ISO 8601 format.",
-        "EventStream$LastUpdatedBy": "The IAM user who last modified the event stream.",
-        "EventStream$RoleArn": "The IAM role that authorizes Amazon Pinpoint to publish events to the stream in your account.",
+        "ADMChannelRequest$ClientId" : "Client ID as gotten from Amazon",
+        "ADMChannelRequest$ClientSecret" : "Client secret as gotten from Amazon",
+        "ADMChannelResponse$ApplicationId" : "The ID of the application to which the channel applies.",
+        "ADMChannelResponse$CreationDate" : "When was this segment created",
+        "ADMChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "ADMChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "ADMChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "ADMChannelResponse$Platform" : "Platform type. Will be \"ADM\"",
+        "ADMMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "ADMMessage$ConsolidationKey" : "Optional. Arbitrary string used to indicate multiple messages are logically the same and that ADM is allowed to drop previously enqueued messages in favor of this one.",
+        "ADMMessage$ExpiresAfter" : "Optional. Number of seconds ADM should retain the message if the device is offline",
+        "ADMMessage$IconReference" : "The icon image name of the asset saved in your application.",
+        "ADMMessage$ImageIconUrl" : "The URL that points to an image used as the large icon to the notification content view.",
+        "ADMMessage$ImageUrl" : "The URL that points to an image used in the push notification.",
+        "ADMMessage$MD5" : "Optional. Base-64-encoded MD5 checksum of the data parameter. Used to verify data integrity",
+        "ADMMessage$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "ADMMessage$SmallImageIconUrl" : "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
+        "ADMMessage$Sound" : "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
+        "ADMMessage$Title" : "The message title that displays above the message on the user's device.",
+        "ADMMessage$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "APNSChannelRequest$BundleId" : "The bundle id used for APNs Tokens.",
+        "APNSChannelRequest$Certificate" : "The distribution certificate from Apple.",
+        "APNSChannelRequest$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSChannelRequest$PrivateKey" : "The certificate private key.",
+        "APNSChannelRequest$TeamId" : "The team id used for APNs Tokens.",
+        "APNSChannelRequest$TokenKey" : "The token key used for APNs Tokens.",
+        "APNSChannelRequest$TokenKeyId" : "The token key used for APNs Tokens.",
+        "APNSChannelResponse$ApplicationId" : "The ID of the application to which the channel applies.",
+        "APNSChannelResponse$CreationDate" : "When was this segment created",
+        "APNSChannelResponse$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSChannelResponse$Id" : "Channel ID. Not used. Present only for backwards compatibility.",
+        "APNSChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "APNSChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "APNSChannelResponse$Platform" : "The platform type. Will be APNS.",
+        "APNSMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "APNSMessage$Category" : "Provide this key with a string value that represents the notification's type. This value corresponds to the value in the identifier property of one of your app's registered categories.",
+        "APNSMessage$CollapseId" : "An ID that, if assigned to multiple messages, causes APNs to coalesce the messages into a single push notification instead of delivering each message individually. The value must not exceed 64 bytes. Amazon Pinpoint uses this value to set the apns-collapse-id request header when it sends the message to APNs.",
+        "APNSMessage$MediaUrl" : "The URL that points to a video used in the push notification.",
+        "APNSMessage$PreferredAuthenticationMethod" : "The preferred authentication method, either \"CERTIFICATE\" or \"TOKEN\"",
+        "APNSMessage$Priority" : "The message priority. Amazon Pinpoint uses this value to set the apns-priority request header when it sends the message to APNs. Accepts the following values:\n\n\"5\" - Low priority. Messages might be delayed, delivered in groups, and throttled.\n\n\"10\" - High priority. Messages are sent immediately. High priority messages must cause an alert, sound, or badge on the receiving device.\n\nThe default value is \"10\".\n\nThe equivalent values for FCM or GCM messages are \"normal\" and \"high\". Amazon Pinpoint accepts these values for APNs messages and converts them.\n\nFor more information about the apns-priority parameter, see Communicating with APNs in the APNs Local and Remote Notification Programming Guide.",
+        "APNSMessage$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "APNSMessage$Sound" : "Include this key when you want the system to play a sound. The value of this key is the name of a sound file in your app's main bundle or in the Library/Sounds folder of your app's data container. If the sound file cannot be found, or if you specify defaultfor the value, the system plays the default alert sound.",
+        "APNSMessage$ThreadId" : "Provide this key with a string value that represents the app-specific identifier for grouping notifications. If you provide a Notification Content app extension, you can use this value to group your notifications together.",
+        "APNSMessage$Title" : "The message title that displays above the message on the user's device.",
+        "APNSMessage$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "APNSSandboxChannelRequest$BundleId" : "The bundle id used for APNs Tokens.",
+        "APNSSandboxChannelRequest$Certificate" : "The distribution certificate from Apple.",
+        "APNSSandboxChannelRequest$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSSandboxChannelRequest$PrivateKey" : "The certificate private key.",
+        "APNSSandboxChannelRequest$TeamId" : "The team id used for APNs Tokens.",
+        "APNSSandboxChannelRequest$TokenKey" : "The token key used for APNs Tokens.",
+        "APNSSandboxChannelRequest$TokenKeyId" : "The token key used for APNs Tokens.",
+        "APNSSandboxChannelResponse$ApplicationId" : "The ID of the application to which the channel applies.",
+        "APNSSandboxChannelResponse$CreationDate" : "When was this segment created",
+        "APNSSandboxChannelResponse$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSSandboxChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "APNSSandboxChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "APNSSandboxChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "APNSSandboxChannelResponse$Platform" : "The platform type. Will be APNS_SANDBOX.",
+        "APNSVoipChannelRequest$BundleId" : "The bundle id used for APNs Tokens.",
+        "APNSVoipChannelRequest$Certificate" : "The distribution certificate from Apple.",
+        "APNSVoipChannelRequest$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSVoipChannelRequest$PrivateKey" : "The certificate private key.",
+        "APNSVoipChannelRequest$TeamId" : "The team id used for APNs Tokens.",
+        "APNSVoipChannelRequest$TokenKey" : "The token key used for APNs Tokens.",
+        "APNSVoipChannelRequest$TokenKeyId" : "The token key used for APNs Tokens.",
+        "APNSVoipChannelResponse$ApplicationId" : "Application id",
+        "APNSVoipChannelResponse$CreationDate" : "When was this segment created",
+        "APNSVoipChannelResponse$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSVoipChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "APNSVoipChannelResponse$LastModifiedBy" : "Who made the last change",
+        "APNSVoipChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "APNSVoipChannelResponse$Platform" : "The platform type. Will be APNS.",
+        "APNSVoipSandboxChannelRequest$BundleId" : "The bundle id used for APNs Tokens.",
+        "APNSVoipSandboxChannelRequest$Certificate" : "The distribution certificate from Apple.",
+        "APNSVoipSandboxChannelRequest$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSVoipSandboxChannelRequest$PrivateKey" : "The certificate private key.",
+        "APNSVoipSandboxChannelRequest$TeamId" : "The team id used for APNs Tokens.",
+        "APNSVoipSandboxChannelRequest$TokenKey" : "The token key used for APNs Tokens.",
+        "APNSVoipSandboxChannelRequest$TokenKeyId" : "The token key used for APNs Tokens.",
+        "APNSVoipSandboxChannelResponse$ApplicationId" : "Application id",
+        "APNSVoipSandboxChannelResponse$CreationDate" : "When was this segment created",
+        "APNSVoipSandboxChannelResponse$DefaultAuthenticationMethod" : "The default authentication method used for APNs.",
+        "APNSVoipSandboxChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "APNSVoipSandboxChannelResponse$LastModifiedBy" : "Who made the last change",
+        "APNSVoipSandboxChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "APNSVoipSandboxChannelResponse$Platform" : "The platform type. Will be APNS.",
+        "ActivityResponse$ApplicationId" : "The ID of the application to which the campaign applies.",
+        "ActivityResponse$CampaignId" : "The ID of the campaign to which the activity applies.",
+        "ActivityResponse$End" : "The actual time the activity was marked CANCELLED or COMPLETED. Provided in ISO 8601 format.",
+        "ActivityResponse$Id" : "The unique activity ID.",
+        "ActivityResponse$Result" : "Indicates whether the activity succeeded.\n\nValid values: SUCCESS, FAIL",
+        "ActivityResponse$ScheduledStart" : "The scheduled start time for the activity in ISO 8601 format.",
+        "ActivityResponse$Start" : "The actual start time of the activity in ISO 8601 format.",
+        "ActivityResponse$State" : "The state of the activity.\n\nValid values: PENDING, INITIALIZING, RUNNING, PAUSED, CANCELLED, COMPLETED",
+        "ActivityResponse$TreatmentId" : "The ID of a variation of the campaign used for A/B testing.",
+        "AddressConfiguration$BodyOverride" : "Body override. If specified will override default body.",
+        "AddressConfiguration$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "AddressConfiguration$TitleOverride" : "Title override. If specified will override default title if applicable.",
+        "ApplicationResponse$Id" : "The unique application ID.",
+        "ApplicationResponse$Name" : "The display name of the application.",
+        "ApplicationSettingsResource$ApplicationId" : "The unique ID for the application.",
+        "ApplicationSettingsResource$LastModifiedDate" : "The date that the settings were last updated in ISO 8601 format.",
+        "ApplicationsResponse$NextToken" : "The string that you use in a subsequent request to get the next page of results in a paginated response.",
+        "AttributesResource$ApplicationId" : "The unique ID for the application.",
+        "AttributesResource$AttributeType" : "The attribute type for the application.",
+        "BaiduChannelRequest$ApiKey" : "Platform credential API key from Baidu.",
+        "BaiduChannelRequest$SecretKey" : "Platform credential Secret key from Baidu.",
+        "BaiduChannelResponse$ApplicationId" : "Application id",
+        "BaiduChannelResponse$CreationDate" : "When was this segment created",
+        "BaiduChannelResponse$Credential" : "The Baidu API key from Baidu.",
+        "BaiduChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "BaiduChannelResponse$LastModifiedBy" : "Who made the last change",
+        "BaiduChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "BaiduChannelResponse$Platform" : "The platform type. Will be BAIDU",
+        "BaiduMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "BaiduMessage$IconReference" : "The icon image name of the asset saved in your application.",
+        "BaiduMessage$ImageIconUrl" : "The URL that points to an image used as the large icon to the notification content view.",
+        "BaiduMessage$ImageUrl" : "The URL that points to an image used in the push notification.",
+        "BaiduMessage$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "BaiduMessage$SmallImageIconUrl" : "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
+        "BaiduMessage$Sound" : "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
+        "BaiduMessage$Title" : "The message title that displays above the message on the user's device.",
+        "BaiduMessage$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "CampaignEmailMessage$Body" : "The email text body.",
+        "CampaignEmailMessage$FromAddress" : "The email address used to send the email from. Defaults to use FromAddress specified in the Email Channel.",
+        "CampaignEmailMessage$HtmlBody" : "The email html body.",
+        "CampaignEmailMessage$Title" : "The email title (Or subject).",
+        "CampaignHook$LambdaFunctionName" : "Lambda function name or arn to be called for delivery",
+        "CampaignHook$WebUrl" : "Web URL to call for hook. If the URL has authentication specified it will be added as authentication to the request",
+        "CampaignResponse$ApplicationId" : "The ID of the application to which the campaign applies.",
+        "CampaignResponse$CreationDate" : "The date the campaign was created in ISO 8601 format.",
+        "CampaignResponse$Description" : "A description of the campaign.",
+        "CampaignResponse$Id" : "The unique campaign ID.",
+        "CampaignResponse$LastModifiedDate" : "The date the campaign was last updated in ISO 8601 format.\t",
+        "CampaignResponse$Name" : "The custom name of the campaign.",
+        "CampaignResponse$SegmentId" : "The ID of the segment to which the campaign sends messages.",
+        "CampaignResponse$TreatmentDescription" : "A custom description for the treatment.",
+        "CampaignResponse$TreatmentName" : "The custom name of a variation of the campaign used for A/B testing.",
+        "CampaignSmsMessage$Body" : "The SMS text body.",
+        "CampaignSmsMessage$SenderId" : "Sender ID of sent message.",
+        "CampaignsResponse$NextToken" : "The string that you use in a subsequent request to get the next page of results in a paginated response.",
+        "ChannelResponse$ApplicationId" : "Application id",
+        "ChannelResponse$CreationDate" : "When was this segment created",
+        "ChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "ChannelResponse$LastModifiedBy" : "Who made the last change",
+        "ChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "CreateApplicationRequest$Name" : "The display name of the application. Used in the Amazon Pinpoint console.",
+        "DefaultMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "DefaultPushNotificationMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "DefaultPushNotificationMessage$Title" : "The message title that displays above the message on the user's device.",
+        "DefaultPushNotificationMessage$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "EmailChannelRequest$FromAddress" : "The email address used to send emails from.",
+        "EmailChannelRequest$Identity" : "The ARN of an identity verified with SES.",
+        "EmailChannelRequest$RoleArn" : "The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service",
+        "EmailChannelResponse$ApplicationId" : "The unique ID of the application to which the email channel belongs.",
+        "EmailChannelResponse$CreationDate" : "The date that the settings were last updated in ISO 8601 format.",
+        "EmailChannelResponse$FromAddress" : "The email address used to send emails from.",
+        "EmailChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "EmailChannelResponse$Identity" : "The ARN of an identity verified with SES.",
+        "EmailChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "EmailChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "EmailChannelResponse$Platform" : "Platform type. Will be \"EMAIL\"",
+        "EmailChannelResponse$RoleArn" : "The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service",
+        "EndpointBatchItem$Address" : "The destination for messages that you send to this endpoint. The address varies by channel. For mobile push channels, use the token provided by the push notification service, such as the APNs device token or the FCM registration token. For the SMS channel, use a phone number in E.164 format, such as +1206XXX5550100. For the email channel, use an email address.",
+        "EndpointBatchItem$EffectiveDate" : "The last time the endpoint was updated. Provided in ISO 8601 format.",
+        "EndpointBatchItem$EndpointStatus" : "Unused.",
+        "EndpointBatchItem$Id" : "The unique Id for the Endpoint in the batch.",
+        "EndpointBatchItem$OptOut" : "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
+        "EndpointBatchItem$RequestId" : "The unique ID for the most recent request to update the endpoint.",
+        "EndpointDemographic$AppVersion" : "The version of the application associated with the endpoint.",
+        "EndpointDemographic$Locale" : "The endpoint locale in the following format: The ISO 639-1 alpha-2 code, followed by an underscore, followed by an ISO 3166-1 alpha-2 value.\n",
+        "EndpointDemographic$Make" : "The endpoint make, such as such as Apple or Samsung.",
+        "EndpointDemographic$Model" : "The endpoint model, such as iPhone.",
+        "EndpointDemographic$ModelVersion" : "The endpoint model version.",
+        "EndpointDemographic$Platform" : "The endpoint platform, such as ios or android.",
+        "EndpointDemographic$PlatformVersion" : "The endpoint platform version.",
+        "EndpointDemographic$Timezone" : "The timezone of the endpoint. Specified as a tz database value, such as Americas/Los_Angeles.",
+        "EndpointLocation$City" : "The city where the endpoint is located.",
+        "EndpointLocation$Country" : "Country according to ISO 3166-1 Alpha-2 codes. For example, US.",
+        "EndpointLocation$PostalCode" : "The postal code or zip code of the endpoint.",
+        "EndpointLocation$Region" : "The region of the endpoint location. For example, corresponds to a state in US.",
+        "EndpointMessageResult$Address" : "Address that endpoint message was delivered to.",
+        "EndpointMessageResult$MessageId" : "Unique message identifier associated with the message that was sent.",
+        "EndpointMessageResult$StatusMessage" : "Status message for message delivery.",
+        "EndpointMessageResult$UpdatedToken" : "If token was updated as part of delivery. (This is GCM Specific)",
+        "EndpointRequest$Address" : "The destination for messages that you send to this endpoint. The address varies by channel. For mobile push channels, use the token provided by the push notification service, such as the APNs device token or the FCM registration token. For the SMS channel, use a phone number in E.164 format, such as +1206XXX5550100. For the email channel, use an email address.",
+        "EndpointRequest$EffectiveDate" : "The last time the endpoint was updated. Provided in ISO 8601 format.",
+        "EndpointRequest$EndpointStatus" : "Unused.",
+        "EndpointRequest$OptOut" : "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
+        "EndpointRequest$RequestId" : "The unique ID for the most recent request to update the endpoint.",
+        "EndpointResponse$Address" : "The address or token of the endpoint as provided by your push provider (e.g. DeviceToken or RegistrationId).",
+        "EndpointResponse$ApplicationId" : "The ID of the application associated with the endpoint.",
+        "EndpointResponse$CohortId" : "A number from 0 - 99 that represents the cohort the endpoint is assigned to. Endpoints are grouped into cohorts randomly, and each cohort contains approximately 1 percent of the endpoints for an app. Amazon Pinpoint assigns cohorts to the holdout or treatment allocations for a campaign.",
+        "EndpointResponse$CreationDate" : "The last time the endpoint was created. Provided in ISO 8601 format.",
+        "EndpointResponse$EffectiveDate" : "The last time the endpoint was updated. Provided in ISO 8601 format.",
+        "EndpointResponse$EndpointStatus" : "Unused.",
+        "EndpointResponse$Id" : "The unique ID that you assigned to the endpoint. The ID should be a globally unique identifier (GUID) to ensure that it is unique compared to all other endpoints for the application.",
+        "EndpointResponse$OptOut" : "Indicates whether a user has opted out of receiving messages with one of the following values:\n\nALL - User has opted out of all messages.\n\nNONE - Users has not opted out and receives all messages.",
+        "EndpointResponse$RequestId" : "The unique ID for the most recent request to update the endpoint.",
+        "EndpointSendConfiguration$BodyOverride" : "Body override. If specified will override default body.",
+        "EndpointSendConfiguration$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "EndpointSendConfiguration$TitleOverride" : "Title override. If specified will override default title if applicable.",
+        "EndpointUser$UserId" : "The unique ID of the user.",
+        "EventStream$ApplicationId" : "The ID of the application from which events should be published.",
+        "EventStream$DestinationStreamArn" : "The Amazon Resource Name (ARN) of the Amazon Kinesis stream or Firehose delivery stream to which you want to publish events.\n Firehose ARN: arn:aws:firehose:REGION:ACCOUNT_ID:deliverystream/STREAM_NAME\n Kinesis ARN: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME",
+        "EventStream$ExternalId" : "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
+        "EventStream$LastModifiedDate" : "The date the event stream was last updated in ISO 8601 format.",
+        "EventStream$LastUpdatedBy" : "The IAM user who last modified the event stream.",
+        "EventStream$RoleArn" : "The IAM role that authorizes Amazon Pinpoint to publish events to the stream in your account.",
         "ExportJobRequest$RoleArn" : "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that endpoints will be exported to.",
-        "ExportJobRequest$S3UrlPrefix" : "A URL that points to the location within an Amazon S3 bucket that will receive the export. The location is typically a folder with multiple files.\nThe URL should follow this format: s3://bucket-name/folder-name/\n\nAmazon Pinpoint will export endpoints to this location.",
-        "ExportJobRequest$SegmentId" : "The ID of the segment to export endpoints from. If not present, all endpoints will be exported.",
+        "ExportJobRequest$S3UrlPrefix" : "A URL that points to the location within an Amazon S3 bucket that will receive the export. The location is typically a folder with multiple files.\n\nThe URL should follow this format: s3://bucket-name/folder-name/\n\nAmazon Pinpoint will export endpoints to this location.",
+        "ExportJobRequest$SegmentId" : "The ID of the segment to export endpoints from. If not present, Amazon Pinpoint exports all of the endpoints that belong to the application.",
         "ExportJobResource$RoleArn" : "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that endpoints will be exported to.",
-        "ExportJobResource$S3UrlPrefix" : "A URL that points to the location within an Amazon S3 bucket that will receive the export. The location is typically a folder with multiple files.\nThe URL should follow this format: s3://bucket-name/folder-name/\n\nAmazon Pinpoint will export endpoints to this location.",
-        "ExportJobResource$SegmentId" : "The ID of the segment to export endpoints from. If not present all endpoints will be exported.",
+        "ExportJobResource$S3UrlPrefix" : "A URL that points to the location within an Amazon S3 bucket that will receive the export. The location is typically a folder with multiple files.\n\nThe URL should follow this format: s3://bucket-name/folder-name/\n\nAmazon Pinpoint will export endpoints to this location.",
+        "ExportJobResource$SegmentId" : "The ID of the segment to export endpoints from. If not present, Amazon Pinpoint exports all of the endpoints that belong to the application.",
         "ExportJobResponse$ApplicationId" : "The unique ID of the application to which the job applies.",
         "ExportJobResponse$CompletionDate" : "The date the job completed in ISO 8601 format.",
         "ExportJobResponse$CreationDate" : "The date the job was created in ISO 8601 format.",
         "ExportJobResponse$Id" : "The unique ID of the job.",
         "ExportJobResponse$Type" : "The job type. Will be 'EXPORT'.",
         "ExportJobsResponse$NextToken" : "The string that you use in a subsequent request to get the next page of results in a paginated response.",
-        "GCMChannelRequest$ApiKey": "Platform credential API key from Google.",
-        "GCMChannelResponse$ApplicationId": "The ID of the application to which the channel applies.",
-        "GCMChannelResponse$CreationDate": "When was this segment created",
-        "GCMChannelResponse$Credential": "The GCM API key from Google.",
-        "GCMChannelResponse$Id": "Channel ID. Not used. Present only for backwards compatibility.",
-        "GCMChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "GCMChannelResponse$LastModifiedDate": "Last date this was updated",
-        "GCMChannelResponse$Platform": "The platform type. Will be GCM",
-        "GCMMessage$Body": "The message body of the notification, the email body or the text message.",
-        "GCMMessage$CollapseKey": "This parameter identifies a group of messages (e.g., with collapse_key: \"Updates Available\") that can be collapsed, so that only the last message gets sent when delivery can be resumed. This is intended to avoid sending too many of the same messages when the device comes back online or becomes active.",
-        "GCMMessage$Data": "The data payload used for a silent push. This payload is added to the notifications' data.pinpoint.jsonBody' object",
-        "GCMMessage$IconReference": "The icon image name of the asset saved in your application.",
-        "GCMMessage$ImageIconUrl": "The URL that points to an image used as the large icon to the notification content view.",
-        "GCMMessage$ImageUrl": "The URL that points to an image used in the push notification.",
-        "GCMMessage$Priority": "The message priority. Amazon Pinpoint uses this value to set the FCM or GCM priority parameter when it sends the message. Accepts the following values:\n\n\"Normal\" - Messages might be delayed. Delivery is optimized for battery usage on the receiving device. Use normal priority unless immediate delivery is required.\n\n\"High\" - Messages are sent immediately and might wake a sleeping device.\n\nThe equivalent values for APNs messages are \"5\" and \"10\". Amazon Pinpoint accepts these values here and converts them.\n\nFor more information, see About FCM Messages in the Firebase documentation.",
-        "GCMMessage$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "GCMMessage$RestrictedPackageName": "This parameter specifies the package name of the application where the registration tokens must match in order to receive the message.",
-        "GCMMessage$SmallImageIconUrl": "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
-        "GCMMessage$Sound": "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
-        "GCMMessage$Title": "The message title that displays above the message on the user's device.",
-        "GCMMessage$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "ImportJobRequest$ExternalId": "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
-        "ImportJobRequest$RoleArn": "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that contains the endpoints to import.",
-        "ImportJobRequest$S3Url": "A URL that points to the location within an Amazon S3 bucket that contains the endpoints to import. The location can be a folder or a single file.\nThe URL should follow this format: s3://bucket-name/folder-name/file-name\n\nAmazon Pinpoint will import endpoints from this location and any subfolders it contains.",
-        "ImportJobRequest$SegmentId": "The ID of the segment to update if the import job is meant to update an existing segment.",
-        "ImportJobRequest$SegmentName": "A custom name for the segment created by the import job. Use if DefineSegment is true.",
-        "ImportJobResource$ExternalId": "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
-        "ImportJobResource$RoleArn": "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that contains the endpoints to import.",
-        "ImportJobResource$S3Url": "A URL that points to the location within an Amazon S3 bucket that contains the endpoints to import. The location can be a folder or a single file.\nThe URL should follow this format: s3://bucket-name/folder-name/file-name\n\nAmazon Pinpoint will import endpoints from this location and any subfolders it contains.",
-        "ImportJobResource$SegmentId": "The ID of the segment to update if the import job is meant to update an existing segment.",
-        "ImportJobResource$SegmentName": "A custom name for the segment created by the import job. Use if DefineSegment is true.",
-        "ImportJobResponse$ApplicationId": "The unique ID of the application to which the import job applies.",
-        "ImportJobResponse$CompletionDate": "The date the import job completed in ISO 8601 format.",
-        "ImportJobResponse$CreationDate": "The date the import job was created in ISO 8601 format.",
-        "ImportJobResponse$Id": "The unique ID of the import job.",
-        "ImportJobResponse$Type": "The job type. Will be Import.",
-        "ImportJobsResponse$NextToken": "The string that you use in a subsequent request to get the next page of results in a paginated response.",
-        "Message$Body": "The message body. Can include up to 140 characters.",
-        "Message$ImageIconUrl": "The URL that points to the icon image for the push notification icon, for example, the app icon.",
-        "Message$ImageSmallIconUrl": "The URL that points to the small icon image for the push notification icon, for example, the app icon.",
-        "Message$ImageUrl": "The URL that points to an image used in the push notification.",
-        "Message$JsonBody": "The JSON payload used for a silent push.",
-        "Message$MediaUrl": "The URL that points to the media resource, for example a .mp4 or .gif file.",
-        "Message$RawContent": "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
-        "Message$Title": "The message title that displays above the message on the user's device.",
-        "Message$Url": "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
-        "MessageBody$Message": "The error message returned from the API.",
-        "MessageBody$RequestID": "The unique message body ID.",
-        "MessageRequest$Context": "A map of custom attributes to attributes to be attached to the message. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
-        "MessageResponse$ApplicationId": "Application id of the message.",
-        "MessageResponse$RequestId": "Original request Id for which this message was delivered.",
-        "MessageResult$StatusMessage": "Status message for message delivery.",
-        "MessageResult$UpdatedToken": "If token was updated as part of delivery. (This is GCM Specific)",
-        "QuietTime$End": "The default end time for quiet time in ISO 8601 format.",
-        "QuietTime$Start": "The default start time for quiet time in ISO 8601 format.",
-        "SMSChannelRequest$SenderId": "Sender identifier of your messages.",
-        "SMSChannelRequest$ShortCode": "ShortCode registered with phone provider.",
-        "SMSChannelResponse$ApplicationId": "The unique ID of the application to which the SMS channel belongs.",
-        "SMSChannelResponse$CreationDate": "The date that the settings were last updated in ISO 8601 format.",
-        "SMSChannelResponse$Id": "Channel ID. Not used, only for backwards compatibility.",
-        "SMSChannelResponse$LastModifiedBy": "Who last updated this entry",
-        "SMSChannelResponse$LastModifiedDate": "Last date this was updated",
-        "SMSChannelResponse$Platform": "Platform type. Will be \"SMS\"",
-        "SMSChannelResponse$SenderId": "Sender identifier of your messages.",
-        "SMSChannelResponse$ShortCode": "The short code registered with the phone provider.",
-        "SMSMessage$Body": "The message body of the notification, the email body or the text message.",
-        "SMSMessage$OriginationNumber": "The phone number that the SMS message originates from. Specify one of the dedicated long codes or short codes that you requested from AWS Support and that is assigned to your account. If this attribute is not specified, Amazon Pinpoint randomly assigns a long code.",
-        "SMSMessage$SenderId": "The sender ID that is shown as the message sender on the recipient's device. Support for sender IDs varies by country or region.",
-        "Schedule$EndTime": "The scheduled time that the campaign ends in ISO 8601 format.",
-        "Schedule$StartTime": "The scheduled time that the campaign begins in ISO 8601 format.",
-        "Schedule$Timezone": "The starting UTC offset for the schedule if the value for isLocalTime is true\n\nValid values: \nUTC\nUTC+01\nUTC+02\nUTC+03\nUTC+03:30\nUTC+04\nUTC+04:30\nUTC+05\nUTC+05:30\nUTC+05:45\nUTC+06\nUTC+06:30\nUTC+07\nUTC+08\nUTC+09\nUTC+09:30\nUTC+10\nUTC+10:30\nUTC+11\nUTC+12\nUTC+13\nUTC-02\nUTC-03\nUTC-04\nUTC-05\nUTC-06\nUTC-07\nUTC-08\nUTC-09\nUTC-10\nUTC-11",
-        "SegmentImportResource$ExternalId": "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
-        "SegmentImportResource$RoleArn": "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the endpoints in Amazon S3.",
-        "SegmentImportResource$S3Url": "A URL that points to the Amazon S3 location from which the endpoints for this segment were imported.",
-        "SegmentResponse$ApplicationId": "The ID of the application to which the segment applies.",
-        "SegmentResponse$CreationDate": "The date the segment was created in ISO 8601 format.",
-        "SegmentResponse$Id": "The unique segment ID.",
-        "SegmentResponse$LastModifiedDate": "The date the segment was last updated in ISO 8601 format.",
-        "SegmentResponse$Name": "The name of segment",
-        "SegmentsResponse$NextToken": "An identifier used to retrieve the next page of results. The token is null if no additional pages exist.",
-        "SendUsersMessageRequest$Context": "A map of custom attributes to attributes to be attached to the message. This payload is added to the push notification's 'data.pinpoint' object or added to the email/sms delivery receipt event attributes.",
-        "SendUsersMessageResponse$ApplicationId": "Application id of the message.",
-        "SendUsersMessageResponse$RequestId": "Original request Id for which this message was delivered.",
-        "TreatmentResource$Id": "The unique treatment ID.",
-        "TreatmentResource$TreatmentDescription": "A custom description for the treatment.",
-        "TreatmentResource$TreatmentName": "The custom name of a variation of the campaign used for A/B testing.",
-        "WriteCampaignRequest$Description": "A description of the campaign.",
-        "WriteCampaignRequest$Name": "The custom name of the campaign.",
-        "WriteCampaignRequest$SegmentId": "The ID of the segment to which the campaign sends messages.",
-        "WriteCampaignRequest$TreatmentDescription": "A custom description for the treatment.",
-        "WriteCampaignRequest$TreatmentName": "The custom name of a variation of the campaign used for A/B testing.",
-        "WriteEventStream$DestinationStreamArn": "The Amazon Resource Name (ARN) of the Amazon Kinesis stream or Firehose delivery stream to which you want to publish events.\n Firehose ARN: arn:aws:firehose:REGION:ACCOUNT_ID:deliverystream/STREAM_NAME\n Kinesis ARN: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME",
-        "WriteEventStream$RoleArn": "The IAM role that authorizes Amazon Pinpoint to publish events to the stream in your account.",
-        "WriteSegmentRequest$Name": "The name of segment",
-        "WriteTreatmentResource$TreatmentDescription": "A custom description for the treatment.",
-        "WriteTreatmentResource$TreatmentName": "The custom name of a variation of the campaign used for A/B testing.",
-        "PutEventStreamRequest$ApplicationId": "Application Id.",
-        "PutEventStreamRequest$WriteEventStream": "Write event stream wrapper.",
-        "GetEventStreamRequest$ApplicationId": "Application Id.",
-        "DeleteEventStreamRequest$ApplicationId": "Application Id."
+        "GCMChannelRequest$ApiKey" : "Platform credential API key from Google.",
+        "GCMChannelResponse$ApplicationId" : "The ID of the application to which the channel applies.",
+        "GCMChannelResponse$CreationDate" : "When was this segment created",
+        "GCMChannelResponse$Credential" : "The GCM API key from Google.",
+        "GCMChannelResponse$Id" : "Channel ID. Not used. Present only for backwards compatibility.",
+        "GCMChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "GCMChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "GCMChannelResponse$Platform" : "The platform type. Will be GCM",
+        "GCMMessage$Body" : "The message body of the notification, the email body or the text message.",
+        "GCMMessage$CollapseKey" : "This parameter identifies a group of messages (e.g., with collapse_key: \"Updates Available\") that can be collapsed, so that only the last message gets sent when delivery can be resumed. This is intended to avoid sending too many of the same messages when the device comes back online or becomes active.",
+        "GCMMessage$IconReference" : "The icon image name of the asset saved in your application.",
+        "GCMMessage$ImageIconUrl" : "The URL that points to an image used as the large icon to the notification content view.",
+        "GCMMessage$ImageUrl" : "The URL that points to an image used in the push notification.",
+        "GCMMessage$Priority" : "The message priority. Amazon Pinpoint uses this value to set the FCM or GCM priority parameter when it sends the message. Accepts the following values:\n\n\"Normal\" - Messages might be delayed. Delivery is optimized for battery usage on the receiving device. Use normal priority unless immediate delivery is required.\n\n\"High\" - Messages are sent immediately and might wake a sleeping device.\n\nThe equivalent values for APNs messages are \"5\" and \"10\". Amazon Pinpoint accepts these values here and converts them.\n\nFor more information, see About FCM Messages in the Firebase documentation.",
+        "GCMMessage$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "GCMMessage$RestrictedPackageName" : "This parameter specifies the package name of the application where the registration tokens must match in order to receive the message.",
+        "GCMMessage$SmallImageIconUrl" : "The URL that points to an image used as the small icon for the notification which will be used to represent the notification in the status bar and content view",
+        "GCMMessage$Sound" : "Indicates a sound to play when the device receives the notification. Supports default, or the filename of a sound resource bundled in the app. Android sound files must reside in /res/raw/",
+        "GCMMessage$Title" : "The message title that displays above the message on the user's device.",
+        "GCMMessage$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "ImportJobRequest$ExternalId" : "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
+        "ImportJobRequest$RoleArn" : "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that contains the endpoints to import.",
+        "ImportJobRequest$S3Url" : "A URL that points to the location within an Amazon S3 bucket that contains the endpoints to import. The location can be a folder or a single file.\nThe URL should follow this format: s3://bucket-name/folder-name/file-name\n\nAmazon Pinpoint will import endpoints from this location and any subfolders it contains.",
+        "ImportJobRequest$SegmentId" : "The ID of the segment to update if the import job is meant to update an existing segment.",
+        "ImportJobRequest$SegmentName" : "A custom name for the segment created by the import job. Use if DefineSegment is true.",
+        "ImportJobResource$ExternalId" : "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
+        "ImportJobResource$RoleArn" : "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the Amazon S3 location that contains the endpoints to import.",
+        "ImportJobResource$S3Url" : "A URL that points to the location within an Amazon S3 bucket that contains the endpoints to import. The location can be a folder or a single file.\nThe URL should follow this format: s3://bucket-name/folder-name/file-name\n\nAmazon Pinpoint will import endpoints from this location and any subfolders it contains.",
+        "ImportJobResource$SegmentId" : "The ID of the segment to update if the import job is meant to update an existing segment.",
+        "ImportJobResource$SegmentName" : "A custom name for the segment created by the import job. Use if DefineSegment is true.",
+        "ImportJobResponse$ApplicationId" : "The unique ID of the application to which the import job applies.",
+        "ImportJobResponse$CompletionDate" : "The date the import job completed in ISO 8601 format.",
+        "ImportJobResponse$CreationDate" : "The date the import job was created in ISO 8601 format.",
+        "ImportJobResponse$Id" : "The unique ID of the import job.",
+        "ImportJobResponse$Type" : "The job type. Will be Import.",
+        "ImportJobsResponse$NextToken" : "The string that you use in a subsequent request to get the next page of results in a paginated response.",
+        "Message$Body" : "The message body. Can include up to 140 characters.",
+        "Message$ImageIconUrl" : "The URL that points to the icon image for the push notification icon, for example, the app icon.",
+        "Message$ImageSmallIconUrl" : "The URL that points to the small icon image for the push notification icon, for example, the app icon.",
+        "Message$ImageUrl" : "The URL that points to an image used in the push notification.",
+        "Message$JsonBody" : "The JSON payload used for a silent push.",
+        "Message$MediaUrl" : "The URL that points to the media resource, for example a .mp4 or .gif file.",
+        "Message$RawContent" : "The Raw JSON formatted string to be used as the payload. This value overrides the message.",
+        "Message$Title" : "The message title that displays above the message on the user's device.",
+        "Message$Url" : "The URL to open in the user's mobile browser. Used if the value for Action is URL.",
+        "MessageBody$Message" : "The error message that's returned from the API.",
+        "MessageBody$RequestID" : "The unique message body ID.",
+        "MessageResponse$ApplicationId" : "Application id of the message.",
+        "MessageResponse$RequestId" : "Original request Id for which this message was delivered.",
+        "MessageResult$MessageId" : "Unique message identifier associated with the message that was sent.",
+        "MessageResult$StatusMessage" : "Status message for message delivery.",
+        "MessageResult$UpdatedToken" : "If token was updated as part of delivery. (This is GCM Specific)",
+        "MetricDimension$ComparisonOperator" : "GREATER_THAN | LESS_THAN | GREATER_THAN_OR_EQUAL | LESS_THAN_OR_EQUAL | EQUAL",
+        "NumberValidateRequest$IsoCountryCode" : "(Optional) The two-character ISO country code for the country where the phone number was originally registered.",
+        "NumberValidateRequest$PhoneNumber" : "The phone number to get information about.",
+        "NumberValidateResponse$Carrier" : "The carrier that the phone number is registered with.",
+        "NumberValidateResponse$City" : "The city where the phone number was originally registered.",
+        "NumberValidateResponse$CleansedPhoneNumberE164" : "The cleansed (standardized) phone number in E.164 format.",
+        "NumberValidateResponse$CleansedPhoneNumberNational" : "The cleansed phone number in national format.",
+        "NumberValidateResponse$Country" : "The country where the phone number was originally registered.",
+        "NumberValidateResponse$CountryCodeIso2" : "The two-character ISO country code for the country where the phone number was originally registered.",
+        "NumberValidateResponse$CountryCodeNumeric" : "The numeric country code for the country where the phone number was originally registered.",
+        "NumberValidateResponse$County" : "The county where the phone number was originally registered.",
+        "NumberValidateResponse$OriginalCountryCodeIso2" : "The two-character ISO country code that was included in the request body.",
+        "NumberValidateResponse$OriginalPhoneNumber" : "The phone number that you included in the request body.",
+        "NumberValidateResponse$PhoneType" : "A description of the phone type. Possible values include MOBILE, LANDLINE, VOIP, INVALID, and OTHER.",
+        "NumberValidateResponse$Timezone" : "The time zone for the location where the phone number was originally registered.",
+        "NumberValidateResponse$ZipCode" : "The zip code for the location where the phone number was originally registered.",
+        "QuietTime$End" : "The default end time for quiet time in ISO 8601 format.",
+        "QuietTime$Start" : "The default start time for quiet time in ISO 8601 format.",
+        "SMSChannelRequest$SenderId" : "Sender identifier of your messages.",
+        "SMSChannelRequest$ShortCode" : "ShortCode registered with phone provider.",
+        "SMSChannelResponse$ApplicationId" : "The unique ID of the application to which the SMS channel belongs.",
+        "SMSChannelResponse$CreationDate" : "The date that the settings were last updated in ISO 8601 format.",
+        "SMSChannelResponse$Id" : "Channel ID. Not used, only for backwards compatibility.",
+        "SMSChannelResponse$LastModifiedBy" : "Who last updated this entry",
+        "SMSChannelResponse$LastModifiedDate" : "Last date this was updated",
+        "SMSChannelResponse$Platform" : "Platform type. Will be \"SMS\"",
+        "SMSChannelResponse$SenderId" : "Sender identifier of your messages.",
+        "SMSChannelResponse$ShortCode" : "The short code registered with the phone provider.",
+        "SMSMessage$Body" : "The body of the SMS message.",
+        "SMSMessage$Keyword" : "The SMS program name that you provided to AWS Support when you requested your dedicated number.",
+        "SMSMessage$OriginationNumber" : "The phone number that the SMS message originates from. Specify one of the dedicated long codes or short codes that you requested from AWS Support and that is assigned to your account. If this attribute is not specified, Amazon Pinpoint randomly assigns a long code.",
+        "SMSMessage$SenderId" : "The sender ID that is shown as the message sender on the recipient's device. Support for sender IDs varies by country or region.",
+        "Schedule$EndTime" : "The scheduled time that the campaign ends in ISO 8601 format.",
+        "Schedule$StartTime" : "The scheduled time that the campaign begins in ISO 8601 format.",
+        "Schedule$Timezone" : "The starting UTC offset for the schedule if the value for isLocalTime is true\n\nValid values: \nUTC\nUTC+01\nUTC+02\nUTC+03\nUTC+03:30\nUTC+04\nUTC+04:30\nUTC+05\nUTC+05:30\nUTC+05:45\nUTC+06\nUTC+06:30\nUTC+07\nUTC+08\nUTC+09\nUTC+09:30\nUTC+10\nUTC+10:30\nUTC+11\nUTC+12\nUTC+13\nUTC-02\nUTC-03\nUTC-04\nUTC-05\nUTC-06\nUTC-07\nUTC-08\nUTC-09\nUTC-10\nUTC-11",
+        "SegmentImportResource$ExternalId" : "DEPRECATED. Your AWS account ID, which you assigned to the ExternalID key in an IAM trust policy. Used by Amazon Pinpoint to assume an IAM role. This requirement is removed, and external IDs are not recommended for IAM roles assumed by Amazon Pinpoint.",
+        "SegmentImportResource$RoleArn" : "The Amazon Resource Name (ARN) of an IAM role that grants Amazon Pinpoint access to the endpoints in Amazon S3.",
+        "SegmentImportResource$S3Url" : "A URL that points to the Amazon S3 location from which the endpoints for this segment were imported.",
+        "SegmentReference$Id" : "Segment Id.",
+        "SegmentResponse$ApplicationId" : "The ID of the application to which the segment applies.",
+        "SegmentResponse$CreationDate" : "The date the segment was created in ISO 8601 format.",
+        "SegmentResponse$Id" : "The unique segment ID.",
+        "SegmentResponse$LastModifiedDate" : "The date the segment was last updated in ISO 8601 format.",
+        "SegmentResponse$Name" : "The name of segment",
+        "SegmentsResponse$NextToken" : "An identifier used to retrieve the next page of results. The token is null if no additional pages exist.",
+        "SendUsersMessageResponse$ApplicationId" : "The unique ID of the Amazon Pinpoint project used to send the message.",
+        "SendUsersMessageResponse$RequestId" : "The unique ID assigned to the users-messages request.",
+        "TreatmentResource$Id" : "The unique treatment ID.",
+        "TreatmentResource$TreatmentDescription" : "A custom description for the treatment.",
+        "TreatmentResource$TreatmentName" : "The custom name of a variation of the campaign used for A/B testing.",
+        "WriteCampaignRequest$Description" : "A description of the campaign.",
+        "WriteCampaignRequest$Name" : "The custom name of the campaign.",
+        "WriteCampaignRequest$SegmentId" : "The ID of the segment to which the campaign sends messages.",
+        "WriteCampaignRequest$TreatmentDescription" : "A custom description for the treatment.",
+        "WriteCampaignRequest$TreatmentName" : "The custom name of a variation of the campaign used for A/B testing.",
+        "WriteEventStream$DestinationStreamArn" : "The Amazon Resource Name (ARN) of the Amazon Kinesis stream or Firehose delivery stream to which you want to publish events.\n Firehose ARN: arn:aws:firehose:REGION:ACCOUNT_ID:deliverystream/STREAM_NAME\n Kinesis ARN: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME",
+        "WriteEventStream$RoleArn" : "The IAM role that authorizes Amazon Pinpoint to publish events to the stream in your account.",
+        "WriteSegmentRequest$Name" : "The name of segment",
+        "WriteTreatmentResource$TreatmentDescription" : "A custom description for the treatment.",
+        "WriteTreatmentResource$TreatmentName" : "The custom name of a variation of the campaign used for A/B testing.",
+        "ListOf__string$member" : null,
+        "MapOf__string$member" : null
       }
     }
   }

--- a/models/apis/sagemaker/2017-07-24/api-2.json
+++ b/models/apis/sagemaker/2017-07-24/api-2.json
@@ -7,6 +7,7 @@
     "protocol":"json",
     "serviceAbbreviation":"SageMaker",
     "serviceFullName":"Amazon SageMaker Service",
+    "serviceId":"SageMaker",
     "signatureVersion":"v4",
     "signingName":"sagemaker",
     "targetPrefix":"SageMaker",
@@ -749,6 +750,18 @@
       "type":"structure",
       "members":{
       }
+    },
+    "DeployedImage":{
+      "type":"structure",
+      "members":{
+        "SpecifiedImage":{"shape":"Image"},
+        "ResolvedImage":{"shape":"Image"},
+        "ResolutionTime":{"shape":"Timestamp"}
+      }
+    },
+    "DeployedImages":{
+      "type":"list",
+      "member":{"shape":"DeployedImage"}
     },
     "DescribeEndpointConfigInput":{
       "type":"structure",
@@ -1704,7 +1717,8 @@
         "Stopping",
         "Stopped",
         "Failed",
-        "Deleting"
+        "Deleting",
+        "Updating"
       ]
     },
     "NotebookInstanceSummary":{
@@ -1853,6 +1867,7 @@
       "required":["VariantName"],
       "members":{
         "VariantName":{"shape":"VariantName"},
+        "DeployedImages":{"shape":"DeployedImages"},
         "CurrentWeight":{"shape":"VariantWeight"},
         "DesiredWeight":{"shape":"VariantWeight"},
         "CurrentInstanceCount":{"shape":"TaskCount"},

--- a/models/apis/sagemaker/2017-07-24/docs-2.json
+++ b/models/apis/sagemaker/2017-07-24/docs-2.json
@@ -3,7 +3,7 @@
   "service": "Definition of the public APIs exposed by SageMaker",
   "operations": {
     "AddTags": "<p>Adds or overwrites one or more tags for the specified Amazon SageMaker resource. You can add tags to notebook instances, training jobs, models, endpoint configurations, and endpoints. </p> <p>Each tag consists of a key and an optional value. Tag keys must be unique per resource. For more information about tags, see <a href=\"http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-what\">Using Cost Allocation Tags</a> in the <i>AWS Billing and Cost Management User Guide</i>. </p>",
-    "CreateEndpoint": "<p>Creates an endpoint using the endpoint configuration specified in the request. Amazon SageMaker uses the endpoint to provision resources and deploy models. You create the endpoint configuration with the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpointConfig.html\">CreateEndpointConfig</a> API. </p> <note> <p> Use this API only for hosting models using Amazon SageMaker hosting services. </p> </note> <p>The endpoint name must be unique within an AWS Region in your AWS account. </p> <p>When it receives the request, Amazon SageMaker creates the endpoint, launches the resources (ML compute instances), and deploys the model(s) on them. </p> <p>When Amazon SageMaker receives the request, it sets the endpoint status to <code>Creating</code>. After it creates the endpoint, it sets the status to <code>InService</code>. Amazon SageMaker can then process incoming requests for inferences. To check the status of an endpoint, use the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html\">DescribeEndpoint</a> API.</p> <p>For an example, see <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/ex1.html\">Exercise 1: Using the K-Means Algorithm Provided by Amazon SageMaker</a>. </p>",
+    "CreateEndpoint": "<p>Creates an endpoint using the endpoint configuration specified in the request. Amazon SageMaker uses the endpoint to provision resources and deploy models. You create the endpoint configuration with the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpointConfig.html\">CreateEndpointConfig</a> API. </p> <note> <p> Use this API only for hosting models using Amazon SageMaker hosting services. </p> </note> <p>The endpoint name must be unique within an AWS Region in your AWS account. </p> <p>When it receives the request, Amazon SageMaker creates the endpoint, launches the resources (ML compute instances), and deploys the model(s) on them. </p> <p>When Amazon SageMaker receives the request, it sets the endpoint status to <code>Creating</code>. After it creates the endpoint, it sets the status to <code>InService</code>. Amazon SageMaker can then process incoming requests for inferences. To check the status of an endpoint, use the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html\">DescribeEndpoint</a> API.</p> <p>For an example, see <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/ex1.html\">Exercise 1: Using the K-Means Algorithm Provided by Amazon SageMaker</a>. </p> <p>If any of the models hosted at this endpoint get model data from an Amazon S3 location, Amazon SageMaker uses AWS Security Token Service to download model artifacts from the S3 path you provided. AWS STS is activated in your IAM user account by default. If you previously deactivated AWS STS for a region, you need to reactivate AWS STS for that region. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and Deactivating AWS STS i an AWS Region</a> in the <i>AWS Identity and Access Management User Guide</i>.</p>",
     "CreateEndpointConfig": "<p>Creates an endpoint configuration that Amazon SageMaker hosting services uses to deploy models. In the configuration, you identify one or more models, created using the <code>CreateModel</code> API, to deploy and the resources that you want Amazon SageMaker to provision. Then you call the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpoint.html\">CreateEndpoint</a> API.</p> <note> <p> Use this API only if you want to use Amazon SageMaker hosting services to deploy models into production. </p> </note> <p>In the request, you define one or more <code>ProductionVariant</code>s, each of which identifies a model. Each <code>ProductionVariant</code> parameter also describes the resources that you want Amazon SageMaker to provision. This includes the number and type of ML compute instances to deploy. </p> <p>If you are hosting multiple models, you also assign a <code>VariantWeight</code> to specify how much traffic you want to allocate to each model. For example, suppose that you want to host two models, A and B, and you assign traffic weight 2 for model A and 1 for model B. Amazon SageMaker distributes two-thirds of the traffic to Model A, and one-third to model B. </p>",
     "CreateHyperParameterTuningJob": "<p>Starts a hyperparameter tuning job.</p>",
     "CreateModel": "<p>Creates a model in Amazon SageMaker. In the request, you name the model and describe one or more containers. For each container, you specify the docker image containing inference code, artifacts (from prior training), and custom environment map that the inference code uses when you deploy the model into production. </p> <p>Use this API to create a model only if you want to use Amazon SageMaker hosting services. To host your model, you create an endpoint configuration with the <code>CreateEndpointConfig</code> API, and then create an endpoint with the <code>CreateEndpoint</code> API. </p> <p>Amazon SageMaker then deploys all of the containers that you defined for the model in the hosting environment. </p> <p>In the <code>CreateModel</code> request, you must define a container with the <code>PrimaryContainer</code> parameter. </p> <p>In the request, you also provide an IAM role that Amazon SageMaker can assume to access model artifacts and docker image for deployment on ML compute hosting instances. In addition, you also use the IAM role to manage permissions the inference code needs. For example, if the inference code access any other AWS resources, you grant necessary permissions via this role.</p>",
@@ -26,21 +26,21 @@
     "DescribeTrainingJob": "<p>Returns information about a training job.</p>",
     "ListEndpointConfigs": "<p>Lists endpoint configurations.</p>",
     "ListEndpoints": "<p>Lists endpoints.</p>",
-    "ListHyperParameterTuningJobs": "<p>Gets a list of objects that describe the hyperparameter tuning jobs launched in your account.</p>",
+    "ListHyperParameterTuningJobs": "<p>Gets a list of <a>HyperParameterTuningJobSummary</a> objects that describe the hyperparameter tuning jobs launched in your account.</p>",
     "ListModels": "<p>Lists models created with the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateModel.html\">CreateModel</a> API.</p>",
-    "ListNotebookInstanceLifecycleConfigs": "<p>Lists notebook instance lifestyle configurations created with the API.</p>",
+    "ListNotebookInstanceLifecycleConfigs": "<p>Lists notebook instance lifestyle configurations created with the <a>CreateNotebookInstanceLifecycleConfig</a> API.</p>",
     "ListNotebookInstances": "<p>Returns a list of the Amazon SageMaker notebook instances in the requester's account in an AWS Region. </p>",
     "ListTags": "<p>Returns the tags for the specified Amazon SageMaker resource.</p>",
     "ListTrainingJobs": "<p>Lists training jobs.</p>",
-    "ListTrainingJobsForHyperParameterTuningJob": "<p>Gets a list of objects that describe the training jobs that a hyperparameter tuning job launched.</p>",
+    "ListTrainingJobsForHyperParameterTuningJob": "<p>Gets a list of <a>TrainingJobSummary</a> objects that describe the training jobs that a hyperparameter tuning job launched.</p>",
     "StartNotebookInstance": "<p>Launches an ML compute instance with the latest version of the libraries and attaches your ML storage volume. After configuring the notebook instance, Amazon SageMaker sets the notebook instance status to <code>InService</code>. A notebook instance's status must be <code>InService</code> before you can connect to your Jupyter notebook. </p>",
     "StopHyperParameterTuningJob": "<p>Stops a running hyperparameter tuning job and all running training jobs that the tuning job launched.</p> <p>All model artifacts output from the training jobs are stored in Amazon Simple Storage Service (Amazon S3). All data that the training jobs write toAmazon CloudWatch Logs are still available in CloudWatch. After the tuning job moves to the <code>Stopped</code> state, it releases all reserved resources for the tuning job.</p>",
     "StopNotebookInstance": "<p>Terminates the ML compute instance. Before terminating the instance, Amazon SageMaker disconnects the ML storage volume from it. Amazon SageMaker preserves the ML storage volume. </p> <p>To access data on the ML storage volume for a notebook instance that has been terminated, call the <code>StartNotebookInstance</code> API. <code>StartNotebookInstance</code> launches another ML compute instance, configures it, and attaches the preserved ML storage volume so you can continue your work. </p>",
     "StopTrainingJob": "<p>Stops a training job. To stop a job, Amazon SageMaker sends the algorithm the <code>SIGTERM</code> signal, which delays job termination for 120 seconds. Algorithms might use this 120-second window to save the model artifacts, so the results of the training is not lost. </p> <p>Training algorithms provided by Amazon SageMaker save the intermediate results of a model training job. This intermediate data is a valid model artifact. You can use the model artifacts that are saved when Amazon SageMaker stops a training job to create a model. </p> <p>When it receives a <code>StopTrainingJob</code> request, Amazon SageMaker changes the status of the job to <code>Stopping</code>. After Amazon SageMaker stops the job, it sets the status to <code>Stopped</code>.</p>",
-    "UpdateEndpoint": "<p> Deploys the new <code>EndpointConfig</code> specified in the request, switches to using newly created endpoint, and then deletes resources provisioned for the endpoint using the previous <code>EndpointConfig</code> (there is no availability loss). </p> <p>When Amazon SageMaker receives the request, it sets the endpoint status to <code>Updating</code>. After updating the endpoint, it sets the status to <code>InService</code>. To check the status of an endpoint, use the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html\">DescribeEndpoint</a> API. </p>",
+    "UpdateEndpoint": "<p> Deploys the new <code>EndpointConfig</code> specified in the request, switches to using newly created endpoint, and then deletes resources provisioned for the endpoint using the previous <code>EndpointConfig</code> (there is no availability loss). </p> <p>When Amazon SageMaker receives the request, it sets the endpoint status to <code>Updating</code>. After updating the endpoint, it sets the status to <code>InService</code>. To check the status of an endpoint, use the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html\">DescribeEndpoint</a> API. </p> <note> <p>You cannot update an endpoint with the current <code>EndpointConfig</code>. To update an endpoint, you must create a new <code>EndpointConfig</code>.</p> </note>",
     "UpdateEndpointWeightsAndCapacities": "<p>Updates variant weight of one or more variants associated with an existing endpoint, or capacity of one variant associated with an existing endpoint. When it receives the request, Amazon SageMaker sets the endpoint status to <code>Updating</code>. After updating the endpoint, it sets the status to <code>InService</code>. To check the status of an endpoint, use the <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html\">DescribeEndpoint</a> API. </p>",
     "UpdateNotebookInstance": "<p>Updates a notebook instance. NotebookInstance updates include upgrading or downgrading the ML compute instance used for your notebook instance to accommodate changes in your workload requirements. You can also update the VPC security groups.</p>",
-    "UpdateNotebookInstanceLifecycleConfig": "<p>Updates a notebook instance lifecycle configuration created with the API.</p>"
+    "UpdateNotebookInstanceLifecycleConfig": "<p>Updates a notebook instance lifecycle configuration created with the <a>CreateNotebookInstanceLifecycleConfig</a> API.</p>"
   },
   "shapes": {
     "AddTagsInput": {
@@ -262,6 +262,18 @@
       "refs": {
       }
     },
+    "DeployedImage": {
+      "base": "<p>Gets the Amazon EC2 Container Registry path of the docker image of the model that is hosted in this <a>ProductionVariant</a>.</p> <p>If you used the <code>registry/repository[:tag]</code> form to to specify the image path of the primary container when you created the model hosted in this <code>ProductionVariant</code>, the path resolves to a path of the form <code>registry/repository[@digest]</code>. A digest is a hash value that identifies a specific version of an image. For information about Amazon ECR paths, see <a href=\"http://docs.aws.amazon.com//AmazonECR/latest/userguide/docker-pull-ecr-image.html\">Pulling an Image</a> in the <i>Amazon ECR User Guide</i>.</p>",
+      "refs": {
+        "DeployedImages$member": null
+      }
+    },
+    "DeployedImages": {
+      "base": null,
+      "refs": {
+        "ProductionVariantSummary$DeployedImages": "<p>An array of <code>DeployedImage</code> objects that specify the Amazon EC2 Container Registry paths of the inference images deployed on instances of this <code>ProductionVariant</code>.</p>"
+      }
+    },
     "DescribeEndpointConfigInput": {
       "base": null,
       "refs": {
@@ -475,7 +487,7 @@
         "DescribeHyperParameterTuningJobResponse$FailureReason": "<p>If the tuning job failed, the reason it failed.</p>",
         "DescribeNotebookInstanceOutput$FailureReason": "<p>If status is failed, the reason it failed.</p>",
         "DescribeTrainingJobResponse$FailureReason": "<p>If the training job failed, the reason it failed. </p>",
-        "HyperParameterTrainingJobSummary$FailureReason": "<p>The reason that the </p>",
+        "HyperParameterTrainingJobSummary$FailureReason": "<p>The reason that the training job failed. </p>",
         "ResourceInUse$Message": null,
         "ResourceLimitExceeded$Message": null,
         "ResourceNotFound$Message": null
@@ -484,32 +496,32 @@
     "FinalHyperParameterTuningJobObjectiveMetric": {
       "base": "<p>Shows the final value for the objective metric for a training job that was launched by a hyperparameter tuning job. You define the objective metric in the <code>HyperParameterTuningJobObjective</code> parameter of <a>HyperParameterTuningJobConfig</a>.</p>",
       "refs": {
-        "HyperParameterTrainingJobSummary$FinalHyperParameterTuningJobObjectiveMetric": "<p>The object that specifies the value of the objective metric of the tuning job that launched this training job.</p>"
+        "HyperParameterTrainingJobSummary$FinalHyperParameterTuningJobObjectiveMetric": "<p>The <a>FinalHyperParameterTuningJobObjectiveMetric</a> object that specifies the value of the objective metric of the tuning job that launched this training job.</p>"
       }
     },
     "HyperParameterAlgorithmSpecification": {
       "base": "<p>Specifies which training algorithm to use for training jobs that a hyperparameter tuning job launches and the metrics to monitor.</p>",
       "refs": {
-        "HyperParameterTrainingJobDefinition$AlgorithmSpecification": "<p>The object that specifies the algorithm to use for the training jobs that the tuning job launches.</p>"
+        "HyperParameterTrainingJobDefinition$AlgorithmSpecification": "<p>The <a>HyperParameterAlgorithmSpecification</a> object that specifies the algorithm to use for the training jobs that the tuning job launches.</p>"
       }
     },
     "HyperParameterTrainingJobDefinition": {
       "base": "<p>Defines the training jobs launched by a hyperparameter tuning job.</p>",
       "refs": {
-        "CreateHyperParameterTuningJobRequest$TrainingJobDefinition": "<p>The object that describes the training jobs that this tuning job launches, including static hyperparameters, input data configuration, output data configuration, resource configuration, and stopping condition.</p>",
-        "DescribeHyperParameterTuningJobResponse$TrainingJobDefinition": "<p>The object that specifies the definition of the training jobs that this tuning job launches.</p>"
+        "CreateHyperParameterTuningJobRequest$TrainingJobDefinition": "<p>The <a>HyperParameterTrainingJobDefinition</a> object that describes the training jobs that this tuning job launches, including static hyperparameters, input data configuration, output data configuration, resource configuration, and stopping condition.</p>",
+        "DescribeHyperParameterTuningJobResponse$TrainingJobDefinition": "<p>The <a>HyperParameterTrainingJobDefinition</a> object that specifies the definition of the training jobs that this tuning job launches.</p>"
       }
     },
     "HyperParameterTrainingJobSummaries": {
       "base": null,
       "refs": {
-        "ListTrainingJobsForHyperParameterTuningJobResponse$TrainingJobSummaries": "<p>A list of objects that describe the training jobs that the <code>ListTrainingJobsForHyperParameterTuningJob</code> request returned.</p>"
+        "ListTrainingJobsForHyperParameterTuningJobResponse$TrainingJobSummaries": "<p>A list of <a>TrainingJobSummary</a> objects that describe the training jobs that the <code>ListTrainingJobsForHyperParameterTuningJob</code> request returned.</p>"
       }
     },
     "HyperParameterTrainingJobSummary": {
       "base": "<p>Specifies summary information about a training job.</p>",
       "refs": {
-        "DescribeHyperParameterTuningJobResponse$BestTrainingJob": "<p>A object that describes the training job that completed with the best current .</p>",
+        "DescribeHyperParameterTuningJobResponse$BestTrainingJob": "<p>A <a>TrainingJobSummary</a> object that describes the training job that completed with the best current <a>HyperParameterTuningJobObjective</a>.</p>",
         "HyperParameterTrainingJobSummaries$member": null
       }
     },
@@ -525,8 +537,8 @@
     "HyperParameterTuningJobConfig": {
       "base": "<p>Configures a hyperparameter tuning job.</p>",
       "refs": {
-        "CreateHyperParameterTuningJobRequest$HyperParameterTuningJobConfig": "<p>The object that describes the tuning job, including the search strategy, metric used to evaluate training jobs, ranges of parameters to search, and resource limits for the tuning job.</p>",
-        "DescribeHyperParameterTuningJobResponse$HyperParameterTuningJobConfig": "<p>The object that specifies the configuration of the tuning job.</p>"
+        "CreateHyperParameterTuningJobRequest$HyperParameterTuningJobConfig": "<p>The <a>HyperParameterTuningJobConfig</a> object that describes the tuning job, including the search strategy, metric used to evaluate training jobs, ranges of parameters to search, and resource limits for the tuning job.</p>",
+        "DescribeHyperParameterTuningJobResponse$HyperParameterTuningJobConfig": "<p>The <a>HyperParameterTuningJobConfig</a> object that specifies the configuration of the tuning job.</p>"
       }
     },
     "HyperParameterTuningJobName": {
@@ -543,7 +555,7 @@
     "HyperParameterTuningJobObjective": {
       "base": "<p>Defines the objective metric for a hyperparameter tuning job. Hyperparameter tuning uses the value of this metric to evaluate the training jobs it launches, and returns the training job that results in either the highest or lowest value for this metric, depending on the value you specify for the <code>Type</code> parameter.</p>",
       "refs": {
-        "HyperParameterTuningJobConfig$HyperParameterTuningJobObjective": "<p>The object that specifies the objective metric for this tuning job.</p>"
+        "HyperParameterTuningJobConfig$HyperParameterTuningJobObjective": "<p>The <a>HyperParameterTuningJobObjective</a> object that specifies the objective metric for this tuning job.</p>"
       }
     },
     "HyperParameterTuningJobObjectiveType": {
@@ -577,7 +589,7 @@
     "HyperParameterTuningJobSummaries": {
       "base": null,
       "refs": {
-        "ListHyperParameterTuningJobsResponse$HyperParameterTuningJobSummaries": "<p>A list of objects that describe the tuning jobs that the <code>ListHyperParameterTuningJobs</code> request returned.</p>"
+        "ListHyperParameterTuningJobsResponse$HyperParameterTuningJobSummaries": "<p>A list of <a>HyperParameterTuningJobSummary</a> objects that describe the tuning jobs that the <code>ListHyperParameterTuningJobs</code> request returned.</p>"
       }
     },
     "HyperParameterTuningJobSummary": {
@@ -598,7 +610,9 @@
     "Image": {
       "base": null,
       "refs": {
-        "ContainerDefinition$Image": "<p>The Amazon EC2 Container Registry (Amazon ECR) path where inference code is stored. If you are using your own custom algorithm instead of an algorithm provided by Amazon SageMaker, the inference code must meet Amazon SageMaker requirements. For more information, see <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms.html\">Using Your Own Algorithms with Amazon SageMaker</a> </p>"
+        "ContainerDefinition$Image": "<p>The Amazon EC2 Container Registry (Amazon ECR) path where inference code is stored. If you are using your own custom algorithm instead of an algorithm provided by Amazon SageMaker, the inference code must meet Amazon SageMaker requirements. Amazon SageMaker supports both <code>registry/repository[:tag]</code> and <code>registry/repository[@digest]</code> image path formats. For more information, see <a href=\"http://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms.html\">Using Your Own Algorithms with Amazon SageMaker</a> </p>",
+        "DeployedImage$SpecifiedImage": "<p>The image path you specified when you created the model.</p>",
+        "DeployedImage$ResolvedImage": "<p>The specific digest path of the image hosted in this <code>ProductionVariant</code>.</p>"
       }
     },
     "InputDataConfig": {
@@ -606,7 +620,7 @@
       "refs": {
         "CreateTrainingJobRequest$InputDataConfig": "<p>An array of <code>Channel</code> objects. Each channel is a named input source. <code>InputDataConfig</code> describes the input data and its location. </p> <p>Algorithms can accept input data from one or more channels. For example, an algorithm might have two channels of input data, <code>training_data</code> and <code>validation_data</code>. The configuration for each channel provides the S3 location where the input data is stored. It also provides information about the stored data: the MIME type, compression method, and whether the data is wrapped in RecordIO format. </p> <p>Depending on the input mode that the algorithm supports, Amazon SageMaker either copies input data files from an S3 bucket to a local directory in the Docker container, or makes it available as input streams. </p>",
         "DescribeTrainingJobResponse$InputDataConfig": "<p>An array of <code>Channel</code> objects that describes each data input channel. </p>",
-        "HyperParameterTrainingJobDefinition$InputDataConfig": "<p>An array of objects that specify the input for the training jobs that the tuning job launches.</p>"
+        "HyperParameterTrainingJobDefinition$InputDataConfig": "<p>An array of <a>Channel</a> objects that specify the input for the training jobs that the tuning job launches.</p>"
       }
     },
     "InstanceType": {
@@ -767,11 +781,11 @@
       "refs": {
         "ListEndpointConfigsInput$MaxResults": "<p>The maximum number of training jobs to return in the response.</p>",
         "ListEndpointsInput$MaxResults": "<p>The maximum number of endpoints to return in the response.</p>",
-        "ListHyperParameterTuningJobsRequest$MaxResults": "<p>The maximum number of tuning jobs to return.</p>",
+        "ListHyperParameterTuningJobsRequest$MaxResults": "<p>The maximum number of tuning jobs to return. The default value is 10.</p>",
         "ListModelsInput$MaxResults": "<p>The maximum number of models to return in the response.</p>",
         "ListNotebookInstanceLifecycleConfigsInput$MaxResults": "<p>The maximum number of lifecycle configurations to return in the response.</p>",
         "ListNotebookInstancesInput$MaxResults": "<p>The maximum number of notebook instances to return.</p>",
-        "ListTrainingJobsForHyperParameterTuningJobRequest$MaxResults": "<p>The maximum number of training jobs to return.</p>",
+        "ListTrainingJobsForHyperParameterTuningJobRequest$MaxResults": "<p>The maximum number of training jobs to return. The default value is 10.</p>",
         "ListTrainingJobsRequest$MaxResults": "<p>The maximum number of training jobs to return in the response.</p>"
       }
     },
@@ -790,7 +804,7 @@
     "MetricDefinitionList": {
       "base": null,
       "refs": {
-        "HyperParameterAlgorithmSpecification$MetricDefinitions": "<p>An array of objects that specify the metrics that the algorithm emits.</p>"
+        "HyperParameterAlgorithmSpecification$MetricDefinitions": "<p>An array of <a>MetricDefinition</a> objects that specify the metrics that the algorithm emits.</p>"
       }
     },
     "MetricName": {
@@ -804,7 +818,7 @@
     "MetricRegex": {
       "base": null,
       "refs": {
-        "MetricDefinition$Regex": "<p>A regular expression that searches the output of a training job and gets the value of the metric. For more information about using regular expressions to define metrics, see <a>hpo-define-metrics</a>.</p>"
+        "MetricDefinition$Regex": "<p>A regular expression that searches the output of a training job and gets the value of the metric. For more information about using regular expressions to define metrics, see <a>automatic-model-tuning-define-metrics</a>.</p>"
       }
     },
     "MetricValue": {
@@ -1053,8 +1067,8 @@
     "ObjectiveStatusCounters": {
       "base": "<p>Specifies the number of training jobs that this hyperparameter tuning job launched, categorized by the status of their objective metric. The objective metric status shows whether the final objective metric for the training job has been evaluated by the tuning job and used in the hyperparameter tuning process.</p>",
       "refs": {
-        "DescribeHyperParameterTuningJobResponse$ObjectiveStatusCounters": "<p>The object that specifies the number of training jobs, categorized by the status of their final objective metric, that this tuning job launched.</p>",
-        "HyperParameterTuningJobSummary$ObjectiveStatusCounters": "<p>The object that specifies the numbers of training jobs, categorized by objective metric status, that this tuning job launched.</p>"
+        "DescribeHyperParameterTuningJobResponse$ObjectiveStatusCounters": "<p>The <a>ObjectiveStatusCounters</a> object that specifies the number of training jobs, categorized by the status of their final objective metric, that this tuning job launched.</p>",
+        "HyperParameterTuningJobSummary$ObjectiveStatusCounters": "<p>The <a>ObjectiveStatusCounters</a> object that specifies the numbers of training jobs, categorized by objective metric status, that this tuning job launched.</p>"
       }
     },
     "OrderKey": {
@@ -1096,7 +1110,7 @@
     "ParameterRanges": {
       "base": "<p>Specifies ranges of integer, continuous, and categorical hyperparameters that a hyperparameter tuning job searches.</p>",
       "refs": {
-        "HyperParameterTuningJobConfig$ParameterRanges": "<p>The object that specifies the ranges of hyperparameters that this tuning job searches.</p>"
+        "HyperParameterTuningJobConfig$ParameterRanges": "<p>The <a>ParameterRanges</a> object that specifies the ranges of hyperparameters that this tuning job searches.</p>"
       }
     },
     "ParameterValue": {
@@ -1144,7 +1158,7 @@
     "ProductionVariantSummaryList": {
       "base": null,
       "refs": {
-        "DescribeEndpointOutput$ProductionVariants": "<p> An array of ProductionVariant objects, one for each model hosted behind this endpoint. </p>"
+        "DescribeEndpointOutput$ProductionVariants": "<p> An array of <a>ProductionVariantSummary</a> objects, one for each model hosted behind this endpoint. </p>"
       }
     },
     "RecordWrapper": {
@@ -1182,8 +1196,8 @@
     "ResourceLimits": {
       "base": "<p>Specifies the maximum number of training jobs and parallel training jobs that a hyperparameter tuning job can launch.</p>",
       "refs": {
-        "HyperParameterTuningJobConfig$ResourceLimits": "<p>The object that specifies the maximum number of training jobs and parallel training jobs for this tuning job.</p>",
-        "HyperParameterTuningJobSummary$ResourceLimits": "<p>The object that specifies the maximum number of training jobs and parallel training jobs allowed for this tuning job.</p>"
+        "HyperParameterTuningJobConfig$ResourceLimits": "<p>The <a>ResourceLimits</a> object that specifies the maximum number of training jobs and parallel training jobs for this tuning job.</p>",
+        "HyperParameterTuningJobSummary$ResourceLimits": "<p>The <a>ResourceLimits</a> object that specifies the maximum number of training jobs and parallel training jobs allowed for this tuning job.</p>"
       }
     },
     "ResourceNotFound": {
@@ -1363,6 +1377,7 @@
     "Timestamp": {
       "base": null,
       "refs": {
+        "DeployedImage$ResolutionTime": "<p>The date and time when the image path for the model resolved to the <code>ResolvedImage</code> </p>",
         "DescribeEndpointConfigOutput$CreationTime": "<p>A timestamp that shows when the endpoint configuration was created.</p>",
         "DescribeEndpointOutput$CreationTime": "<p>A timestamp that shows when the endpoint was created.</p>",
         "DescribeEndpointOutput$LastModifiedTime": "<p>A timestamp that shows when the endpoint was last modified.</p>",
@@ -1447,7 +1462,7 @@
     "TrainingJobSortByOptions": {
       "base": null,
       "refs": {
-        "ListTrainingJobsForHyperParameterTuningJobRequest$SortBy": "<p>The field to sort results by. The default is <code>Name</code>.</p>"
+        "ListTrainingJobsForHyperParameterTuningJobRequest$SortBy": "<p>The field to sort results by. The default is <code>Name</code>.</p> <p>If the value of this field is <code>FinalObjectiveMetricValue</code>, any training jobs that did not return an objective metric are not listed.</p>"
       }
     },
     "TrainingJobStatus": {
@@ -1473,8 +1488,8 @@
     "TrainingJobStatusCounters": {
       "base": "<p>The numbers of training jobs launched by a hyperparameter tuning job, categorized by status.</p>",
       "refs": {
-        "DescribeHyperParameterTuningJobResponse$TrainingJobStatusCounters": "<p>The object that specifies the number of training jobs, categorized by status, that this tuning job launched.</p>",
-        "HyperParameterTuningJobSummary$TrainingJobStatusCounters": "<p>The object that specifies the numbers of training jobs, categorized by status, that this tuning job launched.</p>"
+        "DescribeHyperParameterTuningJobResponse$TrainingJobStatusCounters": "<p>The <a>TrainingJobStatusCounters</a> object that specifies the number of training jobs, categorized by status, that this tuning job launched.</p>",
+        "HyperParameterTuningJobSummary$TrainingJobStatusCounters": "<p>The <a>TrainingJobStatusCounters</a> object that specifies the numbers of training jobs, categorized by status, that this tuning job launched.</p>"
       }
     },
     "TrainingJobSummaries": {
@@ -1532,7 +1547,7 @@
     "Url": {
       "base": null,
       "refs": {
-        "ContainerDefinition$ModelDataUrl": "<p>The S3 path where the model artifacts, which result from model training, are stored. This path must point to a single gzip compressed tar archive (.tar.gz suffix). </p>"
+        "ContainerDefinition$ModelDataUrl": "<p>The S3 path where the model artifacts, which result from model training, are stored. This path must point to a single gzip compressed tar archive (.tar.gz suffix). </p> <p>If you provide a value for this parameter, Amazon SageMaker uses AWS Security Token Service to download model artifacts from the S3 path you provide. AWS STS is activated in your IAM user account by default. If you previously deactivated AWS STS for a region, you need to reactivate AWS STS for that region. For more information, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and Deactivating AWS STS i an AWS Region</a> in the <i>AWS Identity and Access Management User Guide</i>.</p>"
       }
     },
     "VariantName": {
@@ -1561,11 +1576,11 @@
     "VpcConfig": {
       "base": "<p>Specifies a VPC that your training jobs and hosted models have access to. Control access to and from your training and model containers by configuring the VPC. For more information, see <a>host-vpc</a> and <a>train-vpc</a>.</p>",
       "refs": {
-        "CreateModelInput$VpcConfig": "<p>A object that specifies the VPC that you want your model to connect to. Control access to and from your model container by configuring the VPC. For more information, see <a>host-vpc</a>.</p>",
-        "CreateTrainingJobRequest$VpcConfig": "<p>A object that specifies the VPC that you want your training job to connect to. Control access to and from your training container by configuring the VPC. For more information, see <a>train-vpc</a> </p>",
-        "DescribeModelOutput$VpcConfig": "<p>A object that specifies the VPC that this model has access to. For more information, see <a>host-vpc</a> </p>",
-        "DescribeTrainingJobResponse$VpcConfig": "<p>A object that specifies the VPC that this training job has access to. For more information, see <a>train-vpc</a>.</p>",
-        "HyperParameterTrainingJobDefinition$VpcConfig": "<p>The object that specifies the VPC that you want the training jobs that this hyperparameter tuning job launches to connect to. Control access to and from your training container by configuring the VPC. For more information, see <a>train-vpc</a>.</p>"
+        "CreateModelInput$VpcConfig": "<p>A <a>VpcConfig</a> object that specifies the VPC that you want your model to connect to. Control access to and from your model container by configuring the VPC. For more information, see <a>host-vpc</a>.</p>",
+        "CreateTrainingJobRequest$VpcConfig": "<p>A <a>VpcConfig</a> object that specifies the VPC that you want your training job to connect to. Control access to and from your training container by configuring the VPC. For more information, see <a>train-vpc</a> </p>",
+        "DescribeModelOutput$VpcConfig": "<p>A <a>VpcConfig</a> object that specifies the VPC that this model has access to. For more information, see <a>host-vpc</a> </p>",
+        "DescribeTrainingJobResponse$VpcConfig": "<p>A <a>VpcConfig</a> object that specifies the VPC that this training job has access to. For more information, see <a>train-vpc</a>.</p>",
+        "HyperParameterTrainingJobDefinition$VpcConfig": "<p>The <a>VpcConfig</a> object that specifies the VPC that you want the training jobs that this hyperparameter tuning job launches to connect to. Control access to and from your training container by configuring the VPC. For more information, see <a>train-vpc</a>.</p>"
       }
     },
     "VpcSecurityGroupIds": {

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -63,16 +63,22 @@ func (c *Pinpoint) CreateAppRequest(input *CreateAppInput) (req *request.Request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateApp
 func (c *Pinpoint) CreateApp(input *CreateAppInput) (*CreateAppOutput, error) {
@@ -151,16 +157,22 @@ func (c *Pinpoint) CreateCampaignRequest(input *CreateCampaignInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateCampaign
 func (c *Pinpoint) CreateCampaign(input *CreateCampaignInput) (*CreateCampaignOutput, error) {
@@ -239,16 +251,22 @@ func (c *Pinpoint) CreateExportJobRequest(input *CreateExportJobInput) (req *req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateExportJob
 func (c *Pinpoint) CreateExportJob(input *CreateExportJobInput) (*CreateExportJobOutput, error) {
@@ -327,16 +345,22 @@ func (c *Pinpoint) CreateImportJobRequest(input *CreateImportJobInput) (req *req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateImportJob
 func (c *Pinpoint) CreateImportJob(input *CreateImportJobInput) (*CreateImportJobOutput, error) {
@@ -415,16 +439,22 @@ func (c *Pinpoint) CreateSegmentRequest(input *CreateSegmentInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/CreateSegment
 func (c *Pinpoint) CreateSegment(input *CreateSegmentInput) (*CreateSegmentOutput, error) {
@@ -492,7 +522,7 @@ func (c *Pinpoint) DeleteAdmChannelRequest(input *DeleteAdmChannelInput) (req *r
 
 // DeleteAdmChannel API operation for Amazon Pinpoint.
 //
-// Delete an ADM channel
+// Delete an ADM channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -503,16 +533,22 @@ func (c *Pinpoint) DeleteAdmChannelRequest(input *DeleteAdmChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteAdmChannel
 func (c *Pinpoint) DeleteAdmChannel(input *DeleteAdmChannelInput) (*DeleteAdmChannelOutput, error) {
@@ -591,16 +627,22 @@ func (c *Pinpoint) DeleteApnsChannelRequest(input *DeleteApnsChannelInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsChannel
 func (c *Pinpoint) DeleteApnsChannel(input *DeleteApnsChannelInput) (*DeleteApnsChannelOutput, error) {
@@ -668,7 +710,7 @@ func (c *Pinpoint) DeleteApnsSandboxChannelRequest(input *DeleteApnsSandboxChann
 
 // DeleteApnsSandboxChannel API operation for Amazon Pinpoint.
 //
-// Delete an APNS sandbox channel
+// Delete an APNS sandbox channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -679,16 +721,22 @@ func (c *Pinpoint) DeleteApnsSandboxChannelRequest(input *DeleteApnsSandboxChann
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsSandboxChannel
 func (c *Pinpoint) DeleteApnsSandboxChannel(input *DeleteApnsSandboxChannelInput) (*DeleteApnsSandboxChannelOutput, error) {
@@ -767,16 +815,22 @@ func (c *Pinpoint) DeleteApnsVoipChannelRequest(input *DeleteApnsVoipChannelInpu
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipChannel
 func (c *Pinpoint) DeleteApnsVoipChannel(input *DeleteApnsVoipChannelInput) (*DeleteApnsVoipChannelOutput, error) {
@@ -855,16 +909,22 @@ func (c *Pinpoint) DeleteApnsVoipSandboxChannelRequest(input *DeleteApnsVoipSand
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApnsVoipSandboxChannel
 func (c *Pinpoint) DeleteApnsVoipSandboxChannel(input *DeleteApnsVoipSandboxChannelInput) (*DeleteApnsVoipSandboxChannelOutput, error) {
@@ -943,16 +1003,22 @@ func (c *Pinpoint) DeleteAppRequest(input *DeleteAppInput) (req *request.Request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteApp
 func (c *Pinpoint) DeleteApp(input *DeleteAppInput) (*DeleteAppOutput, error) {
@@ -1031,16 +1097,22 @@ func (c *Pinpoint) DeleteBaiduChannelRequest(input *DeleteBaiduChannelInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteBaiduChannel
 func (c *Pinpoint) DeleteBaiduChannel(input *DeleteBaiduChannelInput) (*DeleteBaiduChannelOutput, error) {
@@ -1119,16 +1191,22 @@ func (c *Pinpoint) DeleteCampaignRequest(input *DeleteCampaignInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteCampaign
 func (c *Pinpoint) DeleteCampaign(input *DeleteCampaignInput) (*DeleteCampaignOutput, error) {
@@ -1196,7 +1274,7 @@ func (c *Pinpoint) DeleteEmailChannelRequest(input *DeleteEmailChannelInput) (re
 
 // DeleteEmailChannel API operation for Amazon Pinpoint.
 //
-// Delete an email channel
+// Delete an email channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1207,16 +1285,22 @@ func (c *Pinpoint) DeleteEmailChannelRequest(input *DeleteEmailChannelInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEmailChannel
 func (c *Pinpoint) DeleteEmailChannel(input *DeleteEmailChannelInput) (*DeleteEmailChannelOutput, error) {
@@ -1295,16 +1379,22 @@ func (c *Pinpoint) DeleteEndpointRequest(input *DeleteEndpointInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEndpoint
 func (c *Pinpoint) DeleteEndpoint(input *DeleteEndpointInput) (*DeleteEndpointOutput, error) {
@@ -1383,16 +1473,22 @@ func (c *Pinpoint) DeleteEventStreamRequest(input *DeleteEventStreamInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteEventStream
 func (c *Pinpoint) DeleteEventStream(input *DeleteEventStreamInput) (*DeleteEventStreamOutput, error) {
@@ -1471,16 +1567,22 @@ func (c *Pinpoint) DeleteGcmChannelRequest(input *DeleteGcmChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteGcmChannel
 func (c *Pinpoint) DeleteGcmChannel(input *DeleteGcmChannelInput) (*DeleteGcmChannelOutput, error) {
@@ -1559,16 +1661,22 @@ func (c *Pinpoint) DeleteSegmentRequest(input *DeleteSegmentInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSegment
 func (c *Pinpoint) DeleteSegment(input *DeleteSegmentInput) (*DeleteSegmentOutput, error) {
@@ -1636,7 +1744,7 @@ func (c *Pinpoint) DeleteSmsChannelRequest(input *DeleteSmsChannelInput) (req *r
 
 // DeleteSmsChannel API operation for Amazon Pinpoint.
 //
-// Delete an SMS channel
+// Delete an SMS channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1647,16 +1755,22 @@ func (c *Pinpoint) DeleteSmsChannelRequest(input *DeleteSmsChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteSmsChannel
 func (c *Pinpoint) DeleteSmsChannel(input *DeleteSmsChannelInput) (*DeleteSmsChannelOutput, error) {
@@ -1675,6 +1789,100 @@ func (c *Pinpoint) DeleteSmsChannel(input *DeleteSmsChannelInput) (*DeleteSmsCha
 // for more information on using Contexts.
 func (c *Pinpoint) DeleteSmsChannelWithContext(ctx aws.Context, input *DeleteSmsChannelInput, opts ...request.Option) (*DeleteSmsChannelOutput, error) {
 	req, out := c.DeleteSmsChannelRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteUserEndpoints = "DeleteUserEndpoints"
+
+// DeleteUserEndpointsRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteUserEndpoints operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteUserEndpoints for more information on using the DeleteUserEndpoints
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteUserEndpointsRequest method.
+//    req, resp := client.DeleteUserEndpointsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteUserEndpoints
+func (c *Pinpoint) DeleteUserEndpointsRequest(input *DeleteUserEndpointsInput) (req *request.Request, output *DeleteUserEndpointsOutput) {
+	op := &request.Operation{
+		Name:       opDeleteUserEndpoints,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/v1/apps/{application-id}/users/{user-id}",
+	}
+
+	if input == nil {
+		input = &DeleteUserEndpointsInput{}
+	}
+
+	output = &DeleteUserEndpointsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteUserEndpoints API operation for Amazon Pinpoint.
+//
+// Deletes endpoints associated with an user id.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Pinpoint's
+// API operation DeleteUserEndpoints for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
+//
+//   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/DeleteUserEndpoints
+func (c *Pinpoint) DeleteUserEndpoints(input *DeleteUserEndpointsInput) (*DeleteUserEndpointsOutput, error) {
+	req, out := c.DeleteUserEndpointsRequest(input)
+	return out, req.Send()
+}
+
+// DeleteUserEndpointsWithContext is the same as DeleteUserEndpoints with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteUserEndpoints for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Pinpoint) DeleteUserEndpointsWithContext(ctx aws.Context, input *DeleteUserEndpointsInput, opts ...request.Option) (*DeleteUserEndpointsOutput, error) {
+	req, out := c.DeleteUserEndpointsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1724,7 +1932,7 @@ func (c *Pinpoint) GetAdmChannelRequest(input *GetAdmChannelInput) (req *request
 
 // GetAdmChannel API operation for Amazon Pinpoint.
 //
-// Get an ADM channel
+// Get an ADM channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1735,16 +1943,22 @@ func (c *Pinpoint) GetAdmChannelRequest(input *GetAdmChannelInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetAdmChannel
 func (c *Pinpoint) GetAdmChannel(input *GetAdmChannelInput) (*GetAdmChannelOutput, error) {
@@ -1823,16 +2037,22 @@ func (c *Pinpoint) GetApnsChannelRequest(input *GetApnsChannelInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsChannel
 func (c *Pinpoint) GetApnsChannel(input *GetApnsChannelInput) (*GetApnsChannelOutput, error) {
@@ -1900,7 +2120,7 @@ func (c *Pinpoint) GetApnsSandboxChannelRequest(input *GetApnsSandboxChannelInpu
 
 // GetApnsSandboxChannel API operation for Amazon Pinpoint.
 //
-// Get an APNS sandbox channel
+// Get an APNS sandbox channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1911,16 +2131,22 @@ func (c *Pinpoint) GetApnsSandboxChannelRequest(input *GetApnsSandboxChannelInpu
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsSandboxChannel
 func (c *Pinpoint) GetApnsSandboxChannel(input *GetApnsSandboxChannelInput) (*GetApnsSandboxChannelOutput, error) {
@@ -1999,16 +2225,22 @@ func (c *Pinpoint) GetApnsVoipChannelRequest(input *GetApnsVoipChannelInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipChannel
 func (c *Pinpoint) GetApnsVoipChannel(input *GetApnsVoipChannelInput) (*GetApnsVoipChannelOutput, error) {
@@ -2087,16 +2319,22 @@ func (c *Pinpoint) GetApnsVoipSandboxChannelRequest(input *GetApnsVoipSandboxCha
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApnsVoipSandboxChannel
 func (c *Pinpoint) GetApnsVoipSandboxChannel(input *GetApnsVoipSandboxChannelInput) (*GetApnsVoipSandboxChannelOutput, error) {
@@ -2175,16 +2413,22 @@ func (c *Pinpoint) GetAppRequest(input *GetAppInput) (req *request.Request, outp
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApp
 func (c *Pinpoint) GetApp(input *GetAppInput) (*GetAppOutput, error) {
@@ -2263,16 +2507,22 @@ func (c *Pinpoint) GetApplicationSettingsRequest(input *GetApplicationSettingsIn
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApplicationSettings
 func (c *Pinpoint) GetApplicationSettings(input *GetApplicationSettingsInput) (*GetApplicationSettingsOutput, error) {
@@ -2351,16 +2601,22 @@ func (c *Pinpoint) GetAppsRequest(input *GetAppsInput) (req *request.Request, ou
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetApps
 func (c *Pinpoint) GetApps(input *GetAppsInput) (*GetAppsOutput, error) {
@@ -2439,16 +2695,22 @@ func (c *Pinpoint) GetBaiduChannelRequest(input *GetBaiduChannelInput) (req *req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetBaiduChannel
 func (c *Pinpoint) GetBaiduChannel(input *GetBaiduChannelInput) (*GetBaiduChannelOutput, error) {
@@ -2527,16 +2789,22 @@ func (c *Pinpoint) GetCampaignRequest(input *GetCampaignInput) (req *request.Req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaign
 func (c *Pinpoint) GetCampaign(input *GetCampaignInput) (*GetCampaignOutput, error) {
@@ -2615,16 +2883,22 @@ func (c *Pinpoint) GetCampaignActivitiesRequest(input *GetCampaignActivitiesInpu
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignActivities
 func (c *Pinpoint) GetCampaignActivities(input *GetCampaignActivitiesInput) (*GetCampaignActivitiesOutput, error) {
@@ -2703,16 +2977,22 @@ func (c *Pinpoint) GetCampaignVersionRequest(input *GetCampaignVersionInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersion
 func (c *Pinpoint) GetCampaignVersion(input *GetCampaignVersionInput) (*GetCampaignVersionOutput, error) {
@@ -2791,16 +3071,22 @@ func (c *Pinpoint) GetCampaignVersionsRequest(input *GetCampaignVersionsInput) (
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaignVersions
 func (c *Pinpoint) GetCampaignVersions(input *GetCampaignVersionsInput) (*GetCampaignVersionsOutput, error) {
@@ -2879,16 +3165,22 @@ func (c *Pinpoint) GetCampaignsRequest(input *GetCampaignsInput) (req *request.R
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetCampaigns
 func (c *Pinpoint) GetCampaigns(input *GetCampaignsInput) (*GetCampaignsOutput, error) {
@@ -2907,6 +3199,100 @@ func (c *Pinpoint) GetCampaigns(input *GetCampaignsInput) (*GetCampaignsOutput, 
 // for more information on using Contexts.
 func (c *Pinpoint) GetCampaignsWithContext(ctx aws.Context, input *GetCampaignsInput, opts ...request.Option) (*GetCampaignsOutput, error) {
 	req, out := c.GetCampaignsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetChannels = "GetChannels"
+
+// GetChannelsRequest generates a "aws/request.Request" representing the
+// client's request for the GetChannels operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetChannels for more information on using the GetChannels
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetChannelsRequest method.
+//    req, resp := client.GetChannelsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetChannels
+func (c *Pinpoint) GetChannelsRequest(input *GetChannelsInput) (req *request.Request, output *GetChannelsOutput) {
+	op := &request.Operation{
+		Name:       opGetChannels,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v1/apps/{application-id}/channels",
+	}
+
+	if input == nil {
+		input = &GetChannelsInput{}
+	}
+
+	output = &GetChannelsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetChannels API operation for Amazon Pinpoint.
+//
+// Get all channels.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Pinpoint's
+// API operation GetChannels for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
+//
+//   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetChannels
+func (c *Pinpoint) GetChannels(input *GetChannelsInput) (*GetChannelsOutput, error) {
+	req, out := c.GetChannelsRequest(input)
+	return out, req.Send()
+}
+
+// GetChannelsWithContext is the same as GetChannels with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetChannels for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Pinpoint) GetChannelsWithContext(ctx aws.Context, input *GetChannelsInput, opts ...request.Option) (*GetChannelsOutput, error) {
+	req, out := c.GetChannelsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2956,7 +3342,7 @@ func (c *Pinpoint) GetEmailChannelRequest(input *GetEmailChannelInput) (req *req
 
 // GetEmailChannel API operation for Amazon Pinpoint.
 //
-// Get an email channel
+// Get an email channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2967,16 +3353,22 @@ func (c *Pinpoint) GetEmailChannelRequest(input *GetEmailChannelInput) (req *req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEmailChannel
 func (c *Pinpoint) GetEmailChannel(input *GetEmailChannelInput) (*GetEmailChannelOutput, error) {
@@ -3055,16 +3447,22 @@ func (c *Pinpoint) GetEndpointRequest(input *GetEndpointInput) (req *request.Req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEndpoint
 func (c *Pinpoint) GetEndpoint(input *GetEndpointInput) (*GetEndpointOutput, error) {
@@ -3143,16 +3541,22 @@ func (c *Pinpoint) GetEventStreamRequest(input *GetEventStreamInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetEventStream
 func (c *Pinpoint) GetEventStream(input *GetEventStreamInput) (*GetEventStreamOutput, error) {
@@ -3231,16 +3635,22 @@ func (c *Pinpoint) GetExportJobRequest(input *GetExportJobInput) (req *request.R
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetExportJob
 func (c *Pinpoint) GetExportJob(input *GetExportJobInput) (*GetExportJobOutput, error) {
@@ -3319,16 +3729,22 @@ func (c *Pinpoint) GetExportJobsRequest(input *GetExportJobsInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetExportJobs
 func (c *Pinpoint) GetExportJobs(input *GetExportJobsInput) (*GetExportJobsOutput, error) {
@@ -3407,16 +3823,22 @@ func (c *Pinpoint) GetGcmChannelRequest(input *GetGcmChannelInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetGcmChannel
 func (c *Pinpoint) GetGcmChannel(input *GetGcmChannelInput) (*GetGcmChannelOutput, error) {
@@ -3495,16 +3917,22 @@ func (c *Pinpoint) GetImportJobRequest(input *GetImportJobInput) (req *request.R
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJob
 func (c *Pinpoint) GetImportJob(input *GetImportJobInput) (*GetImportJobOutput, error) {
@@ -3583,16 +4011,22 @@ func (c *Pinpoint) GetImportJobsRequest(input *GetImportJobsInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetImportJobs
 func (c *Pinpoint) GetImportJobs(input *GetImportJobsInput) (*GetImportJobsOutput, error) {
@@ -3671,16 +4105,22 @@ func (c *Pinpoint) GetSegmentRequest(input *GetSegmentInput) (req *request.Reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegment
 func (c *Pinpoint) GetSegment(input *GetSegmentInput) (*GetSegmentOutput, error) {
@@ -3759,16 +4199,22 @@ func (c *Pinpoint) GetSegmentExportJobsRequest(input *GetSegmentExportJobsInput)
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentExportJobs
 func (c *Pinpoint) GetSegmentExportJobs(input *GetSegmentExportJobsInput) (*GetSegmentExportJobsOutput, error) {
@@ -3847,16 +4293,22 @@ func (c *Pinpoint) GetSegmentImportJobsRequest(input *GetSegmentImportJobsInput)
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentImportJobs
 func (c *Pinpoint) GetSegmentImportJobs(input *GetSegmentImportJobsInput) (*GetSegmentImportJobsOutput, error) {
@@ -3935,16 +4387,22 @@ func (c *Pinpoint) GetSegmentVersionRequest(input *GetSegmentVersionInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersion
 func (c *Pinpoint) GetSegmentVersion(input *GetSegmentVersionInput) (*GetSegmentVersionOutput, error) {
@@ -4023,16 +4481,22 @@ func (c *Pinpoint) GetSegmentVersionsRequest(input *GetSegmentVersionsInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegmentVersions
 func (c *Pinpoint) GetSegmentVersions(input *GetSegmentVersionsInput) (*GetSegmentVersionsOutput, error) {
@@ -4111,16 +4575,22 @@ func (c *Pinpoint) GetSegmentsRequest(input *GetSegmentsInput) (req *request.Req
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSegments
 func (c *Pinpoint) GetSegments(input *GetSegmentsInput) (*GetSegmentsOutput, error) {
@@ -4188,7 +4658,7 @@ func (c *Pinpoint) GetSmsChannelRequest(input *GetSmsChannelInput) (req *request
 
 // GetSmsChannel API operation for Amazon Pinpoint.
 //
-// Get an SMS channel
+// Get an SMS channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4199,16 +4669,22 @@ func (c *Pinpoint) GetSmsChannelRequest(input *GetSmsChannelInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetSmsChannel
 func (c *Pinpoint) GetSmsChannel(input *GetSmsChannelInput) (*GetSmsChannelOutput, error) {
@@ -4227,6 +4703,194 @@ func (c *Pinpoint) GetSmsChannel(input *GetSmsChannelInput) (*GetSmsChannelOutpu
 // for more information on using Contexts.
 func (c *Pinpoint) GetSmsChannelWithContext(ctx aws.Context, input *GetSmsChannelInput, opts ...request.Option) (*GetSmsChannelOutput, error) {
 	req, out := c.GetSmsChannelRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetUserEndpoints = "GetUserEndpoints"
+
+// GetUserEndpointsRequest generates a "aws/request.Request" representing the
+// client's request for the GetUserEndpoints operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetUserEndpoints for more information on using the GetUserEndpoints
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetUserEndpointsRequest method.
+//    req, resp := client.GetUserEndpointsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetUserEndpoints
+func (c *Pinpoint) GetUserEndpointsRequest(input *GetUserEndpointsInput) (req *request.Request, output *GetUserEndpointsOutput) {
+	op := &request.Operation{
+		Name:       opGetUserEndpoints,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v1/apps/{application-id}/users/{user-id}",
+	}
+
+	if input == nil {
+		input = &GetUserEndpointsInput{}
+	}
+
+	output = &GetUserEndpointsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetUserEndpoints API operation for Amazon Pinpoint.
+//
+// Returns information about the endpoints associated with an user id.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Pinpoint's
+// API operation GetUserEndpoints for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
+//
+//   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/GetUserEndpoints
+func (c *Pinpoint) GetUserEndpoints(input *GetUserEndpointsInput) (*GetUserEndpointsOutput, error) {
+	req, out := c.GetUserEndpointsRequest(input)
+	return out, req.Send()
+}
+
+// GetUserEndpointsWithContext is the same as GetUserEndpoints with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetUserEndpoints for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Pinpoint) GetUserEndpointsWithContext(ctx aws.Context, input *GetUserEndpointsInput, opts ...request.Option) (*GetUserEndpointsOutput, error) {
+	req, out := c.GetUserEndpointsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPhoneNumberValidate = "PhoneNumberValidate"
+
+// PhoneNumberValidateRequest generates a "aws/request.Request" representing the
+// client's request for the PhoneNumberValidate operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PhoneNumberValidate for more information on using the PhoneNumberValidate
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PhoneNumberValidateRequest method.
+//    req, resp := client.PhoneNumberValidateRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/PhoneNumberValidate
+func (c *Pinpoint) PhoneNumberValidateRequest(input *PhoneNumberValidateInput) (req *request.Request, output *PhoneNumberValidateOutput) {
+	op := &request.Operation{
+		Name:       opPhoneNumberValidate,
+		HTTPMethod: "POST",
+		HTTPPath:   "/v1/phone/number/validate",
+	}
+
+	if input == nil {
+		input = &PhoneNumberValidateInput{}
+	}
+
+	output = &PhoneNumberValidateOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PhoneNumberValidate API operation for Amazon Pinpoint.
+//
+// Returns information about the specified phone number.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Pinpoint's
+// API operation PhoneNumberValidate for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
+//
+//   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/PhoneNumberValidate
+func (c *Pinpoint) PhoneNumberValidate(input *PhoneNumberValidateInput) (*PhoneNumberValidateOutput, error) {
+	req, out := c.PhoneNumberValidateRequest(input)
+	return out, req.Send()
+}
+
+// PhoneNumberValidateWithContext is the same as PhoneNumberValidate with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PhoneNumberValidate for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Pinpoint) PhoneNumberValidateWithContext(ctx aws.Context, input *PhoneNumberValidateInput, opts ...request.Option) (*PhoneNumberValidateOutput, error) {
+	req, out := c.PhoneNumberValidateRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4287,16 +4951,22 @@ func (c *Pinpoint) PutEventStreamRequest(input *PutEventStreamInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/PutEventStream
 func (c *Pinpoint) PutEventStream(input *PutEventStreamInput) (*PutEventStreamOutput, error) {
@@ -4315,6 +4985,100 @@ func (c *Pinpoint) PutEventStream(input *PutEventStreamInput) (*PutEventStreamOu
 // for more information on using Contexts.
 func (c *Pinpoint) PutEventStreamWithContext(ctx aws.Context, input *PutEventStreamInput, opts ...request.Option) (*PutEventStreamOutput, error) {
 	req, out := c.PutEventStreamRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRemoveAttributes = "RemoveAttributes"
+
+// RemoveAttributesRequest generates a "aws/request.Request" representing the
+// client's request for the RemoveAttributes operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RemoveAttributes for more information on using the RemoveAttributes
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RemoveAttributesRequest method.
+//    req, resp := client.RemoveAttributesRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/RemoveAttributes
+func (c *Pinpoint) RemoveAttributesRequest(input *RemoveAttributesInput) (req *request.Request, output *RemoveAttributesOutput) {
+	op := &request.Operation{
+		Name:       opRemoveAttributes,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/v1/apps/{application-id}/attributes/{attribute-type}",
+	}
+
+	if input == nil {
+		input = &RemoveAttributesInput{}
+	}
+
+	output = &RemoveAttributesOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RemoveAttributes API operation for Amazon Pinpoint.
+//
+// Used to remove the attributes for an app
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Pinpoint's
+// API operation RemoveAttributes for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
+//
+//   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/RemoveAttributes
+func (c *Pinpoint) RemoveAttributes(input *RemoveAttributesInput) (*RemoveAttributesOutput, error) {
+	req, out := c.RemoveAttributesRequest(input)
+	return out, req.Send()
+}
+
+// RemoveAttributesWithContext is the same as RemoveAttributes with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RemoveAttributes for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Pinpoint) RemoveAttributesWithContext(ctx aws.Context, input *RemoveAttributesInput, opts ...request.Option) (*RemoveAttributesOutput, error) {
+	req, out := c.RemoveAttributesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -4364,7 +5128,14 @@ func (c *Pinpoint) SendMessagesRequest(input *SendMessagesInput) (req *request.R
 
 // SendMessages API operation for Amazon Pinpoint.
 //
-// Send a batch of messages
+// Use this resource to send a direct message, which is a one time message that
+// you send to a limited audience without creating a campaign. You can send
+// the message to up to 100 recipients. You cannot use the message to engage
+// a segment. When you send the message, Amazon Pinpoint delivers it immediately,
+// and you cannot schedule the delivery. To engage a user segment, and to schedule
+// the message delivery, create a campaign instead of sending a direct message.You
+// can send a direct message as a push notification to your mobile app or as
+// an SMS message to SMS-enabled devices.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4375,16 +5146,22 @@ func (c *Pinpoint) SendMessagesRequest(input *SendMessagesInput) (req *request.R
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendMessages
 func (c *Pinpoint) SendMessages(input *SendMessagesInput) (*SendMessagesOutput, error) {
@@ -4452,7 +5229,22 @@ func (c *Pinpoint) SendUsersMessagesRequest(input *SendUsersMessagesInput) (req 
 
 // SendUsersMessages API operation for Amazon Pinpoint.
 //
-// Send a batch of messages to users
+// Use this resource to message a list of users. Amazon Pinpoint sends the message
+// to all of the endpoints that are associated with each user.A user represents
+// an individual who is assigned a unique user ID, and this ID is assigned to
+// one or more endpoints. For example, if an individual uses your app on multiple
+// devices, your app could assign that person's user ID to the endpoint for
+// each device.With the users-messages resource, you specify the message recipients
+// as user IDs. For each user ID, Amazon Pinpoint delivers the message to all
+// of the user's endpoints. Within the body of your request, you can specify
+// a default message, and you can tailor your message for different channels,
+// including those for mobile push and SMS.With this resource, you send a direct
+// message, which is a one time message that you send to a limited audience
+// without creating a campaign. You can send the message to up to 100 users
+// per request. You cannot use the message to engage a segment. When you send
+// the message, Amazon Pinpoint delivers it immediately, and you cannot schedule
+// the delivery. To engage a user segment, and to schedule the message delivery,
+// create a campaign instead of using the users-messages resource.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4463,16 +5255,22 @@ func (c *Pinpoint) SendUsersMessagesRequest(input *SendUsersMessagesInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/SendUsersMessages
 func (c *Pinpoint) SendUsersMessages(input *SendUsersMessagesInput) (*SendUsersMessagesOutput, error) {
@@ -4540,7 +5338,7 @@ func (c *Pinpoint) UpdateAdmChannelRequest(input *UpdateAdmChannelInput) (req *r
 
 // UpdateAdmChannel API operation for Amazon Pinpoint.
 //
-// Update an ADM channel
+// Update an ADM channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4551,16 +5349,22 @@ func (c *Pinpoint) UpdateAdmChannelRequest(input *UpdateAdmChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateAdmChannel
 func (c *Pinpoint) UpdateAdmChannel(input *UpdateAdmChannelInput) (*UpdateAdmChannelOutput, error) {
@@ -4639,16 +5443,22 @@ func (c *Pinpoint) UpdateApnsChannelRequest(input *UpdateApnsChannelInput) (req 
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsChannel
 func (c *Pinpoint) UpdateApnsChannel(input *UpdateApnsChannelInput) (*UpdateApnsChannelOutput, error) {
@@ -4716,7 +5526,7 @@ func (c *Pinpoint) UpdateApnsSandboxChannelRequest(input *UpdateApnsSandboxChann
 
 // UpdateApnsSandboxChannel API operation for Amazon Pinpoint.
 //
-// Update an APNS sandbox channel
+// Update an APNS sandbox channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4727,16 +5537,22 @@ func (c *Pinpoint) UpdateApnsSandboxChannelRequest(input *UpdateApnsSandboxChann
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsSandboxChannel
 func (c *Pinpoint) UpdateApnsSandboxChannel(input *UpdateApnsSandboxChannelInput) (*UpdateApnsSandboxChannelOutput, error) {
@@ -4815,16 +5631,22 @@ func (c *Pinpoint) UpdateApnsVoipChannelRequest(input *UpdateApnsVoipChannelInpu
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipChannel
 func (c *Pinpoint) UpdateApnsVoipChannel(input *UpdateApnsVoipChannelInput) (*UpdateApnsVoipChannelOutput, error) {
@@ -4903,16 +5725,22 @@ func (c *Pinpoint) UpdateApnsVoipSandboxChannelRequest(input *UpdateApnsVoipSand
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApnsVoipSandboxChannel
 func (c *Pinpoint) UpdateApnsVoipSandboxChannel(input *UpdateApnsVoipSandboxChannelInput) (*UpdateApnsVoipSandboxChannelOutput, error) {
@@ -4991,16 +5819,22 @@ func (c *Pinpoint) UpdateApplicationSettingsRequest(input *UpdateApplicationSett
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateApplicationSettings
 func (c *Pinpoint) UpdateApplicationSettings(input *UpdateApplicationSettingsInput) (*UpdateApplicationSettingsOutput, error) {
@@ -5079,16 +5913,22 @@ func (c *Pinpoint) UpdateBaiduChannelRequest(input *UpdateBaiduChannelInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateBaiduChannel
 func (c *Pinpoint) UpdateBaiduChannel(input *UpdateBaiduChannelInput) (*UpdateBaiduChannelOutput, error) {
@@ -5167,16 +6007,22 @@ func (c *Pinpoint) UpdateCampaignRequest(input *UpdateCampaignInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateCampaign
 func (c *Pinpoint) UpdateCampaign(input *UpdateCampaignInput) (*UpdateCampaignOutput, error) {
@@ -5244,7 +6090,7 @@ func (c *Pinpoint) UpdateEmailChannelRequest(input *UpdateEmailChannelInput) (re
 
 // UpdateEmailChannel API operation for Amazon Pinpoint.
 //
-// Update an email channel
+// Update an email channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5255,16 +6101,22 @@ func (c *Pinpoint) UpdateEmailChannelRequest(input *UpdateEmailChannelInput) (re
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEmailChannel
 func (c *Pinpoint) UpdateEmailChannel(input *UpdateEmailChannelInput) (*UpdateEmailChannelOutput, error) {
@@ -5332,7 +6184,7 @@ func (c *Pinpoint) UpdateEndpointRequest(input *UpdateEndpointInput) (req *reque
 
 // UpdateEndpoint API operation for Amazon Pinpoint.
 //
-// Use to update an endpoint.
+// Creates or updates an endpoint.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5343,16 +6195,22 @@ func (c *Pinpoint) UpdateEndpointRequest(input *UpdateEndpointInput) (req *reque
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpoint
 func (c *Pinpoint) UpdateEndpoint(input *UpdateEndpointInput) (*UpdateEndpointOutput, error) {
@@ -5431,16 +6289,22 @@ func (c *Pinpoint) UpdateEndpointsBatchRequest(input *UpdateEndpointsBatchInput)
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateEndpointsBatch
 func (c *Pinpoint) UpdateEndpointsBatch(input *UpdateEndpointsBatchInput) (*UpdateEndpointsBatchOutput, error) {
@@ -5519,16 +6383,22 @@ func (c *Pinpoint) UpdateGcmChannelRequest(input *UpdateGcmChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateGcmChannel
 func (c *Pinpoint) UpdateGcmChannel(input *UpdateGcmChannelInput) (*UpdateGcmChannelOutput, error) {
@@ -5607,16 +6477,22 @@ func (c *Pinpoint) UpdateSegmentRequest(input *UpdateSegmentInput) (req *request
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSegment
 func (c *Pinpoint) UpdateSegment(input *UpdateSegmentInput) (*UpdateSegmentOutput, error) {
@@ -5684,7 +6560,7 @@ func (c *Pinpoint) UpdateSmsChannelRequest(input *UpdateSmsChannelInput) (req *r
 
 // UpdateSmsChannel API operation for Amazon Pinpoint.
 //
-// Update an SMS channel
+// Update an SMS channel.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5695,16 +6571,22 @@ func (c *Pinpoint) UpdateSmsChannelRequest(input *UpdateSmsChannelInput) (req *r
 //
 // Returned Error Codes:
 //   * ErrCodeBadRequestException "BadRequestException"
+//   Simple message object.
 //
 //   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//   Simple message object.
 //
 //   * ErrCodeForbiddenException "ForbiddenException"
+//   Simple message object.
 //
 //   * ErrCodeNotFoundException "NotFoundException"
+//   Simple message object.
 //
 //   * ErrCodeMethodNotAllowedException "MethodNotAllowedException"
+//   Simple message object.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//   Simple message object.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/pinpoint-2016-12-01/UpdateSmsChannel
 func (c *Pinpoint) UpdateSmsChannel(input *UpdateSmsChannelInput) (*UpdateSmsChannelOutput, error) {
@@ -5783,9 +6665,7 @@ type ADMChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// Indicates whether the channel is configured with ADM credentials. Amazon
-	// Pinpoint uses your credentials to authenticate push notifications with ADM.
-	// Provide your credentials by setting the ClientId and ClientSecret attributes.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Channel ID. Not used, only for backwards compatibility.
@@ -5938,6 +6818,7 @@ type ADMMessage struct {
 	// sound files must reside in /res/raw/
 	Sound *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// The message title that displays above the message on the user's device.
@@ -6157,11 +7038,7 @@ type APNSChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// Indicates whether the channel is configured with APNs credentials. Amazon
-	// Pinpoint uses your credentials to authenticate push notifications with APNs.
-	// To use APNs token authentication, set the BundleId, TeamId, TokenKey, and
-	// TokenKeyId attributes. To use certificate authentication, set the Certificate
-	// and PrivateKey attributes.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Indicates whether the channel is configured with a key for APNs token authentication.
@@ -6337,6 +7214,7 @@ type APNSMessage struct {
 	// if you specify defaultfor the value, the system plays the default alert sound.
 	Sound *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// Provide this key with a string value that represents the app-specific identifier
@@ -6573,11 +7451,7 @@ type APNSSandboxChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// Indicates whether the channel is configured with APNs credentials. Amazon
-	// Pinpoint uses your credentials to authenticate push notifications with APNs.
-	// To use APNs token authentication, set the BundleId, TeamId, TokenKey, and
-	// TokenKeyId attributes. To use certificate authentication, set the Certificate
-	// and PrivateKey attributes.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Indicates whether the channel is configured with a key for APNs token authentication.
@@ -6788,7 +7662,7 @@ type APNSVoipChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// If the channel is registered with a credential for authentication.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// If the channel is registered with a token key for authentication.
@@ -6998,7 +7872,7 @@ type APNSVoipSandboxChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// If the channel is registered with a credential for authentication.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// If the channel is registered with a token key for authentication.
@@ -7284,6 +8158,9 @@ type AddressConfiguration struct {
 	// the message.
 	RawContent *string `type:"string"`
 
+	// A map of substitution values for the message to be merged with the DefaultMessage's
+	// substitutions. Substitutions on this map take precedence over the all other
+	// substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// Title override. If specified will override default title if applicable.
@@ -7476,6 +8353,9 @@ type AttributeDimension struct {
 	// from the segment.
 	AttributeType *string `type:"string" enum:"AttributeType"`
 
+	// The criteria values for the segment dimension. Endpoints with matching attribute
+	// values are included or excluded from the segment, depending on the setting
+	// for Type.
 	Values []*string `type:"list"`
 }
 
@@ -7498,6 +8378,48 @@ func (s *AttributeDimension) SetAttributeType(v string) *AttributeDimension {
 // SetValues sets the Values field's value.
 func (s *AttributeDimension) SetValues(v []*string) *AttributeDimension {
 	s.Values = v
+	return s
+}
+
+// Attributes.
+type AttributesResource struct {
+	_ struct{} `type:"structure"`
+
+	// The unique ID for the application.
+	ApplicationId *string `type:"string"`
+
+	// The attribute type for the application.
+	AttributeType *string `type:"string"`
+
+	// The attributes for the application.
+	Attributes []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s AttributesResource) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AttributesResource) GoString() string {
+	return s.String()
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *AttributesResource) SetApplicationId(v string) *AttributesResource {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetAttributeType sets the AttributeType field's value.
+func (s *AttributesResource) SetAttributeType(v string) *AttributesResource {
+	s.AttributeType = &v
+	return s
+}
+
+// SetAttributes sets the Attributes field's value.
+func (s *AttributesResource) SetAttributes(v []*string) *AttributesResource {
+	s.Attributes = v
 	return s
 }
 
@@ -7559,10 +8481,7 @@ type BaiduChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// Indicates whether the channel is configured with Baidu Cloud Push credentials.
-	// Amazon Pinpoint uses your credentials to authenticate push notifications
-	// with Baidu Cloud Push. Provide your credentials by setting the ApiKey and
-	// SecretKey attributes.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Channel ID. Not used, only for backwards compatibility.
@@ -7708,7 +8627,13 @@ type BaiduMessage struct {
 	// sound files must reside in /res/raw/
 	Sound *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
+
+	// This parameter specifies how long (in seconds) the message should be kept
+	// in Baidu storage if the device is offline. The and the default value and
+	// the maximum time to live supported is 7 days (604800 seconds)
+	TimeToLive *int64 `type:"integer"`
 
 	// The message title that displays above the message on the user's device.
 	Title *string `type:"string"`
@@ -7794,6 +8719,12 @@ func (s *BaiduMessage) SetSubstitutions(v map[string][]*string) *BaiduMessage {
 	return s
 }
 
+// SetTimeToLive sets the TimeToLive field's value.
+func (s *BaiduMessage) SetTimeToLive(v int64) *BaiduMessage {
+	s.TimeToLive = &v
+	return s
+}
+
 // SetTitle sets the Title field's value.
 func (s *BaiduMessage) SetTitle(v string) *BaiduMessage {
 	s.Title = &v
@@ -7858,6 +8789,7 @@ func (s *CampaignEmailMessage) SetTitle(v string) *CampaignEmailMessage {
 	return s
 }
 
+// Campaign hook information.
 type CampaignHook struct {
 	_ struct{} `type:"structure"`
 
@@ -8256,6 +9188,127 @@ func (s *CampaignsResponse) SetNextToken(v string) *CampaignsResponse {
 	return s
 }
 
+// Base definition for channel response.
+type ChannelResponse struct {
+	_ struct{} `type:"structure"`
+
+	// Application id
+	ApplicationId *string `type:"string"`
+
+	// When was this segment created
+	CreationDate *string `type:"string"`
+
+	// If the channel is enabled for sending messages.
+	Enabled *bool `type:"boolean"`
+
+	// Not used. Retained for backwards compatibility.
+	HasCredential *bool `type:"boolean"`
+
+	// Channel ID. Not used, only for backwards compatibility.
+	Id *string `type:"string"`
+
+	// Is this channel archived
+	IsArchived *bool `type:"boolean"`
+
+	// Who made the last change
+	LastModifiedBy *string `type:"string"`
+
+	// Last date this was updated
+	LastModifiedDate *string `type:"string"`
+
+	// Version of channel
+	Version *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s ChannelResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ChannelResponse) GoString() string {
+	return s.String()
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *ChannelResponse) SetApplicationId(v string) *ChannelResponse {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *ChannelResponse) SetCreationDate(v string) *ChannelResponse {
+	s.CreationDate = &v
+	return s
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *ChannelResponse) SetEnabled(v bool) *ChannelResponse {
+	s.Enabled = &v
+	return s
+}
+
+// SetHasCredential sets the HasCredential field's value.
+func (s *ChannelResponse) SetHasCredential(v bool) *ChannelResponse {
+	s.HasCredential = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *ChannelResponse) SetId(v string) *ChannelResponse {
+	s.Id = &v
+	return s
+}
+
+// SetIsArchived sets the IsArchived field's value.
+func (s *ChannelResponse) SetIsArchived(v bool) *ChannelResponse {
+	s.IsArchived = &v
+	return s
+}
+
+// SetLastModifiedBy sets the LastModifiedBy field's value.
+func (s *ChannelResponse) SetLastModifiedBy(v string) *ChannelResponse {
+	s.LastModifiedBy = &v
+	return s
+}
+
+// SetLastModifiedDate sets the LastModifiedDate field's value.
+func (s *ChannelResponse) SetLastModifiedDate(v string) *ChannelResponse {
+	s.LastModifiedDate = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ChannelResponse) SetVersion(v int64) *ChannelResponse {
+	s.Version = &v
+	return s
+}
+
+// Get channels definition
+type ChannelsResponse struct {
+	_ struct{} `type:"structure"`
+
+	// A map of channels, with the ChannelType as the key and the Channel as the
+	// value.
+	Channels map[string]*ChannelResponse `type:"map"`
+}
+
+// String returns the string representation
+func (s ChannelsResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ChannelsResponse) GoString() string {
+	return s.String()
+}
+
+// SetChannels sets the Channels field's value.
+func (s *ChannelsResponse) SetChannels(v map[string]*ChannelResponse) *ChannelsResponse {
+	s.Channels = v
+	return s
+}
+
 type CreateAppInput struct {
 	_ struct{} `type:"structure" payload:"CreateApplicationRequest"`
 
@@ -8424,6 +9477,8 @@ type CreateExportJobInput struct {
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
 
+	// Export job request.
+	//
 	// ExportJobRequest is a required field
 	ExportJobRequest *ExportJobRequest `type:"structure" required:"true"`
 }
@@ -8469,6 +9524,8 @@ func (s *CreateExportJobInput) SetExportJobRequest(v *ExportJobRequest) *CreateE
 type CreateExportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ExportJobResponse"`
 
+	// Export job response.
+	//
 	// ExportJobResponse is a required field
 	ExportJobResponse *ExportJobResponse `type:"structure" required:"true"`
 }
@@ -8495,6 +9552,8 @@ type CreateImportJobInput struct {
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
 
+	// Import job request.
+	//
 	// ImportJobRequest is a required field
 	ImportJobRequest *ImportJobRequest `type:"structure" required:"true"`
 }
@@ -8540,6 +9599,8 @@ func (s *CreateImportJobInput) SetImportJobRequest(v *ImportJobRequest) *CreateI
 type CreateImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
 
+	// Import job response.
+	//
 	// ImportJobResponse is a required field
 	ImportJobResponse *ImportJobResponse `type:"structure" required:"true"`
 }
@@ -8642,6 +9703,7 @@ type DefaultMessage struct {
 	// The message body of the notification, the email body or the text message.
 	Body *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 }
 
@@ -8691,6 +9753,7 @@ type DefaultPushNotificationMessage struct {
 	// can be used for Remote Configuration and Phone Home use cases.
 	SilentPush *bool `type:"boolean"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// The message title that displays above the message on the user's device.
@@ -9390,8 +10453,6 @@ func (s *DeleteEndpointOutput) SetEndpointResponse(v *EndpointResponse) *DeleteE
 type DeleteEventStreamInput struct {
 	_ struct{} `type:"structure"`
 
-	// Application Id.
-	//
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
 }
@@ -9645,7 +10706,81 @@ func (s *DeleteSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *D
 	return s
 }
 
-// The message configuration.
+type DeleteUserEndpointsInput struct {
+	_ struct{} `type:"structure"`
+
+	// ApplicationId is a required field
+	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
+
+	// UserId is a required field
+	UserId *string `location:"uri" locationName:"user-id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteUserEndpointsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserEndpointsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteUserEndpointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteUserEndpointsInput"}
+	if s.ApplicationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.UserId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *DeleteUserEndpointsInput) SetApplicationId(v string) *DeleteUserEndpointsInput {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *DeleteUserEndpointsInput) SetUserId(v string) *DeleteUserEndpointsInput {
+	s.UserId = &v
+	return s
+}
+
+type DeleteUserEndpointsOutput struct {
+	_ struct{} `type:"structure" payload:"EndpointsResponse"`
+
+	// List of endpoints
+	//
+	// EndpointsResponse is a required field
+	EndpointsResponse *EndpointsResponse `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteUserEndpointsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserEndpointsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEndpointsResponse sets the EndpointsResponse field's value.
+func (s *DeleteUserEndpointsOutput) SetEndpointsResponse(v *EndpointsResponse) *DeleteUserEndpointsOutput {
+	s.EndpointsResponse = v
+	return s
+}
+
+// Message definitions for the default message and any messages that are tailored
+// for specific channels.
 type DirectMessageConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -9792,7 +10927,7 @@ type EmailChannelResponse struct {
 	// The email address used to send emails from.
 	FromAddress *string `type:"string"`
 
-	// If the channel is registered with a credential for authentication.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Channel ID. Not used, only for backwards compatibility.
@@ -9809,6 +10944,9 @@ type EmailChannelResponse struct {
 
 	// Last date this was updated
 	LastModifiedDate *string `type:"string"`
+
+	// Messages per second that can be sent
+	MessagesPerSecond *int64 `type:"integer"`
 
 	// Platform type. Will be "EMAIL"
 	Platform *string `type:"string"`
@@ -9891,6 +11029,12 @@ func (s *EmailChannelResponse) SetLastModifiedDate(v string) *EmailChannelRespon
 	return s
 }
 
+// SetMessagesPerSecond sets the MessagesPerSecond field's value.
+func (s *EmailChannelResponse) SetMessagesPerSecond(v int64) *EmailChannelResponse {
+	s.MessagesPerSecond = &v
+	return s
+}
+
 // SetPlatform sets the Platform field's value.
 func (s *EmailChannelResponse) SetPlatform(v string) *EmailChannelResponse {
 	s.Platform = &v
@@ -9913,10 +11057,21 @@ func (s *EmailChannelResponse) SetVersion(v int64) *EmailChannelResponse {
 type EndpointBatchItem struct {
 	_ struct{} `type:"structure"`
 
-	// The address or token of the endpoint as provided by your push provider (e.g.
-	// DeviceToken or RegistrationId).
+	// The destination for messages that you send to this endpoint. The address
+	// varies by channel. For mobile push channels, use the token provided by the
+	// push notification service, such as the APNs device token or the FCM registration
+	// token. For the SMS channel, use a phone number in E.164 format, such as +1206XXX5550100.
+	// For the email channel, use an email address.
 	Address *string `type:"string"`
 
+	// Custom attributes that describe the endpoint by associating a name with an
+	// array of values. For example, an attribute named "interests" might have the
+	// values ["science", "politics", "travel"]. You can use these attributes as
+	// selection criteria when you create a segment of users to engage with a messaging
+	// campaign.The following characters are not recommended in attribute names:
+	// # : ? \ /. The Amazon Pinpoint console does not display attributes that include
+	// these characters in the name. This limitation does not apply to attribute
+	// values.
 	Attributes map[string][]*string `type:"map"`
 
 	// The channel type.Valid values: GCM | APNS | APNS_SANDBOX | APNS_VOIP | APNS_VOIP_SANDBOX
@@ -9929,8 +11084,7 @@ type EndpointBatchItem struct {
 	// The last time the endpoint was updated. Provided in ISO 8601 format.
 	EffectiveDate *string `type:"string"`
 
-	// The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE
-	// if a delivery fails. Will be set to ACTIVE if the address is updated.
+	// Unused.
 	EndpointStatus *string `type:"string"`
 
 	// The unique Id for the Endpoint in the batch.
@@ -10230,6 +11384,9 @@ type EndpointMessageResult struct {
 	// Delivery status of message.
 	DeliveryStatus *string `type:"string" enum:"DeliveryStatus"`
 
+	// Unique message identifier associated with the message that was sent.
+	MessageId *string `type:"string"`
+
 	// Downstream service status code.
 	StatusCode *int64 `type:"integer"`
 
@@ -10262,6 +11419,12 @@ func (s *EndpointMessageResult) SetDeliveryStatus(v string) *EndpointMessageResu
 	return s
 }
 
+// SetMessageId sets the MessageId field's value.
+func (s *EndpointMessageResult) SetMessageId(v string) *EndpointMessageResult {
+	s.MessageId = &v
+	return s
+}
+
 // SetStatusCode sets the StatusCode field's value.
 func (s *EndpointMessageResult) SetStatusCode(v int64) *EndpointMessageResult {
 	s.StatusCode = &v
@@ -10284,10 +11447,21 @@ func (s *EndpointMessageResult) SetUpdatedToken(v string) *EndpointMessageResult
 type EndpointRequest struct {
 	_ struct{} `type:"structure"`
 
-	// The address or token of the endpoint as provided by your push provider (e.g.
-	// DeviceToken or RegistrationId).
+	// The destination for messages that you send to this endpoint. The address
+	// varies by channel. For mobile push channels, use the token provided by the
+	// push notification service, such as the APNs device token or the FCM registration
+	// token. For the SMS channel, use a phone number in E.164 format, such as +1206XXX5550100.
+	// For the email channel, use an email address.
 	Address *string `type:"string"`
 
+	// Custom attributes that describe the endpoint by associating a name with an
+	// array of values. For example, an attribute named "interests" might have the
+	// values ["science", "politics", "travel"]. You can use these attributes as
+	// selection criteria when you create a segment of users to engage with a messaging
+	// campaign.The following characters are not recommended in attribute names:
+	// # : ? \ /. The Amazon Pinpoint console does not display attributes that include
+	// these characters in the name. This limitation does not apply to attribute
+	// values.
 	Attributes map[string][]*string `type:"map"`
 
 	// The channel type.Valid values: GCM | APNS | APNS_SANDBOX | APNS_VOIP | APNS_VOIP_SANDBOX
@@ -10300,8 +11474,7 @@ type EndpointRequest struct {
 	// The last time the endpoint was updated. Provided in ISO 8601 format.
 	EffectiveDate *string `type:"string"`
 
-	// The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE
-	// if a delivery fails. Will be set to ACTIVE if the address is updated.
+	// Unused.
 	EndpointStatus *string `type:"string"`
 
 	// The endpoint location attributes.
@@ -10409,6 +11582,14 @@ type EndpointResponse struct {
 	// The ID of the application associated with the endpoint.
 	ApplicationId *string `type:"string"`
 
+	// Custom attributes that describe the endpoint by associating a name with an
+	// array of values. For example, an attribute named "interests" might have the
+	// values ["science", "politics", "travel"]. You can use these attributes as
+	// selection criteria when you create a segment of users to engage with a messaging
+	// campaign.The following characters are not recommended in attribute names:
+	// # : ? \ /. The Amazon Pinpoint console does not display attributes that include
+	// these characters in the name. This limitation does not apply to attribute
+	// values.
 	Attributes map[string][]*string `type:"map"`
 
 	// The channel type.Valid values: GCM | APNS | APNS_SANDBOX | APNS_VOIP | APNS_VOIP_SANDBOX
@@ -10430,8 +11611,7 @@ type EndpointResponse struct {
 	// The last time the endpoint was updated. Provided in ISO 8601 format.
 	EffectiveDate *string `type:"string"`
 
-	// The endpoint status. Can be either ACTIVE or INACTIVE. Will be set to INACTIVE
-	// if a delivery fails. Will be set to ACTIVE if the address is updated.
+	// Unused.
 	EndpointStatus *string `type:"string"`
 
 	// The unique ID that you assigned to the endpoint. The ID should be a globally
@@ -10573,6 +11753,9 @@ type EndpointSendConfiguration struct {
 	// the message.
 	RawContent *string `type:"string"`
 
+	// A map of substitution values for the message to be merged with the DefaultMessage's
+	// substitutions. Substitutions on this map take precedence over the all other
+	// substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// Title override. If specified will override default title if applicable.
@@ -10623,6 +11806,14 @@ func (s *EndpointSendConfiguration) SetTitleOverride(v string) *EndpointSendConf
 type EndpointUser struct {
 	_ struct{} `type:"structure"`
 
+	// Custom attributes that describe an end user by associating a name with an
+	// array of values. For example, an attribute named "interests" might have the
+	// values ["science", "politics", "travel"]. You can use these attributes as
+	// selection criteria when you create a segment of users to engage with a messaging
+	// campaign.The following characters are not recommended in attribute names:
+	// # : ? \ /. The Amazon Pinpoint console does not display attributes that include
+	// these characters in the name. This limitation does not apply to attribute
+	// values.
 	UserAttributes map[string][]*string `type:"map"`
 
 	// The unique ID of the user.
@@ -10648,6 +11839,30 @@ func (s *EndpointUser) SetUserAttributes(v map[string][]*string) *EndpointUser {
 // SetUserId sets the UserId field's value.
 func (s *EndpointUser) SetUserId(v string) *EndpointUser {
 	s.UserId = &v
+	return s
+}
+
+// List of endpoints
+type EndpointsResponse struct {
+	_ struct{} `type:"structure"`
+
+	// The list of endpoints.
+	Item []*EndpointResponse `type:"list"`
+}
+
+// String returns the string representation
+func (s EndpointsResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EndpointsResponse) GoString() string {
+	return s.String()
+}
+
+// SetItem sets the Item field's value.
+func (s *EndpointsResponse) SetItem(v []*EndpointResponse) *EndpointsResponse {
+	s.Item = v
 	return s
 }
 
@@ -10726,6 +11941,7 @@ func (s *EventStream) SetRoleArn(v string) *EventStream {
 	return s
 }
 
+// Export job request.
 type ExportJobRequest struct {
 	_ struct{} `type:"structure"`
 
@@ -10739,9 +11955,12 @@ type ExportJobRequest struct {
 	// export endpoints to this location.
 	S3UrlPrefix *string `type:"string"`
 
-	// The ID of the segment to export endpoints from. If not present, all endpoints
-	// will be exported.
+	// The ID of the segment to export endpoints from. If not present, Amazon Pinpoint
+	// exports all of the endpoints that belong to the application.
 	SegmentId *string `type:"string"`
+
+	// The version of the segment to export if specified.
+	SegmentVersion *int64 `type:"integer"`
 }
 
 // String returns the string representation
@@ -10772,6 +11991,13 @@ func (s *ExportJobRequest) SetSegmentId(v string) *ExportJobRequest {
 	return s
 }
 
+// SetSegmentVersion sets the SegmentVersion field's value.
+func (s *ExportJobRequest) SetSegmentVersion(v int64) *ExportJobRequest {
+	s.SegmentVersion = &v
+	return s
+}
+
+// Export job resource.
 type ExportJobResource struct {
 	_ struct{} `type:"structure"`
 
@@ -10785,9 +12011,12 @@ type ExportJobResource struct {
 	// export endpoints to this location.
 	S3UrlPrefix *string `type:"string"`
 
-	// The ID of the segment to export endpoints from. If not present all endpoints
-	// will be exported.
+	// The ID of the segment to export endpoints from. If not present, Amazon Pinpoint
+	// exports all of the endpoints that belong to the application.
 	SegmentId *string `type:"string"`
+
+	// The version of the segment to export if specified.
+	SegmentVersion *int64 `type:"integer"`
 }
 
 // String returns the string representation
@@ -10818,6 +12047,13 @@ func (s *ExportJobResource) SetSegmentId(v string) *ExportJobResource {
 	return s
 }
 
+// SetSegmentVersion sets the SegmentVersion field's value.
+func (s *ExportJobResource) SetSegmentVersion(v int64) *ExportJobResource {
+	s.SegmentVersion = &v
+	return s
+}
+
+// Export job response.
 type ExportJobResponse struct {
 	_ struct{} `type:"structure"`
 
@@ -10840,14 +12076,15 @@ type ExportJobResponse struct {
 	// The number of pieces that failed to be processed as of the time of the request.
 	FailedPieces *int64 `type:"integer"`
 
+	// Provides up to 100 of the first failed entries for the job, if any exist.
 	Failures []*string `type:"list"`
 
 	// The unique ID of the job.
 	Id *string `type:"string"`
 
-	// The status of the export job.Valid values: CREATED, INITIALIZING, PROCESSING,
-	// COMPLETING, COMPLETED, FAILING, FAILEDThe job status is FAILED if one or
-	// more pieces failed.
+	// The status of the job.Valid values: CREATED, INITIALIZING, PROCESSING, COMPLETING,
+	// COMPLETED, FAILING, FAILEDThe job status is FAILED if one or more pieces
+	// failed.
 	JobStatus *string `type:"string" enum:"JobStatus"`
 
 	// The number of endpoints that were not processed; for example, because of
@@ -11036,9 +12273,7 @@ type GCMChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// Indicates whether the channel is configured with FCM or GCM credentials.
-	// Amazon Pinpoint uses your credentials to authenticate push notifications
-	// with FCM or GCM. Provide your credentials by setting the ApiKey attribute.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Channel ID. Not used. Present only for backwards compatibility.
@@ -11204,6 +12439,7 @@ type GCMMessage struct {
 	// sound files must reside in /res/raw/
 	Sound *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 
 	// The length of time (in seconds) that FCM or GCM stores and attempts to deliver
@@ -11329,6 +12565,72 @@ func (s *GCMMessage) SetTitle(v string) *GCMMessage {
 // SetUrl sets the Url field's value.
 func (s *GCMMessage) SetUrl(v string) *GCMMessage {
 	s.Url = &v
+	return s
+}
+
+// GPS coordinates
+type GPSCoordinates struct {
+	_ struct{} `type:"structure"`
+
+	// Latitude
+	Latitude *float64 `type:"double"`
+
+	// Longitude
+	Longitude *float64 `type:"double"`
+}
+
+// String returns the string representation
+func (s GPSCoordinates) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GPSCoordinates) GoString() string {
+	return s.String()
+}
+
+// SetLatitude sets the Latitude field's value.
+func (s *GPSCoordinates) SetLatitude(v float64) *GPSCoordinates {
+	s.Latitude = &v
+	return s
+}
+
+// SetLongitude sets the Longitude field's value.
+func (s *GPSCoordinates) SetLongitude(v float64) *GPSCoordinates {
+	s.Longitude = &v
+	return s
+}
+
+// GPS point location dimension
+type GPSPointDimension struct {
+	_ struct{} `type:"structure"`
+
+	// Coordinate to measure distance from.
+	Coordinates *GPSCoordinates `type:"structure"`
+
+	// Range in kilometers from the coordinate.
+	RangeInKilometers *float64 `type:"double"`
+}
+
+// String returns the string representation
+func (s GPSPointDimension) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GPSPointDimension) GoString() string {
+	return s.String()
+}
+
+// SetCoordinates sets the Coordinates field's value.
+func (s *GPSPointDimension) SetCoordinates(v *GPSCoordinates) *GPSPointDimension {
+	s.Coordinates = v
+	return s
+}
+
+// SetRangeInKilometers sets the RangeInKilometers field's value.
+func (s *GPSPointDimension) SetRangeInKilometers(v float64) *GPSPointDimension {
+	s.RangeInKilometers = &v
 	return s
 }
 
@@ -12288,6 +13590,67 @@ func (s *GetCampaignsOutput) SetCampaignsResponse(v *CampaignsResponse) *GetCamp
 	return s
 }
 
+type GetChannelsInput struct {
+	_ struct{} `type:"structure"`
+
+	// ApplicationId is a required field
+	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetChannelsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetChannelsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetChannelsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetChannelsInput"}
+	if s.ApplicationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *GetChannelsInput) SetApplicationId(v string) *GetChannelsInput {
+	s.ApplicationId = &v
+	return s
+}
+
+type GetChannelsOutput struct {
+	_ struct{} `type:"structure" payload:"ChannelsResponse"`
+
+	// Get channels definition
+	//
+	// ChannelsResponse is a required field
+	ChannelsResponse *ChannelsResponse `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s GetChannelsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetChannelsOutput) GoString() string {
+	return s.String()
+}
+
+// SetChannelsResponse sets the ChannelsResponse field's value.
+func (s *GetChannelsOutput) SetChannelsResponse(v *ChannelsResponse) *GetChannelsOutput {
+	s.ChannelsResponse = v
+	return s
+}
+
 type GetEmailChannelInput struct {
 	_ struct{} `type:"structure"`
 
@@ -12425,8 +13788,6 @@ func (s *GetEndpointOutput) SetEndpointResponse(v *EndpointResponse) *GetEndpoin
 type GetEventStreamInput struct {
 	_ struct{} `type:"structure"`
 
-	// Application Id.
-	//
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
 }
@@ -12536,6 +13897,8 @@ func (s *GetExportJobInput) SetJobId(v string) *GetExportJobInput {
 type GetExportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ExportJobResponse"`
 
+	// Export job response.
+	//
 	// ExportJobResponse is a required field
 	ExportJobResponse *ExportJobResponse `type:"structure" required:"true"`
 }
@@ -12745,6 +14108,8 @@ func (s *GetImportJobInput) SetJobId(v string) *GetImportJobInput {
 type GetImportJobOutput struct {
 	_ struct{} `type:"structure" payload:"ImportJobResponse"`
 
+	// Import job response.
+	//
 	// ImportJobResponse is a required field
 	ImportJobResponse *ImportJobResponse `type:"structure" required:"true"`
 }
@@ -13405,6 +14770,80 @@ func (s *GetSmsChannelOutput) SetSMSChannelResponse(v *SMSChannelResponse) *GetS
 	return s
 }
 
+type GetUserEndpointsInput struct {
+	_ struct{} `type:"structure"`
+
+	// ApplicationId is a required field
+	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
+
+	// UserId is a required field
+	UserId *string `location:"uri" locationName:"user-id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetUserEndpointsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUserEndpointsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUserEndpointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUserEndpointsInput"}
+	if s.ApplicationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.UserId == nil {
+		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *GetUserEndpointsInput) SetApplicationId(v string) *GetUserEndpointsInput {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetUserId sets the UserId field's value.
+func (s *GetUserEndpointsInput) SetUserId(v string) *GetUserEndpointsInput {
+	s.UserId = &v
+	return s
+}
+
+type GetUserEndpointsOutput struct {
+	_ struct{} `type:"structure" payload:"EndpointsResponse"`
+
+	// List of endpoints
+	//
+	// EndpointsResponse is a required field
+	EndpointsResponse *EndpointsResponse `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s GetUserEndpointsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUserEndpointsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEndpointsResponse sets the EndpointsResponse field's value.
+func (s *GetUserEndpointsOutput) SetEndpointsResponse(v *EndpointsResponse) *GetUserEndpointsOutput {
+	s.EndpointsResponse = v
+	return s
+}
+
+// Import job request.
 type ImportJobRequest struct {
 	_ struct{} `type:"structure"`
 
@@ -13502,6 +14941,7 @@ func (s *ImportJobRequest) SetSegmentName(v string) *ImportJobRequest {
 	return s
 }
 
+// Import job resource
 type ImportJobResource struct {
 	_ struct{} `type:"structure"`
 
@@ -13599,6 +15039,7 @@ func (s *ImportJobResource) SetSegmentName(v string) *ImportJobResource {
 	return s
 }
 
+// Import job response.
 type ImportJobResponse struct {
 	_ struct{} `type:"structure"`
 
@@ -13621,6 +15062,7 @@ type ImportJobResponse struct {
 	// The number of pieces that have failed to import as of the time of the request.
 	FailedPieces *int64 `type:"integer"`
 
+	// Provides up to 100 of the first failed entries for the job, if any exist.
 	Failures []*string `type:"list"`
 
 	// The unique ID of the import job.
@@ -13768,6 +15210,7 @@ func (s *ImportJobsResponse) SetNextToken(v string) *ImportJobsResponse {
 	return s
 }
 
+// Message to send
 type Message struct {
 	_ struct{} `type:"structure"`
 
@@ -13806,6 +15249,14 @@ type Message struct {
 	// Indicates if the message should display on the users device.Silent pushes
 	// can be used for Remote Configuration and Phone Home use cases.
 	SilentPush *bool `type:"boolean"`
+
+	// This parameter specifies how long (in seconds) the message should be kept
+	// if the service is unable to deliver the notification the first time. If the
+	// value is 0, it treats the notification as if it expires immediately and does
+	// not store the notification or attempt to redeliver it. This value is converted
+	// to the expiration field when sent to the service. It only applies to APNs
+	// and GCM
+	TimeToLive *int64 `type:"integer"`
 
 	// The message title that displays above the message on the user's device.
 	Title *string `type:"string"`
@@ -13879,6 +15330,12 @@ func (s *Message) SetSilentPush(v bool) *Message {
 	return s
 }
 
+// SetTimeToLive sets the TimeToLive field's value.
+func (s *Message) SetTimeToLive(v int64) *Message {
+	s.TimeToLive = &v
+	return s
+}
+
 // SetTitle sets the Title field's value.
 func (s *Message) SetTitle(v string) *Message {
 	s.Title = &v
@@ -13895,7 +15352,7 @@ func (s *Message) SetUrl(v string) *Message {
 type MessageBody struct {
 	_ struct{} `type:"structure"`
 
-	// The error message returned from the API.
+	// The error message that's returned from the API.
 	Message *string `type:"string"`
 
 	// The unique message body ID.
@@ -14010,8 +15467,9 @@ func (s *MessageConfiguration) SetSMSMessage(v *CampaignSmsMessage) *MessageConf
 type MessageRequest struct {
 	_ struct{} `type:"structure"`
 
-	// A map of destination addresses, with the address as the key(Email address,
-	// phone number or push token) and the Address Configuration as the value.
+	// A map of key-value pairs, where each key is an address and each value is
+	// an AddressConfiguration object. An address can be a push notification token,
+	// a phone number, or an email address.
 	Addresses map[string]*AddressConfiguration `type:"map"`
 
 	// A map of custom attributes to attributes to be attached to the message. This
@@ -14019,8 +15477,10 @@ type MessageRequest struct {
 	// to the email/sms delivery receipt event attributes.
 	Context map[string]*string `type:"map"`
 
-	// A map of destination addresses, with the address as the key(Email address,
-	// phone number or push token) and the Address Configuration as the value.
+	// A map of key-value pairs, where each key is an endpoint ID and each value
+	// is an EndpointSendConfiguration object. Within an EndpointSendConfiguration
+	// object, you can tailor the message for an endpoint by specifying message
+	// overrides or substitutions.
 	Endpoints map[string]*EndpointSendConfiguration `type:"map"`
 
 	// Message configuration.
@@ -14122,6 +15582,9 @@ type MessageResult struct {
 	// Delivery status of message.
 	DeliveryStatus *string `type:"string" enum:"DeliveryStatus"`
 
+	// Unique message identifier associated with the message that was sent.
+	MessageId *string `type:"string"`
+
 	// Downstream service status code.
 	StatusCode *int64 `type:"integer"`
 
@@ -14148,6 +15611,12 @@ func (s *MessageResult) SetDeliveryStatus(v string) *MessageResult {
 	return s
 }
 
+// SetMessageId sets the MessageId field's value.
+func (s *MessageResult) SetMessageId(v string) *MessageResult {
+	s.MessageId = &v
+	return s
+}
+
 // SetStatusCode sets the StatusCode field's value.
 func (s *MessageResult) SetStatusCode(v int64) *MessageResult {
 	s.StatusCode = &v
@@ -14166,15 +15635,288 @@ func (s *MessageResult) SetUpdatedToken(v string) *MessageResult {
 	return s
 }
 
+// Custom metric dimension
+type MetricDimension struct {
+	_ struct{} `type:"structure"`
+
+	// GREATER_THAN | LESS_THAN | GREATER_THAN_OR_EQUAL | LESS_THAN_OR_EQUAL | EQUAL
+	ComparisonOperator *string `type:"string"`
+
+	// Value to be compared.
+	Value *float64 `type:"double"`
+}
+
+// String returns the string representation
+func (s MetricDimension) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MetricDimension) GoString() string {
+	return s.String()
+}
+
+// SetComparisonOperator sets the ComparisonOperator field's value.
+func (s *MetricDimension) SetComparisonOperator(v string) *MetricDimension {
+	s.ComparisonOperator = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *MetricDimension) SetValue(v float64) *MetricDimension {
+	s.Value = &v
+	return s
+}
+
+// Phone Number Information request.
+type NumberValidateRequest struct {
+	_ struct{} `type:"structure"`
+
+	// (Optional) The two-character ISO country code for the country where the phone
+	// number was originally registered.
+	IsoCountryCode *string `type:"string"`
+
+	// The phone number to get information about.
+	PhoneNumber *string `type:"string"`
+}
+
+// String returns the string representation
+func (s NumberValidateRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NumberValidateRequest) GoString() string {
+	return s.String()
+}
+
+// SetIsoCountryCode sets the IsoCountryCode field's value.
+func (s *NumberValidateRequest) SetIsoCountryCode(v string) *NumberValidateRequest {
+	s.IsoCountryCode = &v
+	return s
+}
+
+// SetPhoneNumber sets the PhoneNumber field's value.
+func (s *NumberValidateRequest) SetPhoneNumber(v string) *NumberValidateRequest {
+	s.PhoneNumber = &v
+	return s
+}
+
+// Phone Number Information response.
+type NumberValidateResponse struct {
+	_ struct{} `type:"structure"`
+
+	// The carrier that the phone number is registered with.
+	Carrier *string `type:"string"`
+
+	// The city where the phone number was originally registered.
+	City *string `type:"string"`
+
+	// The cleansed (standardized) phone number in E.164 format.
+	CleansedPhoneNumberE164 *string `type:"string"`
+
+	// The cleansed phone number in national format.
+	CleansedPhoneNumberNational *string `type:"string"`
+
+	// The country where the phone number was originally registered.
+	Country *string `type:"string"`
+
+	// The two-character ISO country code for the country where the phone number
+	// was originally registered.
+	CountryCodeIso2 *string `type:"string"`
+
+	// The numeric country code for the country where the phone number was originally
+	// registered.
+	CountryCodeNumeric *string `type:"string"`
+
+	// The county where the phone number was originally registered.
+	County *string `type:"string"`
+
+	// The two-character ISO country code that was included in the request body.
+	OriginalCountryCodeIso2 *string `type:"string"`
+
+	// The phone number that you included in the request body.
+	OriginalPhoneNumber *string `type:"string"`
+
+	// A description of the phone type. Possible values include MOBILE, LANDLINE,
+	// VOIP, INVALID, and OTHER.
+	PhoneType *string `type:"string"`
+
+	// The phone type as an integer. Possible values include 0 (MOBILE), 1 (LANDLINE),
+	// 2 (VOIP), 3 (INVALID), and 4 (OTHER).
+	PhoneTypeCode *int64 `type:"integer"`
+
+	// The time zone for the location where the phone number was originally registered.
+	Timezone *string `type:"string"`
+
+	// The zip code for the location where the phone number was originally registered.
+	ZipCode *string `type:"string"`
+}
+
+// String returns the string representation
+func (s NumberValidateResponse) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s NumberValidateResponse) GoString() string {
+	return s.String()
+}
+
+// SetCarrier sets the Carrier field's value.
+func (s *NumberValidateResponse) SetCarrier(v string) *NumberValidateResponse {
+	s.Carrier = &v
+	return s
+}
+
+// SetCity sets the City field's value.
+func (s *NumberValidateResponse) SetCity(v string) *NumberValidateResponse {
+	s.City = &v
+	return s
+}
+
+// SetCleansedPhoneNumberE164 sets the CleansedPhoneNumberE164 field's value.
+func (s *NumberValidateResponse) SetCleansedPhoneNumberE164(v string) *NumberValidateResponse {
+	s.CleansedPhoneNumberE164 = &v
+	return s
+}
+
+// SetCleansedPhoneNumberNational sets the CleansedPhoneNumberNational field's value.
+func (s *NumberValidateResponse) SetCleansedPhoneNumberNational(v string) *NumberValidateResponse {
+	s.CleansedPhoneNumberNational = &v
+	return s
+}
+
+// SetCountry sets the Country field's value.
+func (s *NumberValidateResponse) SetCountry(v string) *NumberValidateResponse {
+	s.Country = &v
+	return s
+}
+
+// SetCountryCodeIso2 sets the CountryCodeIso2 field's value.
+func (s *NumberValidateResponse) SetCountryCodeIso2(v string) *NumberValidateResponse {
+	s.CountryCodeIso2 = &v
+	return s
+}
+
+// SetCountryCodeNumeric sets the CountryCodeNumeric field's value.
+func (s *NumberValidateResponse) SetCountryCodeNumeric(v string) *NumberValidateResponse {
+	s.CountryCodeNumeric = &v
+	return s
+}
+
+// SetCounty sets the County field's value.
+func (s *NumberValidateResponse) SetCounty(v string) *NumberValidateResponse {
+	s.County = &v
+	return s
+}
+
+// SetOriginalCountryCodeIso2 sets the OriginalCountryCodeIso2 field's value.
+func (s *NumberValidateResponse) SetOriginalCountryCodeIso2(v string) *NumberValidateResponse {
+	s.OriginalCountryCodeIso2 = &v
+	return s
+}
+
+// SetOriginalPhoneNumber sets the OriginalPhoneNumber field's value.
+func (s *NumberValidateResponse) SetOriginalPhoneNumber(v string) *NumberValidateResponse {
+	s.OriginalPhoneNumber = &v
+	return s
+}
+
+// SetPhoneType sets the PhoneType field's value.
+func (s *NumberValidateResponse) SetPhoneType(v string) *NumberValidateResponse {
+	s.PhoneType = &v
+	return s
+}
+
+// SetPhoneTypeCode sets the PhoneTypeCode field's value.
+func (s *NumberValidateResponse) SetPhoneTypeCode(v int64) *NumberValidateResponse {
+	s.PhoneTypeCode = &v
+	return s
+}
+
+// SetTimezone sets the Timezone field's value.
+func (s *NumberValidateResponse) SetTimezone(v string) *NumberValidateResponse {
+	s.Timezone = &v
+	return s
+}
+
+// SetZipCode sets the ZipCode field's value.
+func (s *NumberValidateResponse) SetZipCode(v string) *NumberValidateResponse {
+	s.ZipCode = &v
+	return s
+}
+
+type PhoneNumberValidateInput struct {
+	_ struct{} `type:"structure" payload:"NumberValidateRequest"`
+
+	// Phone Number Information request.
+	//
+	// NumberValidateRequest is a required field
+	NumberValidateRequest *NumberValidateRequest `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s PhoneNumberValidateInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PhoneNumberValidateInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PhoneNumberValidateInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PhoneNumberValidateInput"}
+	if s.NumberValidateRequest == nil {
+		invalidParams.Add(request.NewErrParamRequired("NumberValidateRequest"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetNumberValidateRequest sets the NumberValidateRequest field's value.
+func (s *PhoneNumberValidateInput) SetNumberValidateRequest(v *NumberValidateRequest) *PhoneNumberValidateInput {
+	s.NumberValidateRequest = v
+	return s
+}
+
+type PhoneNumberValidateOutput struct {
+	_ struct{} `type:"structure" payload:"NumberValidateResponse"`
+
+	// Phone Number Information response.
+	//
+	// NumberValidateResponse is a required field
+	NumberValidateResponse *NumberValidateResponse `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s PhoneNumberValidateOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PhoneNumberValidateOutput) GoString() string {
+	return s.String()
+}
+
+// SetNumberValidateResponse sets the NumberValidateResponse field's value.
+func (s *PhoneNumberValidateOutput) SetNumberValidateResponse(v *NumberValidateResponse) *PhoneNumberValidateOutput {
+	s.NumberValidateResponse = v
+	return s
+}
+
 type PutEventStreamInput struct {
 	_ struct{} `type:"structure" payload:"WriteEventStream"`
 
-	// Application Id.
-	//
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
 
-	// Write event stream wrapper.
+	// Request to save an EventStream.
 	//
 	// WriteEventStream is a required field
 	WriteEventStream *WriteEventStream `type:"structure" required:"true"`
@@ -14312,6 +16054,93 @@ func (s *RecencyDimension) SetRecencyType(v string) *RecencyDimension {
 	return s
 }
 
+type RemoveAttributesInput struct {
+	_ struct{} `type:"structure" payload:"UpdateAttributesRequest"`
+
+	// ApplicationId is a required field
+	ApplicationId *string `location:"uri" locationName:"application-id" type:"string" required:"true"`
+
+	// AttributeType is a required field
+	AttributeType *string `location:"uri" locationName:"attribute-type" type:"string" required:"true"`
+
+	// Update attributes request
+	//
+	// UpdateAttributesRequest is a required field
+	UpdateAttributesRequest *UpdateAttributesRequest `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s RemoveAttributesInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveAttributesInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RemoveAttributesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RemoveAttributesInput"}
+	if s.ApplicationId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.AttributeType == nil {
+		invalidParams.Add(request.NewErrParamRequired("AttributeType"))
+	}
+	if s.UpdateAttributesRequest == nil {
+		invalidParams.Add(request.NewErrParamRequired("UpdateAttributesRequest"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetApplicationId sets the ApplicationId field's value.
+func (s *RemoveAttributesInput) SetApplicationId(v string) *RemoveAttributesInput {
+	s.ApplicationId = &v
+	return s
+}
+
+// SetAttributeType sets the AttributeType field's value.
+func (s *RemoveAttributesInput) SetAttributeType(v string) *RemoveAttributesInput {
+	s.AttributeType = &v
+	return s
+}
+
+// SetUpdateAttributesRequest sets the UpdateAttributesRequest field's value.
+func (s *RemoveAttributesInput) SetUpdateAttributesRequest(v *UpdateAttributesRequest) *RemoveAttributesInput {
+	s.UpdateAttributesRequest = v
+	return s
+}
+
+type RemoveAttributesOutput struct {
+	_ struct{} `type:"structure" payload:"AttributesResource"`
+
+	// Attributes.
+	//
+	// AttributesResource is a required field
+	AttributesResource *AttributesResource `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s RemoveAttributesOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RemoveAttributesOutput) GoString() string {
+	return s.String()
+}
+
+// SetAttributesResource sets the AttributesResource field's value.
+func (s *RemoveAttributesOutput) SetAttributesResource(v *AttributesResource) *RemoveAttributesOutput {
+	s.AttributesResource = v
+	return s
+}
+
 // SMS Channel Request
 type SMSChannelRequest struct {
 	_ struct{} `type:"structure"`
@@ -14367,7 +16196,7 @@ type SMSChannelResponse struct {
 	// If the channel is enabled for sending messages.
 	Enabled *bool `type:"boolean"`
 
-	// If the channel is registered with a credential for authentication.
+	// Not used. Retained for backwards compatibility.
 	HasCredential *bool `type:"boolean"`
 
 	// Channel ID. Not used, only for backwards compatibility.
@@ -14385,11 +16214,17 @@ type SMSChannelResponse struct {
 	// Platform type. Will be "SMS"
 	Platform *string `type:"string"`
 
+	// Promotional messages per second that can be sent
+	PromotionalMessagesPerSecond *int64 `type:"integer"`
+
 	// Sender identifier of your messages.
 	SenderId *string `type:"string"`
 
 	// The short code registered with the phone provider.
 	ShortCode *string `type:"string"`
+
+	// Transactional messages per second that can be sent
+	TransactionalMessagesPerSecond *int64 `type:"integer"`
 
 	// Version of channel
 	Version *int64 `type:"integer"`
@@ -14459,6 +16294,12 @@ func (s *SMSChannelResponse) SetPlatform(v string) *SMSChannelResponse {
 	return s
 }
 
+// SetPromotionalMessagesPerSecond sets the PromotionalMessagesPerSecond field's value.
+func (s *SMSChannelResponse) SetPromotionalMessagesPerSecond(v int64) *SMSChannelResponse {
+	s.PromotionalMessagesPerSecond = &v
+	return s
+}
+
 // SetSenderId sets the SenderId field's value.
 func (s *SMSChannelResponse) SetSenderId(v string) *SMSChannelResponse {
 	s.SenderId = &v
@@ -14468,6 +16309,12 @@ func (s *SMSChannelResponse) SetSenderId(v string) *SMSChannelResponse {
 // SetShortCode sets the ShortCode field's value.
 func (s *SMSChannelResponse) SetShortCode(v string) *SMSChannelResponse {
 	s.ShortCode = &v
+	return s
+}
+
+// SetTransactionalMessagesPerSecond sets the TransactionalMessagesPerSecond field's value.
+func (s *SMSChannelResponse) SetTransactionalMessagesPerSecond(v int64) *SMSChannelResponse {
+	s.TransactionalMessagesPerSecond = &v
 	return s
 }
 
@@ -14481,8 +16328,12 @@ func (s *SMSChannelResponse) SetVersion(v int64) *SMSChannelResponse {
 type SMSMessage struct {
 	_ struct{} `type:"structure"`
 
-	// The message body of the notification, the email body or the text message.
+	// The body of the SMS message.
 	Body *string `type:"string"`
+
+	// The SMS program name that you provided to AWS Support when you requested
+	// your dedicated number.
+	Keyword *string `type:"string"`
 
 	// Is this a transaction priority message or lower priority.
 	MessageType *string `type:"string" enum:"MessageType"`
@@ -14497,6 +16348,7 @@ type SMSMessage struct {
 	// Support for sender IDs varies by country or region.
 	SenderId *string `type:"string"`
 
+	// Default message substitutions. Can be overridden by individual address substitutions.
 	Substitutions map[string][]*string `type:"map"`
 }
 
@@ -14513,6 +16365,12 @@ func (s SMSMessage) GoString() string {
 // SetBody sets the Body field's value.
 func (s *SMSMessage) SetBody(v string) *SMSMessage {
 	s.Body = &v
+	return s
+}
+
+// SetKeyword sets the Keyword field's value.
+func (s *SMSMessage) SetKeyword(v string) *SMSMessage {
+	s.Keyword = &v
 	return s
 }
 
@@ -14721,6 +16579,9 @@ type SegmentDimensions struct {
 	// The segment location attributes.
 	Location *SegmentLocation `type:"structure"`
 
+	// Custom segment metrics.
+	Metrics map[string]*MetricDimension `type:"map"`
+
 	// Custom segment user attributes.
 	UserAttributes map[string]*AttributeDimension `type:"map"`
 }
@@ -14759,9 +16620,100 @@ func (s *SegmentDimensions) SetLocation(v *SegmentLocation) *SegmentDimensions {
 	return s
 }
 
+// SetMetrics sets the Metrics field's value.
+func (s *SegmentDimensions) SetMetrics(v map[string]*MetricDimension) *SegmentDimensions {
+	s.Metrics = v
+	return s
+}
+
 // SetUserAttributes sets the UserAttributes field's value.
 func (s *SegmentDimensions) SetUserAttributes(v map[string]*AttributeDimension) *SegmentDimensions {
 	s.UserAttributes = v
+	return s
+}
+
+// Segment group definition.
+type SegmentGroup struct {
+	_ struct{} `type:"structure"`
+
+	// List of dimensions to include or exclude.
+	Dimensions []*SegmentDimensions `type:"list"`
+
+	// Segments that define the source of this segment. Currently a maximum of 1
+	// import segment is supported.
+	SourceSegments []*SegmentReference `type:"list"`
+
+	// Include or exclude the source.
+	SourceType *string `type:"string" enum:"SourceType"`
+
+	// How should the dimensions be applied for the result
+	Type *string `type:"string" enum:"Type"`
+}
+
+// String returns the string representation
+func (s SegmentGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SegmentGroup) GoString() string {
+	return s.String()
+}
+
+// SetDimensions sets the Dimensions field's value.
+func (s *SegmentGroup) SetDimensions(v []*SegmentDimensions) *SegmentGroup {
+	s.Dimensions = v
+	return s
+}
+
+// SetSourceSegments sets the SourceSegments field's value.
+func (s *SegmentGroup) SetSourceSegments(v []*SegmentReference) *SegmentGroup {
+	s.SourceSegments = v
+	return s
+}
+
+// SetSourceType sets the SourceType field's value.
+func (s *SegmentGroup) SetSourceType(v string) *SegmentGroup {
+	s.SourceType = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *SegmentGroup) SetType(v string) *SegmentGroup {
+	s.Type = &v
+	return s
+}
+
+// Segment group definition.
+type SegmentGroupList struct {
+	_ struct{} `type:"structure"`
+
+	// List of dimension groups to evaluate.
+	Groups []*SegmentGroup `type:"list"`
+
+	// How should the groups be applied for the result
+	Include *string `type:"string" enum:"Include"`
+}
+
+// String returns the string representation
+func (s SegmentGroupList) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SegmentGroupList) GoString() string {
+	return s.String()
+}
+
+// SetGroups sets the Groups field's value.
+func (s *SegmentGroupList) SetGroups(v []*SegmentGroup) *SegmentGroupList {
+	s.Groups = v
+	return s
+}
+
+// SetInclude sets the Include field's value.
+func (s *SegmentGroupList) SetInclude(v string) *SegmentGroupList {
+	s.Include = &v
 	return s
 }
 
@@ -14846,6 +16798,9 @@ type SegmentLocation struct {
 
 	// The country filter according to ISO 3166-1 Alpha-2 codes.
 	Country *SetDimension `type:"structure"`
+
+	// The GPS Point dimension.
+	GPSPoint *GPSPointDimension `type:"structure"`
 }
 
 // String returns the string representation
@@ -14861,6 +16816,45 @@ func (s SegmentLocation) GoString() string {
 // SetCountry sets the Country field's value.
 func (s *SegmentLocation) SetCountry(v *SetDimension) *SegmentLocation {
 	s.Country = v
+	return s
+}
+
+// SetGPSPoint sets the GPSPoint field's value.
+func (s *SegmentLocation) SetGPSPoint(v *GPSPointDimension) *SegmentLocation {
+	s.GPSPoint = v
+	return s
+}
+
+// Segment reference.
+type SegmentReference struct {
+	_ struct{} `type:"structure"`
+
+	// Segment Id.
+	Id *string `type:"string"`
+
+	// If specified contains a specific version of the segment included.
+	Version *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s SegmentReference) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SegmentReference) GoString() string {
+	return s.String()
+}
+
+// SetId sets the Id field's value.
+func (s *SegmentReference) SetId(v string) *SegmentReference {
+	s.Id = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *SegmentReference) SetVersion(v int64) *SegmentReference {
+	s.Version = &v
 	return s
 }
 
@@ -14888,6 +16882,10 @@ type SegmentResponse struct {
 
 	// The name of segment
 	Name *string `type:"string"`
+
+	// Segment definition groups. We currently only support one. If specified Dimensions
+	// must be empty.
+	SegmentGroups *SegmentGroupList `type:"structure"`
 
 	// The segment type:DIMENSIONAL - A dynamic segment built from selection criteria
 	// based on endpoint data reported by your app. You create this type of segment
@@ -14951,6 +16949,12 @@ func (s *SegmentResponse) SetLastModifiedDate(v string) *SegmentResponse {
 // SetName sets the Name field's value.
 func (s *SegmentResponse) SetName(v string) *SegmentResponse {
 	s.Name = &v
+	return s
+}
+
+// SetSegmentGroups sets the SegmentGroups field's value.
+func (s *SegmentResponse) SetSegmentGroups(v *SegmentGroupList) *SegmentResponse {
+	s.SegmentGroups = v
 	return s
 }
 
@@ -15079,16 +17083,19 @@ func (s *SendMessagesOutput) SetMessageResponse(v *MessageResponse) *SendMessage
 type SendUsersMessageRequest struct {
 	_ struct{} `type:"structure"`
 
-	// A map of custom attributes to attributes to be attached to the message. This
-	// payload is added to the push notification's 'data.pinpoint' object or added
-	// to the email/sms delivery receipt event attributes.
+	// A map of custom attribute-value pairs. Amazon Pinpoint adds these attributes
+	// to the data.pinpoint object in the body of the push notification payload.
+	// Amazon Pinpoint also provides these attributes in the events that it generates
+	// for users-messages deliveries.
 	Context map[string]*string `type:"map"`
 
-	// Message configuration.
+	// Message definitions for the default message and any messages that are tailored
+	// for specific channels.
 	MessageConfiguration *DirectMessageConfiguration `type:"structure"`
 
-	// A map of destination endpoints, with the EndpointId as the key Endpoint Message
-	// Configuration as the value.
+	// A map that associates user IDs with EndpointSendConfiguration objects. Within
+	// an EndpointSendConfiguration object, you can tailor the message for a user
+	// by specifying message overrides or substitutions.
 	Users map[string]*EndpointSendConfiguration `type:"map"`
 }
 
@@ -15124,13 +17131,16 @@ func (s *SendUsersMessageRequest) SetUsers(v map[string]*EndpointSendConfigurati
 type SendUsersMessageResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Application id of the message.
+	// The unique ID of the Amazon Pinpoint project used to send the message.
 	ApplicationId *string `type:"string"`
 
-	// Original request Id for which this message was delivered.
+	// The unique ID assigned to the users-messages request.
 	RequestId *string `type:"string"`
 
-	// A map containing of UserId to Map of EndpointId to Endpoint Message Result.
+	// An object that shows the endpoints that were messaged for each user. The
+	// object provides a list of user IDs. For each user ID, it provides the endpoint
+	// IDs that were messaged. For each endpoint ID, it provides an EndpointMessageResult
+	// object.
 	Result map[string]map[string]*EndpointMessageResult `type:"map"`
 }
 
@@ -15246,6 +17256,9 @@ type SetDimension struct {
 	// from the segment.
 	DimensionType *string `type:"string" enum:"DimensionType"`
 
+	// The criteria values for the segment dimension. Endpoints with matching attribute
+	// values are included or excluded from the segment, depending on the setting
+	// for Type.
 	Values []*string `type:"list"`
 }
 
@@ -15796,6 +17809,30 @@ func (s UpdateApplicationSettingsOutput) GoString() string {
 // SetApplicationSettingsResource sets the ApplicationSettingsResource field's value.
 func (s *UpdateApplicationSettingsOutput) SetApplicationSettingsResource(v *ApplicationSettingsResource) *UpdateApplicationSettingsOutput {
 	s.ApplicationSettingsResource = v
+	return s
+}
+
+// Update attributes request
+type UpdateAttributesRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The GLOB wildcard for removing the attributes in the application
+	Blacklist []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s UpdateAttributesRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAttributesRequest) GoString() string {
+	return s.String()
+}
+
+// SetBlacklist sets the Blacklist field's value.
+func (s *UpdateAttributesRequest) SetBlacklist(v []*string) *UpdateAttributesRequest {
+	s.Blacklist = v
 	return s
 }
 
@@ -16442,6 +18479,9 @@ type WriteApplicationSettingsRequest struct {
 	// Default campaign hook information.
 	CampaignHook *CampaignHook `type:"structure"`
 
+	// The CloudWatchMetrics settings for the app.
+	CloudWatchMetricsEnabled *bool `type:"boolean"`
+
 	// The default campaign limits for the app. These limits apply to each campaign
 	// for the app, unless the campaign overrides the default with limits of its
 	// own.
@@ -16466,6 +18506,12 @@ func (s WriteApplicationSettingsRequest) GoString() string {
 // SetCampaignHook sets the CampaignHook field's value.
 func (s *WriteApplicationSettingsRequest) SetCampaignHook(v *CampaignHook) *WriteApplicationSettingsRequest {
 	s.CampaignHook = v
+	return s
+}
+
+// SetCloudWatchMetricsEnabled sets the CloudWatchMetricsEnabled field's value.
+func (s *WriteApplicationSettingsRequest) SetCloudWatchMetricsEnabled(v bool) *WriteApplicationSettingsRequest {
+	s.CloudWatchMetricsEnabled = &v
 	return s
 }
 
@@ -16660,6 +18706,10 @@ type WriteSegmentRequest struct {
 
 	// The name of segment
 	Name *string `type:"string"`
+
+	// Segment definition groups. We currently only support one. If specified Dimensions
+	// must be empty.
+	SegmentGroups *SegmentGroupList `type:"structure"`
 }
 
 // String returns the string representation
@@ -16681,6 +18731,12 @@ func (s *WriteSegmentRequest) SetDimensions(v *SegmentDimensions) *WriteSegmentR
 // SetName sets the Name field's value.
 func (s *WriteSegmentRequest) SetName(v string) *WriteSegmentRequest {
 	s.Name = &v
+	return s
+}
+
+// SetSegmentGroups sets the SegmentGroups field's value.
+func (s *WriteSegmentRequest) SetSegmentGroups(v *SegmentGroupList) *WriteSegmentRequest {
+	s.SegmentGroups = v
 	return s
 }
 
@@ -16778,6 +18834,9 @@ const (
 
 	// CampaignStatusPaused is a CampaignStatus enum value
 	CampaignStatusPaused = "PAUSED"
+
+	// CampaignStatusDeleted is a CampaignStatus enum value
+	CampaignStatusDeleted = "DELETED"
 )
 
 const (
@@ -16883,6 +18942,17 @@ const (
 )
 
 const (
+	// IncludeAll is a Include enum value
+	IncludeAll = "ALL"
+
+	// IncludeAny is a Include enum value
+	IncludeAny = "ANY"
+
+	// IncludeNone is a Include enum value
+	IncludeNone = "NONE"
+)
+
+const (
 	// JobStatusCreated is a JobStatus enum value
 	JobStatusCreated = "CREATED"
 
@@ -16935,4 +19005,23 @@ const (
 
 	// SegmentTypeImport is a SegmentType enum value
 	SegmentTypeImport = "IMPORT"
+)
+
+const (
+	// SourceTypeAll is a SourceType enum value
+	SourceTypeAll = "ALL"
+
+	// SourceTypeAny is a SourceType enum value
+	SourceTypeAny = "ANY"
+)
+
+const (
+	// TypeAll is a Type enum value
+	TypeAll = "ALL"
+
+	// TypeAny is a Type enum value
+	TypeAny = "ANY"
+
+	// TypeNone is a Type enum value
+	TypeNone = "NONE"
 )

--- a/service/pinpoint/errors.go
+++ b/service/pinpoint/errors.go
@@ -6,25 +6,37 @@ const (
 
 	// ErrCodeBadRequestException for service response error code
 	// "BadRequestException".
+	//
+	// Simple message object.
 	ErrCodeBadRequestException = "BadRequestException"
 
 	// ErrCodeForbiddenException for service response error code
 	// "ForbiddenException".
+	//
+	// Simple message object.
 	ErrCodeForbiddenException = "ForbiddenException"
 
 	// ErrCodeInternalServerErrorException for service response error code
 	// "InternalServerErrorException".
+	//
+	// Simple message object.
 	ErrCodeInternalServerErrorException = "InternalServerErrorException"
 
 	// ErrCodeMethodNotAllowedException for service response error code
 	// "MethodNotAllowedException".
+	//
+	// Simple message object.
 	ErrCodeMethodNotAllowedException = "MethodNotAllowedException"
 
 	// ErrCodeNotFoundException for service response error code
 	// "NotFoundException".
+	//
+	// Simple message object.
 	ErrCodeNotFoundException = "NotFoundException"
 
 	// ErrCodeTooManyRequestsException for service response error code
 	// "TooManyRequestsException".
+	//
+	// Simple message object.
 	ErrCodeTooManyRequestsException = "TooManyRequestsException"
 )

--- a/service/pinpoint/pinpointiface/interface.go
+++ b/service/pinpoint/pinpointiface/interface.go
@@ -136,6 +136,10 @@ type PinpointAPI interface {
 	DeleteSmsChannelWithContext(aws.Context, *pinpoint.DeleteSmsChannelInput, ...request.Option) (*pinpoint.DeleteSmsChannelOutput, error)
 	DeleteSmsChannelRequest(*pinpoint.DeleteSmsChannelInput) (*request.Request, *pinpoint.DeleteSmsChannelOutput)
 
+	DeleteUserEndpoints(*pinpoint.DeleteUserEndpointsInput) (*pinpoint.DeleteUserEndpointsOutput, error)
+	DeleteUserEndpointsWithContext(aws.Context, *pinpoint.DeleteUserEndpointsInput, ...request.Option) (*pinpoint.DeleteUserEndpointsOutput, error)
+	DeleteUserEndpointsRequest(*pinpoint.DeleteUserEndpointsInput) (*request.Request, *pinpoint.DeleteUserEndpointsOutput)
+
 	GetAdmChannel(*pinpoint.GetAdmChannelInput) (*pinpoint.GetAdmChannelOutput, error)
 	GetAdmChannelWithContext(aws.Context, *pinpoint.GetAdmChannelInput, ...request.Option) (*pinpoint.GetAdmChannelOutput, error)
 	GetAdmChannelRequest(*pinpoint.GetAdmChannelInput) (*request.Request, *pinpoint.GetAdmChannelOutput)
@@ -191,6 +195,10 @@ type PinpointAPI interface {
 	GetCampaigns(*pinpoint.GetCampaignsInput) (*pinpoint.GetCampaignsOutput, error)
 	GetCampaignsWithContext(aws.Context, *pinpoint.GetCampaignsInput, ...request.Option) (*pinpoint.GetCampaignsOutput, error)
 	GetCampaignsRequest(*pinpoint.GetCampaignsInput) (*request.Request, *pinpoint.GetCampaignsOutput)
+
+	GetChannels(*pinpoint.GetChannelsInput) (*pinpoint.GetChannelsOutput, error)
+	GetChannelsWithContext(aws.Context, *pinpoint.GetChannelsInput, ...request.Option) (*pinpoint.GetChannelsOutput, error)
+	GetChannelsRequest(*pinpoint.GetChannelsInput) (*request.Request, *pinpoint.GetChannelsOutput)
 
 	GetEmailChannel(*pinpoint.GetEmailChannelInput) (*pinpoint.GetEmailChannelOutput, error)
 	GetEmailChannelWithContext(aws.Context, *pinpoint.GetEmailChannelInput, ...request.Option) (*pinpoint.GetEmailChannelOutput, error)
@@ -252,9 +260,21 @@ type PinpointAPI interface {
 	GetSmsChannelWithContext(aws.Context, *pinpoint.GetSmsChannelInput, ...request.Option) (*pinpoint.GetSmsChannelOutput, error)
 	GetSmsChannelRequest(*pinpoint.GetSmsChannelInput) (*request.Request, *pinpoint.GetSmsChannelOutput)
 
+	GetUserEndpoints(*pinpoint.GetUserEndpointsInput) (*pinpoint.GetUserEndpointsOutput, error)
+	GetUserEndpointsWithContext(aws.Context, *pinpoint.GetUserEndpointsInput, ...request.Option) (*pinpoint.GetUserEndpointsOutput, error)
+	GetUserEndpointsRequest(*pinpoint.GetUserEndpointsInput) (*request.Request, *pinpoint.GetUserEndpointsOutput)
+
+	PhoneNumberValidate(*pinpoint.PhoneNumberValidateInput) (*pinpoint.PhoneNumberValidateOutput, error)
+	PhoneNumberValidateWithContext(aws.Context, *pinpoint.PhoneNumberValidateInput, ...request.Option) (*pinpoint.PhoneNumberValidateOutput, error)
+	PhoneNumberValidateRequest(*pinpoint.PhoneNumberValidateInput) (*request.Request, *pinpoint.PhoneNumberValidateOutput)
+
 	PutEventStream(*pinpoint.PutEventStreamInput) (*pinpoint.PutEventStreamOutput, error)
 	PutEventStreamWithContext(aws.Context, *pinpoint.PutEventStreamInput, ...request.Option) (*pinpoint.PutEventStreamOutput, error)
 	PutEventStreamRequest(*pinpoint.PutEventStreamInput) (*request.Request, *pinpoint.PutEventStreamOutput)
+
+	RemoveAttributes(*pinpoint.RemoveAttributesInput) (*pinpoint.RemoveAttributesOutput, error)
+	RemoveAttributesWithContext(aws.Context, *pinpoint.RemoveAttributesInput, ...request.Option) (*pinpoint.RemoveAttributesOutput, error)
+	RemoveAttributesRequest(*pinpoint.RemoveAttributesInput) (*request.Request, *pinpoint.RemoveAttributesOutput)
 
 	SendMessages(*pinpoint.SendMessagesInput) (*pinpoint.SendMessagesOutput, error)
 	SendMessagesWithContext(aws.Context, *pinpoint.SendMessagesInput, ...request.Option) (*pinpoint.SendMessagesOutput, error)

--- a/service/sagemaker/api.go
+++ b/service/sagemaker/api.go
@@ -159,6 +159,14 @@ func (c *SageMaker) CreateEndpointRequest(input *CreateEndpointInput) (req *requ
 // For an example, see Exercise 1: Using the K-Means Algorithm Provided by Amazon
 // SageMaker (http://docs.aws.amazon.com/sagemaker/latest/dg/ex1.html).
 //
+// If any of the models hosted at this endpoint get model data from an Amazon
+// S3 location, Amazon SageMaker uses AWS Security Token Service to download
+// model artifacts from the S3 path you provided. AWS STS is activated in your
+// IAM user account by default. If you previously deactivated AWS STS for a
+// region, you need to reactivate AWS STS for that region. For more information,
+// see Activating and Deactivating AWS STS i an AWS Region (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+// in the AWS Identity and Access Management User Guide.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -2191,8 +2199,8 @@ func (c *SageMaker) ListHyperParameterTuningJobsRequest(input *ListHyperParamete
 
 // ListHyperParameterTuningJobs API operation for Amazon SageMaker Service.
 //
-// Gets a list of objects that describe the hyperparameter tuning jobs launched
-// in your account.
+// Gets a list of HyperParameterTuningJobSummary objects that describe the hyperparameter
+// tuning jobs launched in your account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2453,7 +2461,8 @@ func (c *SageMaker) ListNotebookInstanceLifecycleConfigsRequest(input *ListNoteb
 
 // ListNotebookInstanceLifecycleConfigs API operation for Amazon SageMaker Service.
 //
-// Lists notebook instance lifestyle configurations created with the API.
+// Lists notebook instance lifestyle configurations created with the CreateNotebookInstanceLifecycleConfig
+// API.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2974,8 +2983,8 @@ func (c *SageMaker) ListTrainingJobsForHyperParameterTuningJobRequest(input *Lis
 
 // ListTrainingJobsForHyperParameterTuningJob API operation for Amazon SageMaker Service.
 //
-// Gets a list of objects that describe the training jobs that a hyperparameter
-// tuning job launched.
+// Gets a list of TrainingJobSummary objects that describe the training jobs
+// that a hyperparameter tuning job launched.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3462,6 +3471,9 @@ func (c *SageMaker) UpdateEndpointRequest(input *UpdateEndpointInput) (req *requ
 // check the status of an endpoint, use the DescribeEndpoint (http://docs.aws.amazon.com/sagemaker/latest/dg/API_DescribeEndpoint.html)
 // API.
 //
+// You cannot update an endpoint with the current EndpointConfig. To update
+// an endpoint, you must create a new EndpointConfig.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -3708,7 +3720,8 @@ func (c *SageMaker) UpdateNotebookInstanceLifecycleConfigRequest(input *UpdateNo
 
 // UpdateNotebookInstanceLifecycleConfig API operation for Amazon SageMaker Service.
 //
-// Updates a notebook instance lifecycle configuration created with the API.
+// Updates a notebook instance lifecycle configuration created with the CreateNotebookInstanceLifecycleConfig
+// API.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4074,8 +4087,9 @@ type ContainerDefinition struct {
 	// The Amazon EC2 Container Registry (Amazon ECR) path where inference code
 	// is stored. If you are using your own custom algorithm instead of an algorithm
 	// provided by Amazon SageMaker, the inference code must meet Amazon SageMaker
-	// requirements. For more information, see Using Your Own Algorithms with Amazon
-	// SageMaker (http://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms.html)
+	// requirements. Amazon SageMaker supports both registry/repository[:tag] and
+	// registry/repository[@digest] image path formats. For more information, see
+	// Using Your Own Algorithms with Amazon SageMaker (http://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms.html)
 	//
 	// Image is a required field
 	Image *string `type:"string" required:"true"`
@@ -4083,6 +4097,14 @@ type ContainerDefinition struct {
 	// The S3 path where the model artifacts, which result from model training,
 	// are stored. This path must point to a single gzip compressed tar archive
 	// (.tar.gz suffix).
+	//
+	// If you provide a value for this parameter, Amazon SageMaker uses AWS Security
+	// Token Service to download model artifacts from the S3 path you provide. AWS
+	// STS is activated in your IAM user account by default. If you previously deactivated
+	// AWS STS for a region, you need to reactivate AWS STS for that region. For
+	// more information, see Activating and Deactivating AWS STS i an AWS Region
+	// (http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)
+	// in the AWS Identity and Access Management User Guide.
 	ModelDataUrl *string `type:"string"`
 }
 
@@ -4430,9 +4452,9 @@ func (s *CreateEndpointOutput) SetEndpointArn(v string) *CreateEndpointOutput {
 type CreateHyperParameterTuningJobInput struct {
 	_ struct{} `type:"structure"`
 
-	// The object that describes the tuning job, including the search strategy,
-	// metric used to evaluate training jobs, ranges of parameters to search, and
-	// resource limits for the tuning job.
+	// The HyperParameterTuningJobConfig object that describes the tuning job, including
+	// the search strategy, metric used to evaluate training jobs, ranges of parameters
+	// to search, and resource limits for the tuning job.
 	//
 	// HyperParameterTuningJobConfig is a required field
 	HyperParameterTuningJobConfig *HyperParameterTuningJobConfig `type:"structure" required:"true"`
@@ -4451,9 +4473,10 @@ type CreateHyperParameterTuningJobInput struct {
 	// in the AWS Billing and Cost Management User Guide.
 	Tags []*Tag `type:"list"`
 
-	// The object that describes the training jobs that this tuning job launches,
-	// including static hyperparameters, input data configuration, output data configuration,
-	// resource configuration, and stopping condition.
+	// The HyperParameterTrainingJobDefinition object that describes the training
+	// jobs that this tuning job launches, including static hyperparameters, input
+	// data configuration, output data configuration, resource configuration, and
+	// stopping condition.
 	//
 	// TrainingJobDefinition is a required field
 	TrainingJobDefinition *HyperParameterTrainingJobDefinition `type:"structure" required:"true"`
@@ -4591,9 +4614,9 @@ type CreateModelInput struct {
 	// in the AWS Billing and Cost Management User Guide.
 	Tags []*Tag `type:"list"`
 
-	// A object that specifies the VPC that you want your model to connect to. Control
-	// access to and from your model container by configuring the VPC. For more
-	// information, see host-vpc.
+	// A VpcConfig object that specifies the VPC that you want your model to connect
+	// to. Control access to and from your model container by configuring the VPC.
+	// For more information, see host-vpc.
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -5149,9 +5172,9 @@ type CreateTrainingJobInput struct {
 	// TrainingJobName is a required field
 	TrainingJobName *string `min:"1" type:"string" required:"true"`
 
-	// A object that specifies the VPC that you want your training job to connect
-	// to. Control access to and from your training container by configuring the
-	// VPC. For more information, see train-vpc
+	// A VpcConfig object that specifies the VPC that you want your training job
+	// to connect to. Control access to and from your training container by configuring
+	// the VPC. For more information, see train-vpc
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -5708,6 +5731,56 @@ func (s DeleteTagsOutput) GoString() string {
 	return s.String()
 }
 
+// Gets the Amazon EC2 Container Registry path of the docker image of the model
+// that is hosted in this ProductionVariant.
+//
+// If you used the registry/repository[:tag] form to to specify the image path
+// of the primary container when you created the model hosted in this ProductionVariant,
+// the path resolves to a path of the form registry/repository[@digest]. A digest
+// is a hash value that identifies a specific version of an image. For information
+// about Amazon ECR paths, see Pulling an Image (http://docs.aws.amazon.com//AmazonECR/latest/userguide/docker-pull-ecr-image.html)
+// in the Amazon ECR User Guide.
+type DeployedImage struct {
+	_ struct{} `type:"structure"`
+
+	// The date and time when the image path for the model resolved to the ResolvedImage
+	ResolutionTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The specific digest path of the image hosted in this ProductionVariant.
+	ResolvedImage *string `type:"string"`
+
+	// The image path you specified when you created the model.
+	SpecifiedImage *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DeployedImage) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeployedImage) GoString() string {
+	return s.String()
+}
+
+// SetResolutionTime sets the ResolutionTime field's value.
+func (s *DeployedImage) SetResolutionTime(v time.Time) *DeployedImage {
+	s.ResolutionTime = &v
+	return s
+}
+
+// SetResolvedImage sets the ResolvedImage field's value.
+func (s *DeployedImage) SetResolvedImage(v string) *DeployedImage {
+	s.ResolvedImage = &v
+	return s
+}
+
+// SetSpecifiedImage sets the SpecifiedImage field's value.
+func (s *DeployedImage) SetSpecifiedImage(v string) *DeployedImage {
+	s.SpecifiedImage = &v
+	return s
+}
+
 type DescribeEndpointConfigInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5889,8 +5962,8 @@ type DescribeEndpointOutput struct {
 	// LastModifiedTime is a required field
 	LastModifiedTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	// An array of ProductionVariant objects, one for each model hosted behind this
-	// endpoint.
+	// An array of ProductionVariantSummary objects, one for each model hosted behind
+	// this endpoint.
 	ProductionVariants []*ProductionVariantSummary `min:"1" type:"list"`
 }
 
@@ -5996,8 +6069,8 @@ func (s *DescribeHyperParameterTuningJobInput) SetHyperParameterTuningJobName(v 
 type DescribeHyperParameterTuningJobOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A object that describes the training job that completed with the best current
-	// .
+	// A TrainingJobSummary object that describes the training job that completed
+	// with the best current HyperParameterTuningJobObjective.
 	BestTrainingJob *HyperParameterTrainingJobSummary `type:"structure"`
 
 	// The date and time that the tuning job started.
@@ -6016,7 +6089,8 @@ type DescribeHyperParameterTuningJobOutput struct {
 	// HyperParameterTuningJobArn is a required field
 	HyperParameterTuningJobArn *string `type:"string" required:"true"`
 
-	// The object that specifies the configuration of the tuning job.
+	// The HyperParameterTuningJobConfig object that specifies the configuration
+	// of the tuning job.
 	//
 	// HyperParameterTuningJobConfig is a required field
 	HyperParameterTuningJobConfig *HyperParameterTuningJobConfig `type:"structure" required:"true"`
@@ -6035,20 +6109,21 @@ type DescribeHyperParameterTuningJobOutput struct {
 	// The date and time that the status of the tuning job was modified.
 	LastModifiedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The object that specifies the number of training jobs, categorized by the
-	// status of their final objective metric, that this tuning job launched.
+	// The ObjectiveStatusCounters object that specifies the number of training
+	// jobs, categorized by the status of their final objective metric, that this
+	// tuning job launched.
 	//
 	// ObjectiveStatusCounters is a required field
 	ObjectiveStatusCounters *ObjectiveStatusCounters `type:"structure" required:"true"`
 
-	// The object that specifies the definition of the training jobs that this tuning
-	// job launches.
+	// The HyperParameterTrainingJobDefinition object that specifies the definition
+	// of the training jobs that this tuning job launches.
 	//
 	// TrainingJobDefinition is a required field
 	TrainingJobDefinition *HyperParameterTrainingJobDefinition `type:"structure" required:"true"`
 
-	// The object that specifies the number of training jobs, categorized by status,
-	// that this tuning job launched.
+	// The TrainingJobStatusCounters object that specifies the number of training
+	// jobs, categorized by status, that this tuning job launched.
 	//
 	// TrainingJobStatusCounters is a required field
 	TrainingJobStatusCounters *TrainingJobStatusCounters `type:"structure" required:"true"`
@@ -6204,8 +6279,8 @@ type DescribeModelOutput struct {
 	// PrimaryContainer is a required field
 	PrimaryContainer *ContainerDefinition `type:"structure" required:"true"`
 
-	// A object that specifies the VPC that this model has access to. For more information,
-	// see host-vpc
+	// A VpcConfig object that specifies the VPC that this model has access to.
+	// For more information, see host-vpc
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -6710,8 +6785,8 @@ type DescribeTrainingJobOutput struct {
 	// if the training job was launched by a hyperparameter tuning job.
 	TuningJobArn *string `type:"string"`
 
-	// A object that specifies the VPC that this training job has access to. For
-	// more information, see train-vpc.
+	// A VpcConfig object that specifies the VPC that this training job has access
+	// to. For more information, see train-vpc.
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -7071,7 +7146,8 @@ func (s *FinalHyperParameterTuningJobObjectiveMetric) SetValue(v float64) *Final
 type HyperParameterAlgorithmSpecification struct {
 	_ struct{} `type:"structure"`
 
-	// An array of objects that specify the metrics that the algorithm emits.
+	// An array of MetricDefinition objects that specify the metrics that the algorithm
+	// emits.
 	MetricDefinitions []*MetricDefinition `type:"list"`
 
 	// The registry path of the Docker image that contains the training algorithm.
@@ -7156,14 +7232,14 @@ func (s *HyperParameterAlgorithmSpecification) SetTrainingInputMode(v string) *H
 type HyperParameterTrainingJobDefinition struct {
 	_ struct{} `type:"structure"`
 
-	// The object that specifies the algorithm to use for the training jobs that
-	// the tuning job launches.
+	// The HyperParameterAlgorithmSpecification object that specifies the algorithm
+	// to use for the training jobs that the tuning job launches.
 	//
 	// AlgorithmSpecification is a required field
 	AlgorithmSpecification *HyperParameterAlgorithmSpecification `type:"structure" required:"true"`
 
-	// An array of objects that specify the input for the training jobs that the
-	// tuning job launches.
+	// An array of Channel objects that specify the input for the training jobs
+	// that the tuning job launches.
 	//
 	// InputDataConfig is a required field
 	InputDataConfig []*Channel `min:"1" type:"list" required:"true"`
@@ -7210,10 +7286,10 @@ type HyperParameterTrainingJobDefinition struct {
 	// StoppingCondition is a required field
 	StoppingCondition *StoppingCondition `type:"structure" required:"true"`
 
-	// The object that specifies the VPC that you want the training jobs that this
-	// hyperparameter tuning job launches to connect to. Control access to and from
-	// your training container by configuring the VPC. For more information, see
-	// train-vpc.
+	// The VpcConfig object that specifies the VPC that you want the training jobs
+	// that this hyperparameter tuning job launches to connect to. Control access
+	// to and from your training container by configuring the VPC. For more information,
+	// see train-vpc.
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -7353,11 +7429,12 @@ type HyperParameterTrainingJobSummary struct {
 	// CreationTime is a required field
 	CreationTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
 
-	// The reason that the
+	// The reason that the training job failed.
 	FailureReason *string `type:"string"`
 
-	// The object that specifies the value of the objective metric of the tuning
-	// job that launched this training job.
+	// The FinalHyperParameterTuningJobObjectiveMetric object that specifies the
+	// value of the objective metric of the tuning job that launched this training
+	// job.
 	FinalHyperParameterTuningJobObjectiveMetric *FinalHyperParameterTuningJobObjectiveMetric `type:"structure"`
 
 	// The status of the objective metric for the training job:
@@ -7475,19 +7552,20 @@ func (s *HyperParameterTrainingJobSummary) SetTunedHyperParameters(v map[string]
 type HyperParameterTuningJobConfig struct {
 	_ struct{} `type:"structure"`
 
-	// The object that specifies the objective metric for this tuning job.
+	// The HyperParameterTuningJobObjective object that specifies the objective
+	// metric for this tuning job.
 	//
 	// HyperParameterTuningJobObjective is a required field
 	HyperParameterTuningJobObjective *HyperParameterTuningJobObjective `type:"structure" required:"true"`
 
-	// The object that specifies the ranges of hyperparameters that this tuning
-	// job searches.
+	// The ParameterRanges object that specifies the ranges of hyperparameters that
+	// this tuning job searches.
 	//
 	// ParameterRanges is a required field
 	ParameterRanges *ParameterRanges `type:"structure" required:"true"`
 
-	// The object that specifies the maximum number of training jobs and parallel
-	// training jobs for this tuning job.
+	// The ResourceLimits object that specifies the maximum number of training jobs
+	// and parallel training jobs for this tuning job.
 	//
 	// ResourceLimits is a required field
 	ResourceLimits *ResourceLimits `type:"structure" required:"true"`
@@ -7659,14 +7737,14 @@ type HyperParameterTuningJobSummary struct {
 	// The date and time that the tuning job was modified.
 	LastModifiedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The object that specifies the numbers of training jobs, categorized by objective
-	// metric status, that this tuning job launched.
+	// The ObjectiveStatusCounters object that specifies the numbers of training
+	// jobs, categorized by objective metric status, that this tuning job launched.
 	//
 	// ObjectiveStatusCounters is a required field
 	ObjectiveStatusCounters *ObjectiveStatusCounters `type:"structure" required:"true"`
 
-	// The object that specifies the maximum number of training jobs and parallel
-	// training jobs allowed for this tuning job.
+	// The ResourceLimits object that specifies the maximum number of training jobs
+	// and parallel training jobs allowed for this tuning job.
 	ResourceLimits *ResourceLimits `type:"structure"`
 
 	// Specifies the search strategy hyperparameter tuning uses to choose which
@@ -7676,8 +7754,8 @@ type HyperParameterTuningJobSummary struct {
 	// Strategy is a required field
 	Strategy *string `type:"string" required:"true" enum:"HyperParameterTuningJobStrategyType"`
 
-	// The object that specifies the numbers of training jobs, categorized by status,
-	// that this tuning job launched.
+	// The TrainingJobStatusCounters object that specifies the numbers of training
+	// jobs, categorized by status, that this tuning job launched.
 	//
 	// TrainingJobStatusCounters is a required field
 	TrainingJobStatusCounters *TrainingJobStatusCounters `type:"structure" required:"true"`
@@ -8129,7 +8207,7 @@ type ListHyperParameterTuningJobsInput struct {
 	// time.
 	LastModifiedTimeBefore *time.Time `type:"timestamp" timestampFormat:"unix"`
 
-	// The maximum number of tuning jobs to return.
+	// The maximum number of tuning jobs to return. The default value is 10.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// A string in the tuning job name. This filter returns only tuning jobs whose
@@ -8237,8 +8315,8 @@ func (s *ListHyperParameterTuningJobsInput) SetStatusEquals(v string) *ListHyper
 type ListHyperParameterTuningJobsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of objects that describe the tuning jobs that the ListHyperParameterTuningJobs
-	// request returned.
+	// A list of HyperParameterTuningJobSummary objects that describe the tuning
+	// jobs that the ListHyperParameterTuningJobs request returned.
 	//
 	// HyperParameterTuningJobSummaries is a required field
 	HyperParameterTuningJobSummaries []*HyperParameterTuningJobSummary `type:"list" required:"true"`
@@ -8824,7 +8902,7 @@ type ListTrainingJobsForHyperParameterTuningJobInput struct {
 	// HyperParameterTuningJobName is a required field
 	HyperParameterTuningJobName *string `min:"1" type:"string" required:"true"`
 
-	// The maximum number of training jobs to return.
+	// The maximum number of training jobs to return. The default value is 10.
 	MaxResults *int64 `min:"1" type:"integer"`
 
 	// If the result of the previous ListTrainingJobsForHyperParameterTuningJob
@@ -8833,6 +8911,9 @@ type ListTrainingJobsForHyperParameterTuningJobInput struct {
 	NextToken *string `type:"string"`
 
 	// The field to sort results by. The default is Name.
+	//
+	// If the value of this field is FinalObjectiveMetricValue, any training jobs
+	// that did not return an objective metric are not listed.
 	SortBy *string `type:"string" enum:"TrainingJobSortByOptions"`
 
 	// The sort order for results. The default is Ascending.
@@ -8915,8 +8996,8 @@ type ListTrainingJobsForHyperParameterTuningJobOutput struct {
 	// of training jobs, use the token in the next request.
 	NextToken *string `type:"string"`
 
-	// A list of objects that describe the training jobs that the ListTrainingJobsForHyperParameterTuningJob
-	// request returned.
+	// A list of TrainingJobSummary objects that describe the training jobs that
+	// the ListTrainingJobsForHyperParameterTuningJob request returned.
 	//
 	// TrainingJobSummaries is a required field
 	TrainingJobSummaries []*HyperParameterTrainingJobSummary `type:"list" required:"true"`
@@ -9116,7 +9197,7 @@ type MetricDefinition struct {
 
 	// A regular expression that searches the output of a training job and gets
 	// the value of the metric. For more information about using regular expressions
-	// to define metrics, see hpo-define-metrics.
+	// to define metrics, see automatic-model-tuning-define-metrics.
 	//
 	// Regex is a required field
 	Regex *string `min:"1" type:"string" required:"true"`
@@ -9751,6 +9832,10 @@ type ProductionVariantSummary struct {
 	// The weight associated with the variant.
 	CurrentWeight *float64 `type:"float"`
 
+	// An array of DeployedImage objects that specify the Amazon EC2 Container Registry
+	// paths of the inference images deployed on instances of this ProductionVariant.
+	DeployedImages []*DeployedImage `type:"list"`
+
 	// The number of instances requested in the UpdateEndpointWeightsAndCapacities
 	// request.
 	DesiredInstanceCount *int64 `min:"1" type:"integer"`
@@ -9784,6 +9869,12 @@ func (s *ProductionVariantSummary) SetCurrentInstanceCount(v int64) *ProductionV
 // SetCurrentWeight sets the CurrentWeight field's value.
 func (s *ProductionVariantSummary) SetCurrentWeight(v float64) *ProductionVariantSummary {
 	s.CurrentWeight = &v
+	return s
+}
+
+// SetDeployedImages sets the DeployedImages field's value.
+func (s *ProductionVariantSummary) SetDeployedImages(v []*DeployedImage) *ProductionVariantSummary {
+	s.DeployedImages = v
 	return s
 }
 
@@ -11159,6 +11250,9 @@ const (
 
 	// NotebookInstanceStatusDeleting is a NotebookInstanceStatus enum value
 	NotebookInstanceStatusDeleting = "Deleting"
+
+	// NotebookInstanceStatusUpdating is a NotebookInstanceStatus enum value
+	NotebookInstanceStatusUpdating = "Updating"
 )
 
 const (


### PR DESCRIPTION
Release v1.14.20 (2018-07-05)
===

### Service Client Updates
* `service/pinpoint`: Updates service API and documentation
  * This release of the Amazon Pinpoint SDK adds the ability to create complex segments and validate phone numbers for SMS messages. It also adds the ability to get or delete endpoints based on user IDs, remove attributes from endpoints, and list the defined channels for an app.
* `service/sagemaker`: Updates service API and documentation
  * Amazon SageMaker NotebookInstances supports 'Updating' as a NotebookInstanceStatus.  In addition, DescribeEndpointOutput now includes Docker repository digest of deployed Model images.

