### PR TITLE
service/dynamodb/dynamodbattribute: Unmarshalling empty maps or lists to empty, not NULL [#1606]

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -172,23 +172,23 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	}
 
 	switch {
-	case len(av.B) != 0:
+	case av.B != nil:
 		return d.decodeBinary(av.B, v)
 	case av.BOOL != nil:
 		return d.decodeBool(av.BOOL, v)
-	case len(av.BS) != 0:
+	case av.BS != nil:
 		return d.decodeBinarySet(av.BS, v)
-	case len(av.L) != 0:
+	case av.L != nil:
 		return d.decodeList(av.L, v)
-	case len(av.M) != 0:
+	case av.M != nil:
 		return d.decodeMap(av.M, v)
 	case av.N != nil:
 		return d.decodeNumber(av.N, v, fieldTag)
-	case len(av.NS) != 0:
+	case av.NS != nil:
 		return d.decodeNumberSet(av.NS, v)
 	case av.S != nil:
 		return d.decodeString(av.S, v, fieldTag)
-	case len(av.SS) != 0:
+	case av.SS != nil:
 		return d.decodeStringSet(av.SS, v)
 	}
 

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -235,7 +235,7 @@ func TestUnmarshalEmpties(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		err := Unmarshal(c.in, c.actual)
+		err := UnmarshalWithEmpties(c.in, c.actual)
 		assertConvertTest(t, i, c.actual, c.expected, err, c.err)
 	}
 }

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -178,6 +178,68 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
+func TestUnmarshalEmpties(t *testing.T) {
+	cases := []struct {
+		in               *dynamodb.AttributeValue
+		actual, expected interface{}
+		err              error
+	}{
+		//------------
+		// Sets
+		//------------
+		{
+			in:       &dynamodb.AttributeValue{SS: []*string{}},
+			actual:   &[]*string{},
+			expected: &[]*string{},
+		},
+		//------------
+		// Interfaces
+		//------------
+		{
+			in: &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{}},
+			actual: func() interface{} {
+				var v interface{}
+				return &v
+			}(),
+			expected: []interface{}{},
+		},
+		{
+			in: &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{}},
+			actual: func() interface{} {
+				var v interface{}
+				return &v
+			}(),
+			expected: map[string]interface{}{},
+		},
+		{
+			in: &dynamodb.AttributeValue{S: aws.String("")},
+			actual: func() interface{} {
+				var v interface{}
+				return &v
+			}(),
+			expected: "",
+		},
+		{
+			in: &dynamodb.AttributeValue{SS: []*string{}},
+			actual: func() interface{} {
+				var v interface{}
+				return &v
+			}(),
+			expected: []string{},
+		},
+		{
+			in:       &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{}},
+			actual:   &struct{ Abc, Cba string }{},
+			expected: struct{ Abc, Cba string }{},
+		},
+	}
+
+	for i, c := range cases {
+		err := Unmarshal(c.in, c.actual)
+		assertConvertTest(t, i, c.actual, c.expected, err, c.err)
+	}
+}
+
 func TestInterfaceInput(t *testing.T) {
 	var v interface{}
 	expected := []interface{}{"abc", "123"}


### PR DESCRIPTION
This one would resolve at least the part of unmarshalling M and L dynamodb attributes with no elements but not nulls.