### PR TITLE
v1.14.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Release v1.14.21 (2018-07-06)
+===
+
+### Service Client Updates
+* `service/mediaconvert`: Updates service API and documentation
+  * This release adds support for the following 1) users can specify tags to be attached to queues, presets, and templates during creation of those resources on MediaConvert. 2) users can now view the count of jobs in submitted state and in progressing state on a per queue basis.
+* `service/serverlessrepo`: Updates service API and documentation
+
 Release v1.14.20 (2018-07-05)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.20"
+const SDKVersion = "1.14.21"

--- a/models/apis/mediaconvert/2017-08-29/api-2.json
+++ b/models/apis/mediaconvert/2017-08-29/api-2.json
@@ -590,6 +590,108 @@
         }
       ]
     },
+    "ListTagsForResource": {
+      "name": "ListTagsForResource",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2017-08-29/tags/{arn}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListTagsForResourceRequest"
+      },
+      "output": {
+        "shape": "ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "ConflictException"
+        }
+      ]
+    },
+    "TagResource": {
+      "name": "TagResource",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2017-08-29/tags",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "TagResourceRequest"
+      },
+      "output": {
+        "shape": "TagResourceResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "ConflictException"
+        }
+      ]
+    },
+    "UntagResource": {
+      "name": "UntagResource",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/2017-08-29/tags",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UntagResourceRequest"
+      },
+      "output": {
+        "shape": "UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        },
+        {
+          "shape": "ConflictException"
+        }
+      ]
+    },
     "UpdateJobTemplate": {
       "name": "UpdateJobTemplate",
       "http": {
@@ -1853,6 +1955,10 @@
         "Settings": {
           "shape": "JobTemplateSettings",
           "locationName": "settings"
+        },
+        "Tags": {
+          "shape": "__mapOf__string",
+          "locationName": "tags"
         }
       },
       "required": [
@@ -1887,6 +1993,10 @@
         "Settings": {
           "shape": "PresetSettings",
           "locationName": "settings"
+        },
+        "Tags": {
+          "shape": "__mapOf__string",
+          "locationName": "tags"
         }
       },
       "required": [
@@ -1913,6 +2023,10 @@
         "Name": {
           "shape": "__string",
           "locationName": "name"
+        },
+        "Tags": {
+          "shape": "__mapOf__string",
+          "locationName": "tags"
         }
       },
       "required": [
@@ -4433,7 +4547,7 @@
           "location": "querystring"
         },
         "MaxResults": {
-          "shape": "__integer",
+          "shape": "__integerMin1Max20",
           "locationName": "maxResults",
           "location": "querystring"
         },
@@ -4466,7 +4580,7 @@
       "type": "structure",
       "members": {
         "MaxResults": {
-          "shape": "__integer",
+          "shape": "__integerMin1Max20",
           "locationName": "maxResults",
           "location": "querystring"
         },
@@ -4519,7 +4633,7 @@
           "location": "querystring"
         },
         "MaxResults": {
-          "shape": "__integer",
+          "shape": "__integerMin1Max20",
           "locationName": "maxResults",
           "location": "querystring"
         },
@@ -4557,7 +4671,7 @@
           "location": "querystring"
         },
         "MaxResults": {
-          "shape": "__integer",
+          "shape": "__integerMin1Max20",
           "locationName": "maxResults",
           "location": "querystring"
         },
@@ -4583,6 +4697,28 @@
         "Queues": {
           "shape": "__listOfQueue",
           "locationName": "queues"
+        }
+      }
+    },
+    "ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn",
+          "location": "uri"
+        }
+      },
+      "required": [
+        "Arn"
+      ]
+    },
+    "ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "ResourceTags": {
+          "shape": "ResourceTags",
+          "locationName": "resourceTags"
         }
       }
     },
@@ -5770,9 +5906,17 @@
           "shape": "__string",
           "locationName": "name"
         },
+        "ProgressingJobsCount": {
+          "shape": "__integer",
+          "locationName": "progressingJobsCount"
+        },
         "Status": {
           "shape": "QueueStatus",
           "locationName": "status"
+        },
+        "SubmittedJobsCount": {
+          "shape": "__integer",
+          "locationName": "submittedJobsCount"
         },
         "Type": {
           "shape": "Type",
@@ -5845,6 +5989,19 @@
         "ChannelMapping",
         "ChannelsIn"
       ]
+    },
+    "ResourceTags": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "Tags": {
+          "shape": "__mapOf__string",
+          "locationName": "tags"
+        }
+      }
     },
     "RespondToAfd": {
       "type": "string",
@@ -5925,6 +6082,28 @@
         "Url",
         "StaticKeyValue"
       ]
+    },
+    "TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "Tags": {
+          "shape": "__mapOf__string",
+          "locationName": "tags"
+        }
+      },
+      "required": [
+        "Arn",
+        "Tags"
+      ]
+    },
+    "TagResourceResponse": {
+      "type": "structure",
+      "members": {
+      }
     },
     "TeletextDestinationSettings": {
       "type": "structure",
@@ -6075,6 +6254,24 @@
         "SYSTEM",
         "CUSTOM"
       ]
+    },
+    "UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "shape": "__string",
+          "locationName": "arn"
+        },
+        "TagKeys": {
+          "shape": "__listOf__string",
+          "locationName": "tagKeys"
+        }
+      }
+    },
+    "UntagResourceResponse": {
+      "type": "structure",
+      "members": {
+      }
     },
     "UpdateJobTemplateRequest": {
       "type": "structure",
@@ -6587,6 +6784,11 @@
       "min": 1,
       "max": 2
     },
+    "__integerMin1Max20": {
+      "type": "integer",
+      "min": 1,
+      "max": 20
+    },
     "__integerMin1Max2147483647": {
       "type": "integer",
       "min": 1,
@@ -6858,6 +7060,12 @@
       "type": "list",
       "member": {
         "shape": "__integerMinNegative60Max6"
+      }
+    },
+    "__listOf__string": {
+      "type": "list",
+      "member": {
+        "shape": "__string"
       }
     },
     "__listOf__stringMin1": {

--- a/models/apis/mediaconvert/2017-08-29/docs-2.json
+++ b/models/apis/mediaconvert/2017-08-29/docs-2.json
@@ -19,6 +19,9 @@
     "ListJobs": "Retrieve a JSON array of up to twenty of your most recently created jobs. This array includes in-process, completed, and errored jobs. This will return the jobs themselves, not just a list of the jobs. To retrieve the twenty next most recent jobs, use the nextToken string returned with the array.",
     "ListPresets": "Retrieve a JSON array of up to twenty of your presets. This will return the presets themselves, not just a list of them. To retrieve the next twenty presets, use the nextToken string returned with the array.",
     "ListQueues": "Retrieve a JSON array of up to twenty of your queues. This will return the queues themselves, not just a list of them. To retrieve the next twenty queues, use the nextToken string returned with the array.",
+    "ListTagsForResource": "Retrieve the tags for a MediaConvert resource.",
+    "TagResource": "Tag a MediaConvert queue, preset, or job template. For information about these resource types, see the User Guide at http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html",
+    "UntagResource": "Untag a MediaConvert queue, preset, or job template. For information about these resource types, see the User Guide at http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html",
     "UpdateJobTemplate": "Modify one of your existing job templates.",
     "UpdatePreset": "Modify one of your existing presets.",
     "UpdateQueue": "Modify one of your existing queues."
@@ -1436,6 +1439,16 @@
       "refs": {
       }
     },
+    "ListTagsForResourceRequest": {
+      "base": "List the tags for your MediaConvert resource by sending a request with the Amazon Resource Name (ARN) of the resource. To get the ARN, send a GET request with the resource name.",
+      "refs": {
+      }
+    },
+    "ListTagsForResourceResponse": {
+      "base": "Successful list tags for resource requests return a JSON map of tags.",
+      "refs": {
+      }
+    },
     "M2tsAudioBufferModel": {
       "base": "Selects between the DVB and ATSC buffer models for Dolby Digital audio.",
       "refs": {
@@ -1936,6 +1949,12 @@
         "AudioSelector$RemixSettings": "Use these settings to reorder the audio channels of one input to match those of another input. This allows you to combine the two files into a single output, one after the other."
       }
     },
+    "ResourceTags": {
+      "base": "The Amazon Resource Name (ARN) and tags for an AWS Elemental MediaConvert resource.",
+      "refs": {
+        "ListTagsForResourceResponse$ResourceTags": null
+      }
+    },
     "RespondToAfd": {
       "base": "Use Respond to AFD (RespondToAfd) to specify how the service changes the video itself in response to AFD values in the input. * Choose Respond to clip the input video frame according to the AFD value, input display aspect ratio, and output display aspect ratio. * Choose Passthrough to include the input AFD values. Do not choose this when AfdSignaling is set to (NONE). A preferred implementation of this workflow is to set RespondToAfd to (NONE) and set AfdSignaling to (AUTO). * Choose None to remove all input AFD values from this output.",
       "refs": {
@@ -1973,6 +1992,16 @@
       "refs": {
         "CmafEncryptionSettings$StaticKeyProvider": null,
         "HlsEncryptionSettings$StaticKeyProvider": null
+      }
+    },
+    "TagResourceRequest": {
+      "base": "To tag a queue, preset, or job template, send a request with the tags and the Amazon Resource Name (ARN) of the resource that you want to tag.",
+      "refs": {
+      }
+    },
+    "TagResourceResponse": {
+      "base": "Successful tag resource requests return an OK message.",
+      "refs": {
       }
     },
     "TeletextDestinationSettings": {
@@ -2054,6 +2083,16 @@
         "JobTemplate$Type": "A job template can be of two types: system or custom. System or built-in job templates can't be modified or deleted by the user.",
         "Preset$Type": "A preset can be of two types: system or custom. System or built-in preset can't be modified or deleted by the user.",
         "Queue$Type": "A queue can be of two types: system or custom. System or built-in queues can't be modified or deleted by the user."
+      }
+    },
+    "UntagResourceRequest": {
+      "base": "To remove tags from a resource, send a request with the Amazon Resource Name (ARN) of the resource and the keys of the tags that you want to remove.",
+      "refs": {
+      }
+    },
+    "UntagResourceResponse": {
+      "base": "Successful untag resource requests return an OK message.",
+      "refs": {
       }
     },
     "UpdateJobTemplateRequest": {
@@ -2178,11 +2217,9 @@
       "refs": {
         "DescribeEndpointsRequest$MaxResults": "Optional. Max number of endpoints, up to twenty, that will be returned at one time.",
         "Job$ErrorCode": "Error code for the job",
-        "ListJobTemplatesRequest$MaxResults": "Optional. Number of job templates, up to twenty, that will be returned at one time.",
-        "ListJobsRequest$MaxResults": "Optional. Number of jobs, up to twenty, that will be returned at one time.",
-        "ListPresetsRequest$MaxResults": "Optional. Number of presets, up to twenty, that will be returned at one time",
-        "ListQueuesRequest$MaxResults": "Optional. Number of queues, up to twenty, that will be returned at one time.",
         "OutputDetail$DurationInMs": "Duration in milliseconds",
+        "Queue$ProgressingJobsCount": "Estimated number of jobs in PROGRESSING status.",
+        "Queue$SubmittedJobsCount": "Estimated number of jobs in SUBMITTED status.",
         "VideoDetail$HeightInPx": "Height in pixels for the output",
         "VideoDetail$WidthInPx": "Width in pixels for the output"
       }
@@ -2456,6 +2493,15 @@
       "refs": {
         "AiffSettings$Channels": "Set Channels to specify the number of channels in this output audio track. Choosing Mono in the console will give you 1 output channel; choosing Stereo will give you 2. In the API, valid values are 1 and 2.",
         "Mp2Settings$Channels": "Set Channels to specify the number of channels in this output audio track. Choosing Mono in the console will give you 1 output channel; choosing Stereo will give you 2. In the API, valid values are 1 and 2."
+      }
+    },
+    "__integerMin1Max20": {
+      "base": null,
+      "refs": {
+        "ListJobTemplatesRequest$MaxResults": "Optional. Number of job templates, up to twenty, that will be returned at one time.",
+        "ListJobsRequest$MaxResults": "Optional. Number of jobs, up to twenty, that will be returned at one time.",
+        "ListPresetsRequest$MaxResults": "Optional. Number of presets, up to twenty, that will be returned at one time",
+        "ListQueuesRequest$MaxResults": "Optional. Number of queues, up to twenty, that will be returned at one time."
       }
     },
     "__integerMin1Max2147483647": {
@@ -2835,10 +2881,16 @@
         "OutputChannelMapping$InputChannels": "List of input channels"
       }
     },
+    "__listOf__string": {
+      "base": null,
+      "refs": {
+        "UntagResourceRequest$TagKeys": "The keys of the tags that you want to remove from the resource."
+      }
+    },
     "__listOf__stringMin1": {
       "base": null,
       "refs": {
-        "AudioSelectorGroup$AudioSelectorNames": "Name of an Audio Selector within the same input to include in the group.  Audio selector names are standardized, based on their order within the input (e.g., \"Audio Selector 1\").  The audio selector name parameter can be repeated to add any number of audio selectors to the group."
+        "AudioSelectorGroup$AudioSelectorNames": "Name of an Audio Selector within the same input to include in the group.  Audio selector names are standardized, based on their order within the input (e.g., \"Audio Selector 1\"). The audio selector name parameter can be repeated to add any number of audio selectors to the group."
       }
     },
     "__listOf__stringPattern09aFAF809aFAF409aFAF409aFAF409aFAF12": {
@@ -2872,7 +2924,12 @@
       "base": null,
       "refs": {
         "CreateJobRequest$UserMetadata": "User-defined metadata that you want to associate with an MediaConvert job. You specify metadata in key/value pairs.",
-        "Job$UserMetadata": "User-defined metadata that you want to associate with an MediaConvert job. You specify metadata in key/value pairs."
+        "CreateJobTemplateRequest$Tags": "The tags that you want to add to the resource. You can tag resources with a key-value pair or with only a key.",
+        "CreatePresetRequest$Tags": "The tags that you want to add to the resource. You can tag resources with a key-value pair or with only a key.",
+        "CreateQueueRequest$Tags": "The tags that you want to add to the resource. You can tag resources with a key-value pair or with only a key.",
+        "Job$UserMetadata": "User-defined metadata that you want to associate with an MediaConvert job. You specify metadata in key/value pairs.",
+        "ResourceTags$Tags": "The tags for the resource.",
+        "TagResourceRequest$Tags": "The tags that you want to add to the resource. You can tag resources with a key-value pair or with only a key."
       }
     },
     "__string": {
@@ -2935,6 +2992,7 @@
         "ListPresetsResponse$NextToken": "Use this string to request the next batch of presets.",
         "ListQueuesRequest$NextToken": "Use this string, provided with the response to a previous request, to request the next batch of queues.",
         "ListQueuesResponse$NextToken": "Use this string to request the next batch of queues.",
+        "ListTagsForResourceRequest$Arn": "The Amazon Resource Name (ARN) of the resource that you want to list tags for. To get the ARN, send a GET request with the resource name.",
         "Mp4Settings$Mp4MajorBrand": "Overrides the \"Major Brand\" field in the output file. Usually not necessary to specify.",
         "NielsenConfiguration$DistributorId": "Use Distributor ID (DistributorID) to specify the distributor ID that is assigned to your organization by Neilsen.",
         "Output$Extension": "Use Extension (Extension) to specify the file extension for outputs in File output groups. If you do not specify a value, the service will use default extensions by container type as follows * MPEG-2 transport stream, m2ts * Quicktime, mov * MXF container, mxf * MPEG-4 container, mp4 * No Container, the service will use codec extensions (e.g. AAC, H265, H265, AC3)",
@@ -2947,8 +3005,11 @@
         "Queue$Arn": "An identifier for this resource that is unique within all of AWS.",
         "Queue$Description": "An optional description you create for each queue.",
         "Queue$Name": "A name you create for each queue. Each name must be unique within your account.",
+        "ResourceTags$Arn": "The Amazon Resource Name (ARN) of the resource.",
         "SpekeKeyProvider$ResourceId": "The SPEKE-compliant server uses Resource ID (ResourceId) to identify content.",
         "StaticKeyProvider$Url": "Relates to DRM implementation. The location of the license server used for protecting content.",
+        "TagResourceRequest$Arn": "The Amazon Resource Name (ARN) of the resource that you want to tag. To get the ARN, send a GET request with the resource name.",
+        "UntagResourceRequest$Arn": "The Amazon Resource Name (ARN) of the resource that you want to remove tags from. To get the ARN, send a GET request with the resource name.",
         "UpdateJobTemplateRequest$Category": "The new category for the job template, if you are changing it.",
         "UpdateJobTemplateRequest$Description": "The new description for the job template, if you are changing it.",
         "UpdateJobTemplateRequest$Name": "The name of the job template you are modifying",
@@ -2958,6 +3019,7 @@
         "UpdatePresetRequest$Name": "The name of the preset you are modifying.",
         "UpdateQueueRequest$Description": "The new description for the queue, if you are changing it.",
         "UpdateQueueRequest$Name": "The name of the queue you are modifying.",
+        "__listOf__string$member": null,
         "__mapOf__string$member": null
       }
     },

--- a/models/apis/serverlessrepo/2017-09-08/api-2.json
+++ b/models/apis/serverlessrepo/2017-09-08/api-2.json
@@ -581,7 +581,8 @@
           "shape" : "__string",
           "locationName" : "templateUrl"
         }
-      }
+      },
+      "required" : [ "Description", "Name", "Author" ]
     },
     "CreateApplicationResponse" : {
       "type" : "structure",
@@ -745,7 +746,7 @@
           "locationName" : "stackName"
         }
       },
-      "required" : [ "ApplicationId" ]
+      "required" : [ "ApplicationId", "StackName" ]
     },
     "CreateCloudFormationChangeSetResponse" : {
       "type" : "structure",
@@ -1067,7 +1068,7 @@
           "locationName" : "statements"
         }
       },
-      "required" : [ "ApplicationId" ]
+      "required" : [ "ApplicationId", "Statements" ]
     },
     "PutApplicationPolicyResponse" : {
       "type" : "structure",

--- a/models/apis/serverlessrepo/2017-09-08/docs-2.json
+++ b/models/apis/serverlessrepo/2017-09-08/docs-2.json
@@ -4,13 +4,13 @@
   "operations" : {
     "CreateApplication" : "<p>Creates an application, optionally including an AWS SAM file to create the first application version in the same call.</p>",
     "CreateApplicationVersion" : "<p>Creates an application version.</p>",
-    "CreateCloudFormationChangeSet" : "<p>Creates an AWS CloudFormation ChangeSet for the given application.</p>",
+    "CreateCloudFormationChangeSet" : "<p>Creates an AWS CloudFormation change set for the given application.</p>",
     "DeleteApplication" : "<p>Deletes the specified application.</p>",
     "GetApplication" : "<p>Gets the specified application.</p>",
-    "GetApplicationPolicy" : "<p>Gets the policy for the specified application.</p>",
+    "GetApplicationPolicy" : "<p>Retrieves the policy for the application.</p>",
     "ListApplicationVersions" : "<p>Lists versions for the specified application.</p>",
     "ListApplications" : "<p>Lists applications owned by the requester.</p>",
-    "PutApplicationPolicy" : "<p>Puts the policy for the specified application.</p>",
+    "PutApplicationPolicy" : "<p>Sets the permission policy for an application. See\n <a href=\"https://docs.aws.amazon.com/serverlessrepo/latest/devguide/access-control-resource-based.html#application-permissions\">Application Permissions</a>\n for the list of supported actions that can be used with this operation.</p>",
     "UpdateApplication" : "<p>Updates the specified application.</p>"
   },
   "shapes" : {
@@ -19,7 +19,7 @@
       "refs" : { }
     },
     "ApplicationPage" : {
-      "base" : "<p>List of application details.</p>",
+      "base" : "<p>A list of application details.</p>",
       "refs" : { }
     },
     "ApplicationPolicy" : {
@@ -39,7 +39,7 @@
       }
     },
     "ApplicationVersionPage" : {
-      "base" : "<p>List of version summaries for the application.</p>",
+      "base" : "<p>A list of version summaries for the application.</p>",
       "refs" : { }
     },
     "BadRequestException" : {
@@ -55,15 +55,15 @@
       "refs" : { }
     },
     "CreateApplicationInput" : {
-      "base" : "<p>Create application request.</p>",
+      "base" : "<p>Create an application request.</p>",
       "refs" : { }
     },
     "CreateApplicationVersionInput" : {
-      "base" : "<p>Create version request.</p>",
+      "base" : "<p>Create a version request.</p>",
       "refs" : { }
     },
     "CreateCloudFormationChangeSetInput" : {
-      "base" : "<p>Create application ChangeSet request.</p>",
+      "base" : "<p>Create an application change set request.</p>",
       "refs" : { }
     },
     "ForbiddenException" : {
@@ -75,7 +75,7 @@
       "refs" : { }
     },
     "NotFoundException" : {
-      "base" : "<p>The resource (for example, an access policy statement) specified in the request does not exist.</p>",
+      "base" : "<p>The resource (for example, an access policy statement) specified in the request doesn't exist.</p>",
       "refs" : { }
     },
     "ParameterDefinition" : {
@@ -91,11 +91,11 @@
       }
     },
     "TooManyRequestsException" : {
-      "base" : "<p>The client is sending more than the allowed number of requests per unit time.</p>",
+      "base" : "<p>The client is sending more than the allowed number of requests per unit of time.</p>",
       "refs" : { }
     },
     "UpdateApplicationInput" : {
-      "base" : "<p>Update application request.</p>",
+      "base" : "<p>Update the application request.</p>",
       "refs" : { }
     },
     "Version" : {
@@ -105,7 +105,7 @@
       }
     },
     "VersionSummary" : {
-      "base" : "<p>Application version summary.</p>",
+      "base" : "<p>An application version summary.</p>",
       "refs" : {
         "__listOfVersionSummary$member" : null
       }
@@ -119,28 +119,28 @@
     "__integer" : {
       "base" : null,
       "refs" : {
-        "ParameterDefinition$MaxLength" : "<p>An integer value that determines the largest number of characters you want to allow for String types.</p>",
-        "ParameterDefinition$MaxValue" : "<p>A numeric value that determines the largest numeric value you want to allow for Number types.</p>",
-        "ParameterDefinition$MinLength" : "<p>An integer value that determines the smallest number of characters you want to allow for String types.</p>",
-        "ParameterDefinition$MinValue" : "<p>A numeric value that determines the smallest numeric value you want to allow for Number types.</p>"
+        "ParameterDefinition$MaxLength" : "<p>An integer value that determines the largest number of characters that you want to allow for String types.</p>",
+        "ParameterDefinition$MaxValue" : "<p>A numeric value that determines the largest numeric value that you want to allow for Number types.</p>",
+        "ParameterDefinition$MinLength" : "<p>An integer value that determines the smallest number of characters that you want to allow for String types.</p>",
+        "ParameterDefinition$MinValue" : "<p>A numeric value that determines the smallest numeric value that you want to allow for Number types.</p>"
       }
     },
     "__listOfApplicationPolicyStatement" : {
       "base" : null,
       "refs" : {
-        "ApplicationPolicy$Statements" : "<p>Array of policy statements applied to the application.</p>"
+        "ApplicationPolicy$Statements" : "<p>An array of policy statements applied to the application.</p>"
       }
     },
     "__listOfApplicationSummary" : {
       "base" : null,
       "refs" : {
-        "ApplicationPage$Applications" : "<p>Array of application summaries.</p>"
+        "ApplicationPage$Applications" : "<p>An array of application summaries.</p>"
       }
     },
     "__listOfParameterDefinition" : {
       "base" : null,
       "refs" : {
-        "Version$ParameterDefinitions" : "<p>Array of parameter types supported by the application.</p>"
+        "Version$ParameterDefinitions" : "<p>An array of parameter types supported by the application.</p>"
       }
     },
     "__listOfParameterValue" : {
@@ -152,65 +152,65 @@
     "__listOfVersionSummary" : {
       "base" : null,
       "refs" : {
-        "ApplicationVersionPage$Versions" : "<p>Array of version summaries for the application.</p>"
+        "ApplicationVersionPage$Versions" : "<p>An array of version summaries for the application.</p>"
       }
     },
     "__listOf__string" : {
       "base" : null,
       "refs" : {
-        "Application$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Min Length=1. Max Length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
-        "ApplicationPolicyStatement$Actions" : "<p>A list of supported actions:</p><p>\n GetApplication\n </p><p>\n CreateCloudFormationChangeSet\n </p><p>\n ListApplicationVersions\n </p><p>\n SearchApplications\n </p><p>\n Deploy (Note: This action enables all other actions above.)</p>",
+        "Application$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
+        "ApplicationPolicyStatement$Actions" : "<p>See <a href=\"https://docs.aws.amazon.com/serverlessrepo/latest/devguide/access-control-resource-based.html#application-permissions\">Application Permissions</a> for the list of supported actions.</p>",
         "ApplicationPolicyStatement$Principals" : "<p>An AWS account ID, or * to make the application public.</p>",
-        "ApplicationSummary$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Min Length=1. Max Length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
-        "CreateApplicationInput$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Min Length=1. Max Length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
-        "ParameterDefinition$AllowedValues" : "<p>Array containing the list of values allowed for the parameter.</p>",
+        "ApplicationSummary$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
+        "CreateApplicationInput$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>",
+        "ParameterDefinition$AllowedValues" : "<p>An array containing the list of values allowed for the parameter.</p>",
         "ParameterDefinition$ReferencedByResources" : "<p>A list of AWS SAM resources that use this parameter.</p>",
-        "UpdateApplicationInput$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Min Length=1. Max Length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>"
+        "UpdateApplicationInput$Labels" : "<p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: \"^[a-zA-Z0-9+\\\\-_:\\\\/@]+$\";</p>"
       }
     },
     "__string" : {
       "base" : null,
       "refs" : {
         "Application$ApplicationId" : "<p>The application Amazon Resource Name (ARN).</p>",
-        "Application$Author" : "<p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
-        "Application$CreationTime" : "<p>The date/time this resource was created.</p>",
-        "Application$Description" : "<p>The description of the application.</p><p>Min Length=1. Max Length=256</p>",
+        "Application$Author" : "<p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
+        "Application$CreationTime" : "<p>The date and time this resource was created.</p>",
+        "Application$Description" : "<p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>",
         "Application$HomePageUrl" : "<p>A URL with more information about the application, for example\n the location of your GitHub repository for the application.</p>",
-        "Application$LicenseUrl" : "<p>A link to a license file of the app that matches the spdxLicenseID of your application.</p><p>Max size 5 MB</p>",
-        "Application$Name" : "<p>The name of the application.</p><p>Min Length=1. Max Length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
-        "Application$ReadmeUrl" : "<p>A link to the readme file that contains a more detailed description of the application and how it works in Markdown language.</p><p>Max size 5 MB</p>",
+        "Application$LicenseUrl" : "<p>A link to a license file of the app that matches the spdxLicenseID value of your application.</p><p>Maximum size 5 MB</p>",
+        "Application$Name" : "<p>The name of the application.</p><p>Minimum length=1. Maximum length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
+        "Application$ReadmeUrl" : "<p>A link to the readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>",
         "Application$SpdxLicenseId" : "<p>A valid identifier from https://spdx.org/licenses/.</p>",
         "ApplicationPage$NextToken" : "<p>The token to request the next page of results.</p>",
         "ApplicationPolicyStatement$StatementId" : "<p>A unique ID for the statement.</p>",
-        "ApplicationSummary$ApplicationId" : "<p>The application ARN.</p>",
-        "ApplicationSummary$Author" : "<p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
-        "ApplicationSummary$CreationTime" : "<p>The date/time this resource was created.</p>",
-        "ApplicationSummary$Description" : "<p>The description of the application.</p><p>Min Length=1. Max Length=256</p>",
+        "ApplicationSummary$ApplicationId" : "<p>The application Amazon Resource Name (ARN).</p>",
+        "ApplicationSummary$Author" : "<p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
+        "ApplicationSummary$CreationTime" : "<p>The date and time this resource was created.</p>",
+        "ApplicationSummary$Description" : "<p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>",
         "ApplicationSummary$HomePageUrl" : "<p>A URL with more information about the application, for example\n the location of your GitHub repository for the application.</p>",
-        "ApplicationSummary$Name" : "<p>The name of the application.</p><p>Min Length=1. Max Length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
+        "ApplicationSummary$Name" : "<p>The name of the application.</p><p>Minimum length=1. Maximum length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
         "ApplicationSummary$SpdxLicenseId" : "<p>A valid identifier from <a href=\"https://spdx.org/licenses/\">https://spdx.org/licenses/</a>.</p>",
         "ApplicationVersionPage$NextToken" : "<p>The token to request the next page of results.</p>",
         "BadRequestException$ErrorCode" : "<p>400</p>",
         "BadRequestException$Message" : "<p>One of the parameters in the request is invalid.</p>",
         "ChangeSetDetails$ApplicationId" : "<p>The application Amazon Resource Name (ARN).</p>",
-        "ChangeSetDetails$ChangeSetId" : "<p>The ARN of the change set.</p><p>Length Constraints: Minimum length of 1.</p><p>Pattern: Amazon Resource Name (ARN):[-a-zA-Z0-9:/]*</p>",
+        "ChangeSetDetails$ChangeSetId" : "<p>The Amazon Resource Name (ARN) of the change set.</p><p>Length constraints: Minimum length of 1.</p><p>Pattern: ARN:[-a-zA-Z0-9:/]*</p>",
         "ChangeSetDetails$SemanticVersion" : "<p>The semantic version of the application:</p><p>\n <a href=\"https://semver.org/\">https://semver.org/</a>\n </p>",
         "ChangeSetDetails$StackId" : "<p>The unique ID of the stack.</p>",
         "ConflictException$ErrorCode" : "<p>409</p>",
         "ConflictException$Message" : "<p>The resource already exists.</p>",
-        "CreateApplicationInput$Author" : "<p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
-        "CreateApplicationInput$Description" : "<p>The description of the application.</p><p>Min Length=1. Max Length=256</p>",
+        "CreateApplicationInput$Author" : "<p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
+        "CreateApplicationInput$Description" : "<p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>",
         "CreateApplicationInput$HomePageUrl" : "<p>A URL with more information about the application, for example\n the location of your GitHub repository for the application.</p>",
-        "CreateApplicationInput$LicenseBody" : "<p>A raw text file that contains the license of the app that matches the spdxLicenseID of your application.</p><p>Max size 5 MB</p>",
-        "CreateApplicationInput$LicenseUrl" : "<p>A link to a license file of the app that matches the spdxLicenseID of your application.</p><p>Max size 5 MB</p>",
-        "CreateApplicationInput$Name" : "<p>The name of the application you want to publish.</p><p>Min Length=1. Max Length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
-        "CreateApplicationInput$ReadmeBody" : "<p>A raw text Readme file that contains a more detailed description of the application and how it works in markdown language.</p><p>Max size 5 MB</p>",
-        "CreateApplicationInput$ReadmeUrl" : "<p>A link to the Readme file that contains a more detailed description of the application and how it works in markdown language.</p><p>Max size 5 MB</p>",
+        "CreateApplicationInput$LicenseBody" : "<p>A local text file that contains the license of the app that matches the spdxLicenseID value of your application.\n The file is of the format file://&lt;path>/&lt;filename>.</p><p>Maximum size 5 MB</p><p>Note: Only one of licenseBody and licenseUrl can be specified, otherwise an error will result.</p>",
+        "CreateApplicationInput$LicenseUrl" : "<p>A link to the S3 object that contains the license of the app that matches the spdxLicenseID value of your application.</p><p>Maximum size 5 MB</p><p>Note: Only one of licenseBody and licenseUrl can be specified, otherwise an error will result.</p>",
+        "CreateApplicationInput$Name" : "<p>The name of the application that you want to publish.</p><p>Minimum length=1. Maximum length=140</p><p>Pattern: \"[a-zA-Z0-9\\\\-]+\";</p>",
+        "CreateApplicationInput$ReadmeBody" : "<p>A local text readme file in Markdown language that contains a more detailed description of the application and how it works.\n The file is of the format file://&lt;path>/&lt;filename>.</p><p>Maximum size 5 MB</p><p>Note: Only one of readmeBody and readmeUrl can be specified, otherwise an error will result.</p>",
+        "CreateApplicationInput$ReadmeUrl" : "<p>A link to the S3 object in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p><p>Note: Only one of readmeBody and readmeUrl can be specified, otherwise an error will result.</p>",
         "CreateApplicationInput$SemanticVersion" : "<p>The semantic version of the application:</p><p>\n <a href=\"https://semver.org/\">https://semver.org/</a>\n </p>",
         "CreateApplicationInput$SourceCodeUrl" : "<p>A link to a public repository for the source code of your application.</p>",
         "CreateApplicationInput$SpdxLicenseId" : "<p>A valid identifier from <a href=\"https://spdx.org/licenses/\">https://spdx.org/licenses/</a>.</p>",
-        "CreateApplicationInput$TemplateBody" : "<p>The raw packaged AWS SAM template of your application.</p>",
-        "CreateApplicationInput$TemplateUrl" : "<p>A link to the packaged AWS SAM template of your application.</p>",
+        "CreateApplicationInput$TemplateBody" : "<p>The local raw packaged AWS SAM template file of your application.\n The file is of the format file://&lt;path>/&lt;filename>.</p><p>Note: Only one of templateBody and templateUrl can be specified, otherwise an error will result.</p>",
+        "CreateApplicationInput$TemplateUrl" : "<p>A link to the S3 object cotaining the packaged AWS SAM template of your application.</p><p>Note: Only one of templateBody and templateUrl can be specified, otherwise an error will result.</p>",
         "CreateApplicationVersionInput$SourceCodeUrl" : "<p>A link to a public repository for the source code of your application.</p>",
         "CreateApplicationVersionInput$TemplateBody" : "<p>The raw packaged AWS SAM template of your application.</p>",
         "CreateApplicationVersionInput$TemplateUrl" : "<p>A link to the packaged AWS SAM template of your application.</p>",
@@ -221,29 +221,29 @@
         "InternalServerErrorException$ErrorCode" : "<p>500</p>",
         "InternalServerErrorException$Message" : "<p>The AWS Serverless Application Repository service encountered an internal error.</p>",
         "NotFoundException$ErrorCode" : "<p>404</p>",
-        "NotFoundException$Message" : "<p>The resource (for example, an access policy statement) specified in the request does not exist.</p>",
+        "NotFoundException$Message" : "<p>The resource (for example, an access policy statement) specified in the request doesn't exist.</p>",
         "ParameterDefinition$AllowedPattern" : "<p>A regular expression that represents the patterns to allow for String types.</p>",
-        "ParameterDefinition$ConstraintDescription" : "<p>A string that explains a constraint when the constraint is violated. For example, without a constraint description,\n a parameter that has an allowed pattern of [A-Za-z0-9]+ displays the following error message when the user\n specifies an invalid value:</p><p>\n Malformed input-Parameter MyParameter must match pattern [A-Za-z0-9]+\n </p><p>By adding a constraint description, such as \"must contain only uppercase and lowercase letters, and numbers,\" you can display\n the following customized error message:</p><p>\n Malformed input-Parameter MyParameter must contain only uppercase and lowercase letters and numbers.\n </p>",
+        "ParameterDefinition$ConstraintDescription" : "<p>A string that explains a constraint when the constraint is violated. For example, without a constraint description,\n a parameter that has an allowed pattern of [A-Za-z0-9]+ displays the following error message when the user\n specifies an invalid value:</p><p>\n Malformed input-Parameter MyParameter must match pattern [A-Za-z0-9]+\n </p><p>By adding a constraint description, such as \"must contain only uppercase and lowercase letters and numbers,\" you can display\n the following customized error message:</p><p>\n Malformed input-Parameter MyParameter must contain only uppercase and lowercase letters and numbers.\n </p>",
         "ParameterDefinition$DefaultValue" : "<p>A value of the appropriate type for the template to use if no value is specified when a stack is created.\n If you define constraints for the parameter, you must specify a value that adheres to those constraints.</p>",
         "ParameterDefinition$Description" : "<p>A string of up to 4,000 characters that describes the parameter.</p>",
         "ParameterDefinition$Name" : "<p>The name of the parameter.</p>",
-        "ParameterDefinition$Type" : "<p>The type of the parameter.</p><p>Valid values: String | Number | List&lt;Number> | CommaDelimitedList\n </p><p>\n String: A literal string.</p><p>For example, users could specify \"MyUserName\".</p><p>\n Number: An integer or float. AWS CloudFormation validates the parameter value as a number; however, when you use the\n parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a string.</p><p>For example, users could specify \"8888\".</p><p>\n List&lt;Number>: An array of integers or floats that are separated by commas. AWS CloudFormation validates the parameter value as numbers; however, when\n you use the parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a list of strings.</p><p>For example, users could specify \"80,20\", and a Ref results in [\"80\",\"20\"].</p><p>\n CommaDelimitedList: An array of literal strings that are separated by commas. The total number of strings should be one more than the total number of commas.\n Also, each member string is space-trimmed.</p><p>For example, users could specify \"test,dev,prod\", and a Ref results in [\"test\",\"dev\",\"prod\"].</p>",
+        "ParameterDefinition$Type" : "<p>The type of the parameter.</p><p>Valid values: String | Number | List&lt;Number> | CommaDelimitedList\n </p><p>\n String: A literal string.</p><p>For example, users can specify \"MyUserName\".</p><p>\n Number: An integer or float. AWS CloudFormation validates the parameter value as a number. However, when you use the\n parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a string.</p><p>For example, users might specify \"8888\".</p><p>\n List&lt;Number>: An array of integers or floats that are separated by commas. AWS CloudFormation validates the parameter value as numbers. However, when\n you use the parameter elsewhere in your template (for example, by using the Ref intrinsic function), the parameter value becomes a list of strings.</p><p>For example, users might specify \"80,20\", and then Ref results in [\"80\",\"20\"].</p><p>\n CommaDelimitedList: An array of literal strings that are separated by commas. The total number of strings should be one more than the total number of commas.\n Also, each member string is space-trimmed.</p><p>For example, users might specify \"test,dev,prod\", and then Ref results in [\"test\",\"dev\",\"prod\"].</p>",
         "ParameterValue$Name" : "<p>The key associated with the parameter. If you don't specify a key and value for a particular parameter, AWS CloudFormation\n uses the default value that is specified in your template.</p>",
         "ParameterValue$Value" : "<p>The input value associated with the parameter.</p>",
         "TooManyRequestsException$ErrorCode" : "<p>429</p>",
-        "TooManyRequestsException$Message" : "<p>The client is sending more than the allowed number of requests per unit time.</p>",
-        "UpdateApplicationInput$Author" : "<p>The name of the author publishing the app.</p><p>Min Length=1. Max Length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
-        "UpdateApplicationInput$Description" : "<p>The description of the application.</p><p>Min Length=1. Max Length=256</p>",
+        "TooManyRequestsException$Message" : "<p>The client is sending more than the allowed number of requests per unit of time.</p>",
+        "UpdateApplicationInput$Author" : "<p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern \"^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$\";</p>",
+        "UpdateApplicationInput$Description" : "<p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>",
         "UpdateApplicationInput$HomePageUrl" : "<p>A URL with more information about the application, for example\n the location of your GitHub repository for the application.</p>",
-        "UpdateApplicationInput$ReadmeBody" : "<p>A raw text Readme file that contains a more detailed description of the application and how it works in markdown language.</p><p>Max size 5 MB</p>",
-        "UpdateApplicationInput$ReadmeUrl" : "<p>A link to the Readme file that contains a more detailed description of the application and how it works in markdown language.</p><p>Max size 5 MB</p>",
+        "UpdateApplicationInput$ReadmeBody" : "<p>A text readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>",
+        "UpdateApplicationInput$ReadmeUrl" : "<p>A link to the readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>",
         "Version$ApplicationId" : "<p>The application Amazon Resource Name (ARN).</p>",
-        "Version$CreationTime" : "<p>The date/time this resource was created.</p>",
+        "Version$CreationTime" : "<p>The date and time this resource was created.</p>",
         "Version$SemanticVersion" : "<p>The semantic version of the application:</p><p>\n <a href=\"https://semver.org/\">https://semver.org/</a>\n </p>",
         "Version$SourceCodeUrl" : "<p>A link to a public repository for the source code of your application.</p>",
         "Version$TemplateUrl" : "<p>A link to the packaged AWS SAM template of your application.</p>",
         "VersionSummary$ApplicationId" : "<p>The application Amazon Resource Name (ARN).</p>",
-        "VersionSummary$CreationTime" : "<p>The date/time this resource was created.</p>",
+        "VersionSummary$CreationTime" : "<p>The date and time this resource was created.</p>",
         "VersionSummary$SemanticVersion" : "<p>The semantic version of the application:</p><p>\n <a href=\"https://semver.org/\">https://semver.org/</a>\n </p>",
         "VersionSummary$SourceCodeUrl" : "<p>A link to a public repository for the source code of your application.</p>",
         "__listOf__string$member" : null

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -1522,6 +1522,272 @@ func (c *MediaConvert) ListQueuesWithContext(ctx aws.Context, input *ListQueuesI
 	return out, req.Send()
 }
 
+const opListTagsForResource = "ListTagsForResource"
+
+// ListTagsForResourceRequest generates a "aws/request.Request" representing the
+// client's request for the ListTagsForResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListTagsForResource for more information on using the ListTagsForResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListTagsForResourceRequest method.
+//    req, resp := client.ListTagsForResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/ListTagsForResource
+func (c *MediaConvert) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
+	op := &request.Operation{
+		Name:       opListTagsForResource,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2017-08-29/tags/{arn}",
+	}
+
+	if input == nil {
+		input = &ListTagsForResourceInput{}
+	}
+
+	output = &ListTagsForResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTagsForResource API operation for AWS Elemental MediaConvert.
+//
+// Retrieve the tags for a MediaConvert resource.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaConvert's
+// API operation ListTagsForResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/ListTagsForResource
+func (c *MediaConvert) ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error) {
+	req, out := c.ListTagsForResourceRequest(input)
+	return out, req.Send()
+}
+
+// ListTagsForResourceWithContext is the same as ListTagsForResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTagsForResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaConvert) ListTagsForResourceWithContext(ctx aws.Context, input *ListTagsForResourceInput, opts ...request.Option) (*ListTagsForResourceOutput, error) {
+	req, out := c.ListTagsForResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opTagResource = "TagResource"
+
+// TagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the TagResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TagResource for more information on using the TagResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TagResourceRequest method.
+//    req, resp := client.TagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/TagResource
+func (c *MediaConvert) TagResourceRequest(input *TagResourceInput) (req *request.Request, output *TagResourceOutput) {
+	op := &request.Operation{
+		Name:       opTagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/2017-08-29/tags",
+	}
+
+	if input == nil {
+		input = &TagResourceInput{}
+	}
+
+	output = &TagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// TagResource API operation for AWS Elemental MediaConvert.
+//
+// Tag a MediaConvert queue, preset, or job template. For information about
+// these resource types, see the User Guide at http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaConvert's
+// API operation TagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/TagResource
+func (c *MediaConvert) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	return out, req.Send()
+}
+
+// TagResourceWithContext is the same as TagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaConvert) TagResourceWithContext(ctx aws.Context, input *TagResourceInput, opts ...request.Option) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUntagResource = "UntagResource"
+
+// UntagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the UntagResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UntagResource for more information on using the UntagResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UntagResourceRequest method.
+//    req, resp := client.UntagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/UntagResource
+func (c *MediaConvert) UntagResourceRequest(input *UntagResourceInput) (req *request.Request, output *UntagResourceOutput) {
+	op := &request.Operation{
+		Name:       opUntagResource,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/2017-08-29/tags",
+	}
+
+	if input == nil {
+		input = &UntagResourceInput{}
+	}
+
+	output = &UntagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UntagResource API operation for AWS Elemental MediaConvert.
+//
+// Untag a MediaConvert queue, preset, or job template. For information about
+// these resource types, see the User Guide at http://docs.aws.amazon.com/mediaconvert/latest/ug/what-is.html
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Elemental MediaConvert's
+// API operation UntagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequestException "BadRequestException"
+//
+//   * ErrCodeInternalServerErrorException "InternalServerErrorException"
+//
+//   * ErrCodeForbiddenException "ForbiddenException"
+//
+//   * ErrCodeNotFoundException "NotFoundException"
+//
+//   * ErrCodeTooManyRequestsException "TooManyRequestsException"
+//
+//   * ErrCodeConflictException "ConflictException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/mediaconvert-2017-08-29/UntagResource
+func (c *MediaConvert) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
+	return out, req.Send()
+}
+
+// UntagResourceWithContext is the same as UntagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UntagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *MediaConvert) UntagResourceWithContext(ctx aws.Context, input *UntagResourceInput, opts ...request.Option) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateJobTemplate = "UpdateJobTemplate"
 
 // UpdateJobTemplateRequest generates a "aws/request.Request" representing the
@@ -4226,6 +4492,10 @@ type CreateJobTemplateInput struct {
 	//
 	// Settings is a required field
 	Settings *JobTemplateSettings `locationName:"settings" type:"structure" required:"true"`
+
+	// The tags that you want to add to the resource. You can tag resources with
+	// a key-value pair or with only a key.
+	Tags map[string]*string `locationName:"tags" type:"map"`
 }
 
 // String returns the string representation
@@ -4289,6 +4559,12 @@ func (s *CreateJobTemplateInput) SetSettings(v *JobTemplateSettings) *CreateJobT
 	return s
 }
 
+// SetTags sets the Tags field's value.
+func (s *CreateJobTemplateInput) SetTags(v map[string]*string) *CreateJobTemplateInput {
+	s.Tags = v
+	return s
+}
+
 // Successful create job template requests will return the template JSON.
 type CreateJobTemplateOutput struct {
 	_ struct{} `type:"structure"`
@@ -4334,6 +4610,10 @@ type CreatePresetInput struct {
 	//
 	// Settings is a required field
 	Settings *PresetSettings `locationName:"settings" type:"structure" required:"true"`
+
+	// The tags that you want to add to the resource. You can tag resources with
+	// a key-value pair or with only a key.
+	Tags map[string]*string `locationName:"tags" type:"map"`
 }
 
 // String returns the string representation
@@ -4391,6 +4671,12 @@ func (s *CreatePresetInput) SetSettings(v *PresetSettings) *CreatePresetInput {
 	return s
 }
 
+// SetTags sets the Tags field's value.
+func (s *CreatePresetInput) SetTags(v map[string]*string) *CreatePresetInput {
+	s.Tags = v
+	return s
+}
+
 // Successful create preset requests will return the preset JSON.
 type CreatePresetOutput struct {
 	_ struct{} `type:"structure"`
@@ -4427,6 +4713,10 @@ type CreateQueueInput struct {
 	//
 	// Name is a required field
 	Name *string `locationName:"name" type:"string" required:"true"`
+
+	// The tags that you want to add to the resource. You can tag resources with
+	// a key-value pair or with only a key.
+	Tags map[string]*string `locationName:"tags" type:"map"`
 }
 
 // String returns the string representation
@@ -4461,6 +4751,12 @@ func (s *CreateQueueInput) SetDescription(v string) *CreateQueueInput {
 // SetName sets the Name field's value.
 func (s *CreateQueueInput) SetName(v string) *CreateQueueInput {
 	s.Name = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateQueueInput) SetTags(v map[string]*string) *CreateQueueInput {
+	s.Tags = v
 	return s
 }
 
@@ -9163,7 +9459,7 @@ type ListJobTemplatesInput struct {
 
 	// Optional. Number of job templates, up to twenty, that will be returned at
 	// one time.
-	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
 	// Use this string, provided with the response to a previous request, to request
 	// the next batch of job templates.
@@ -9182,6 +9478,19 @@ func (s ListJobTemplatesInput) String() string {
 // GoString returns the string representation
 func (s ListJobTemplatesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobTemplatesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobTemplatesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetCategory sets the Category field's value.
@@ -9257,7 +9566,7 @@ type ListJobsInput struct {
 	_ struct{} `type:"structure"`
 
 	// Optional. Number of jobs, up to twenty, that will be returned at one time.
-	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
 	// Use this string, provided with the response to a previous request, to request
 	// the next batch of jobs.
@@ -9282,6 +9591,19 @@ func (s ListJobsInput) String() string {
 // GoString returns the string representation
 func (s ListJobsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListJobsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetMaxResults sets the MaxResults field's value.
@@ -9366,7 +9688,7 @@ type ListPresetsInput struct {
 	ListBy *string `location:"querystring" locationName:"listBy" type:"string" enum:"PresetListBy"`
 
 	// Optional. Number of presets, up to twenty, that will be returned at one time
-	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
 	// Use this string, provided with the response to a previous request, to request
 	// the next batch of presets.
@@ -9385,6 +9707,19 @@ func (s ListPresetsInput) String() string {
 // GoString returns the string representation
 func (s ListPresetsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListPresetsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListPresetsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetCategory sets the Category field's value.
@@ -9463,7 +9798,7 @@ type ListQueuesInput struct {
 	ListBy *string `location:"querystring" locationName:"listBy" type:"string" enum:"QueueListBy"`
 
 	// Optional. Number of queues, up to twenty, that will be returned at one time.
-	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
 
 	// Use this string, provided with the response to a previous request, to request
 	// the next batch of queues.
@@ -9482,6 +9817,19 @@ func (s ListQueuesInput) String() string {
 // GoString returns the string representation
 func (s ListQueuesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListQueuesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListQueuesInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetListBy sets the ListBy field's value.
@@ -9539,6 +9887,73 @@ func (s *ListQueuesOutput) SetNextToken(v string) *ListQueuesOutput {
 // SetQueues sets the Queues field's value.
 func (s *ListQueuesOutput) SetQueues(v []*Queue) *ListQueuesOutput {
 	s.Queues = v
+	return s
+}
+
+// List the tags for your MediaConvert resource by sending a request with the
+// Amazon Resource Name (ARN) of the resource. To get the ARN, send a GET request
+// with the resource name.
+type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the resource that you want to list tags
+	// for. To get the ARN, send a GET request with the resource name.
+	//
+	// Arn is a required field
+	Arn *string `location:"uri" locationName:"arn" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetArn sets the Arn field's value.
+func (s *ListTagsForResourceInput) SetArn(v string) *ListTagsForResourceInput {
+	s.Arn = &v
+	return s
+}
+
+// Successful list tags for resource requests return a JSON map of tags.
+type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) and tags for an AWS Elemental MediaConvert
+	// resource.
+	ResourceTags *ResourceTags `locationName:"resourceTags" type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceOutput) GoString() string {
+	return s.String()
+}
+
+// SetResourceTags sets the ResourceTags field's value.
+func (s *ListTagsForResourceOutput) SetResourceTags(v *ResourceTags) *ListTagsForResourceOutput {
+	s.ResourceTags = v
 	return s
 }
 
@@ -11891,10 +12306,16 @@ type Queue struct {
 	// Name is a required field
 	Name *string `locationName:"name" type:"string" required:"true"`
 
+	// Estimated number of jobs in PROGRESSING status.
+	ProgressingJobsCount *int64 `locationName:"progressingJobsCount" type:"integer"`
+
 	// Queues can be ACTIVE or PAUSED. If you pause a queue, jobs in that queue
 	// will not begin. Jobs running when a queue is paused continue to run until
 	// they finish or error out.
 	Status *string `locationName:"status" type:"string" enum:"QueueStatus"`
+
+	// Estimated number of jobs in SUBMITTED status.
+	SubmittedJobsCount *int64 `locationName:"submittedJobsCount" type:"integer"`
 
 	// A queue can be of two types: system or custom. System or built-in queues
 	// can't be modified or deleted by the user.
@@ -11941,9 +12362,21 @@ func (s *Queue) SetName(v string) *Queue {
 	return s
 }
 
+// SetProgressingJobsCount sets the ProgressingJobsCount field's value.
+func (s *Queue) SetProgressingJobsCount(v int64) *Queue {
+	s.ProgressingJobsCount = &v
+	return s
+}
+
 // SetStatus sets the Status field's value.
 func (s *Queue) SetStatus(v string) *Queue {
 	s.Status = &v
+	return s
+}
+
+// SetSubmittedJobsCount sets the SubmittedJobsCount field's value.
+func (s *Queue) SetSubmittedJobsCount(v int64) *Queue {
+	s.SubmittedJobsCount = &v
 	return s
 }
 
@@ -12134,6 +12567,40 @@ func (s *RemixSettings) SetChannelsOut(v int64) *RemixSettings {
 	return s
 }
 
+// The Amazon Resource Name (ARN) and tags for an AWS Elemental MediaConvert
+// resource.
+type ResourceTags struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the resource.
+	Arn *string `locationName:"arn" type:"string"`
+
+	// The tags for the resource.
+	Tags map[string]*string `locationName:"tags" type:"map"`
+}
+
+// String returns the string representation
+func (s ResourceTags) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResourceTags) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *ResourceTags) SetArn(v string) *ResourceTags {
+	s.Arn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *ResourceTags) SetTags(v map[string]*string) *ResourceTags {
+	s.Tags = v
+	return s
+}
+
 // Settings for SCC caption output.
 type SccDestinationSettings struct {
 	_ struct{} `type:"structure"`
@@ -12305,6 +12772,77 @@ func (s *StaticKeyProvider) SetStaticKeyValue(v string) *StaticKeyProvider {
 func (s *StaticKeyProvider) SetUrl(v string) *StaticKeyProvider {
 	s.Url = &v
 	return s
+}
+
+// To tag a queue, preset, or job template, send a request with the tags and
+// the Amazon Resource Name (ARN) of the resource that you want to tag.
+type TagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the resource that you want to tag. To get
+	// the ARN, send a GET request with the resource name.
+	//
+	// Arn is a required field
+	Arn *string `locationName:"arn" type:"string" required:"true"`
+
+	// The tags that you want to add to the resource. You can tag resources with
+	// a key-value pair or with only a key.
+	//
+	// Tags is a required field
+	Tags map[string]*string `locationName:"tags" type:"map" required:"true"`
+}
+
+// String returns the string representation
+func (s TagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagResourceInput"}
+	if s.Arn == nil {
+		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetArn sets the Arn field's value.
+func (s *TagResourceInput) SetArn(v string) *TagResourceInput {
+	s.Arn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagResourceInput) SetTags(v map[string]*string) *TagResourceInput {
+	s.Tags = v
+	return s
+}
+
+// Successful tag resource requests return an OK message.
+type TagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceOutput) GoString() string {
+	return s.String()
 }
 
 // Settings for Teletext caption output
@@ -12647,6 +13185,56 @@ func (s TtmlDestinationSettings) GoString() string {
 func (s *TtmlDestinationSettings) SetStylePassthrough(v string) *TtmlDestinationSettings {
 	s.StylePassthrough = &v
 	return s
+}
+
+// To remove tags from a resource, send a request with the Amazon Resource Name
+// (ARN) of the resource and the keys of the tags that you want to remove.
+type UntagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the resource that you want to remove tags
+	// from. To get the ARN, send a GET request with the resource name.
+	Arn *string `locationName:"arn" type:"string"`
+
+	// The keys of the tags that you want to remove from the resource.
+	TagKeys []*string `locationName:"tagKeys" type:"list"`
+}
+
+// String returns the string representation
+func (s UntagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceInput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *UntagResourceInput) SetArn(v string) *UntagResourceInput {
+	s.Arn = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
+	s.TagKeys = v
+	return s
+}
+
+// Successful untag resource requests return an OK message.
+type UntagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceOutput) GoString() string {
+	return s.String()
 }
 
 // Modify a job template by sending a request with the job template name and

--- a/service/mediaconvert/mediaconvertiface/interface.go
+++ b/service/mediaconvert/mediaconvertiface/interface.go
@@ -128,6 +128,18 @@ type MediaConvertAPI interface {
 	ListQueuesWithContext(aws.Context, *mediaconvert.ListQueuesInput, ...request.Option) (*mediaconvert.ListQueuesOutput, error)
 	ListQueuesRequest(*mediaconvert.ListQueuesInput) (*request.Request, *mediaconvert.ListQueuesOutput)
 
+	ListTagsForResource(*mediaconvert.ListTagsForResourceInput) (*mediaconvert.ListTagsForResourceOutput, error)
+	ListTagsForResourceWithContext(aws.Context, *mediaconvert.ListTagsForResourceInput, ...request.Option) (*mediaconvert.ListTagsForResourceOutput, error)
+	ListTagsForResourceRequest(*mediaconvert.ListTagsForResourceInput) (*request.Request, *mediaconvert.ListTagsForResourceOutput)
+
+	TagResource(*mediaconvert.TagResourceInput) (*mediaconvert.TagResourceOutput, error)
+	TagResourceWithContext(aws.Context, *mediaconvert.TagResourceInput, ...request.Option) (*mediaconvert.TagResourceOutput, error)
+	TagResourceRequest(*mediaconvert.TagResourceInput) (*request.Request, *mediaconvert.TagResourceOutput)
+
+	UntagResource(*mediaconvert.UntagResourceInput) (*mediaconvert.UntagResourceOutput, error)
+	UntagResourceWithContext(aws.Context, *mediaconvert.UntagResourceInput, ...request.Option) (*mediaconvert.UntagResourceOutput, error)
+	UntagResourceRequest(*mediaconvert.UntagResourceInput) (*request.Request, *mediaconvert.UntagResourceOutput)
+
 	UpdateJobTemplate(*mediaconvert.UpdateJobTemplateInput) (*mediaconvert.UpdateJobTemplateOutput, error)
 	UpdateJobTemplateWithContext(aws.Context, *mediaconvert.UpdateJobTemplateInput, ...request.Option) (*mediaconvert.UpdateJobTemplateOutput, error)
 	UpdateJobTemplateRequest(*mediaconvert.UpdateJobTemplateInput) (*request.Request, *mediaconvert.UpdateJobTemplateOutput)

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -68,7 +68,8 @@ func (c *ServerlessApplicationRepository) CreateApplicationRequest(input *Create
 //
 // Returned Error Codes:
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -160,7 +161,8 @@ func (c *ServerlessApplicationRepository) CreateApplicationVersionRequest(input 
 //
 // Returned Error Codes:
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -241,7 +243,7 @@ func (c *ServerlessApplicationRepository) CreateCloudFormationChangeSetRequest(i
 
 // CreateCloudFormationChangeSet API operation for AWSServerlessApplicationRepository.
 //
-// Creates an AWS CloudFormation ChangeSet for the given application.
+// Creates an AWS CloudFormation change set for the given application.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -252,7 +254,8 @@ func (c *ServerlessApplicationRepository) CreateCloudFormationChangeSetRequest(i
 //
 // Returned Error Codes:
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -354,10 +357,11 @@ func (c *ServerlessApplicationRepository) DeleteApplicationRequest(input *Delete
 //
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeConflictException "ConflictException"
 //   The resource already exists.
@@ -440,10 +444,11 @@ func (c *ServerlessApplicationRepository) GetApplicationRequest(input *GetApplic
 // Returned Error Codes:
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -521,7 +526,7 @@ func (c *ServerlessApplicationRepository) GetApplicationPolicyRequest(input *Get
 
 // GetApplicationPolicy API operation for AWSServerlessApplicationRepository.
 //
-// Gets the policy for the specified application.
+// Retrieves the policy for the application.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -533,10 +538,11 @@ func (c *ServerlessApplicationRepository) GetApplicationPolicyRequest(input *Get
 // Returned Error Codes:
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -632,10 +638,11 @@ func (c *ServerlessApplicationRepository) ListApplicationVersionsRequest(input *
 // Returned Error Codes:
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -781,7 +788,7 @@ func (c *ServerlessApplicationRepository) ListApplicationsRequest(input *ListApp
 // Returned Error Codes:
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -909,7 +916,9 @@ func (c *ServerlessApplicationRepository) PutApplicationPolicyRequest(input *Put
 
 // PutApplicationPolicy API operation for AWSServerlessApplicationRepository.
 //
-// Puts the policy for the specified application.
+// Sets the permission policy for an application. See Application Permissions
+// (https://docs.aws.amazon.com/serverlessrepo/latest/devguide/access-control-resource-based.html#application-permissions)
+// for the list of supported actions that can be used with this operation.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -921,10 +930,11 @@ func (c *ServerlessApplicationRepository) PutApplicationPolicyRequest(input *Put
 // Returned Error Codes:
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeBadRequestException "BadRequestException"
 //   One of the parameters in the request is invalid.
@@ -1024,10 +1034,11 @@ func (c *ServerlessApplicationRepository) UpdateApplicationRequest(input *Update
 //
 //   * ErrCodeNotFoundException "NotFoundException"
 //   The resource (for example, an access policy statement) specified in the request
-//   does not exist.
+//   doesn't exist.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   The client is sending more than the allowed number of requests per unit time.
+//   The client is sending more than the allowed number of requests per unit of
+//   time.
 //
 //   * ErrCodeConflictException "ConflictException"
 //   The resource already exists.
@@ -1058,17 +1069,8 @@ func (c *ServerlessApplicationRepository) UpdateApplicationWithContext(ctx aws.C
 type ApplicationPolicyStatement struct {
 	_ struct{} `type:"structure"`
 
-	// A list of supported actions:
-	//
-	// GetApplication
-	//
-	// CreateCloudFormationChangeSet
-	//
-	// ListApplicationVersions
-	//
-	// SearchApplications
-	//
-	// Deploy (Note: This action enables all other actions above.)
+	// See Application Permissions (https://docs.aws.amazon.com/serverlessrepo/latest/devguide/access-control-resource-based.html#application-permissions)
+	// for the list of supported actions.
 	//
 	// Actions is a required field
 	Actions []*string `locationName:"actions" type:"list" required:"true"`
@@ -1130,26 +1132,26 @@ func (s *ApplicationPolicyStatement) SetStatementId(v string) *ApplicationPolicy
 type ApplicationSummary struct {
 	_ struct{} `type:"structure"`
 
-	// The application ARN.
+	// The application Amazon Resource Name (ARN).
 	//
 	// ApplicationId is a required field
 	ApplicationId *string `locationName:"applicationId" type:"string" required:"true"`
 
 	// The name of the author publishing the app.
 	//
-	// Min Length=1. Max Length=127.
+	// Minimum length=1. Maximum length=127.
 	//
 	// Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";
 	//
 	// Author is a required field
 	Author *string `locationName:"author" type:"string" required:"true"`
 
-	// The date/time this resource was created.
+	// The date and time this resource was created.
 	CreationTime *string `locationName:"creationTime" type:"string"`
 
 	// The description of the application.
 	//
-	// Min Length=1. Max Length=256
+	// Minimum length=1. Maximum length=256
 	//
 	// Description is a required field
 	Description *string `locationName:"description" type:"string" required:"true"`
@@ -1160,14 +1162,14 @@ type ApplicationSummary struct {
 
 	// Labels to improve discovery of apps in search results.
 	//
-	// Min Length=1. Max Length=127. Maximum number of labels: 10
+	// Minimum length=1. Maximum length=127. Maximum number of labels: 10
 	//
 	// Pattern: "^[a-zA-Z0-9+\\-_:\\/@]+$";
 	Labels []*string `locationName:"labels" type:"list"`
 
 	// The name of the application.
 	//
-	// Min Length=1. Max Length=140
+	// Minimum length=1. Maximum length=140
 	//
 	// Pattern: "[a-zA-Z0-9\\-]+";
 	//
@@ -1342,9 +1344,11 @@ func (s *CreateApplicationOutput) SetVersion(v *Version) *CreateApplicationOutpu
 type CreateApplicationRequest struct {
 	_ struct{} `type:"structure"`
 
-	Author *string `locationName:"author" type:"string"`
+	// Author is a required field
+	Author *string `locationName:"author" type:"string" required:"true"`
 
-	Description *string `locationName:"description" type:"string"`
+	// Description is a required field
+	Description *string `locationName:"description" type:"string" required:"true"`
 
 	HomePageUrl *string `locationName:"homePageUrl" type:"string"`
 
@@ -1354,7 +1358,8 @@ type CreateApplicationRequest struct {
 
 	LicenseUrl *string `locationName:"licenseUrl" type:"string"`
 
-	Name *string `locationName:"name" type:"string"`
+	// Name is a required field
+	Name *string `locationName:"name" type:"string" required:"true"`
 
 	ReadmeBody *string `locationName:"readmeBody" type:"string"`
 
@@ -1379,6 +1384,25 @@ func (s CreateApplicationRequest) String() string {
 // GoString returns the string representation
 func (s CreateApplicationRequest) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateApplicationRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateApplicationRequest"}
+	if s.Author == nil {
+		invalidParams.Add(request.NewErrParamRequired("Author"))
+	}
+	if s.Description == nil {
+		invalidParams.Add(request.NewErrParamRequired("Description"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetAuthor sets the Author field's value.
@@ -1655,7 +1679,8 @@ type CreateCloudFormationChangeSetRequest struct {
 
 	SemanticVersion *string `locationName:"semanticVersion" type:"string"`
 
-	StackName *string `locationName:"stackName" type:"string"`
+	// StackName is a required field
+	StackName *string `locationName:"stackName" type:"string" required:"true"`
 }
 
 // String returns the string representation
@@ -1673,6 +1698,9 @@ func (s *CreateCloudFormationChangeSetRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateCloudFormationChangeSetRequest"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
 	}
 	if s.ParameterOverrides != nil {
 		for i, v := range s.ParameterOverrides {
@@ -2135,7 +2163,7 @@ type ParameterDefinition struct {
 	// A regular expression that represents the patterns to allow for String types.
 	AllowedPattern *string `locationName:"allowedPattern" type:"string"`
 
-	// Array containing the list of values allowed for the parameter.
+	// An array containing the list of values allowed for the parameter.
 	AllowedValues []*string `locationName:"allowedValues" type:"list"`
 
 	// A string that explains a constraint when the constraint is violated. For
@@ -2146,7 +2174,7 @@ type ParameterDefinition struct {
 	// Malformed input-Parameter MyParameter must match pattern [A-Za-z0-9]+
 	//
 	// By adding a constraint description, such as "must contain only uppercase
-	// and lowercase letters, and numbers," you can display the following customized
+	// and lowercase letters and numbers," you can display the following customized
 	// error message:
 	//
 	// Malformed input-Parameter MyParameter must contain only uppercase and lowercase
@@ -2161,20 +2189,20 @@ type ParameterDefinition struct {
 	// A string of up to 4,000 characters that describes the parameter.
 	Description *string `locationName:"description" type:"string"`
 
-	// An integer value that determines the largest number of characters you want
-	// to allow for String types.
+	// An integer value that determines the largest number of characters that you
+	// want to allow for String types.
 	MaxLength *int64 `locationName:"maxLength" type:"integer"`
 
-	// A numeric value that determines the largest numeric value you want to allow
-	// for Number types.
+	// A numeric value that determines the largest numeric value that you want to
+	// allow for Number types.
 	MaxValue *int64 `locationName:"maxValue" type:"integer"`
 
-	// An integer value that determines the smallest number of characters you want
-	// to allow for String types.
+	// An integer value that determines the smallest number of characters that you
+	// want to allow for String types.
 	MinLength *int64 `locationName:"minLength" type:"integer"`
 
-	// A numeric value that determines the smallest numeric value you want to allow
-	// for Number types.
+	// A numeric value that determines the smallest numeric value that you want
+	// to allow for Number types.
 	MinValue *int64 `locationName:"minValue" type:"integer"`
 
 	// The name of the parameter.
@@ -2198,27 +2226,28 @@ type ParameterDefinition struct {
 	//
 	// String: A literal string.
 	//
-	// For example, users could specify "MyUserName".
+	// For example, users can specify "MyUserName".
 	//
 	// Number: An integer or float. AWS CloudFormation validates the parameter value
-	// as a number; however, when you use the parameter elsewhere in your template
+	// as a number. However, when you use the parameter elsewhere in your template
 	// (for example, by using the Ref intrinsic function), the parameter value becomes
 	// a string.
 	//
-	// For example, users could specify "8888".
+	// For example, users might specify "8888".
 	//
 	// List<Number>: An array of integers or floats that are separated by commas.
-	// AWS CloudFormation validates the parameter value as numbers; however, when
+	// AWS CloudFormation validates the parameter value as numbers. However, when
 	// you use the parameter elsewhere in your template (for example, by using the
 	// Ref intrinsic function), the parameter value becomes a list of strings.
 	//
-	// For example, users could specify "80,20", and a Ref results in ["80","20"].
+	// For example, users might specify "80,20", and then Ref results in ["80","20"].
 	//
 	// CommaDelimitedList: An array of literal strings that are separated by commas.
 	// The total number of strings should be one more than the total number of commas.
 	// Also, each member string is space-trimmed.
 	//
-	// For example, users could specify "test,dev,prod", and a Ref results in ["test","dev","prod"].
+	// For example, users might specify "test,dev,prod", and then Ref results in
+	// ["test","dev","prod"].
 	Type *string `locationName:"type" type:"string"`
 }
 
@@ -2371,7 +2400,8 @@ type PutApplicationPolicyInput struct {
 	// ApplicationId is a required field
 	ApplicationId *string `location:"uri" locationName:"applicationId" type:"string" required:"true"`
 
-	Statements []*ApplicationPolicyStatement `locationName:"statements" type:"list"`
+	// Statements is a required field
+	Statements []*ApplicationPolicyStatement `locationName:"statements" type:"list" required:"true"`
 }
 
 // String returns the string representation
@@ -2389,6 +2419,9 @@ func (s *PutApplicationPolicyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutApplicationPolicyInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.Statements == nil {
+		invalidParams.Add(request.NewErrParamRequired("Statements"))
 	}
 	if s.Statements != nil {
 		for i, v := range s.Statements {
@@ -2637,12 +2670,12 @@ type Version struct {
 	// ApplicationId is a required field
 	ApplicationId *string `locationName:"applicationId" type:"string" required:"true"`
 
-	// The date/time this resource was created.
+	// The date and time this resource was created.
 	//
 	// CreationTime is a required field
 	CreationTime *string `locationName:"creationTime" type:"string" required:"true"`
 
-	// Array of parameter types supported by the application.
+	// An array of parameter types supported by the application.
 	//
 	// ParameterDefinitions is a required field
 	ParameterDefinitions []*ParameterDefinition `locationName:"parameterDefinitions" type:"list" required:"true"`
@@ -2709,7 +2742,7 @@ func (s *Version) SetTemplateUrl(v string) *Version {
 	return s
 }
 
-// Application version summary.
+// An application version summary.
 type VersionSummary struct {
 	_ struct{} `type:"structure"`
 
@@ -2718,7 +2751,7 @@ type VersionSummary struct {
 	// ApplicationId is a required field
 	ApplicationId *string `locationName:"applicationId" type:"string" required:"true"`
 
-	// The date/time this resource was created.
+	// The date and time this resource was created.
 	//
 	// CreationTime is a required field
 	CreationTime *string `locationName:"creationTime" type:"string" required:"true"`

--- a/service/serverlessapplicationrepository/errors.go
+++ b/service/serverlessapplicationrepository/errors.go
@@ -33,12 +33,13 @@ const (
 	// "NotFoundException".
 	//
 	// The resource (for example, an access policy statement) specified in the request
-	// does not exist.
+	// doesn't exist.
 	ErrCodeNotFoundException = "NotFoundException"
 
 	// ErrCodeTooManyRequestsException for service response error code
 	// "TooManyRequestsException".
 	//
-	// The client is sending more than the allowed number of requests per unit time.
+	// The client is sending more than the allowed number of requests per unit of
+	// time.
 	ErrCodeTooManyRequestsException = "TooManyRequestsException"
 )


### PR DESCRIPTION
Release v1.14.21 (2018-07-06)
===

### Service Client Updates
* `service/mediaconvert`: Updates service API and documentation
  * This release adds support for the following 1) users can specify tags to be attached to queues, presets, and templates during creation of those resources on MediaConvert. 2) users can now view the count of jobs in submitted state and in progressing state on a per queue basis.
* `service/serverlessrepo`: Updates service API and documentation

