### PR TITLE
private/model/api: Prevent codegen of EventStream over HTTP/2 until supported

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -70,6 +70,7 @@ type Metadata struct {
 	JSONVersion         string
 	TargetPrefix        string
 	Protocol            string
+	ProtocolSettings    ProtocolSettings
 	UID                 string
 	EndpointsID         string
 	ServiceID           string
@@ -77,8 +78,15 @@ type Metadata struct {
 	NoResolveEndpoint bool
 }
 
+// ProtocolSettings define how the SDK should handle requests in the context
+// of of a protocol.
+type ProtocolSettings struct {
+	HTTP2 string `json:"h2,omitempty"`
+}
+
 var serviceAliases map[string]string
 
+// Bootstrap loads SDK model customizations prior to the API model is parsed.
 func Bootstrap() error {
 	b, err := ioutil.ReadFile(filepath.Join("..", "models", "customizations", "service-aliases.json"))
 	if err != nil {

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -48,6 +48,7 @@ func (a *API) Setup() {
 	a.updateTopLevelShapeReferences()
 	a.createInputOutputShapes()
 	a.setupEventStreams()
+	a.supressHTTP2EventStreams()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -48,7 +48,7 @@ func (a *API) Setup() {
 	a.updateTopLevelShapeReferences()
 	a.createInputOutputShapes()
 	a.setupEventStreams()
-	a.supressHTTP2EventStreams()
+	a.suppressHTTP2EventStreams()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -361,3 +361,16 @@ func (a *API) setMetadataEndpointsKey() {
 		a.Metadata.EndpointsID = a.Metadata.EndpointPrefix
 	}
 }
+
+func (a *API) supressHTTP2EventStreams() {
+	if a.Metadata.ProtocolSettings.HTTP2 != "eventstream" {
+		return
+	}
+
+	for name, op := range a.Operations {
+		if op.EventStreamAPI != nil {
+			a.removeOperation(name)
+			a.HasEventStream = false
+		}
+	}
+}

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -362,7 +362,7 @@ func (a *API) setMetadataEndpointsKey() {
 	}
 }
 
-func (a *API) supressHTTP2EventStreams() {
+func (a *API) suppressHTTP2EventStreams() {
 	if a.Metadata.ProtocolSettings.HTTP2 != "eventstream" {
 		return
 	}

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -244,9 +244,9 @@ func TestSupressHTTP2EventStreams(t *testing.T) {
     "endpointPrefix":"rpcservice",
     "jsonVersion":"1.1",
     "protocol":"json",
-	"protocolSettings":{
+    "protocolSettings":{
       "h2":"{h2Option}"
-	},
+    },
     "serviceAbbreviation":"RPCService",
     "serviceFullName":"RPC Service",
     "serviceId":"RPCService",

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -228,6 +230,121 @@ func TestCollidingFields(t *testing.T) {
 				if e, a := c.Expect[i], name; e != a {
 					t.Errorf("expect %v, got %v", e, a)
 				}
+			}
+		})
+	}
+}
+
+func TestSupressHTTP2EventStreams(t *testing.T) {
+	const baseModel = `
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"0000-00-00",
+    "endpointPrefix":"rpcservice",
+    "jsonVersion":"1.1",
+    "protocol":"json",
+	"protocolSettings":{
+      "h2":"{h2Option}"
+	},
+    "serviceAbbreviation":"RPCService",
+    "serviceFullName":"RPC Service",
+    "serviceId":"RPCService",
+    "signatureVersion":"v4",
+    "targetPrefix":"RPCService_00000000",
+    "uid":"RPCService-0000-00-00"
+  },
+  "operations":{
+    "BarOp":{
+      "name":"BarOp",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape": "BarOpRequest"},
+      "output":{"shape":"BarOpResponse"}
+    },
+    "EventStreamOp":{
+      "name":"EventStreamOp",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape": "EventStreamOpRequest"},
+      "output":{"shape":"EventStreamOpResponse"}
+    },
+    "FooOp":{
+      "name":"FooOp",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape": "FooOpRequest"},
+      "output":{"shape":"FooOpResponse"}
+    }
+  },
+  "shapes":{
+    "BarRequest":{
+      "type":"structure",
+      "members":{}
+    },
+    "BarResponse":{
+      "type":"structure",
+      "members":{}
+    },
+    "EventStreamRequest":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "EventStreamResponse":{
+      "type":"structure",
+      "members":{
+        "EventStream":{"shape":"EventStream"}
+      }
+    },
+    "FooRequest":{
+      "type":"structure",
+      "members":{}
+    },
+    "FooResponse":{
+      "type":"structure",
+      "members":{}
+    },
+    "EventStream":{
+      "type":"structure",
+      "members":{},
+      "eventstream":true
+    },
+  }
+}
+`
+
+	cases := map[string]struct {
+		Model     string
+		ExpectOps []string
+	}{
+		"control": {
+			Model:     strings.Replace(baseModel, "{h2Option}", "", -1),
+			ExpectOps: []string{"BarOp", "EventStreamOp", "FooOp"},
+		},
+		"HTTP/2 with EventStreams": {
+			Model:     strings.Replace(baseModel, "{h2Option}", "eventstream", 1),
+			ExpectOps: []string{"BarOp", "FooOp"},
+		},
+		"HTTP/2 with optional": {
+			Model:     strings.Replace(baseModel, "{h2Option}", "optional", 1),
+			ExpectOps: []string{"BarOp", "EventStreamOp", "FooOp"},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var a API
+			a.AttachString(c.Model)
+
+			if e, a := c.ExpectOps, a.OperationNames(); !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v ops, got %v", e, a)
 			}
 		})
 	}


### PR DESCRIPTION
Prevents the SDK from generating EventStream based API operation which
are required to be performed over HTTP/2.