### PR TITLE
aws/credentials/ec2rolecreds: Avoid unnecessary redirect

### DIFF
--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/internal/sdkuri"
 )
 
 // ProviderName provides a name of EC2Role provider
@@ -152,7 +153,7 @@ func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 // If the credentials cannot be found, or there is an error reading the response
 // and error will be returned.
 func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCredRespBody, error) {
-	resp, err := client.GetMetadata(iamSecurityCredsPath + credsName)
+	resp, err := client.GetMetadata(sdkuri.PathJoin(iamSecurityCredsPath, credsName))
 	if err != nil {
 		return ec2RoleCredRespBody{},
 			awserr.New("EC2RoleRequestError",

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -125,7 +124,7 @@ type ec2RoleCredRespBody struct {
 	Message string
 }
 
-const iamSecurityCredsPath = "/iam/security-credentials/"
+const iamSecurityCredsPath = "iam/security-credentials/"
 
 // requestCredList requests a list of credentials from the EC2 service.
 // If there are no credentials, or there is an error making or receiving the request
@@ -153,7 +152,7 @@ func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 // If the credentials cannot be found, or there is an error reading the response
 // and error will be returned.
 func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCredRespBody, error) {
-	resp, err := client.GetMetadata(path.Join(iamSecurityCredsPath, credsName))
+	resp, err := client.GetMetadata(iamSecurityCredsPath + credsName)
 	if err != nil {
 		return ec2RoleCredRespBody{},
 			awserr.New("EC2RoleRequestError",

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -125,7 +125,7 @@ type ec2RoleCredRespBody struct {
 	Message string
 }
 
-const iamSecurityCredsPath = "/iam/security-credentials"
+const iamSecurityCredsPath = "/iam/security-credentials/"
 
 // requestCredList requests a list of credentials from the EC2 service.
 // If there are no credentials, or there is an error making or receiving the request

--- a/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
@@ -34,7 +34,7 @@ const credsFailRespTmpl = `{
 
 func initTestServer(expireOn string, failAssume bool) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/latest/meta-data/iam/security-credentials" {
+		if r.URL.Path == "/latest/meta-data/iam/security-credentials/" {
 			fmt.Fprintln(w, "RoleName")
 		} else if r.URL.Path == "/latest/meta-data/iam/security-credentials/RoleName" {
 			if failAssume {

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 	"strings"
 	"time"
 
@@ -19,7 +18,7 @@ func (c *EC2Metadata) GetMetadata(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "meta-data", p),
+		HTTPPath:   "/meta-data/" + p,
 	}
 
 	output := &metadataOutput{}
@@ -35,7 +34,7 @@ func (c *EC2Metadata) GetUserData() (string, error) {
 	op := &request.Operation{
 		Name:       "GetUserData",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "user-data"),
+		HTTPPath:   "/user-data",
 	}
 
 	output := &metadataOutput{}
@@ -56,7 +55,7 @@ func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetDynamicData",
 		HTTPMethod: "GET",
-		HTTPPath:   path.Join("/", "dynamic", p),
+		HTTPPath:   "/dynamic/" + p,
 	}
 
 	output := &metadataOutput{}

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/internal/sdkuri"
 )
 
 // GetMetadata uses the path provided to request information from the EC2
@@ -18,7 +19,7 @@ func (c *EC2Metadata) GetMetadata(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
-		HTTPPath:   "/meta-data/" + p,
+		HTTPPath:   sdkuri.PathJoin("/meta-data", p),
 	}
 
 	output := &metadataOutput{}
@@ -55,7 +56,7 @@ func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
 	op := &request.Operation{
 		Name:       "GetDynamicData",
 		HTTPMethod: "GET",
-		HTTPPath:   "/dynamic/" + p,
+		HTTPPath:   sdkuri.PathJoin("/dynamic", p),
 	}
 
 	output := &metadataOutput{}

--- a/internal/sdkuri/path.go
+++ b/internal/sdkuri/path.go
@@ -1,0 +1,23 @@
+package sdkuri
+
+import (
+	"path"
+	"strings"
+)
+
+// PathJoin will join the elements of the path delimited by the "/"
+// character. Similar to path.Join with the exception the trailing "/"
+// character is preserved if present.
+func PathJoin(elems ...string) string {
+	if len(elems) == 0 {
+		return ""
+	}
+
+	hasTrailing := strings.HasSuffix(elems[len(elems)-1], "/")
+	str := path.Join(elems...)
+	if hasTrailing && str != "/" {
+		str += "/"
+	}
+
+	return str
+}

--- a/internal/sdkuri/path_test.go
+++ b/internal/sdkuri/path_test.go
@@ -1,0 +1,21 @@
+package sdkuri
+
+import "testing"
+
+func TestPathJoin(t *testing.T) {
+	cases := []struct {
+		Elems  []string
+		Expect string
+	}{
+		{Elems: []string{"/"}, Expect: "/"},
+		{Elems: []string{}, Expect: ""},
+		{Elems: []string{"blah", "el", "blah/"}, Expect: "blah/el/blah/"},
+		{Elems: []string{"/asd", "asdfa", "asdfasd/"}, Expect: "/asd/asdfa/asdfasd/"},
+		{Elems: []string{"asdfa", "asdfa", "asdfads"}, Expect: "asdfa/asdfa/asdfads"},
+	}
+	for _, c := range cases {
+		if e, a := c.Expect, PathJoin(c.Elems...); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+	}
+}


### PR DESCRIPTION
Updates #2002 to preserve the trailing slash on EC2 Metadata requests. This removes the unnecessary redirect for `/latest/meta-data/iam/security-credentials/`.