### PR TITLE
Dereference *int64 BytesProcessed in S3 select example

### DIFF
--- a/service/s3/eventstream_exampe_test.go
+++ b/service/s3/eventstream_exampe_test.go
@@ -51,7 +51,7 @@ func ExampleS3_SelectObjectContent() {
 			case *RecordsEvent:
 				resultWriter.Write(e.Payload)
 			case *StatsEvent:
-				fmt.Printf("Processed %d bytes\n", e.Details.BytesProcessed)
+				fmt.Printf("Processed %d bytes\n", *e.Details.BytesProcessed)
 			}
 		}
 	}()


### PR DESCRIPTION
Stats.BytesProcessed is an *int64, needs to be dereferenced before formatting.

This produced some surprising (and rather alarming in terms of cost :) ) output while I was playing around with S3 select, e.g.

    Processed 842353860960 bytes