### PR TITLE
private/protocol/json/jsonutil: avoid unnecessary allocation in unmarshalScalar

### DIFF
--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -172,9 +172,6 @@ func unmarshalMap(value reflect.Value, data interface{}, tag reflect.StructTag) 
 }
 
 func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTag) error {
-	errf := func() error {
-		return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
-	}
 
 	switch d := data.(type) {
 	case nil:
@@ -197,7 +194,7 @@ func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTa
 			}
 			value.Set(reflect.ValueOf(v))
 		default:
-			return errf()
+			return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
 		}
 	case float64:
 		switch value.Interface().(type) {
@@ -210,14 +207,14 @@ func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTa
 			t := time.Unix(int64(d), 0).UTC()
 			value.Set(reflect.ValueOf(&t))
 		default:
-			return errf()
+			return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
 		}
 	case bool:
 		switch value.Interface().(type) {
 		case *bool:
 			value.Set(reflect.ValueOf(&d))
 		default:
-			return errf()
+			return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
 		}
 	default:
 		return fmt.Errorf("unsupported JSON value (%v)", data)


### PR DESCRIPTION
Avoid allocating a func on each call to `unmarshalScalar` at the cost of a small amount of duplication.

In our application this is accounting for roughly 33% of the memory allocated by `unmarshalScalar` and we're handling relatively large Base64 blobs as well.

```
         .          .    170:
         .          .    171:	return nil
         .          .    172:}
         .          .    173:
         .          .    174:func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTag) error {
  790.02MB   790.02MB    175:	errf := func() error {
         .          .    176:		return fmt.Errorf("unsupported value: %v (%s)", value.Interface(), value.Type())
         .          .    177:	}
         .          .    178:
   66.50MB    66.50MB    179:	switch d := data.(type) {
         .          .    180:	case nil:
         .          .    181:		return nil // nothing to do here
         .          .    182:	case string:
         .    30.50MB    183:		switch value.Interface().(type) {
         .          .    184:		case *string:
         .          .    185:			value.Set(reflect.ValueOf(&d))
         .          .    186:		case []byte:
         .     1.39GB    187:			b, err := base64.StdEncoding.DecodeString(d)
         .          .    188:			if err != nil {
         .          .    189:				return err
         .          .    190:			}
   26.50MB    26.50MB    191:			value.Set(reflect.ValueOf(b))
         .          .    192:		case aws.JSONValue:
         .          .    193:			// No need to use escaping as the value is a non-quoted string.
         .          .    194:			v, err := protocol.DecodeJSONValue(d, protocol.NoEscape)
         .          .    195:			if err != nil {
         .          .    196:				return err
```