### PR TITLE
aws/signer/v4: avoid 32KB alloc when hashing body

### DIFF
--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -687,7 +687,11 @@ func (ctx *signingCtx) buildBodyDigest() error {
 			if !aws.IsReaderSeekable(ctx.Body) {
 				return fmt.Errorf("cannot use unseekable request body %T, for signed request with body", ctx.Body)
 			}
-			hash = hex.EncodeToString(makeSha256Reader(ctx.Body))
+			hashBytes, err := makeSha256Reader(ctx.Body)
+			if err != nil {
+				return nil
+			}
+			hash = hex.EncodeToString(hashBytes)
 		}
 
 		if includeSHA256Header {
@@ -734,13 +738,20 @@ func makeSha256(data []byte) []byte {
 	return hash.Sum(nil)
 }
 
-func makeSha256Reader(reader io.ReadSeeker) []byte {
+func makeSha256Reader(reader io.ReadSeeker) ([]byte, error) {
 	hash := sha256.New()
 	start, _ := reader.Seek(0, sdkio.SeekCurrent)
 	defer reader.Seek(start, sdkio.SeekStart)
 
-	io.Copy(hash, reader)
-	return hash.Sum(nil)
+	// Use CopyN to avoid allocating the 32KB buffer in io.Copy for bodies
+	// smaller than 32KB.
+	len, err := aws.SeekerLen(reader)
+	if err != nil {
+		return nil, err
+	}
+	io.CopyN(hash, reader, len)
+
+	return hash.Sum(nil), nil
 }
 
 const doubleSpace = "  "

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -62,6 +62,11 @@ func TestStripExcessHeaders(t *testing.T) {
 }
 
 func buildRequest(serviceName, region, body string) (*http.Request, io.ReadSeeker) {
+	reader := strings.NewReader(body)
+	return buildRequestWithBodyReader(serviceName, region, reader)
+}
+
+func buildRequestReaderSeeker(serviceName, region, body string) (*http.Request, io.ReadSeeker) {
 	reader := &readerSeekerWrapper{strings.NewReader(body)}
 	return buildRequestWithBodyReader(serviceName, region, reader)
 }
@@ -694,18 +699,16 @@ func TestRequestHost(t *testing.T) {
 }
 
 func BenchmarkPresignRequest(b *testing.B) {
-	b.ReportAllocs()
 	signer := buildSigner()
-	req, body := buildRequest("dynamodb", "us-east-1", "{}")
+	req, body := buildRequestReaderSeeker("dynamodb", "us-east-1", "{}")
 	for i := 0; i < b.N; i++ {
 		signer.Presign(req, body, "dynamodb", "us-east-1", 300*time.Second, time.Now())
 	}
 }
 
 func BenchmarkSignRequest(b *testing.B) {
-	b.ReportAllocs()
 	signer := buildSigner()
-	req, body := buildRequest("dynamodb", "us-east-1", "{}")
+	req, body := buildRequestReaderSeeker("dynamodb", "us-east-1", "{}")
 	for i := 0; i < b.N; i++ {
 		signer.Sign(req, body, "dynamodb", "us-east-1", time.Now())
 	}


### PR DESCRIPTION
Determine the body length and use `io.CopyN` instead of `io.Copy`
because the latter would otherwise allocate a 32KB temporary buffer.

This provides a 4x reduction in bytes allocated by Sign and a little performance bump:

```
name                 old time/op    new time/op    delta
PresignRequest-4       38.1µs ±13%    29.6µs ± 2%  -22.42%  (p=0.008 n=5+5)
SignRequest-4          28.4µs ±14%    20.1µs ± 2%  -29.07%  (p=0.008 n=5+5)
StripExcessSpaces-4     868ns ± 2%     892ns ± 1%   +2.76%  (p=0.032 n=5+5)

name                 old alloc/op   new alloc/op   delta
PresignRequest-4       46.1kB ± 0%    13.3kB ± 0%     ~     (p=0.079 n=4+5)
SignRequest-4          42.6kB ± 0%     9.9kB ± 0%  -76.83%  (p=0.008 n=5+5)

name                 old allocs/op  new allocs/op  delta
PresignRequest-4          139 ± 0%       140 ± 0%   +0.72%  (p=0.008 n=5+5)
SignRequest-4             109 ± 0%       110 ± 0%   +0.92%  (p=0.008 n=5+5)
```

There might be other ways to tackle this. If `*request.offsetReader` implemented `WriteTo` then `io.Copy` wouldn't have to allocate the temporary buffer. However, it wasn't immediately obvious how to do that since the underlying `buf` there is an `io.ReaderSeeker`.