### PR TITLE
private/model/api: Fix eventstream over HTTP/2 suppression and tests

### DIFF
--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -75,6 +75,16 @@ The events that can be sent are:
 	return commentify(w.String())
 }
 
+func hasEventStream(topShape *Shape) bool {
+	for _, ref := range topShape.MemberRefs {
+		if ref.Shape.IsEventStream {
+			return true
+		}
+	}
+
+	return false
+}
+
 func eventStreamAPIShapeRefDoc(refName string) string {
 	return commentify(fmt.Sprintf("Use %s to use the API's stream.", refName))
 }

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -47,8 +47,8 @@ func (a *API) Setup() {
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()
 	a.createInputOutputShapes()
-	a.setupEventStreams()
 	a.suppressHTTP2EventStreams()
+	a.setupEventStreams()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -255,8 +255,8 @@ func (a *API) renameCollidingFields() {
 	for _, v := range a.Shapes {
 		namesWithSet := map[string]struct{}{}
 		for k, field := range v.MemberRefs {
-			if strings.HasPrefix(k, "Set") {
-				namesWithSet[k] = struct{}{}
+			if _, ok := v.MemberRefs["Set"+k]; ok {
+				namesWithSet["Set"+k] = struct{}{}
 			}
 
 			if collides(k) || (v.Exception && exceptionCollides(k)) {
@@ -266,9 +266,8 @@ func (a *API) renameCollidingFields() {
 
 		// checks if any field names collide with setters.
 		for name := range namesWithSet {
-			if field, ok := v.MemberRefs["Set"+name]; ok {
-				renameCollidingField(name, v, field)
-			}
+			field := v.MemberRefs[name]
+			renameCollidingField(name, v, field)
 		}
 	}
 }

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -362,15 +362,20 @@ func (a *API) setMetadataEndpointsKey() {
 	}
 }
 
+// Suppress event stream must be run before setup event stream
 func (a *API) suppressHTTP2EventStreams() {
 	if a.Metadata.ProtocolSettings.HTTP2 != "eventstream" {
 		return
 	}
 
 	for name, op := range a.Operations {
-		if op.EventStreamAPI != nil {
-			a.removeOperation(name)
-			a.HasEventStream = false
+		outbound := hasEventStream(op.InputRef.Shape)
+		inbound := hasEventStream(op.OutputRef.Shape)
+
+		if !(outbound || inbound) {
+			continue
 		}
+
+		a.removeOperation(name)
 	}
 }

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -645,7 +645,6 @@ type {{ .ShapeName }} struct {
 	{{ end }}
 {{ end }}
 
-{{ if .API.HasEventStream -}}
 {{ if $.EventStreamsMemberName }}
 	{{ template "eventStreamAPILoopMethodTmpl" $ }}
 {{ end }}
@@ -656,7 +655,6 @@ type {{ .ShapeName }} struct {
 	{{- if $.Exception }}
 		{{ template "eventStreamExceptionEventShapeTmpl" $ }}
 	{{ end -}}
-{{ end -}}
 {{ end }}
 `
 


### PR DESCRIPTION
Fixes the SDK's eventstream over HTTP/2 suppression, and fixes the SDK's code generation test cases incorrectly being skipped due to an invalid build tag.