### PR TITLE
v1.14.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Release v1.14.27 (2018-07-13)
+===
+
+### Service Client Updates
+* `service/appstream`: Updates service API, documentation, and paginators
+  * This API update adds support for sharing AppStream images across AWS accounts within the same region.
+* `service/kinesis-video-archived-media`: Updates service API and documentation
+* `service/kinesisvideo`: Updates service API and documentation
+  * Adds support for HLS video playback of Kinesis Video streams using the KinesisVideo client by including "GET_HLS_STREAMING_SESSION_URL" as an additional APIName parameter in the GetDataEndpoint input.
+
 Release v1.14.26 (2018-07-12)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.26"
+const SDKVersion = "1.14.27"

--- a/models/apis/appstream/2016-12-01/api-2.json
+++ b/models/apis/appstream/2016-12-01/api-2.json
@@ -78,7 +78,8 @@
         {"shape":"InvalidRoleException"},
         {"shape":"ConcurrentModificationException"},
         {"shape":"InvalidParameterCombinationException"},
-        {"shape":"IncompatibleImageException"}
+        {"shape":"IncompatibleImageException"},
+        {"shape":"OperationNotPermittedException"}
       ]
     },
     "CreateImageBuilder":{
@@ -98,7 +99,8 @@
         {"shape":"InvalidRoleException"},
         {"shape":"ConcurrentModificationException"},
         {"shape":"InvalidParameterCombinationException"},
-        {"shape":"IncompatibleImageException"}
+        {"shape":"IncompatibleImageException"},
+        {"shape":"OperationNotPermittedException"}
       ]
     },
     "CreateImageBuilderStreamingURL":{
@@ -203,6 +205,19 @@
         {"shape":"ConcurrentModificationException"}
       ]
     },
+    "DeleteImagePermissions":{
+      "name":"DeleteImagePermissions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DeleteImagePermissionsRequest"},
+      "output":{"shape":"DeleteImagePermissionsResult"},
+      "errors":[
+        {"shape":"ResourceNotAvailableException"},
+        {"shape":"ResourceNotFoundException"}
+      ]
+    },
     "DeleteStack":{
       "name":"DeleteStack",
       "http":{
@@ -253,6 +268,18 @@
         {"shape":"ResourceNotFoundException"}
       ]
     },
+    "DescribeImagePermissions":{
+      "name":"DescribeImagePermissions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeImagePermissionsRequest"},
+      "output":{"shape":"DescribeImagePermissionsResult"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"}
+      ]
+    },
     "DescribeImages":{
       "name":"DescribeImages",
       "http":{
@@ -262,6 +289,7 @@
       "input":{"shape":"DescribeImagesRequest"},
       "output":{"shape":"DescribeImagesResult"},
       "errors":[
+        {"shape":"InvalidParameterCombinationException"},
         {"shape":"ResourceNotFoundException"}
       ]
     },
@@ -462,6 +490,20 @@
         {"shape":"OperationNotPermittedException"}
       ]
     },
+    "UpdateImagePermissions":{
+      "name":"UpdateImagePermissions",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"UpdateImagePermissionsRequest"},
+      "output":{"shape":"UpdateImagePermissionsResult"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceNotAvailableException"},
+        {"shape":"LimitExceededException"}
+      ]
+    },
     "UpdateStack":{
       "name":"UpdateStack",
       "http":{
@@ -529,6 +571,10 @@
       "type":"string",
       "pattern":"^arn:aws:[A-Za-z0-9][A-Za-z0-9_/.-]{0,62}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-Za-z0-9:_/+=,@.-]{0,1023}$"
     },
+    "ArnList":{
+      "type":"list",
+      "member":{"shape":"Arn"}
+    },
     "AssociateFleetRequest":{
       "type":"structure",
       "required":[
@@ -552,6 +598,16 @@
         "SAML",
         "USERPOOL"
       ]
+    },
+    "AwsAccountId":{
+      "type":"string",
+      "pattern":"^\\d+$"
+    },
+    "AwsAccountIdList":{
+      "type":"list",
+      "member":{"shape":"AwsAccountId"},
+      "max":5,
+      "min":1
     },
     "Boolean":{"type":"boolean"},
     "BooleanObject":{"type":"boolean"},
@@ -622,13 +678,13 @@
       "type":"structure",
       "required":[
         "Name",
-        "ImageName",
         "InstanceType",
         "ComputeCapacity"
       ],
       "members":{
         "Name":{"shape":"Name"},
         "ImageName":{"shape":"String"},
+        "ImageArn":{"shape":"Arn"},
         "InstanceType":{"shape":"String"},
         "FleetType":{"shape":"FleetType"},
         "ComputeCapacity":{"shape":"ComputeCapacity"},
@@ -651,12 +707,12 @@
       "type":"structure",
       "required":[
         "Name",
-        "ImageName",
         "InstanceType"
       ],
       "members":{
         "Name":{"shape":"Name"},
         "ImageName":{"shape":"String"},
+        "ImageArn":{"shape":"Arn"},
         "InstanceType":{"shape":"String"},
         "Description":{"shape":"Description"},
         "DisplayName":{"shape":"DisplayName"},
@@ -766,6 +822,22 @@
         "ImageBuilder":{"shape":"ImageBuilder"}
       }
     },
+    "DeleteImagePermissionsRequest":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "SharedAccountId"
+      ],
+      "members":{
+        "Name":{"shape":"Name"},
+        "SharedAccountId":{"shape":"AwsAccountId"}
+      }
+    },
+    "DeleteImagePermissionsResult":{
+      "type":"structure",
+      "members":{
+      }
+    },
     "DeleteImageRequest":{
       "type":"structure",
       "required":["Name"],
@@ -835,6 +907,24 @@
         "NextToken":{"shape":"String"}
       }
     },
+    "DescribeImagePermissionsRequest":{
+      "type":"structure",
+      "required":["Name"],
+      "members":{
+        "Name":{"shape":"Name"},
+        "MaxResults":{"shape":"MaxResults"},
+        "SharedAwsAccountIds":{"shape":"AwsAccountIdList"},
+        "NextToken":{"shape":"String"}
+      }
+    },
+    "DescribeImagePermissionsResult":{
+      "type":"structure",
+      "members":{
+        "Name":{"shape":"Name"},
+        "SharedImagePermissionsList":{"shape":"SharedImagePermissionsList"},
+        "NextToken":{"shape":"String"}
+      }
+    },
     "DescribeImagesMaxResults":{
       "type":"integer",
       "box":true,
@@ -845,6 +935,8 @@
       "type":"structure",
       "members":{
         "Names":{"shape":"StringList"},
+        "Arns":{"shape":"ArnList"},
+        "Type":{"shape":"VisibilityType"},
         "NextToken":{"shape":"String"},
         "MaxResults":{"shape":"DescribeImagesMaxResults"}
       }
@@ -973,7 +1065,6 @@
       "required":[
         "Arn",
         "Name",
-        "ImageName",
         "InstanceType",
         "ComputeCapacityStatus",
         "State"
@@ -984,6 +1075,7 @@
         "DisplayName":{"shape":"String"},
         "Description":{"shape":"String"},
         "ImageName":{"shape":"String"},
+        "ImageArn":{"shape":"Arn"},
         "InstanceType":{"shape":"String"},
         "FleetType":{"shape":"FleetType"},
         "ComputeCapacityStatus":{"shape":"ComputeCapacityStatus"},
@@ -1088,7 +1180,8 @@
         "Applications":{"shape":"Applications"},
         "CreatedTime":{"shape":"Timestamp"},
         "PublicBaseImageReleasedDate":{"shape":"Timestamp"},
-        "AppstreamAgentVersion":{"shape":"AppstreamAgentVersion"}
+        "AppstreamAgentVersion":{"shape":"AppstreamAgentVersion"},
+        "ImagePermissions":{"shape":"ImagePermissions"}
       }
     },
     "ImageBuilder":{
@@ -1147,6 +1240,13 @@
     "ImageList":{
       "type":"list",
       "member":{"shape":"Image"}
+    },
+    "ImagePermissions":{
+      "type":"structure",
+      "members":{
+        "allowFleet":{"shape":"BooleanObject"},
+        "allowImageBuilder":{"shape":"BooleanObject"}
+      }
     },
     "ImageState":{
       "type":"string",
@@ -1253,6 +1353,12 @@
       }
     },
     "Long":{"type":"long"},
+    "MaxResults":{
+      "type":"integer",
+      "box":true,
+      "max":500,
+      "min":0
+    },
     "Metadata":{
       "type":"map",
       "key":{"shape":"String"},
@@ -1394,6 +1500,21 @@
         "PENDING",
         "EXPIRED"
       ]
+    },
+    "SharedImagePermissions":{
+      "type":"structure",
+      "required":[
+        "sharedAccountId",
+        "imagePermissions"
+      ],
+      "members":{
+        "sharedAccountId":{"shape":"AwsAccountId"},
+        "imagePermissions":{"shape":"ImagePermissions"}
+      }
+    },
+    "SharedImagePermissionsList":{
+      "type":"list",
+      "member":{"shape":"SharedImagePermissions"}
     },
     "Stack":{
       "type":"structure",
@@ -1615,9 +1736,9 @@
     },
     "UpdateFleetRequest":{
       "type":"structure",
-      "required":["Name"],
       "members":{
         "ImageName":{"shape":"String"},
+        "ImageArn":{"shape":"Arn"},
         "Name":{"shape":"String"},
         "InstanceType":{"shape":"String"},
         "ComputeCapacity":{"shape":"ComputeCapacity"},
@@ -1639,6 +1760,24 @@
       "type":"structure",
       "members":{
         "Fleet":{"shape":"Fleet"}
+      }
+    },
+    "UpdateImagePermissionsRequest":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "SharedAccountId",
+        "ImagePermissions"
+      ],
+      "members":{
+        "Name":{"shape":"Name"},
+        "SharedAccountId":{"shape":"AwsAccountId"},
+        "ImagePermissions":{"shape":"ImagePermissions"}
+      }
+    },
+    "UpdateImagePermissionsResult":{
+      "type":"structure",
+      "members":{
       }
     },
     "UpdateStackRequest":{
@@ -1690,7 +1829,8 @@
       "type":"string",
       "enum":[
         "PUBLIC",
-        "PRIVATE"
+        "PRIVATE",
+        "SHARED"
       ]
     },
     "VpcConfig":{

--- a/models/apis/appstream/2016-12-01/docs-2.json
+++ b/models/apis/appstream/2016-12-01/docs-2.json
@@ -14,10 +14,12 @@
     "DeleteFleet": "<p>Deletes the specified fleet.</p>",
     "DeleteImage": "<p>Deletes the specified image. You cannot delete an image when it is in use. After you delete an image, you cannot provision new capacity using the image.</p>",
     "DeleteImageBuilder": "<p>Deletes the specified image builder and releases the capacity.</p>",
+    "DeleteImagePermissions": "<p>Deletes permissions for the specified private image. After you delete permissions for an image, AWS accounts to which you previously granted these permissions can no longer use the image.</p>",
     "DeleteStack": "<p>Deletes the specified stack. After the stack is deleted, the application streaming environment provided by the stack is no longer available to users. Also, any reservations made for application streaming sessions for the stack are released.</p>",
     "DescribeDirectoryConfigs": "<p>Retrieves a list that describes one or more specified Directory Config objects for AppStream 2.0, if the names for these objects are provided. Otherwise, all Directory Config objects in the account are described. These objects include the information required to join streaming instances to an Active Directory domain. </p> <p>Although the response syntax in this topic includes the account password, this password is not returned in the actual response.</p>",
     "DescribeFleets": "<p>Retrieves a list that describes one or more specified fleets, if the fleet names are provided. Otherwise, all fleets in the account are described.</p>",
     "DescribeImageBuilders": "<p>Retrieves a list that describes one or more specified image builders, if the image builder names are provided. Otherwise, all image builders in the account are described.</p>",
+    "DescribeImagePermissions": "<p>Retrieves a list that describes the permissions for a private image that you own. </p>",
     "DescribeImages": "<p>Retrieves a list that describes one or more specified images, if the image names are provided. Otherwise, all images in the account are described.</p>",
     "DescribeSessions": "<p>Retrieves a list that describes the streaming sessions for a specified stack and fleet. If a user ID is provided for the stack and fleet, only streaming sessions for that user are described. If an authentication type is not provided, the default is to authenticate users using a streaming URL.</p>",
     "DescribeStacks": "<p>Retrieves a list that describes one or more specified stacks, if the stack names are provided. Otherwise, all stacks in the account are described.</p>",
@@ -34,6 +36,7 @@
     "UntagResource": "<p>Disassociates one or more specified tags from the specified AppStream 2.0 resource.</p> <p>To list the current tags for your resources, use <a>ListTagsForResource</a>.</p> <p>For more information about tags, see <a href=\"http://docs.aws.amazon.com/appstream2/latest/developerguide/tagging-basic.html\">Tagging Your Resources</a> in the <i>Amazon AppStream 2.0 Developer Guide</i>.</p>",
     "UpdateDirectoryConfig": "<p>Updates the specified Directory Config object in AppStream 2.0. This object includes the information required to join streaming instances to an Active Directory domain.</p>",
     "UpdateFleet": "<p>Updates the specified fleet.</p> <p>If the fleet is in the <code>STOPPED</code> state, you can update any attribute except the fleet name. If the fleet is in the <code>RUNNING</code> state, you can update the <code>DisplayName</code> and <code>ComputeCapacity</code> attributes. If the fleet is in the <code>STARTING</code> or <code>STOPPING</code> state, you can't update it.</p>",
+    "UpdateImagePermissions": "<p>Adds or updates permissions for the specified private image. </p>",
     "UpdateStack": "<p>Updates the specified fields for the specified stack.</p>"
   },
   "shapes": {
@@ -79,7 +82,11 @@
     "Arn": {
       "base": null,
       "refs": {
+        "ArnList$member": null,
+        "CreateFleetRequest$ImageArn": "<p>The ARN of the public, private, or shared image to use.</p>",
+        "CreateImageBuilderRequest$ImageArn": "<p>The ARN of the public, private, or shared image to use.</p>",
         "Fleet$Arn": "<p>The ARN for the fleet.</p>",
+        "Fleet$ImageArn": "<p>The ARN for the public, private, or shared image.</p>",
         "Image$Arn": "<p>The ARN of the image.</p>",
         "Image$BaseImageArn": "<p>The ARN of the image from which this image was created.</p>",
         "ImageBuilder$Arn": "<p>The ARN for the image builder.</p>",
@@ -87,7 +94,14 @@
         "ListTagsForResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource.</p>",
         "Stack$Arn": "<p>The ARN of the stack.</p>",
         "TagResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource.</p>",
-        "UntagResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource.</p>"
+        "UntagResourceRequest$ResourceArn": "<p>The Amazon Resource Name (ARN) of the resource.</p>",
+        "UpdateFleetRequest$ImageArn": "<p>The ARN of the public, private, or shared image to use.</p>"
+      }
+    },
+    "ArnList": {
+      "base": null,
+      "refs": {
+        "DescribeImagesRequest$Arns": "<p>The ARNs of the public, private, and shared images to describe.</p>"
       }
     },
     "AssociateFleetRequest": {
@@ -107,6 +121,21 @@
         "Session$AuthenticationType": "<p>The authentication method. The user is authenticated using a streaming URL (<code>API</code>) or SAML federation (<code>SAML</code>).</p>"
       }
     },
+    "AwsAccountId": {
+      "base": null,
+      "refs": {
+        "AwsAccountIdList$member": null,
+        "DeleteImagePermissionsRequest$SharedAccountId": "<p>The 12-digit ID of the AWS account for which to delete image permissions.</p>",
+        "SharedImagePermissions$sharedAccountId": "<p>The 12-digit ID of the AWS account with which the image is shared.</p>",
+        "UpdateImagePermissionsRequest$SharedAccountId": "<p>The 12-digit ID of the AWS account for which you want add or update image permissions.</p>"
+      }
+    },
+    "AwsAccountIdList": {
+      "base": null,
+      "refs": {
+        "DescribeImagePermissionsRequest$SharedAwsAccountIds": "<p>The 12-digit ID of one or more AWS accounts with which the image is shared.</p>"
+      }
+    },
     "Boolean": {
       "base": null,
       "refs": {
@@ -123,6 +152,8 @@
         "CreateImageBuilderRequest$EnableDefaultInternetAccess": "<p>Enables or disables default internet access for the image builder.</p>",
         "Fleet$EnableDefaultInternetAccess": "<p>Indicates whether default internet access is enabled for the fleet.</p>",
         "ImageBuilder$EnableDefaultInternetAccess": "<p>Enables or disables default internet access for the image builder.</p>",
+        "ImagePermissions$allowFleet": "<p>Indicates whether the image can be used for a fleet.</p>",
+        "ImagePermissions$allowImageBuilder": "<p>Indicates whether the image can be used for an image builder.</p>",
         "UpdateFleetRequest$EnableDefaultInternetAccess": "<p>Enables or disables default internet access for the fleet.</p>"
       }
     },
@@ -244,6 +275,16 @@
       "refs": {
       }
     },
+    "DeleteImagePermissionsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DeleteImagePermissionsResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DeleteImageRequest": {
       "base": null,
       "refs": {
@@ -294,10 +335,20 @@
       "refs": {
       }
     },
+    "DescribeImagePermissionsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeImagePermissionsResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "DescribeImagesMaxResults": {
       "base": null,
       "refs": {
-        "DescribeImagesRequest$MaxResults": "<p>The maximum size of each results page.</p>"
+        "DescribeImagesRequest$MaxResults": "<p>The maximum size of each page of results.</p>"
       }
     },
     "DescribeImagesRequest": {
@@ -553,6 +604,14 @@
         "DescribeImagesResult$Images": "<p>Information about the images.</p>"
       }
     },
+    "ImagePermissions": {
+      "base": "<p>Describes the permissions for an image. </p>",
+      "refs": {
+        "Image$ImagePermissions": "<p>The permissions to provide to the destination AWS account for the specified image.</p>",
+        "SharedImagePermissions$imagePermissions": "<p>Describes the permissions for a shared image.</p>",
+        "UpdateImagePermissionsRequest$ImagePermissions": "<p>The permissions for the image.</p>"
+      }
+    },
     "ImageState": {
       "base": null,
       "refs": {
@@ -652,6 +711,12 @@
         "CreateStreamingURLRequest$Validity": "<p>The time that the streaming URL will be valid, in seconds. Specify a value between 1 and 604800 seconds. The default is 60 seconds.</p>"
       }
     },
+    "MaxResults": {
+      "base": null,
+      "refs": {
+        "DescribeImagePermissionsRequest$MaxResults": "<p>The maximum size of each results page.</p>"
+      }
+    },
     "Metadata": {
       "base": null,
       "refs": {
@@ -668,7 +733,11 @@
         "CreateImageBuilderRequest$Name": "<p>A unique name for the image builder.</p>",
         "CreateStackRequest$Name": "<p>The name of the stack.</p>",
         "DeleteImageBuilderRequest$Name": "<p>The name of the image builder.</p>",
-        "DeleteImageRequest$Name": "<p>The name of the image.</p>"
+        "DeleteImagePermissionsRequest$Name": "<p>The name of the private image.</p>",
+        "DeleteImageRequest$Name": "<p>The name of the image.</p>",
+        "DescribeImagePermissionsRequest$Name": "<p>The name of the private image for which to describe permissions. The image must be one that you own. </p>",
+        "DescribeImagePermissionsResult$Name": "<p>The name of the private image.</p>",
+        "UpdateImagePermissionsRequest$Name": "<p>The name of the private image.</p>"
       }
     },
     "NetworkAccessConfiguration": {
@@ -792,6 +861,18 @@
       "base": "<p>Possible values for the state of a streaming session.</p>",
       "refs": {
         "Session$State": "<p>The current state of the streaming session.</p>"
+      }
+    },
+    "SharedImagePermissions": {
+      "base": "<p>Describes the permissions that are available to the specified AWS account for a shared image.</p>",
+      "refs": {
+        "SharedImagePermissionsList$member": null
+      }
+    },
+    "SharedImagePermissionsList": {
+      "base": null,
+      "refs": {
+        "DescribeImagePermissionsResult$SharedImagePermissionsList": "<p>The permissions for a private image that you own. </p>"
       }
     },
     "Stack": {
@@ -933,8 +1014,10 @@
         "DescribeFleetsResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
         "DescribeImageBuildersRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",
         "DescribeImageBuildersResult$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>",
+        "DescribeImagePermissionsRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results. If this value is empty, only the first page is retrieved.</p>",
+        "DescribeImagePermissionsResult$NextToken": "<p>The pagination token to use to retrieve the next page of results. If this value is empty, only the first page is retrieved.</p>",
         "DescribeImagesRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results. If this value is empty, only the first page is retrieved.</p>",
-        "DescribeImagesResult$NextToken": "<p>The pagination token used to retrieve the next page of results. If this value is empty, only the first page is retrieved.</p>",
+        "DescribeImagesResult$NextToken": "<p>The pagination token to use to retrieve the next page of results. If there are no more pages, this value is null.</p>",
         "DescribeSessionsRequest$StackName": "<p>The name of the stack. This value is case-sensitive.</p>",
         "DescribeSessionsRequest$FleetName": "<p>The name of the fleet. This value is case-sensitive.</p>",
         "DescribeSessionsRequest$NextToken": "<p>The pagination token to use to retrieve the next page of results for this operation. If this value is null, it retrieves the first page.</p>",
@@ -1087,6 +1170,16 @@
       "refs": {
       }
     },
+    "UpdateImagePermissionsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "UpdateImagePermissionsResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "UpdateStackRequest": {
       "base": null,
       "refs": {
@@ -1121,6 +1214,7 @@
     "VisibilityType": {
       "base": null,
       "refs": {
+        "DescribeImagesRequest$Type": "<p>The type of image (public, private, or shared) to describe. </p>",
         "Image$Visibility": "<p>Indicates whether the image is public or private.</p>"
       }
     },

--- a/models/apis/appstream/2016-12-01/paginators-1.json
+++ b/models/apis/appstream/2016-12-01/paginators-1.json
@@ -1,4 +1,14 @@
 {
   "pagination": {
+    "DescribeImagePermissions": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
+    "DescribeImages": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    }
   }
 }

--- a/models/apis/kinesis-video-archived-media/2017-09-30/api-2.json
+++ b/models/apis/kinesis-video-archived-media/2017-09-30/api-2.json
@@ -11,6 +11,25 @@
     "uid":"kinesis-video-archived-media-2017-09-30"
   },
   "operations":{
+    "GetHLSStreamingSessionURL":{
+      "name":"GetHLSStreamingSessionURL",
+      "http":{
+        "method":"POST",
+        "requestUri":"/getHLSStreamingSessionURL"
+      },
+      "input":{"shape":"GetHLSStreamingSessionURLInput"},
+      "output":{"shape":"GetHLSStreamingSessionURLOutput"},
+      "errors":[
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"InvalidArgumentException"},
+        {"shape":"ClientLimitExceededException"},
+        {"shape":"NotAuthorizedException"},
+        {"shape":"UnsupportedStreamMediaTypeException"},
+        {"shape":"NoDataRetentionException"},
+        {"shape":"MissingCodecPrivateDataException"},
+        {"shape":"InvalidCodecPrivateDataException"}
+      ]
+    },
     "GetMediaForFragmentList":{
       "name":"GetMediaForFragmentList",
       "http":{
@@ -57,7 +76,19 @@
       "min":1,
       "pattern":"^[a-zA-Z0-9_\\.\\-]+$"
     },
+    "DiscontinuityMode":{
+      "type":"string",
+      "enum":[
+        "ALWAYS",
+        "NEVER"
+      ]
+    },
     "ErrorMessage":{"type":"string"},
+    "Expires":{
+      "type":"integer",
+      "max":43200,
+      "min":300
+    },
     "Fragment":{
       "type":"structure",
       "members":{
@@ -74,7 +105,9 @@
     },
     "FragmentNumberList":{
       "type":"list",
-      "member":{"shape":"FragmentNumberString"}
+      "member":{"shape":"FragmentNumberString"},
+      "max":1000,
+      "min":1
     },
     "FragmentNumberString":{
       "type":"string",
@@ -100,6 +133,24 @@
         "SERVER_TIMESTAMP"
       ]
     },
+    "GetHLSStreamingSessionURLInput":{
+      "type":"structure",
+      "members":{
+        "StreamName":{"shape":"StreamName"},
+        "StreamARN":{"shape":"ResourceARN"},
+        "PlaybackMode":{"shape":"PlaybackMode"},
+        "HLSFragmentSelector":{"shape":"HLSFragmentSelector"},
+        "DiscontinuityMode":{"shape":"DiscontinuityMode"},
+        "Expires":{"shape":"Expires"},
+        "MaxMediaPlaylistFragmentResults":{"shape":"PageLimit"}
+      }
+    },
+    "GetHLSStreamingSessionURLOutput":{
+      "type":"structure",
+      "members":{
+        "HLSStreamingSessionURL":{"shape":"HLSStreamingSessionURL"}
+      }
+    },
     "GetMediaForFragmentListInput":{
       "type":"structure",
       "required":[
@@ -123,7 +174,37 @@
       },
       "payload":"Payload"
     },
+    "HLSFragmentSelector":{
+      "type":"structure",
+      "members":{
+        "FragmentSelectorType":{"shape":"HLSFragmentSelectorType"},
+        "TimestampRange":{"shape":"HLSTimestampRange"}
+      }
+    },
+    "HLSFragmentSelectorType":{
+      "type":"string",
+      "enum":[
+        "PRODUCER_TIMESTAMP",
+        "SERVER_TIMESTAMP"
+      ]
+    },
+    "HLSStreamingSessionURL":{"type":"string"},
+    "HLSTimestampRange":{
+      "type":"structure",
+      "members":{
+        "StartTimestamp":{"shape":"Timestamp"},
+        "EndTimestamp":{"shape":"Timestamp"}
+      }
+    },
     "InvalidArgumentException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"ErrorMessage"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true
+    },
+    "InvalidCodecPrivateDataException":{
       "type":"structure",
       "members":{
         "Message":{"shape":"ErrorMessage"}
@@ -149,6 +230,22 @@
       }
     },
     "Long":{"type":"long"},
+    "MissingCodecPrivateDataException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"ErrorMessage"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true
+    },
+    "NoDataRetentionException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"ErrorMessage"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true
+    },
     "NotAuthorizedException":{
       "type":"structure",
       "members":{
@@ -165,6 +262,19 @@
     "Payload":{
       "type":"blob",
       "streaming":true
+    },
+    "PlaybackMode":{
+      "type":"string",
+      "enum":[
+        "LIVE",
+        "ON_DEMAND"
+      ]
+    },
+    "ResourceARN":{
+      "type":"string",
+      "max":1024,
+      "min":1,
+      "pattern":"arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
     },
     "ResourceNotFoundException":{
       "type":"structure",
@@ -195,6 +305,14 @@
         "StartTimestamp":{"shape":"Timestamp"},
         "EndTimestamp":{"shape":"Timestamp"}
       }
+    },
+    "UnsupportedStreamMediaTypeException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"ErrorMessage"}
+      },
+      "error":{"httpStatusCode":400},
+      "exception":true
     }
   }
 }

--- a/models/apis/kinesis-video-archived-media/2017-09-30/docs-2.json
+++ b/models/apis/kinesis-video-archived-media/2017-09-30/docs-2.json
@@ -2,7 +2,8 @@
   "version": "2.0",
   "service": "<p/>",
   "operations": {
-    "GetMediaForFragmentList": "<p>Gets media for a list of fragments (specified by fragment number) from the archived data in a Kinesis video stream.</p> <note> <p>This operation is only available for the AWS SDK for Java. It is not supported in AWS SDKs for other languages.</p> </note> <p>The following limits apply when using the <code>GetMediaForFragmentList</code> API:</p> <ul> <li> <p>A client can call <code>GetMediaForFragmentList</code> up to five times per second per stream. </p> </li> <li> <p>Kinesis Video Streams sends media data at a rate of up to 25 megabytes per second (or 200 megabits per second) during a <code>GetMediaForFragmentList</code> session. </p> </li> </ul>",
+    "GetHLSStreamingSessionURL": "<p>Retrieves an HTTP Live Streaming (HLS) URL for the stream. You can then open the URL in a browser or media player to view the stream contents.</p> <p>You must specify either the <code>StreamName</code> or the <code>StreamARN</code>.</p> <p>An Amazon Kinesis video stream has the following requirements for providing data through HLS:</p> <ul> <li> <p>The media type must be <code>video/h264</code>.</p> </li> <li> <p>Data retention must be greater than 0.</p> </li> <li> <p>The fragments must contain codec private data in the AVC (Advanced Video Coding) for H.264 format (<a href=\"https://www.iso.org/standard/55980.html\">MPEG-4 specification ISO/IEC 14496-15</a>). For information about adapting stream data to a given format, see <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/latest/dg/producer-reference-nal.html\">NAL Adaptation Flags</a>.</p> </li> </ul> <p>Kinesis Video Streams HLS sessions contain fragments in the fragmented MPEG-4 form (also called fMP4 or CMAF), rather than the MPEG-2 form (also called TS chunks, which the HLS specification also supports). For more information about HLS fragment types, see the <a href=\"https://tools.ietf.org/html/draft-pantos-http-live-streaming-23\">HLS specification</a>.</p> <p>The following procedure shows how to use HLS with Kinesis Video Streams:</p> <ol> <li> <p>Get an endpoint using <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_GetDataEndpoint.html\">GetDataEndpoint</a>, specifying <code>GET_HLS_STREAMING_SESSION_URL</code> for the <code>APIName</code> parameter.</p> </li> <li> <p>Retrieve the HLS URL using <code>GetHLSStreamingSessionURL</code>. Kinesis Video Streams creates an HLS streaming session to be used for accessing content in a stream using the HLS protocol. <code>GetHLSStreamingSessionURL</code> returns an authenticated URL (that includes an encrypted session token) for the session's HLS <i>master playlist</i> (the root resource needed for streaming with HLS).</p> <note> <p>Don't share or store this token where an unauthorized entity could access it. The token provides access to the content of the stream. Safeguard the token with the same measures that you would use with your AWS credentials.</p> </note> <p>The media that is made available through the playlist consists only of the requested stream, time range, and format. No other media data (such as frames outside the requested window or alternate bit rates) is made available.</p> </li> <li> <p>Provide the URL (containing the encrypted session token) for the HLS master playlist to a media player that supports the HLS protocol. Kinesis Video Streams makes the HLS media playlist, initialization fragment, and media fragments available through the master playlist URL. The initialization fragment contains the codec private data for the stream, and other data needed to set up the video decoder and renderer. The media fragments contain H.264-encoded video frames and time stamps.</p> </li> <li> <p>The media player receives the authenticated URL and requests stream metadata and media data normally. When the media player requests data, it calls the following actions:</p> <ul> <li> <p> <b>GetHLSMasterPlaylist:</b> Retrieves an HLS master playlist, which contains a URL for the <code>GetHLSMediaPlaylist</code> action, and additional metadata for the media player, including estimated bit rate and resolution.</p> </li> <li> <p> <b>GetHLSMediaPlaylist:</b> Retrieves an HLS media playlist, which contains a URL to access the MP4 initialization fragment with the <code>GetMP4InitFragment</code> action, and URLs to access the MP4 media fragments with the <code>GetMP4MediaFragment</code> actions. The HLS media playlist also contains metadata about the stream that the player needs to play it, such as whether the <code>PlaybackMode</code> is <code>LIVE</code> or <code>ON_DEMAND</code>. The HLS media playlist is typically static for sessions with a <code>PlaybackType</code> of <code>ON_DEMAND</code>. The HLS media playlist is continually updated with new fragments for sessions with a <code>PlaybackType</code> of <code>LIVE</code>.</p> </li> <li> <p> <b>GetMP4InitFragment:</b> Retrieves the MP4 initialization fragment. The media player typically loads the initialization fragment before loading any media fragments. This fragment contains the \"<code>fytp</code>\" and \"<code>moov</code>\" MP4 atoms, and the child atoms that are needed to initialize the media player decoder.</p> <p>The initialization fragment does not correspond to a fragment in a Kinesis video stream. It contains only the codec private data for the stream, which the media player needs to decode video frames.</p> </li> <li> <p> <b>GetMP4MediaFragment:</b> Retrieves MP4 media fragments. These fragments contain the \"<code>moof</code>\" and \"<code>mdat</code>\" MP4 atoms and their child atoms, containing the encoded fragment's video frames and their time stamps. </p> <note> <p>After the first media fragment is made available in a streaming session, any fragments that don't contain the same codec private data are excluded in the HLS media playlist. Therefore, the codec private data does not change between fragments in a session.</p> </note> <p>Data retrieved with this action is billable. See <a href=\"aws.amazon.comkinesis/video-streams/pricing/\">Pricing</a> for details.</p> </li> </ul> </li> </ol> <note> <p>The following restrictions apply to HLS sessions:</p> <ul> <li> <p>A streaming session URL should not be shared between players. The service might throttle a session if multiple media players are sharing it. For connection limits, see <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html\">Kinesis Video Streams Limits</a>.</p> </li> <li> <p>A Kinesis video stream can have a maximum of five active HLS streaming sessions. If a new session is created when the maximum number of sessions is already active, the oldest (earliest created) session is closed. The number of active <code>GetMedia</code> connections on a Kinesis video stream does not count against this limit, and the number of active HLS sessions does not count against the active <code>GetMedia</code> connection limit.</p> </li> </ul> </note> <p>You can monitor the amount of data that the media player consumes by monitoring the <code>GetMP4MediaFragment.OutgoingBytes</code> Amazon CloudWatch metric. For information about using CloudWatch to monitor Kinesis Video Streams, see <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/monitoring.html\">Monitoring Kinesis Video Streams</a>. For pricing information, see <a href=\"https://aws.amazon.com/kinesis/video-streams/pricing/\">Amazon Kinesis Video Streams Pricing</a> and <a href=\"https://aws.amazon.com/pricing/\">AWS Pricing</a>. Charges for both HLS sessions and outgoing AWS data apply.</p> <p>For more information about HLS, see <a href=\"https://developer.apple.com/streaming/\">HTTP Live Streaming</a> on the <a href=\"https://developer.apple.com\">Apple Developer site</a>.</p>",
+    "GetMediaForFragmentList": "<p>Gets media for a list of fragments (specified by fragment number) from the archived data in an Amazon Kinesis video stream.</p> <p>The following limits apply when using the <code>GetMediaForFragmentList</code> API:</p> <ul> <li> <p>A client can call <code>GetMediaForFragmentList</code> up to five times per second per stream. </p> </li> <li> <p>Kinesis Video Streams sends media data at a rate of up to 25 megabytes per second (or 200 megabits per second) during a <code>GetMediaForFragmentList</code> session. </p> </li> </ul>",
     "ListFragments": "<p>Returns a list of <a>Fragment</a> objects from the specified stream and start location within the archived data.</p>"
   },
   "shapes": {
@@ -17,13 +18,29 @@
         "GetMediaForFragmentListOutput$ContentType": "<p>The content type of the requested media.</p>"
       }
     },
+    "DiscontinuityMode": {
+      "base": null,
+      "refs": {
+        "GetHLSStreamingSessionURLInput$DiscontinuityMode": "<p>Specifies when flags marking discontinuities between fragments will be added to the media playlists. The default is <code>ALWAYS</code> when <a>HLSFragmentSelector</a> is <code>SERVER_TIMESTAMP</code>, and <code>NEVER</code> when it is <code>PRODUCER_TIMESTAMP</code>.</p> <p>Media players typically build a timeline of media content to play, based on the time stamps of each fragment. This means that if there is any overlap between fragments (as is typical if <a>HLSFragmentSelector</a> is <code>SERVER_TIMESTAMP</code>), the media player timeline has small gaps between fragments in some places, and overwrites frames in other places. When there are discontinuity flags between fragments, the media player is expected to reset the timeline, resulting in the fragment being played immediately after the previous fragment. We recommend that you always have discontinuity flags between fragments if the fragment time stamps are not accurate or if fragments might be missing. You should not place discontinuity flags between fragments for the player timeline to accurately map to the producer time stamps.</p>"
+      }
+    },
     "ErrorMessage": {
       "base": null,
       "refs": {
         "ClientLimitExceededException$Message": null,
         "InvalidArgumentException$Message": null,
+        "InvalidCodecPrivateDataException$Message": null,
+        "MissingCodecPrivateDataException$Message": null,
+        "NoDataRetentionException$Message": null,
         "NotAuthorizedException$Message": null,
-        "ResourceNotFoundException$Message": null
+        "ResourceNotFoundException$Message": null,
+        "UnsupportedStreamMediaTypeException$Message": null
+      }
+    },
+    "Expires": {
+      "base": null,
+      "refs": {
+        "GetHLSStreamingSessionURLInput$Expires": "<p>The time in seconds until the requested session expires. This value can be between 300 (5 minutes) and 43200 (12 hours).</p> <p>When a session expires, no new calls to <code>GetHLSMasterPlaylist</code>, <code>GetHLSMediaPlaylist</code>, <code>GetMP4InitFragment</code>, or <code>GetMP4MediaFragment</code> can be made for that session.</p> <p>The default is 300 (5 minutes).</p>"
       }
     },
     "Fragment": {
@@ -62,6 +79,16 @@
         "FragmentSelector$FragmentSelectorType": "<p>The origin of the time stamps to use (Server or Producer).</p>"
       }
     },
+    "GetHLSStreamingSessionURLInput": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "GetHLSStreamingSessionURLOutput": {
+      "base": null,
+      "refs": {
+      }
+    },
     "GetMediaForFragmentListInput": {
       "base": null,
       "refs": {
@@ -72,8 +99,37 @@
       "refs": {
       }
     },
+    "HLSFragmentSelector": {
+      "base": "<p>Contains the range of time stamps for the requested media, and the source of the time stamps.</p>",
+      "refs": {
+        "GetHLSStreamingSessionURLInput$HLSFragmentSelector": "<p>The time range of the requested fragment, and the source of the time stamps.</p> <p>This parameter is required if <code>PlaybackMode</code> is <code>ON_DEMAND</code>. This parameter is optional if <code>PlaybackMode</code> is <code>LIVE</code>. If <code>PlaybackMode</code> is <code>LIVE</code>, the <code>FragmentSelectorType</code> can be set, but the <code>TimestampRange</code> should not be set. If <code>PlaybackMode</code> is <code>ON_DEMAND</code>, both <code>FragmentSelectorType</code> and <code>TimestampRange</code> must be set.</p>"
+      }
+    },
+    "HLSFragmentSelectorType": {
+      "base": null,
+      "refs": {
+        "HLSFragmentSelector$FragmentSelectorType": "<p>The source of the time stamps for the requested media.</p> <p>When <code>FragmentSelectorType</code> is set to <code>PRODUCER_TIMESTAMP</code> and <a>GetHLSStreamingSessionURLInput$PlaybackMode</a> is <code>ON_DEMAND</code>, the first fragment ingested with a producer time stamp within the specified <a>FragmentSelector$TimestampRange</a> is included in the media playlist. In addition, the fragments with producer time stamps within the <code>TimestampRange</code> ingested immediately following the first fragment (up to the <a>GetHLSStreamingSessionURLInput$MaxMediaPlaylistFragmentResults</a> value) are included. </p> <p>Fragments that have duplicate producer time stamps are deduplicated. This means that if producers are producing a stream of fragments with producer time stamps that are approximately equal to the true clock time, the HLS media playlists will contain all of the fragments within the requested time stamp range. If some fragments are ingested within the same time range and very different points in time, only the oldest ingested collection of fragments are returned.</p> <p>When <code>FragmentSelectorType</code> is set to <code>PRODUCER_TIMESTAMP</code> and <a>GetHLSStreamingSessionURLInput$PlaybackMode</a> is <code>LIVE</code>, the producer time stamps are used in the MP4 fragments and for deduplication. But the most recently ingested fragments based on server time stamps are included in the HLS media playlist. This means that even if fragments ingested in the past have producer time stamps with values now, they are not included in the HLS media playlist.</p> <p>The default is <code>SERVER_TIMESTAMP</code>.</p>"
+      }
+    },
+    "HLSStreamingSessionURL": {
+      "base": null,
+      "refs": {
+        "GetHLSStreamingSessionURLOutput$HLSStreamingSessionURL": "<p>The URL (containing the session token) that a media player can use to retrieve the HLS master playlist.</p>"
+      }
+    },
+    "HLSTimestampRange": {
+      "base": "<p>The start and end of the time stamp range for the requested media.</p> <p>This value should not be present if <code>PlaybackType</code> is <code>LIVE</code>.</p> <note> <p>The values in the <code>HLSTimestampRange</code> are inclusive. Fragments that begin before the start time but continue past it, or fragments that begin before the end time but continue past it, are included in the session.</p> </note>",
+      "refs": {
+        "HLSFragmentSelector$TimestampRange": "<p>The start and end of the time stamp range for the requested media.</p> <p>This value should not be present if <code>PlaybackType</code> is <code>LIVE</code>.</p>"
+      }
+    },
     "InvalidArgumentException": {
       "base": "<p>A specified parameter exceeds its restrictions, is not supported, or can't be used.</p>",
+      "refs": {
+      }
+    },
+    "InvalidCodecPrivateDataException": {
+      "base": "<p>The Codec Private Data in the video stream is not valid for this operation.</p>",
       "refs": {
       }
     },
@@ -94,6 +150,16 @@
         "Fragment$FragmentLengthInMilliseconds": "<p>The playback duration or other time value associated with the fragment.</p>"
       }
     },
+    "MissingCodecPrivateDataException": {
+      "base": "<p>No Codec Private Data was found in the video stream.</p>",
+      "refs": {
+      }
+    },
+    "NoDataRetentionException": {
+      "base": "<p>A <code>PlaybackMode</code> of <code>ON_DEMAND</code> was requested for a stream that does not retain data (that is, has a <code>DataRetentionInHours</code> of 0). </p>",
+      "refs": {
+      }
+    },
     "NotAuthorizedException": {
       "base": "<p>Status Code: 403, The caller is not authorized to perform an operation on the given stream, or the token has expired.</p>",
       "refs": {
@@ -102,23 +168,37 @@
     "PageLimit": {
       "base": null,
       "refs": {
+        "GetHLSStreamingSessionURLInput$MaxMediaPlaylistFragmentResults": "<p>The maximum number of fragments that are returned in the HLS media playlists.</p> <p>When the <code>PlaybackMode</code> is <code>LIVE</code>, the most recent fragments are returned up to this value. When the <code>PlaybackMode</code> is <code>ON_DEMAND</code>, the oldest fragments are returned, up to this maximum number.</p> <p>When there are a higher number of fragments available in a live HLS media playlist, video players often buffer content before starting playback. Increasing the buffer size increases the playback latency, but it decreases the likelihood that rebuffering will occur during playback. We recommend that a live HLS media playlist have a minimum of 3 fragments and a maximum of 10 fragments.</p> <p>The default is 5 fragments if <code>PlaybackMode</code> is <code>LIVE</code>, and 1,000 if <code>PlaybackMode</code> is <code>ON_DEMAND</code>. </p> <p>The maximum value of 1,000 fragments corresponds to more than 16 minutes of video on streams with 1-second fragments, and more than 2 1/2 hours of video on streams with 10-second fragments.</p>",
         "ListFragmentsInput$MaxResults": "<p>The total number of fragments to return. If the total number of fragments available is more than the value specified in <code>max-results</code>, then a <a>ListFragmentsOutput$NextToken</a> is provided in the output that you can use to resume pagination.</p>"
       }
     },
     "Payload": {
       "base": null,
       "refs": {
-        "GetMediaForFragmentListOutput$Payload": "<p>The payload that Kinesis Video Streams returns is a sequence of chunks from the specified stream. For information about the chunks, see <a href=\"docs.aws.amazon.com/acuity/latest/dg/API_dataplane_PutMedia.html\">PutMedia</a>. The chunks that Kinesis Video Streams returns in the <code>GetMediaForFragmentList</code> call also include the following additional Matroska (MKV) tags: </p> <ul> <li> <p>AWS_KINESISVIDEO_FRAGMENT_NUMBER - Fragment number returned in the chunk.</p> </li> <li> <p>AWS_KINESISVIDEO_SERVER_SIDE_TIMESTAMP - Server-side time stamp of the fragment.</p> </li> <li> <p>AWS_KINESISVIDEO_PRODUCER_SIDE_TIMESTAMP - Producer-side time stamp of the fragment.</p> </li> </ul> <p>The following tags will be included if an exception occurs:</p> <ul> <li> <p>AWS_KINESISVIDEO_FRAGMENT_NUMBER - The number of the fragment that threw the exception</p> </li> <li> <p>AWS_KINESISVIDEO_EXCEPTION_ERROR_CODE - The integer code of the exception</p> </li> <li> <p>AWS_KINESISVIDEO_EXCEPTION_MESSAGE - A text description of the exception</p> </li> </ul>"
+        "GetMediaForFragmentListOutput$Payload": "<p>The payload that Kinesis Video Streams returns is a sequence of chunks from the specified stream. For information about the chunks, see <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_dataplane_PutMedia.html\">PutMedia</a>. The chunks that Kinesis Video Streams returns in the <code>GetMediaForFragmentList</code> call also include the following additional Matroska (MKV) tags: </p> <ul> <li> <p>AWS_KINESISVIDEO_FRAGMENT_NUMBER - Fragment number returned in the chunk.</p> </li> <li> <p>AWS_KINESISVIDEO_SERVER_SIDE_TIMESTAMP - Server-side time stamp of the fragment.</p> </li> <li> <p>AWS_KINESISVIDEO_PRODUCER_SIDE_TIMESTAMP - Producer-side time stamp of the fragment.</p> </li> </ul> <p>The following tags will be included if an exception occurs:</p> <ul> <li> <p>AWS_KINESISVIDEO_FRAGMENT_NUMBER - The number of the fragment that threw the exception</p> </li> <li> <p>AWS_KINESISVIDEO_EXCEPTION_ERROR_CODE - The integer code of the exception</p> </li> <li> <p>AWS_KINESISVIDEO_EXCEPTION_MESSAGE - A text description of the exception</p> </li> </ul>"
+      }
+    },
+    "PlaybackMode": {
+      "base": null,
+      "refs": {
+        "GetHLSStreamingSessionURLInput$PlaybackMode": "<p>Whether to retrieve live or archived, on-demand data.</p> <p>Features of the two types of session include the following:</p> <ul> <li> <p> <b> <code>LIVE</code> </b>: For sessions of this type, the HLS media playlist is continually updated with the latest fragments as they become available. We recommend that the media player retrieve a new playlist on a one-second interval. When this type of session is played in a media player, the user interface typically displays a \"live\" notification, with no scrubber control for choosing the position in the playback window to display.</p> <note> <p>In <code>LIVE</code> mode, the newest available fragments are included in an HLS media playlist, even if there is a gap between fragments (that is, if a fragment is missing). A gap like this might cause a media player to halt or cause a jump in playback. In this mode, fragments are not added to the HLS media playlist if they are older than the newest fragment in the playlist. If the missing fragment becomes available after a subsequent fragment is added to the playlist, the older fragment is not added, and the gap is not filled.</p> </note> </li> <li> <p> <b> <code>ON_DEMAND</code> </b>: For sessions of this type, the HLS media playlist contains all the fragments for the session, up to the number that is specified in <code>MaxMediaPlaylistFragmentResults</code>. The playlist must be retrieved only once for each session. When this type of session is played in a media player, the user interface typically displays a scrubber control for choosing the position in the playback window to display.</p> </li> </ul> <p>In both playback modes, if <code>FragmentSelectorType</code> is <code>PRODUCER_TIMESTAMP</code>, and if there are multiple fragments with the same start time stamp, the fragment that has the larger fragment number (that is, the newer fragment) is included in the HLS media playlist. The other fragments are not included. Fragments that have different time stamps but have overlapping durations are still included in the HLS media playlist. This can lead to unexpected behavior in the media player.</p> <p>The default is <code>LIVE</code>.</p>"
+      }
+    },
+    "ResourceARN": {
+      "base": null,
+      "refs": {
+        "GetHLSStreamingSessionURLInput$StreamARN": "<p>The Amazon Resource Name (ARN) of the stream for which to retrieve the HLS master playlist URL.</p> <p>You must specify either the <code>StreamName</code> or the <code>StreamARN</code>.</p>"
       }
     },
     "ResourceNotFoundException": {
-      "base": "<p>Kinesis Video Streams can't find the stream that you specified.</p>",
+      "base": "<p> <code>GetMedia</code> throws this error when Kinesis Video Streams can't find the stream that you specified.</p> <p> <code>GetHLSStreamingSessionURL</code> throws this error if a session with a <code>PlaybackMode</code> of <code>ON_DEMAND</code> is requested for a stream that has no fragments within the requested time range, or if a session with a <code>PlaybackMode</code> of <code>LIVE</code> is requested for a stream that has no fragments within the last 30 seconds.</p>",
       "refs": {
       }
     },
     "StreamName": {
       "base": null,
       "refs": {
+        "GetHLSStreamingSessionURLInput$StreamName": "<p>The name of the stream for which to retrieve the HLS master playlist URL.</p> <p>You must specify either the <code>StreamName</code> or the <code>StreamARN</code>.</p>",
         "GetMediaForFragmentListInput$StreamName": "<p>The name of the stream from which to retrieve fragment media.</p>",
         "ListFragmentsInput$StreamName": "<p>The name of the stream from which to retrieve a fragment list.</p>"
       }
@@ -136,6 +216,8 @@
       "refs": {
         "Fragment$ProducerTimestamp": "<p>The time stamp from the producer corresponding to the fragment.</p>",
         "Fragment$ServerTimestamp": "<p>The time stamp from the AWS server corresponding to the fragment.</p>",
+        "HLSTimestampRange$StartTimestamp": "<p>The start of the time stamp range for the requested media.</p> <p>If the <code>HLSTimestampRange</code> value is specified, the <code>StartTimestamp</code> value is required.</p> <note> <p>This value is inclusive. Fragments that start before the <code>StartTimestamp</code> and continue past it are included in the session. If <code>FragmentSelectorType</code> is <code>SERVER_TIMESTAMP</code>, the <code>StartTimestamp</code> must be later than the stream head.</p> </note>",
+        "HLSTimestampRange$EndTimestamp": "<p>The end of the time stamp range for the requested media. This value must be within 3 hours of the specified <code>StartTimestamp</code>, and it must be later than the <code>StartTimestamp</code> value.</p> <p>If <code>FragmentSelectorType</code> for the request is <code>SERVER_TIMESTAMP</code>, this value must be in the past.</p> <p>If the <code>HLSTimestampRange</code> value is specified, the <code>EndTimestamp</code> value is required.</p> <note> <p>This value is inclusive. The <code>EndTimestamp</code> is compared to the (starting) time stamp of the fragment. Fragments that start before the <code>EndTimestamp</code> value and continue past it are included in the session.</p> </note>",
         "TimestampRange$StartTimestamp": "<p>The starting time stamp in the range of time stamps for which to return fragments.</p>",
         "TimestampRange$EndTimestamp": "<p>The ending time stamp in the range of time stamps for which to return fragments.</p>"
       }
@@ -144,6 +226,11 @@
       "base": "<p>The range of time stamps for which to return fragments.</p>",
       "refs": {
         "FragmentSelector$TimestampRange": "<p>The range of time stamps to return.</p>"
+      }
+    },
+    "UnsupportedStreamMediaTypeException": {
+      "base": "<p>An HLS streaming session was requested for a stream with a media type that is not <code>video/h264</code>.</p>",
+      "refs": {
       }
     }
   }

--- a/models/apis/kinesisvideo/2017-09-30/api-2.json
+++ b/models/apis/kinesisvideo/2017-09-30/api-2.json
@@ -177,7 +177,8 @@
         "PUT_MEDIA",
         "GET_MEDIA",
         "LIST_FRAGMENTS",
-        "GET_MEDIA_FOR_FRAGMENT_LIST"
+        "GET_MEDIA_FOR_FRAGMENT_LIST",
+        "GET_HLS_STREAMING_SESSION_URL"
       ]
     },
     "AccountStreamLimitExceededException":{

--- a/models/apis/kinesisvideo/2017-09-30/docs-2.json
+++ b/models/apis/kinesisvideo/2017-09-30/docs-2.json
@@ -61,7 +61,7 @@
     "DataRetentionInHours": {
       "base": null,
       "refs": {
-        "CreateStreamInput$DataRetentionInHours": "<p>The number of hours that you want to retain the data in the stream. Kinesis Video Streams retains the data in a data store that is associated with the stream.</p> <p>The default value is 0, indicating that the stream does not persist data.</p>",
+        "CreateStreamInput$DataRetentionInHours": "<p>The number of hours that you want to retain the data in the stream. Kinesis Video Streams retains the data in a data store that is associated with the stream.</p> <p>The default value is 0, indicating that the stream does not persist data.</p> <p>When the <code>DataRetentionInHours</code> value is 0, consumers can still consume the fragments that remain in the service host buffer, which has a retention time limit of 5 minutes and a retention memory limit of 200 MB. Fragments are removed from the buffer when either limit is reached.</p>",
         "StreamInfo$DataRetentionInHours": "<p>How long the stream retains data, in hours.</p>"
       }
     },
@@ -177,7 +177,7 @@
       "refs": {
         "CreateStreamInput$MediaType": "<p>The media type of the stream. Consumers of the stream can use this information when processing the stream. For more information about media types, see <a href=\"http://www.iana.org/assignments/media-types/media-types.xhtml\">Media Types</a>. If you choose to specify the <code>MediaType</code>, see <a href=\"https://tools.ietf.org/html/rfc6838#section-4.2\">Naming Requirements</a> for guidelines.</p> <p>To play video on the console, the media must be H.264 encoded, and you need to specify this video type in this parameter as <code>video/h264</code>. </p> <p>This parameter is optional; the default value is <code>null</code> (or empty in JSON).</p>",
         "StreamInfo$MediaType": "<p>The <code>MediaType</code> of the stream. </p>",
-        "UpdateStreamInput$MediaType": "<p>The stream's media type. Use <code>MediaType</code> to specify the type of content that the stream contains to the consumers of the stream. For more information about media types, see <a href=\"http://www.iana.org/assignments/media-types/media-types.xhtml\">Media Types</a>. If you choose to specify the <code>MediaType</code>, see <a href=\"https://tools.sietf.org/html/rfc6838#section-4.2\">Naming Requirements</a>.</p> <p>To play video on the console, you must specify the correct video type. For example, if the video in the stream is H.264, specify <code>video/h264</code> as the <code>MediaType</code>.</p>"
+        "UpdateStreamInput$MediaType": "<p>The stream's media type. Use <code>MediaType</code> to specify the type of content that the stream contains to the consumers of the stream. For more information about media types, see <a href=\"http://www.iana.org/assignments/media-types/media-types.xhtml\">Media Types</a>. If you choose to specify the <code>MediaType</code>, see <a href=\"https://tools.ietf.org/html/rfc6838#section-4.2\">Naming Requirements</a>.</p> <p>To play video on the console, you must specify the correct video type. For example, if the video in the stream is H.264, specify <code>video/h264</code> as the <code>MediaType</code>.</p>"
       }
     },
     "NextToken": {
@@ -352,7 +352,7 @@
       }
     },
     "VersionMismatchException": {
-      "base": "<p>The stream version that you specified is not the latest version. To get the latest version, use the <a href=\"http://docs.aws.amazon.com/kinesisvideo/latest/dg/API_DescribeStream.html\">DescribeStream</a> API.</p>",
+      "base": "<p>The stream version that you specified is not the latest version. To get the latest version, use the <a href=\"http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html\">DescribeStream</a> API.</p>",
       "refs": {
       }
     }

--- a/service/appstream/api.go
+++ b/service/appstream/api.go
@@ -373,6 +373,9 @@ func (c *AppStream) CreateFleetRequest(input *CreateFleetInput) (req *request.Re
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
 //
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   The attempted operation is not permitted.
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateFleet
 func (c *AppStream) CreateFleet(input *CreateFleetInput) (*CreateFleetOutput, error) {
 	req, out := c.CreateFleetRequest(input)
@@ -480,6 +483,9 @@ func (c *AppStream) CreateImageBuilderRequest(input *CreateImageBuilderInput) (r
 //
 //   * ErrCodeIncompatibleImageException "IncompatibleImageException"
 //   The image does not support storage connectors.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   The attempted operation is not permitted.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/CreateImageBuilder
 func (c *AppStream) CreateImageBuilder(input *CreateImageBuilderInput) (*CreateImageBuilderOutput, error) {
@@ -1117,6 +1123,90 @@ func (c *AppStream) DeleteImageBuilderWithContext(ctx aws.Context, input *Delete
 	return out, req.Send()
 }
 
+const opDeleteImagePermissions = "DeleteImagePermissions"
+
+// DeleteImagePermissionsRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteImagePermissions operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteImagePermissions for more information on using the DeleteImagePermissions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteImagePermissionsRequest method.
+//    req, resp := client.DeleteImagePermissionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteImagePermissions
+func (c *AppStream) DeleteImagePermissionsRequest(input *DeleteImagePermissionsInput) (req *request.Request, output *DeleteImagePermissionsOutput) {
+	op := &request.Operation{
+		Name:       opDeleteImagePermissions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteImagePermissionsInput{}
+	}
+
+	output = &DeleteImagePermissionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DeleteImagePermissions API operation for Amazon AppStream.
+//
+// Deletes permissions for the specified private image. After you delete permissions
+// for an image, AWS accounts to which you previously granted these permissions
+// can no longer use the image.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation DeleteImagePermissions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotAvailableException "ResourceNotAvailableException"
+//   The specified resource exists and is not in use, but isn't available.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DeleteImagePermissions
+func (c *AppStream) DeleteImagePermissions(input *DeleteImagePermissionsInput) (*DeleteImagePermissionsOutput, error) {
+	req, out := c.DeleteImagePermissionsRequest(input)
+	return out, req.Send()
+}
+
+// DeleteImagePermissionsWithContext is the same as DeleteImagePermissions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteImagePermissions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DeleteImagePermissionsWithContext(ctx aws.Context, input *DeleteImagePermissionsInput, opts ...request.Option) (*DeleteImagePermissionsOutput, error) {
+	req, out := c.DeleteImagePermissionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteStack = "DeleteStack"
 
 // DeleteStackRequest generates a "aws/request.Request" representing the
@@ -1452,6 +1542,142 @@ func (c *AppStream) DescribeImageBuildersWithContext(ctx aws.Context, input *Des
 	return out, req.Send()
 }
 
+const opDescribeImagePermissions = "DescribeImagePermissions"
+
+// DescribeImagePermissionsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeImagePermissions operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeImagePermissions for more information on using the DescribeImagePermissions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeImagePermissionsRequest method.
+//    req, resp := client.DescribeImagePermissionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeImagePermissions
+func (c *AppStream) DescribeImagePermissionsRequest(input *DescribeImagePermissionsInput) (req *request.Request, output *DescribeImagePermissionsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeImagePermissions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeImagePermissionsInput{}
+	}
+
+	output = &DescribeImagePermissionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeImagePermissions API operation for Amazon AppStream.
+//
+// Retrieves a list that describes the permissions for a private image that
+// you own.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation DescribeImagePermissions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/DescribeImagePermissions
+func (c *AppStream) DescribeImagePermissions(input *DescribeImagePermissionsInput) (*DescribeImagePermissionsOutput, error) {
+	req, out := c.DescribeImagePermissionsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeImagePermissionsWithContext is the same as DescribeImagePermissions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeImagePermissions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DescribeImagePermissionsWithContext(ctx aws.Context, input *DescribeImagePermissionsInput, opts ...request.Option) (*DescribeImagePermissionsOutput, error) {
+	req, out := c.DescribeImagePermissionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeImagePermissionsPages iterates over the pages of a DescribeImagePermissions operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeImagePermissions method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeImagePermissions operation.
+//    pageNum := 0
+//    err := client.DescribeImagePermissionsPages(params,
+//        func(page *DescribeImagePermissionsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *AppStream) DescribeImagePermissionsPages(input *DescribeImagePermissionsInput, fn func(*DescribeImagePermissionsOutput, bool) bool) error {
+	return c.DescribeImagePermissionsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeImagePermissionsPagesWithContext same as DescribeImagePermissionsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DescribeImagePermissionsPagesWithContext(ctx aws.Context, input *DescribeImagePermissionsInput, fn func(*DescribeImagePermissionsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeImagePermissionsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImagePermissionsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeImagePermissionsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opDescribeImages = "DescribeImages"
 
 // DescribeImagesRequest generates a "aws/request.Request" representing the
@@ -1483,6 +1709,12 @@ func (c *AppStream) DescribeImagesRequest(input *DescribeImagesInput) (req *requ
 		Name:       opDescribeImages,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -1507,6 +1739,9 @@ func (c *AppStream) DescribeImagesRequest(input *DescribeImagesInput) (req *requ
 // API operation DescribeImages for usage and error information.
 //
 // Returned Error Codes:
+//   * ErrCodeInvalidParameterCombinationException "InvalidParameterCombinationException"
+//   Indicates an incorrect combination of parameters, or a missing parameter.
+//
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
 //   The specified resource was not found.
 //
@@ -1530,6 +1765,56 @@ func (c *AppStream) DescribeImagesWithContext(ctx aws.Context, input *DescribeIm
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// DescribeImagesPages iterates over the pages of a DescribeImages operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeImages method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeImages operation.
+//    pageNum := 0
+//    err := client.DescribeImagesPages(params,
+//        func(page *DescribeImagesOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *AppStream) DescribeImagesPages(input *DescribeImagesInput, fn func(*DescribeImagesOutput, bool) bool) error {
+	return c.DescribeImagesPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeImagesPagesWithContext same as DescribeImagesPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) DescribeImagesPagesWithContext(ctx aws.Context, input *DescribeImagesInput, fn func(*DescribeImagesOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeImagesInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeImagesRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeImagesOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opDescribeSessions = "DescribeSessions"
@@ -2815,6 +3100,91 @@ func (c *AppStream) UpdateFleetWithContext(ctx aws.Context, input *UpdateFleetIn
 	return out, req.Send()
 }
 
+const opUpdateImagePermissions = "UpdateImagePermissions"
+
+// UpdateImagePermissionsRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateImagePermissions operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateImagePermissions for more information on using the UpdateImagePermissions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateImagePermissionsRequest method.
+//    req, resp := client.UpdateImagePermissionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateImagePermissions
+func (c *AppStream) UpdateImagePermissionsRequest(input *UpdateImagePermissionsInput) (req *request.Request, output *UpdateImagePermissionsOutput) {
+	op := &request.Operation{
+		Name:       opUpdateImagePermissions,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateImagePermissionsInput{}
+	}
+
+	output = &UpdateImagePermissionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateImagePermissions API operation for Amazon AppStream.
+//
+// Adds or updates permissions for the specified private image.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon AppStream's
+// API operation UpdateImagePermissions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified resource was not found.
+//
+//   * ErrCodeResourceNotAvailableException "ResourceNotAvailableException"
+//   The specified resource exists and is not in use, but isn't available.
+//
+//   * ErrCodeLimitExceededException "LimitExceededException"
+//   The requested limit exceeds the permitted limit for an account.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/appstream-2016-12-01/UpdateImagePermissions
+func (c *AppStream) UpdateImagePermissions(input *UpdateImagePermissionsInput) (*UpdateImagePermissionsOutput, error) {
+	req, out := c.UpdateImagePermissionsRequest(input)
+	return out, req.Send()
+}
+
+// UpdateImagePermissionsWithContext is the same as UpdateImagePermissions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateImagePermissions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AppStream) UpdateImagePermissionsWithContext(ctx aws.Context, input *UpdateImagePermissionsInput, opts ...request.Option) (*UpdateImagePermissionsOutput, error) {
+	req, out := c.UpdateImagePermissionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opUpdateStack = "UpdateStack"
 
 // UpdateStackRequest generates a "aws/request.Request" representing the
@@ -3392,10 +3762,11 @@ type CreateFleetInput struct {
 	// apps.
 	FleetType *string `type:"string" enum:"FleetType"`
 
+	// The ARN of the public, private, or shared image to use.
+	ImageArn *string `type:"string"`
+
 	// The name of the image used to create the fleet.
-	//
-	// ImageName is a required field
-	ImageName *string `min:"1" type:"string" required:"true"`
+	ImageName *string `min:"1" type:"string"`
 
 	// The instance type to use when launching fleet instances. The following instance
 	// types are available:
@@ -3472,9 +3843,6 @@ func (s *CreateFleetInput) Validate() error {
 	if s.ComputeCapacity == nil {
 		invalidParams.Add(request.NewErrParamRequired("ComputeCapacity"))
 	}
-	if s.ImageName == nil {
-		invalidParams.Add(request.NewErrParamRequired("ImageName"))
-	}
 	if s.ImageName != nil && len(*s.ImageName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ImageName", 1))
 	}
@@ -3538,6 +3906,12 @@ func (s *CreateFleetInput) SetEnableDefaultInternetAccess(v bool) *CreateFleetIn
 // SetFleetType sets the FleetType field's value.
 func (s *CreateFleetInput) SetFleetType(v string) *CreateFleetInput {
 	s.FleetType = &v
+	return s
+}
+
+// SetImageArn sets the ImageArn field's value.
+func (s *CreateFleetInput) SetImageArn(v string) *CreateFleetInput {
+	s.ImageArn = &v
 	return s
 }
 
@@ -3613,10 +3987,11 @@ type CreateImageBuilderInput struct {
 	// Enables or disables default internet access for the image builder.
 	EnableDefaultInternetAccess *bool `type:"boolean"`
 
+	// The ARN of the public, private, or shared image to use.
+	ImageArn *string `type:"string"`
+
 	// The name of the image used to create the builder.
-	//
-	// ImageName is a required field
-	ImageName *string `min:"1" type:"string" required:"true"`
+	ImageName *string `min:"1" type:"string"`
 
 	// The instance type to use when launching the image builder.
 	//
@@ -3647,9 +4022,6 @@ func (s *CreateImageBuilderInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateImageBuilderInput"}
 	if s.AppstreamAgentVersion != nil && len(*s.AppstreamAgentVersion) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("AppstreamAgentVersion", 1))
-	}
-	if s.ImageName == nil {
-		invalidParams.Add(request.NewErrParamRequired("ImageName"))
 	}
 	if s.ImageName != nil && len(*s.ImageName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ImageName", 1))
@@ -3697,6 +4069,12 @@ func (s *CreateImageBuilderInput) SetDomainJoinInfo(v *DomainJoinInfo) *CreateIm
 // SetEnableDefaultInternetAccess sets the EnableDefaultInternetAccess field's value.
 func (s *CreateImageBuilderInput) SetEnableDefaultInternetAccess(v bool) *CreateImageBuilderInput {
 	s.EnableDefaultInternetAccess = &v
+	return s
+}
+
+// SetImageArn sets the ImageArn field's value.
+func (s *CreateImageBuilderInput) SetImageArn(v string) *CreateImageBuilderInput {
+	s.ImageArn = &v
 	return s
 }
 
@@ -4342,6 +4720,72 @@ func (s *DeleteImageOutput) SetImage(v *Image) *DeleteImageOutput {
 	return s
 }
 
+type DeleteImagePermissionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the private image.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The 12-digit ID of the AWS account for which to delete image permissions.
+	//
+	// SharedAccountId is a required field
+	SharedAccountId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteImagePermissionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteImagePermissionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteImagePermissionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteImagePermissionsInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SharedAccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SharedAccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteImagePermissionsInput) SetName(v string) *DeleteImagePermissionsInput {
+	s.Name = &v
+	return s
+}
+
+// SetSharedAccountId sets the SharedAccountId field's value.
+func (s *DeleteImagePermissionsInput) SetSharedAccountId(v string) *DeleteImagePermissionsInput {
+	s.SharedAccountId = &v
+	return s
+}
+
+type DeleteImagePermissionsOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteImagePermissionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteImagePermissionsOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteStackInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4654,10 +5098,128 @@ func (s *DescribeImageBuildersOutput) SetNextToken(v string) *DescribeImageBuild
 	return s
 }
 
-type DescribeImagesInput struct {
+type DescribeImagePermissionsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The maximum size of each results page.
+	MaxResults *int64 `type:"integer"`
+
+	// The name of the private image for which to describe permissions. The image
+	// must be one that you own.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The pagination token to use to retrieve the next page of results. If this
+	// value is empty, only the first page is retrieved.
+	NextToken *string `min:"1" type:"string"`
+
+	// The 12-digit ID of one or more AWS accounts with which the image is shared.
+	SharedAwsAccountIds []*string `min:"1" type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeImagePermissionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagePermissionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeImagePermissionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeImagePermissionsInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+	if s.SharedAwsAccountIds != nil && len(s.SharedAwsAccountIds) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SharedAwsAccountIds", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeImagePermissionsInput) SetMaxResults(v int64) *DescribeImagePermissionsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeImagePermissionsInput) SetName(v string) *DescribeImagePermissionsInput {
+	s.Name = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImagePermissionsInput) SetNextToken(v string) *DescribeImagePermissionsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSharedAwsAccountIds sets the SharedAwsAccountIds field's value.
+func (s *DescribeImagePermissionsInput) SetSharedAwsAccountIds(v []*string) *DescribeImagePermissionsInput {
+	s.SharedAwsAccountIds = v
+	return s
+}
+
+type DescribeImagePermissionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the private image.
+	Name *string `type:"string"`
+
+	// The pagination token to use to retrieve the next page of results. If this
+	// value is empty, only the first page is retrieved.
+	NextToken *string `min:"1" type:"string"`
+
+	// The permissions for a private image that you own.
+	SharedImagePermissionsList []*SharedImagePermissions `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeImagePermissionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagePermissionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeImagePermissionsOutput) SetName(v string) *DescribeImagePermissionsOutput {
+	s.Name = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeImagePermissionsOutput) SetNextToken(v string) *DescribeImagePermissionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSharedImagePermissionsList sets the SharedImagePermissionsList field's value.
+func (s *DescribeImagePermissionsOutput) SetSharedImagePermissionsList(v []*SharedImagePermissions) *DescribeImagePermissionsOutput {
+	s.SharedImagePermissionsList = v
+	return s
+}
+
+type DescribeImagesInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARNs of the public, private, and shared images to describe.
+	Arns []*string `type:"list"`
+
+	// The maximum size of each page of results.
 	MaxResults *int64 `type:"integer"`
 
 	// The names of the images to describe.
@@ -4666,6 +5228,9 @@ type DescribeImagesInput struct {
 	// The pagination token to use to retrieve the next page of results. If this
 	// value is empty, only the first page is retrieved.
 	NextToken *string `min:"1" type:"string"`
+
+	// The type of image (public, private, or shared) to describe.
+	Type *string `type:"string" enum:"VisibilityType"`
 }
 
 // String returns the string representation
@@ -4691,6 +5256,12 @@ func (s *DescribeImagesInput) Validate() error {
 	return nil
 }
 
+// SetArns sets the Arns field's value.
+func (s *DescribeImagesInput) SetArns(v []*string) *DescribeImagesInput {
+	s.Arns = v
+	return s
+}
+
 // SetMaxResults sets the MaxResults field's value.
 func (s *DescribeImagesInput) SetMaxResults(v int64) *DescribeImagesInput {
 	s.MaxResults = &v
@@ -4709,14 +5280,20 @@ func (s *DescribeImagesInput) SetNextToken(v string) *DescribeImagesInput {
 	return s
 }
 
+// SetType sets the Type field's value.
+func (s *DescribeImagesInput) SetType(v string) *DescribeImagesInput {
+	s.Type = &v
+	return s
+}
+
 type DescribeImagesOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Information about the images.
 	Images []*Image `type:"list"`
 
-	// The pagination token used to retrieve the next page of results. If this value
-	// is empty, only the first page is retrieved.
+	// The pagination token to use to retrieve the next page of results. If there
+	// are no more pages, this value is null.
 	NextToken *string `min:"1" type:"string"`
 }
 
@@ -5221,10 +5798,11 @@ type Fleet struct {
 	// apps.
 	FleetType *string `type:"string" enum:"FleetType"`
 
+	// The ARN for the public, private, or shared image.
+	ImageArn *string `type:"string"`
+
 	// The name of the image used to create the fleet.
-	//
-	// ImageName is a required field
-	ImageName *string `min:"1" type:"string" required:"true"`
+	ImageName *string `min:"1" type:"string"`
 
 	// The instance type to use when launching fleet instances.
 	//
@@ -5316,6 +5894,12 @@ func (s *Fleet) SetFleetErrors(v []*FleetError) *Fleet {
 // SetFleetType sets the FleetType field's value.
 func (s *Fleet) SetFleetType(v string) *Fleet {
 	s.FleetType = &v
+	return s
+}
+
+// SetImageArn sets the ImageArn field's value.
+func (s *Fleet) SetImageArn(v string) *Fleet {
+	s.ImageArn = &v
 	return s
 }
 
@@ -5417,6 +6001,10 @@ type Image struct {
 	// Indicates whether an image builder can be launched from this image.
 	ImageBuilderSupported *bool `type:"boolean"`
 
+	// The permissions to provide to the destination AWS account for the specified
+	// image.
+	ImagePermissions *ImagePermissions `type:"structure"`
+
 	// The name of the image.
 	//
 	// Name is a required field
@@ -5495,6 +6083,12 @@ func (s *Image) SetDisplayName(v string) *Image {
 // SetImageBuilderSupported sets the ImageBuilderSupported field's value.
 func (s *Image) SetImageBuilderSupported(v bool) *Image {
 	s.ImageBuilderSupported = &v
+	return s
+}
+
+// SetImagePermissions sets the ImagePermissions field's value.
+func (s *Image) SetImagePermissions(v *ImagePermissions) *Image {
+	s.ImagePermissions = v
 	return s
 }
 
@@ -5718,6 +6312,39 @@ func (s *ImageBuilderStateChangeReason) SetCode(v string) *ImageBuilderStateChan
 // SetMessage sets the Message field's value.
 func (s *ImageBuilderStateChangeReason) SetMessage(v string) *ImageBuilderStateChangeReason {
 	s.Message = &v
+	return s
+}
+
+// Describes the permissions for an image.
+type ImagePermissions struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether the image can be used for a fleet.
+	AllowFleet *bool `locationName:"allowFleet" type:"boolean"`
+
+	// Indicates whether the image can be used for an image builder.
+	AllowImageBuilder *bool `locationName:"allowImageBuilder" type:"boolean"`
+}
+
+// String returns the string representation
+func (s ImagePermissions) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ImagePermissions) GoString() string {
+	return s.String()
+}
+
+// SetAllowFleet sets the AllowFleet field's value.
+func (s *ImagePermissions) SetAllowFleet(v bool) *ImagePermissions {
+	s.AllowFleet = &v
+	return s
+}
+
+// SetAllowImageBuilder sets the AllowImageBuilder field's value.
+func (s *ImagePermissions) SetAllowImageBuilder(v bool) *ImagePermissions {
+	s.AllowImageBuilder = &v
 	return s
 }
 
@@ -6215,6 +6842,44 @@ func (s *Session) SetState(v string) *Session {
 // SetUserId sets the UserId field's value.
 func (s *Session) SetUserId(v string) *Session {
 	s.UserId = &v
+	return s
+}
+
+// Describes the permissions that are available to the specified AWS account
+// for a shared image.
+type SharedImagePermissions struct {
+	_ struct{} `type:"structure"`
+
+	// Describes the permissions for a shared image.
+	//
+	// ImagePermissions is a required field
+	ImagePermissions *ImagePermissions `locationName:"imagePermissions" type:"structure" required:"true"`
+
+	// The 12-digit ID of the AWS account with which the image is shared.
+	//
+	// SharedAccountId is a required field
+	SharedAccountId *string `locationName:"sharedAccountId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s SharedImagePermissions) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SharedImagePermissions) GoString() string {
+	return s.String()
+}
+
+// SetImagePermissions sets the ImagePermissions field's value.
+func (s *SharedImagePermissions) SetImagePermissions(v *ImagePermissions) *SharedImagePermissions {
+	s.ImagePermissions = v
+	return s
+}
+
+// SetSharedAccountId sets the SharedAccountId field's value.
+func (s *SharedImagePermissions) SetSharedAccountId(v string) *SharedImagePermissions {
+	s.SharedAccountId = &v
 	return s
 }
 
@@ -6927,6 +7592,9 @@ type UpdateFleetInput struct {
 	// Enables or disables default internet access for the fleet.
 	EnableDefaultInternetAccess *bool `type:"boolean"`
 
+	// The ARN of the public, private, or shared image to use.
+	ImageArn *string `type:"string"`
+
 	// The name of the image used to create the fleet.
 	ImageName *string `min:"1" type:"string"`
 
@@ -6979,9 +7647,7 @@ type UpdateFleetInput struct {
 	MaxUserDurationInSeconds *int64 `type:"integer"`
 
 	// A unique name for the fleet.
-	//
-	// Name is a required field
-	Name *string `min:"1" type:"string" required:"true"`
+	Name *string `min:"1" type:"string"`
 
 	// The VPC configuration for the fleet.
 	VpcConfig *VpcConfig `type:"structure"`
@@ -7005,9 +7671,6 @@ func (s *UpdateFleetInput) Validate() error {
 	}
 	if s.InstanceType != nil && len(*s.InstanceType) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("InstanceType", 1))
-	}
-	if s.Name == nil {
-		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
 	if s.Name != nil && len(*s.Name) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
@@ -7072,6 +7735,12 @@ func (s *UpdateFleetInput) SetEnableDefaultInternetAccess(v bool) *UpdateFleetIn
 	return s
 }
 
+// SetImageArn sets the ImageArn field's value.
+func (s *UpdateFleetInput) SetImageArn(v string) *UpdateFleetInput {
+	s.ImageArn = &v
+	return s
+}
+
 // SetImageName sets the ImageName field's value.
 func (s *UpdateFleetInput) SetImageName(v string) *UpdateFleetInput {
 	s.ImageName = &v
@@ -7123,6 +7792,87 @@ func (s UpdateFleetOutput) GoString() string {
 func (s *UpdateFleetOutput) SetFleet(v *Fleet) *UpdateFleetOutput {
 	s.Fleet = v
 	return s
+}
+
+type UpdateImagePermissionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The permissions for the image.
+	//
+	// ImagePermissions is a required field
+	ImagePermissions *ImagePermissions `type:"structure" required:"true"`
+
+	// The name of the private image.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The 12-digit ID of the AWS account for which you want add or update image
+	// permissions.
+	//
+	// SharedAccountId is a required field
+	SharedAccountId *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateImagePermissionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateImagePermissionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateImagePermissionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateImagePermissionsInput"}
+	if s.ImagePermissions == nil {
+		invalidParams.Add(request.NewErrParamRequired("ImagePermissions"))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.SharedAccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("SharedAccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetImagePermissions sets the ImagePermissions field's value.
+func (s *UpdateImagePermissionsInput) SetImagePermissions(v *ImagePermissions) *UpdateImagePermissionsInput {
+	s.ImagePermissions = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateImagePermissionsInput) SetName(v string) *UpdateImagePermissionsInput {
+	s.Name = &v
+	return s
+}
+
+// SetSharedAccountId sets the SharedAccountId field's value.
+func (s *UpdateImagePermissionsInput) SetSharedAccountId(v string) *UpdateImagePermissionsInput {
+	s.SharedAccountId = &v
+	return s
+}
+
+type UpdateImagePermissionsOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateImagePermissionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateImagePermissionsOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateStackInput struct {
@@ -7657,4 +8407,7 @@ const (
 
 	// VisibilityTypePrivate is a VisibilityType enum value
 	VisibilityTypePrivate = "PRIVATE"
+
+	// VisibilityTypeShared is a VisibilityType enum value
+	VisibilityTypeShared = "SHARED"
 )

--- a/service/appstream/appstreamiface/interface.go
+++ b/service/appstream/appstreamiface/interface.go
@@ -108,6 +108,10 @@ type AppStreamAPI interface {
 	DeleteImageBuilderWithContext(aws.Context, *appstream.DeleteImageBuilderInput, ...request.Option) (*appstream.DeleteImageBuilderOutput, error)
 	DeleteImageBuilderRequest(*appstream.DeleteImageBuilderInput) (*request.Request, *appstream.DeleteImageBuilderOutput)
 
+	DeleteImagePermissions(*appstream.DeleteImagePermissionsInput) (*appstream.DeleteImagePermissionsOutput, error)
+	DeleteImagePermissionsWithContext(aws.Context, *appstream.DeleteImagePermissionsInput, ...request.Option) (*appstream.DeleteImagePermissionsOutput, error)
+	DeleteImagePermissionsRequest(*appstream.DeleteImagePermissionsInput) (*request.Request, *appstream.DeleteImagePermissionsOutput)
+
 	DeleteStack(*appstream.DeleteStackInput) (*appstream.DeleteStackOutput, error)
 	DeleteStackWithContext(aws.Context, *appstream.DeleteStackInput, ...request.Option) (*appstream.DeleteStackOutput, error)
 	DeleteStackRequest(*appstream.DeleteStackInput) (*request.Request, *appstream.DeleteStackOutput)
@@ -124,9 +128,19 @@ type AppStreamAPI interface {
 	DescribeImageBuildersWithContext(aws.Context, *appstream.DescribeImageBuildersInput, ...request.Option) (*appstream.DescribeImageBuildersOutput, error)
 	DescribeImageBuildersRequest(*appstream.DescribeImageBuildersInput) (*request.Request, *appstream.DescribeImageBuildersOutput)
 
+	DescribeImagePermissions(*appstream.DescribeImagePermissionsInput) (*appstream.DescribeImagePermissionsOutput, error)
+	DescribeImagePermissionsWithContext(aws.Context, *appstream.DescribeImagePermissionsInput, ...request.Option) (*appstream.DescribeImagePermissionsOutput, error)
+	DescribeImagePermissionsRequest(*appstream.DescribeImagePermissionsInput) (*request.Request, *appstream.DescribeImagePermissionsOutput)
+
+	DescribeImagePermissionsPages(*appstream.DescribeImagePermissionsInput, func(*appstream.DescribeImagePermissionsOutput, bool) bool) error
+	DescribeImagePermissionsPagesWithContext(aws.Context, *appstream.DescribeImagePermissionsInput, func(*appstream.DescribeImagePermissionsOutput, bool) bool, ...request.Option) error
+
 	DescribeImages(*appstream.DescribeImagesInput) (*appstream.DescribeImagesOutput, error)
 	DescribeImagesWithContext(aws.Context, *appstream.DescribeImagesInput, ...request.Option) (*appstream.DescribeImagesOutput, error)
 	DescribeImagesRequest(*appstream.DescribeImagesInput) (*request.Request, *appstream.DescribeImagesOutput)
+
+	DescribeImagesPages(*appstream.DescribeImagesInput, func(*appstream.DescribeImagesOutput, bool) bool) error
+	DescribeImagesPagesWithContext(aws.Context, *appstream.DescribeImagesInput, func(*appstream.DescribeImagesOutput, bool) bool, ...request.Option) error
 
 	DescribeSessions(*appstream.DescribeSessionsInput) (*appstream.DescribeSessionsOutput, error)
 	DescribeSessionsWithContext(aws.Context, *appstream.DescribeSessionsInput, ...request.Option) (*appstream.DescribeSessionsOutput, error)
@@ -187,6 +201,10 @@ type AppStreamAPI interface {
 	UpdateFleet(*appstream.UpdateFleetInput) (*appstream.UpdateFleetOutput, error)
 	UpdateFleetWithContext(aws.Context, *appstream.UpdateFleetInput, ...request.Option) (*appstream.UpdateFleetOutput, error)
 	UpdateFleetRequest(*appstream.UpdateFleetInput) (*request.Request, *appstream.UpdateFleetOutput)
+
+	UpdateImagePermissions(*appstream.UpdateImagePermissionsInput) (*appstream.UpdateImagePermissionsOutput, error)
+	UpdateImagePermissionsWithContext(aws.Context, *appstream.UpdateImagePermissionsInput, ...request.Option) (*appstream.UpdateImagePermissionsOutput, error)
+	UpdateImagePermissionsRequest(*appstream.UpdateImagePermissionsInput) (*request.Request, *appstream.UpdateImagePermissionsOutput)
 
 	UpdateStack(*appstream.UpdateStackInput) (*appstream.UpdateStackOutput, error)
 	UpdateStackWithContext(aws.Context, *appstream.UpdateStackInput, ...request.Option) (*appstream.UpdateStackOutput, error)

--- a/service/kinesisvideo/api.go
+++ b/service/kinesisvideo/api.go
@@ -876,7 +876,7 @@ func (c *KinesisVideo) UpdateDataRetentionRequest(input *UpdateDataRetentionInpu
 //
 //   * ErrCodeVersionMismatchException "VersionMismatchException"
 //   The stream version that you specified is not the latest version. To get the
-//   latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideo/latest/dg/API_DescribeStream.html)
+//   latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html)
 //   API.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kinesisvideo-2017-09-30/UpdateDataRetention
@@ -984,7 +984,7 @@ func (c *KinesisVideo) UpdateStreamRequest(input *UpdateStreamInput) (req *reque
 //
 //   * ErrCodeVersionMismatchException "VersionMismatchException"
 //   The stream version that you specified is not the latest version. To get the
-//   latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideo/latest/dg/API_DescribeStream.html)
+//   latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html)
 //   API.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kinesisvideo-2017-09-30/UpdateStream
@@ -1017,6 +1017,11 @@ type CreateStreamInput struct {
 	// stream.
 	//
 	// The default value is 0, indicating that the stream does not persist data.
+	//
+	// When the DataRetentionInHours value is 0, consumers can still consume the
+	// fragments that remain in the service host buffer, which has a retention time
+	// limit of 5 minutes and a retention memory limit of 200 MB. Fragments are
+	// removed from the buffer when either limit is reached.
 	DataRetentionInHours *int64 `type:"integer"`
 
 	// The name of the device that is writing to the stream.
@@ -1998,7 +2003,7 @@ type UpdateStreamInput struct {
 	// The stream's media type. Use MediaType to specify the type of content that
 	// the stream contains to the consumers of the stream. For more information
 	// about media types, see Media Types (http://www.iana.org/assignments/media-types/media-types.xhtml).
-	// If you choose to specify the MediaType, see Naming Requirements (https://tools.sietf.org/html/rfc6838#section-4.2).
+	// If you choose to specify the MediaType, see Naming Requirements (https://tools.ietf.org/html/rfc6838#section-4.2).
 	//
 	// To play video on the console, you must specify the correct video type. For
 	// example, if the video in the stream is H.264, specify video/h264 as the MediaType.
@@ -2108,6 +2113,9 @@ const (
 
 	// APINameGetMediaForFragmentList is a APIName enum value
 	APINameGetMediaForFragmentList = "GET_MEDIA_FOR_FRAGMENT_LIST"
+
+	// APINameGetHlsStreamingSessionUrl is a APIName enum value
+	APINameGetHlsStreamingSessionUrl = "GET_HLS_STREAMING_SESSION_URL"
 )
 
 const (

--- a/service/kinesisvideo/errors.go
+++ b/service/kinesisvideo/errors.go
@@ -70,7 +70,7 @@ const (
 	// "VersionMismatchException".
 	//
 	// The stream version that you specified is not the latest version. To get the
-	// latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideo/latest/dg/API_DescribeStream.html)
+	// latest version, use the DescribeStream (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_DescribeStream.html)
 	// API.
 	ErrCodeVersionMismatchException = "VersionMismatchException"
 )

--- a/service/kinesisvideoarchivedmedia/api.go
+++ b/service/kinesisvideoarchivedmedia/api.go
@@ -11,6 +11,226 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+const opGetHLSStreamingSessionURL = "GetHLSStreamingSessionURL"
+
+// GetHLSStreamingSessionURLRequest generates a "aws/request.Request" representing the
+// client's request for the GetHLSStreamingSessionURL operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetHLSStreamingSessionURL for more information on using the GetHLSStreamingSessionURL
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetHLSStreamingSessionURLRequest method.
+//    req, resp := client.GetHLSStreamingSessionURLRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kinesis-video-archived-media-2017-09-30/GetHLSStreamingSessionURL
+func (c *KinesisVideoArchivedMedia) GetHLSStreamingSessionURLRequest(input *GetHLSStreamingSessionURLInput) (req *request.Request, output *GetHLSStreamingSessionURLOutput) {
+	op := &request.Operation{
+		Name:       opGetHLSStreamingSessionURL,
+		HTTPMethod: "POST",
+		HTTPPath:   "/getHLSStreamingSessionURL",
+	}
+
+	if input == nil {
+		input = &GetHLSStreamingSessionURLInput{}
+	}
+
+	output = &GetHLSStreamingSessionURLOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetHLSStreamingSessionURL API operation for Amazon Kinesis Video Streams Archived Media.
+//
+// Retrieves an HTTP Live Streaming (HLS) URL for the stream. You can then open
+// the URL in a browser or media player to view the stream contents.
+//
+// You must specify either the StreamName or the StreamARN.
+//
+// An Amazon Kinesis video stream has the following requirements for providing
+// data through HLS:
+//
+//    * The media type must be video/h264.
+//
+//    * Data retention must be greater than 0.
+//
+//    * The fragments must contain codec private data in the AVC (Advanced Video
+//    Coding) for H.264 format (MPEG-4 specification ISO/IEC 14496-15 (https://www.iso.org/standard/55980.html)).
+//    For information about adapting stream data to a given format, see NAL
+//    Adaptation Flags (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/latest/dg/producer-reference-nal.html).
+//
+// Kinesis Video Streams HLS sessions contain fragments in the fragmented MPEG-4
+// form (also called fMP4 or CMAF), rather than the MPEG-2 form (also called
+// TS chunks, which the HLS specification also supports). For more information
+// about HLS fragment types, see the HLS specification (https://tools.ietf.org/html/draft-pantos-http-live-streaming-23).
+//
+// The following procedure shows how to use HLS with Kinesis Video Streams:
+//
+// Get an endpoint using GetDataEndpoint (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_GetDataEndpoint.html),
+// specifying GET_HLS_STREAMING_SESSION_URL for the APIName parameter.
+//
+// Retrieve the HLS URL using GetHLSStreamingSessionURL. Kinesis Video Streams
+// creates an HLS streaming session to be used for accessing content in a stream
+// using the HLS protocol. GetHLSStreamingSessionURL returns an authenticated
+// URL (that includes an encrypted session token) for the session's HLS master
+// playlist (the root resource needed for streaming with HLS).
+//
+// Don't share or store this token where an unauthorized entity could access
+// it. The token provides access to the content of the stream. Safeguard the
+// token with the same measures that you would use with your AWS credentials.
+//
+// The media that is made available through the playlist consists only of the
+// requested stream, time range, and format. No other media data (such as frames
+// outside the requested window or alternate bit rates) is made available.
+//
+// Provide the URL (containing the encrypted session token) for the HLS master
+// playlist to a media player that supports the HLS protocol. Kinesis Video
+// Streams makes the HLS media playlist, initialization fragment, and media
+// fragments available through the master playlist URL. The initialization fragment
+// contains the codec private data for the stream, and other data needed to
+// set up the video decoder and renderer. The media fragments contain H.264-encoded
+// video frames and time stamps.
+//
+// The media player receives the authenticated URL and requests stream metadata
+// and media data normally. When the media player requests data, it calls the
+// following actions:
+//
+// GetHLSMasterPlaylist: Retrieves an HLS master playlist, which contains a
+// URL for the GetHLSMediaPlaylist action, and additional metadata for the media
+// player, including estimated bit rate and resolution.
+//
+// GetHLSMediaPlaylist: Retrieves an HLS media playlist, which contains a URL
+// to access the MP4 initialization fragment with the GetMP4InitFragment action,
+// and URLs to access the MP4 media fragments with the GetMP4MediaFragment actions.
+// The HLS media playlist also contains metadata about the stream that the player
+// needs to play it, such as whether the PlaybackMode is LIVE or ON_DEMAND.
+// The HLS media playlist is typically static for sessions with a PlaybackType
+// of ON_DEMAND. The HLS media playlist is continually updated with new fragments
+// for sessions with a PlaybackType of LIVE.
+//
+// GetMP4InitFragment: Retrieves the MP4 initialization fragment. The media
+// player typically loads the initialization fragment before loading any media
+// fragments. This fragment contains the "fytp" and "moov" MP4 atoms, and the
+// child atoms that are needed to initialize the media player decoder.
+//
+// The initialization fragment does not correspond to a fragment in a Kinesis
+// video stream. It contains only the codec private data for the stream, which
+// the media player needs to decode video frames.
+//
+// GetMP4MediaFragment: Retrieves MP4 media fragments. These fragments contain
+// the "moof" and "mdat" MP4 atoms and their child atoms, containing the encoded
+// fragment's video frames and their time stamps.
+//
+// After the first media fragment is made available in a streaming session,
+// any fragments that don't contain the same codec private data are excluded
+// in the HLS media playlist. Therefore, the codec private data does not change
+// between fragments in a session.
+//
+// Data retrieved with this action is billable. See Pricing (aws.amazon.comkinesis/video-streams/pricing/)
+// for details.
+//
+// The following restrictions apply to HLS sessions:
+//
+// A streaming session URL should not be shared between players. The service
+// might throttle a session if multiple media players are sharing it. For connection
+// limits, see Kinesis Video Streams Limits (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/limits.html).
+//
+// A Kinesis video stream can have a maximum of five active HLS streaming sessions.
+// If a new session is created when the maximum number of sessions is already
+// active, the oldest (earliest created) session is closed. The number of active
+// GetMedia connections on a Kinesis video stream does not count against this
+// limit, and the number of active HLS sessions does not count against the active
+// GetMedia connection limit.
+//
+// You can monitor the amount of data that the media player consumes by monitoring
+// the GetMP4MediaFragment.OutgoingBytes Amazon CloudWatch metric. For information
+// about using CloudWatch to monitor Kinesis Video Streams, see Monitoring Kinesis
+// Video Streams (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/monitoring.html).
+// For pricing information, see Amazon Kinesis Video Streams Pricing (https://aws.amazon.com/kinesis/video-streams/pricing/)
+// and AWS Pricing (https://aws.amazon.com/pricing/). Charges for both HLS sessions
+// and outgoing AWS data apply.
+//
+// For more information about HLS, see HTTP Live Streaming (https://developer.apple.com/streaming/)
+// on the Apple Developer site (https://developer.apple.com).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Kinesis Video Streams Archived Media's
+// API operation GetHLSStreamingSessionURL for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   GetMedia throws this error when Kinesis Video Streams can't find the stream
+//   that you specified.
+//
+//   GetHLSStreamingSessionURL throws this error if a session with a PlaybackMode
+//   of ON_DEMAND is requested for a stream that has no fragments within the requested
+//   time range, or if a session with a PlaybackMode of LIVE is requested for
+//   a stream that has no fragments within the last 30 seconds.
+//
+//   * ErrCodeInvalidArgumentException "InvalidArgumentException"
+//   A specified parameter exceeds its restrictions, is not supported, or can't
+//   be used.
+//
+//   * ErrCodeClientLimitExceededException "ClientLimitExceededException"
+//   Kinesis Video Streams has throttled the request because you have exceeded
+//   the limit of allowed client calls. Try making the call later.
+//
+//   * ErrCodeNotAuthorizedException "NotAuthorizedException"
+//   Status Code: 403, The caller is not authorized to perform an operation on
+//   the given stream, or the token has expired.
+//
+//   * ErrCodeUnsupportedStreamMediaTypeException "UnsupportedStreamMediaTypeException"
+//   An HLS streaming session was requested for a stream with a media type that
+//   is not video/h264.
+//
+//   * ErrCodeNoDataRetentionException "NoDataRetentionException"
+//   A PlaybackMode of ON_DEMAND was requested for a stream that does not retain
+//   data (that is, has a DataRetentionInHours of 0).
+//
+//   * ErrCodeMissingCodecPrivateDataException "MissingCodecPrivateDataException"
+//   No Codec Private Data was found in the video stream.
+//
+//   * ErrCodeInvalidCodecPrivateDataException "InvalidCodecPrivateDataException"
+//   The Codec Private Data in the video stream is not valid for this operation.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kinesis-video-archived-media-2017-09-30/GetHLSStreamingSessionURL
+func (c *KinesisVideoArchivedMedia) GetHLSStreamingSessionURL(input *GetHLSStreamingSessionURLInput) (*GetHLSStreamingSessionURLOutput, error) {
+	req, out := c.GetHLSStreamingSessionURLRequest(input)
+	return out, req.Send()
+}
+
+// GetHLSStreamingSessionURLWithContext is the same as GetHLSStreamingSessionURL with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetHLSStreamingSessionURL for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *KinesisVideoArchivedMedia) GetHLSStreamingSessionURLWithContext(ctx aws.Context, input *GetHLSStreamingSessionURLInput, opts ...request.Option) (*GetHLSStreamingSessionURLOutput, error) {
+	req, out := c.GetHLSStreamingSessionURLRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetMediaForFragmentList = "GetMediaForFragmentList"
 
 // GetMediaForFragmentListRequest generates a "aws/request.Request" representing the
@@ -56,10 +276,7 @@ func (c *KinesisVideoArchivedMedia) GetMediaForFragmentListRequest(input *GetMed
 // GetMediaForFragmentList API operation for Amazon Kinesis Video Streams Archived Media.
 //
 // Gets media for a list of fragments (specified by fragment number) from the
-// archived data in a Kinesis video stream.
-//
-// This operation is only available for the AWS SDK for Java. It is not supported
-// in AWS SDKs for other languages.
+// archived data in an Amazon Kinesis video stream.
 //
 // The following limits apply when using the GetMediaForFragmentList API:
 //
@@ -79,7 +296,13 @@ func (c *KinesisVideoArchivedMedia) GetMediaForFragmentListRequest(input *GetMed
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   Kinesis Video Streams can't find the stream that you specified.
+//   GetMedia throws this error when Kinesis Video Streams can't find the stream
+//   that you specified.
+//
+//   GetHLSStreamingSessionURL throws this error if a session with a PlaybackMode
+//   of ON_DEMAND is requested for a stream that has no fragments within the requested
+//   time range, or if a session with a PlaybackMode of LIVE is requested for
+//   a stream that has no fragments within the last 30 seconds.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -171,7 +394,13 @@ func (c *KinesisVideoArchivedMedia) ListFragmentsRequest(input *ListFragmentsInp
 //
 // Returned Error Codes:
 //   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
-//   Kinesis Video Streams can't find the stream that you specified.
+//   GetMedia throws this error when Kinesis Video Streams can't find the stream
+//   that you specified.
+//
+//   GetHLSStreamingSessionURL throws this error if a session with a PlaybackMode
+//   of ON_DEMAND is requested for a stream that has no fragments within the requested
+//   time range, or if a session with a PlaybackMode of LIVE is requested for
+//   a stream that has no fragments within the last 30 seconds.
 //
 //   * ErrCodeInvalidArgumentException "InvalidArgumentException"
 //   A specified parameter exceeds its restrictions, is not supported, or can't
@@ -326,6 +555,211 @@ func (s *FragmentSelector) SetTimestampRange(v *TimestampRange) *FragmentSelecto
 	return s
 }
 
+type GetHLSStreamingSessionURLInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies when flags marking discontinuities between fragments will be added
+	// to the media playlists. The default is ALWAYS when HLSFragmentSelector is
+	// SERVER_TIMESTAMP, and NEVER when it is PRODUCER_TIMESTAMP.
+	//
+	// Media players typically build a timeline of media content to play, based
+	// on the time stamps of each fragment. This means that if there is any overlap
+	// between fragments (as is typical if HLSFragmentSelector is SERVER_TIMESTAMP),
+	// the media player timeline has small gaps between fragments in some places,
+	// and overwrites frames in other places. When there are discontinuity flags
+	// between fragments, the media player is expected to reset the timeline, resulting
+	// in the fragment being played immediately after the previous fragment. We
+	// recommend that you always have discontinuity flags between fragments if the
+	// fragment time stamps are not accurate or if fragments might be missing. You
+	// should not place discontinuity flags between fragments for the player timeline
+	// to accurately map to the producer time stamps.
+	DiscontinuityMode *string `type:"string" enum:"DiscontinuityMode"`
+
+	// The time in seconds until the requested session expires. This value can be
+	// between 300 (5 minutes) and 43200 (12 hours).
+	//
+	// When a session expires, no new calls to GetHLSMasterPlaylist, GetHLSMediaPlaylist,
+	// GetMP4InitFragment, or GetMP4MediaFragment can be made for that session.
+	//
+	// The default is 300 (5 minutes).
+	Expires *int64 `min:"300" type:"integer"`
+
+	// The time range of the requested fragment, and the source of the time stamps.
+	//
+	// This parameter is required if PlaybackMode is ON_DEMAND. This parameter is
+	// optional if PlaybackMode is LIVE. If PlaybackMode is LIVE, the FragmentSelectorType
+	// can be set, but the TimestampRange should not be set. If PlaybackMode is
+	// ON_DEMAND, both FragmentSelectorType and TimestampRange must be set.
+	HLSFragmentSelector *HLSFragmentSelector `type:"structure"`
+
+	// The maximum number of fragments that are returned in the HLS media playlists.
+	//
+	// When the PlaybackMode is LIVE, the most recent fragments are returned up
+	// to this value. When the PlaybackMode is ON_DEMAND, the oldest fragments are
+	// returned, up to this maximum number.
+	//
+	// When there are a higher number of fragments available in a live HLS media
+	// playlist, video players often buffer content before starting playback. Increasing
+	// the buffer size increases the playback latency, but it decreases the likelihood
+	// that rebuffering will occur during playback. We recommend that a live HLS
+	// media playlist have a minimum of 3 fragments and a maximum of 10 fragments.
+	//
+	// The default is 5 fragments if PlaybackMode is LIVE, and 1,000 if PlaybackMode
+	// is ON_DEMAND.
+	//
+	// The maximum value of 1,000 fragments corresponds to more than 16 minutes
+	// of video on streams with 1-second fragments, and more than 2 1/2 hours of
+	// video on streams with 10-second fragments.
+	MaxMediaPlaylistFragmentResults *int64 `min:"1" type:"long"`
+
+	// Whether to retrieve live or archived, on-demand data.
+	//
+	// Features of the two types of session include the following:
+	//
+	//    * LIVE: For sessions of this type, the HLS media playlist is continually
+	//    updated with the latest fragments as they become available. We recommend
+	//    that the media player retrieve a new playlist on a one-second interval.
+	//    When this type of session is played in a media player, the user interface
+	//    typically displays a "live" notification, with no scrubber control for
+	//    choosing the position in the playback window to display.
+	//
+	// In LIVE mode, the newest available fragments are included in an HLS media
+	//    playlist, even if there is a gap between fragments (that is, if a fragment
+	//    is missing). A gap like this might cause a media player to halt or cause
+	//    a jump in playback. In this mode, fragments are not added to the HLS media
+	//    playlist if they are older than the newest fragment in the playlist. If
+	//    the missing fragment becomes available after a subsequent fragment is
+	//    added to the playlist, the older fragment is not added, and the gap is
+	//    not filled.
+	//
+	//    * ON_DEMAND: For sessions of this type, the HLS media playlist contains
+	//    all the fragments for the session, up to the number that is specified
+	//    in MaxMediaPlaylistFragmentResults. The playlist must be retrieved only
+	//    once for each session. When this type of session is played in a media
+	//    player, the user interface typically displays a scrubber control for choosing
+	//    the position in the playback window to display.
+	//
+	// In both playback modes, if FragmentSelectorType is PRODUCER_TIMESTAMP, and
+	// if there are multiple fragments with the same start time stamp, the fragment
+	// that has the larger fragment number (that is, the newer fragment) is included
+	// in the HLS media playlist. The other fragments are not included. Fragments
+	// that have different time stamps but have overlapping durations are still
+	// included in the HLS media playlist. This can lead to unexpected behavior
+	// in the media player.
+	//
+	// The default is LIVE.
+	PlaybackMode *string `type:"string" enum:"PlaybackMode"`
+
+	// The Amazon Resource Name (ARN) of the stream for which to retrieve the HLS
+	// master playlist URL.
+	//
+	// You must specify either the StreamName or the StreamARN.
+	StreamARN *string `min:"1" type:"string"`
+
+	// The name of the stream for which to retrieve the HLS master playlist URL.
+	//
+	// You must specify either the StreamName or the StreamARN.
+	StreamName *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s GetHLSStreamingSessionURLInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetHLSStreamingSessionURLInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetHLSStreamingSessionURLInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetHLSStreamingSessionURLInput"}
+	if s.Expires != nil && *s.Expires < 300 {
+		invalidParams.Add(request.NewErrParamMinValue("Expires", 300))
+	}
+	if s.MaxMediaPlaylistFragmentResults != nil && *s.MaxMediaPlaylistFragmentResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxMediaPlaylistFragmentResults", 1))
+	}
+	if s.StreamARN != nil && len(*s.StreamARN) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamARN", 1))
+	}
+	if s.StreamName != nil && len(*s.StreamName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StreamName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDiscontinuityMode sets the DiscontinuityMode field's value.
+func (s *GetHLSStreamingSessionURLInput) SetDiscontinuityMode(v string) *GetHLSStreamingSessionURLInput {
+	s.DiscontinuityMode = &v
+	return s
+}
+
+// SetExpires sets the Expires field's value.
+func (s *GetHLSStreamingSessionURLInput) SetExpires(v int64) *GetHLSStreamingSessionURLInput {
+	s.Expires = &v
+	return s
+}
+
+// SetHLSFragmentSelector sets the HLSFragmentSelector field's value.
+func (s *GetHLSStreamingSessionURLInput) SetHLSFragmentSelector(v *HLSFragmentSelector) *GetHLSStreamingSessionURLInput {
+	s.HLSFragmentSelector = v
+	return s
+}
+
+// SetMaxMediaPlaylistFragmentResults sets the MaxMediaPlaylistFragmentResults field's value.
+func (s *GetHLSStreamingSessionURLInput) SetMaxMediaPlaylistFragmentResults(v int64) *GetHLSStreamingSessionURLInput {
+	s.MaxMediaPlaylistFragmentResults = &v
+	return s
+}
+
+// SetPlaybackMode sets the PlaybackMode field's value.
+func (s *GetHLSStreamingSessionURLInput) SetPlaybackMode(v string) *GetHLSStreamingSessionURLInput {
+	s.PlaybackMode = &v
+	return s
+}
+
+// SetStreamARN sets the StreamARN field's value.
+func (s *GetHLSStreamingSessionURLInput) SetStreamARN(v string) *GetHLSStreamingSessionURLInput {
+	s.StreamARN = &v
+	return s
+}
+
+// SetStreamName sets the StreamName field's value.
+func (s *GetHLSStreamingSessionURLInput) SetStreamName(v string) *GetHLSStreamingSessionURLInput {
+	s.StreamName = &v
+	return s
+}
+
+type GetHLSStreamingSessionURLOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The URL (containing the session token) that a media player can use to retrieve
+	// the HLS master playlist.
+	HLSStreamingSessionURL *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GetHLSStreamingSessionURLOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetHLSStreamingSessionURLOutput) GoString() string {
+	return s.String()
+}
+
+// SetHLSStreamingSessionURL sets the HLSStreamingSessionURL field's value.
+func (s *GetHLSStreamingSessionURLOutput) SetHLSStreamingSessionURL(v string) *GetHLSStreamingSessionURLOutput {
+	s.HLSStreamingSessionURL = &v
+	return s
+}
+
 type GetMediaForFragmentListInput struct {
 	_ struct{} `type:"structure"`
 
@@ -333,7 +767,7 @@ type GetMediaForFragmentListInput struct {
 	// these values with ListFragments.
 	//
 	// Fragments is a required field
-	Fragments []*string `type:"list" required:"true"`
+	Fragments []*string `min:"1" type:"list" required:"true"`
 
 	// The name of the stream from which to retrieve fragment media.
 	//
@@ -356,6 +790,9 @@ func (s *GetMediaForFragmentListInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetMediaForFragmentListInput"}
 	if s.Fragments == nil {
 		invalidParams.Add(request.NewErrParamRequired("Fragments"))
+	}
+	if s.Fragments != nil && len(s.Fragments) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Fragments", 1))
 	}
 	if s.StreamName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StreamName"))
@@ -389,7 +826,7 @@ type GetMediaForFragmentListOutput struct {
 	ContentType *string `location:"header" locationName:"Content-Type" min:"1" type:"string"`
 
 	// The payload that Kinesis Video Streams returns is a sequence of chunks from
-	// the specified stream. For information about the chunks, see PutMedia (docs.aws.amazon.com/acuity/latest/dg/API_dataplane_PutMedia.html).
+	// the specified stream. For information about the chunks, see PutMedia (http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_dataplane_PutMedia.html).
 	// The chunks that Kinesis Video Streams returns in the GetMediaForFragmentList
 	// call also include the following additional Matroska (MKV) tags:
 	//
@@ -431,6 +868,123 @@ func (s *GetMediaForFragmentListOutput) SetContentType(v string) *GetMediaForFra
 // SetPayload sets the Payload field's value.
 func (s *GetMediaForFragmentListOutput) SetPayload(v io.ReadCloser) *GetMediaForFragmentListOutput {
 	s.Payload = v
+	return s
+}
+
+// Contains the range of time stamps for the requested media, and the source
+// of the time stamps.
+type HLSFragmentSelector struct {
+	_ struct{} `type:"structure"`
+
+	// The source of the time stamps for the requested media.
+	//
+	// When FragmentSelectorType is set to PRODUCER_TIMESTAMP and GetHLSStreamingSessionURLInput$PlaybackMode
+	// is ON_DEMAND, the first fragment ingested with a producer time stamp within
+	// the specified FragmentSelector$TimestampRange is included in the media playlist.
+	// In addition, the fragments with producer time stamps within the TimestampRange
+	// ingested immediately following the first fragment (up to the GetHLSStreamingSessionURLInput$MaxMediaPlaylistFragmentResults
+	// value) are included.
+	//
+	// Fragments that have duplicate producer time stamps are deduplicated. This
+	// means that if producers are producing a stream of fragments with producer
+	// time stamps that are approximately equal to the true clock time, the HLS
+	// media playlists will contain all of the fragments within the requested time
+	// stamp range. If some fragments are ingested within the same time range and
+	// very different points in time, only the oldest ingested collection of fragments
+	// are returned.
+	//
+	// When FragmentSelectorType is set to PRODUCER_TIMESTAMP and GetHLSStreamingSessionURLInput$PlaybackMode
+	// is LIVE, the producer time stamps are used in the MP4 fragments and for deduplication.
+	// But the most recently ingested fragments based on server time stamps are
+	// included in the HLS media playlist. This means that even if fragments ingested
+	// in the past have producer time stamps with values now, they are not included
+	// in the HLS media playlist.
+	//
+	// The default is SERVER_TIMESTAMP.
+	FragmentSelectorType *string `type:"string" enum:"HLSFragmentSelectorType"`
+
+	// The start and end of the time stamp range for the requested media.
+	//
+	// This value should not be present if PlaybackType is LIVE.
+	TimestampRange *HLSTimestampRange `type:"structure"`
+}
+
+// String returns the string representation
+func (s HLSFragmentSelector) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s HLSFragmentSelector) GoString() string {
+	return s.String()
+}
+
+// SetFragmentSelectorType sets the FragmentSelectorType field's value.
+func (s *HLSFragmentSelector) SetFragmentSelectorType(v string) *HLSFragmentSelector {
+	s.FragmentSelectorType = &v
+	return s
+}
+
+// SetTimestampRange sets the TimestampRange field's value.
+func (s *HLSFragmentSelector) SetTimestampRange(v *HLSTimestampRange) *HLSFragmentSelector {
+	s.TimestampRange = v
+	return s
+}
+
+// The start and end of the time stamp range for the requested media.
+//
+// This value should not be present if PlaybackType is LIVE.
+//
+// The values in the HLSTimestampRange are inclusive. Fragments that begin before
+// the start time but continue past it, or fragments that begin before the end
+// time but continue past it, are included in the session.
+type HLSTimestampRange struct {
+	_ struct{} `type:"structure"`
+
+	// The end of the time stamp range for the requested media. This value must
+	// be within 3 hours of the specified StartTimestamp, and it must be later than
+	// the StartTimestamp value.
+	//
+	// If FragmentSelectorType for the request is SERVER_TIMESTAMP, this value must
+	// be in the past.
+	//
+	// If the HLSTimestampRange value is specified, the EndTimestamp value is required.
+	//
+	// This value is inclusive. The EndTimestamp is compared to the (starting) time
+	// stamp of the fragment. Fragments that start before the EndTimestamp value
+	// and continue past it are included in the session.
+	EndTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The start of the time stamp range for the requested media.
+	//
+	// If the HLSTimestampRange value is specified, the StartTimestamp value is
+	// required.
+	//
+	// This value is inclusive. Fragments that start before the StartTimestamp and
+	// continue past it are included in the session. If FragmentSelectorType is
+	// SERVER_TIMESTAMP, the StartTimestamp must be later than the stream head.
+	StartTimestamp *time.Time `type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s HLSTimestampRange) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s HLSTimestampRange) GoString() string {
+	return s.String()
+}
+
+// SetEndTimestamp sets the EndTimestamp field's value.
+func (s *HLSTimestampRange) SetEndTimestamp(v time.Time) *HLSTimestampRange {
+	s.EndTimestamp = &v
+	return s
+}
+
+// SetStartTimestamp sets the StartTimestamp field's value.
+func (s *HLSTimestampRange) SetStartTimestamp(v time.Time) *HLSTimestampRange {
+	s.StartTimestamp = &v
 	return s
 }
 
@@ -605,9 +1159,33 @@ func (s *TimestampRange) SetStartTimestamp(v time.Time) *TimestampRange {
 }
 
 const (
+	// DiscontinuityModeAlways is a DiscontinuityMode enum value
+	DiscontinuityModeAlways = "ALWAYS"
+
+	// DiscontinuityModeNever is a DiscontinuityMode enum value
+	DiscontinuityModeNever = "NEVER"
+)
+
+const (
 	// FragmentSelectorTypeProducerTimestamp is a FragmentSelectorType enum value
 	FragmentSelectorTypeProducerTimestamp = "PRODUCER_TIMESTAMP"
 
 	// FragmentSelectorTypeServerTimestamp is a FragmentSelectorType enum value
 	FragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
+)
+
+const (
+	// HLSFragmentSelectorTypeProducerTimestamp is a HLSFragmentSelectorType enum value
+	HLSFragmentSelectorTypeProducerTimestamp = "PRODUCER_TIMESTAMP"
+
+	// HLSFragmentSelectorTypeServerTimestamp is a HLSFragmentSelectorType enum value
+	HLSFragmentSelectorTypeServerTimestamp = "SERVER_TIMESTAMP"
+)
+
+const (
+	// PlaybackModeLive is a PlaybackMode enum value
+	PlaybackModeLive = "LIVE"
+
+	// PlaybackModeOnDemand is a PlaybackMode enum value
+	PlaybackModeOnDemand = "ON_DEMAND"
 )

--- a/service/kinesisvideoarchivedmedia/errors.go
+++ b/service/kinesisvideoarchivedmedia/errors.go
@@ -18,6 +18,25 @@ const (
 	// be used.
 	ErrCodeInvalidArgumentException = "InvalidArgumentException"
 
+	// ErrCodeInvalidCodecPrivateDataException for service response error code
+	// "InvalidCodecPrivateDataException".
+	//
+	// The Codec Private Data in the video stream is not valid for this operation.
+	ErrCodeInvalidCodecPrivateDataException = "InvalidCodecPrivateDataException"
+
+	// ErrCodeMissingCodecPrivateDataException for service response error code
+	// "MissingCodecPrivateDataException".
+	//
+	// No Codec Private Data was found in the video stream.
+	ErrCodeMissingCodecPrivateDataException = "MissingCodecPrivateDataException"
+
+	// ErrCodeNoDataRetentionException for service response error code
+	// "NoDataRetentionException".
+	//
+	// A PlaybackMode of ON_DEMAND was requested for a stream that does not retain
+	// data (that is, has a DataRetentionInHours of 0).
+	ErrCodeNoDataRetentionException = "NoDataRetentionException"
+
 	// ErrCodeNotAuthorizedException for service response error code
 	// "NotAuthorizedException".
 	//
@@ -28,6 +47,19 @@ const (
 	// ErrCodeResourceNotFoundException for service response error code
 	// "ResourceNotFoundException".
 	//
-	// Kinesis Video Streams can't find the stream that you specified.
+	// GetMedia throws this error when Kinesis Video Streams can't find the stream
+	// that you specified.
+	//
+	// GetHLSStreamingSessionURL throws this error if a session with a PlaybackMode
+	// of ON_DEMAND is requested for a stream that has no fragments within the requested
+	// time range, or if a session with a PlaybackMode of LIVE is requested for
+	// a stream that has no fragments within the last 30 seconds.
 	ErrCodeResourceNotFoundException = "ResourceNotFoundException"
+
+	// ErrCodeUnsupportedStreamMediaTypeException for service response error code
+	// "UnsupportedStreamMediaTypeException".
+	//
+	// An HLS streaming session was requested for a stream with a media type that
+	// is not video/h264.
+	ErrCodeUnsupportedStreamMediaTypeException = "UnsupportedStreamMediaTypeException"
 )

--- a/service/kinesisvideoarchivedmedia/kinesisvideoarchivedmediaiface/interface.go
+++ b/service/kinesisvideoarchivedmedia/kinesisvideoarchivedmediaiface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // Amazon Kinesis Video Streams Archived Media.
 //    func myFunc(svc kinesisvideoarchivedmediaiface.KinesisVideoArchivedMediaAPI) bool {
-//        // Make svc.GetMediaForFragmentList request
+//        // Make svc.GetHLSStreamingSessionURL request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockKinesisVideoArchivedMediaClient struct {
 //        kinesisvideoarchivedmediaiface.KinesisVideoArchivedMediaAPI
 //    }
-//    func (m *mockKinesisVideoArchivedMediaClient) GetMediaForFragmentList(input *kinesisvideoarchivedmedia.GetMediaForFragmentListInput) (*kinesisvideoarchivedmedia.GetMediaForFragmentListOutput, error) {
+//    func (m *mockKinesisVideoArchivedMediaClient) GetHLSStreamingSessionURL(input *kinesisvideoarchivedmedia.GetHLSStreamingSessionURLInput) (*kinesisvideoarchivedmedia.GetHLSStreamingSessionURLOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,10 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type KinesisVideoArchivedMediaAPI interface {
+	GetHLSStreamingSessionURL(*kinesisvideoarchivedmedia.GetHLSStreamingSessionURLInput) (*kinesisvideoarchivedmedia.GetHLSStreamingSessionURLOutput, error)
+	GetHLSStreamingSessionURLWithContext(aws.Context, *kinesisvideoarchivedmedia.GetHLSStreamingSessionURLInput, ...request.Option) (*kinesisvideoarchivedmedia.GetHLSStreamingSessionURLOutput, error)
+	GetHLSStreamingSessionURLRequest(*kinesisvideoarchivedmedia.GetHLSStreamingSessionURLInput) (*request.Request, *kinesisvideoarchivedmedia.GetHLSStreamingSessionURLOutput)
+
 	GetMediaForFragmentList(*kinesisvideoarchivedmedia.GetMediaForFragmentListInput) (*kinesisvideoarchivedmedia.GetMediaForFragmentListOutput, error)
 	GetMediaForFragmentListWithContext(aws.Context, *kinesisvideoarchivedmedia.GetMediaForFragmentListInput, ...request.Option) (*kinesisvideoarchivedmedia.GetMediaForFragmentListOutput, error)
 	GetMediaForFragmentListRequest(*kinesisvideoarchivedmedia.GetMediaForFragmentListInput) (*request.Request, *kinesisvideoarchivedmedia.GetMediaForFragmentListOutput)


### PR DESCRIPTION
Release v1.14.27 (2018-07-13)
===

### Service Client Updates
* `service/appstream`: Updates service API, documentation, and paginators
  * This API update adds support for sharing AppStream images across AWS accounts within the same region.
* `service/kinesis-video-archived-media`: Updates service API and documentation
* `service/kinesisvideo`: Updates service API and documentation
  * Adds support for HLS video playback of Kinesis Video streams using the KinesisVideo client by including "GET_HLS_STREAMING_SESSION_URL" as an additional APIName parameter in the GetDataEndpoint input.

