### PR TITLE
service/dynamodb/dynamodbattribute: Add support for custom struct tag keys

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -127,7 +127,6 @@ func NewDecoder(opts ...func(*Decoder)) *Decoder {
 	d := &Decoder{
 		MarshalOptions: MarshalOptions{
 			SupportJSONTags: true,
-			SupportYAMLTags: true,
 		},
 	}
 	for _, o := range opts {

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -127,6 +127,7 @@ func NewDecoder(opts ...func(*Decoder)) *Decoder {
 	d := &Decoder{
 		MarshalOptions: MarshalOptions{
 			SupportJSONTags: true,
+			SupportYAMLTags: true,
 		},
 	}
 	for _, o := range opts {

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -214,6 +214,7 @@ func NewEncoder(opts ...func(*Encoder)) *Encoder {
 	e := &Encoder{
 		MarshalOptions: MarshalOptions{
 			SupportJSONTags: true,
+			SupportYAMLTags: true,
 		},
 		NullEmptyString: true,
 	}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -190,9 +190,10 @@ type MarshalOptions struct {
 	// Enabled by default.
 	SupportJSONTags bool
 
-	// Similarly supported for the YAML struct tag.
-	// Enabled by default.
-	SupportYAMLTags bool
+	// Support other custom struct tag keys, such as `yaml` or `toml`.
+	// Note that values provided with a custom TagKey must also be supported
+	// by the (un)marshalers in this package.
+	TagKey string
 }
 
 // An Encoder provides marshaling Go value types to AttributeValues.
@@ -214,7 +215,6 @@ func NewEncoder(opts ...func(*Encoder)) *Encoder {
 	e := &Encoder{
 		MarshalOptions: MarshalOptions{
 			SupportJSONTags: true,
-			SupportYAMLTags: true,
 		},
 		NullEmptyString: true,
 	}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -189,6 +189,10 @@ type MarshalOptions struct {
 	//
 	// Enabled by default.
 	SupportJSONTags bool
+
+	// Similarly supported for the YAML struct tag.
+	// Enabled by default.
+	SupportYAMLTags bool
 }
 
 // An Encoder provides marshaling Go value types to AttributeValues.

--- a/service/dynamodb/dynamodbattribute/field.go
+++ b/service/dynamodb/dynamodbattribute/field.go
@@ -99,11 +99,12 @@ func enumFields(t reflect.Type, opts MarshalOptions) []field {
 
 				fieldTag := tag{}
 				fieldTag.parseAVTag(sf.Tag)
-				if opts.SupportJSONTags && fieldTag == (tag{}) {
+				// Because MarshalOptions.TagKey must be explicitly set, use it
+				// over JSON, which is enabled by default.
+				if opts.TagKey != "" && fieldTag == (tag{}) {
+					fieldTag.parseStructTag(opts.TagKey, sf.Tag)
+				} else if opts.SupportJSONTags && fieldTag == (tag{}) {
 					fieldTag.parseStructTag("json", sf.Tag)
-				}
-				if opts.SupportYAMLTags && fieldTag == (tag{}) {
-					fieldTag.parseStructTag("yaml", sf.Tag)
 				}
 
 				if fieldTag.Ignore {

--- a/service/dynamodb/dynamodbattribute/field.go
+++ b/service/dynamodb/dynamodbattribute/field.go
@@ -100,7 +100,10 @@ func enumFields(t reflect.Type, opts MarshalOptions) []field {
 				fieldTag := tag{}
 				fieldTag.parseAVTag(sf.Tag)
 				if opts.SupportJSONTags && fieldTag == (tag{}) {
-					fieldTag.parseJSONTag(sf.Tag)
+					fieldTag.parseStructTag("json", sf.Tag)
+				}
+				if opts.SupportYAMLTags && fieldTag == (tag{}) {
+					fieldTag.parseStructTag("yaml", sf.Tag)
 				}
 
 				if fieldTag.Ignore {

--- a/service/dynamodb/dynamodbattribute/marshaler_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_test.go
@@ -571,3 +571,65 @@ func BenchmarkMarshal(b *testing.B) {
 		}
 	}
 }
+
+func Test_Encode_YAML_TagKey(t *testing.T) {
+	input := struct {
+		String      string         `yaml:"string"`
+		EmptyString string         `yaml:"empty"`
+		OmitString  string         `yaml:"omitted,omitempty"`
+		Ignored     string         `yaml:"-"`
+		Byte        []byte         `yaml:"byte"`
+		Float32     float32        `yaml:"float32"`
+		Float64     float64        `yaml:"float64"`
+		Int         int            `yaml:"int"`
+		Uint        uint           `yaml:"uint"`
+		Slice       []string       `yaml:"slice"`
+		Map         map[string]int `yaml:"map"`
+		NoTag       string
+	}{
+		String:  "String",
+		Ignored: "Ignored",
+		Slice:   []string{"one", "two"},
+		Map: map[string]int{
+			"one": 1,
+			"two": 2,
+		},
+		NoTag: "NoTag",
+	}
+
+	expected := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"string":  {S: aws.String("String")},
+			"empty":   {NULL: &trueValue},
+			"byte":    {NULL: &trueValue},
+			"float32": {N: aws.String("0")},
+			"float64": {N: aws.String("0")},
+			"int":     {N: aws.String("0")},
+			"uint":    {N: aws.String("0")},
+			"slice": {
+				L: []*dynamodb.AttributeValue{
+					{S: aws.String("one")},
+					{S: aws.String("two")},
+				},
+			},
+			"map": {
+				M: map[string]*dynamodb.AttributeValue{
+					"one": {N: aws.String("1")},
+					"two": {N: aws.String("2")},
+				},
+			},
+			"NoTag": {S: aws.String("NoTag")},
+		},
+	}
+
+	enc := NewEncoder(func(e *Encoder) {
+		e.TagKey = "yaml"
+	})
+
+	actual, err := enc.Encode(input)
+	if err != nil {
+		t.Errorf("Encode with input %#v retured error `%s`, expected nil", input, err)
+	}
+
+	compareObjects(t, expected, actual)
+}

--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -24,8 +24,8 @@ func (t *tag) parseAVTag(structTag reflect.StructTag) {
 	t.parseTagStr(tagStr)
 }
 
-func (t *tag) parseJSONTag(structTag reflect.StructTag) {
-	tagStr := structTag.Get("json")
+func (t *tag) parseStructTag(tag string, structTag reflect.StructTag) {
+	tagStr := structTag.Get(tag)
 	if len(tagStr) == 0 {
 		return
 	}

--- a/service/dynamodb/dynamodbattribute/tag_test.go
+++ b/service/dynamodb/dynamodbattribute/tag_test.go
@@ -7,35 +7,44 @@ import (
 
 func TestTagParse(t *testing.T) {
 	cases := []struct {
-		in       reflect.StructTag
-		json, av bool
-		expect   tag
+		in             reflect.StructTag
+		json, yaml, av bool
+		expect         tag
 	}{
-		{`json:""`, true, false, tag{}},
-		{`json:"name"`, true, false, tag{Name: "name"}},
-		{`json:"name,omitempty"`, true, false, tag{Name: "name", OmitEmpty: true}},
-		{`json:"-"`, true, false, tag{Ignore: true}},
-		{`json:",omitempty"`, true, false, tag{OmitEmpty: true}},
-		{`json:",string"`, true, false, tag{AsString: true}},
-		{`dynamodbav:""`, false, true, tag{}},
-		{`dynamodbav:","`, false, true, tag{}},
-		{`dynamodbav:"name"`, false, true, tag{Name: "name"}},
-		{`dynamodbav:"name"`, false, true, tag{Name: "name"}},
-		{`dynamodbav:"-"`, false, true, tag{Ignore: true}},
-		{`dynamodbav:",omitempty"`, false, true, tag{OmitEmpty: true}},
-		{`dynamodbav:",omitemptyelem"`, false, true, tag{OmitEmptyElem: true}},
-		{`dynamodbav:",string"`, false, true, tag{AsString: true}},
-		{`dynamodbav:",binaryset"`, false, true, tag{AsBinSet: true}},
-		{`dynamodbav:",numberset"`, false, true, tag{AsNumSet: true}},
-		{`dynamodbav:",stringset"`, false, true, tag{AsStrSet: true}},
-		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true, OmitEmptyElem: true}},
-		{`dynamodbav:"name,stringset,omitemptyelem"`, false, true, tag{Name: "name", AsStrSet: true, OmitEmptyElem: true}},
+		{`json:""`, true, false, false, tag{}},
+		{`json:"name"`, true, false, false, tag{Name: "name"}},
+		{`json:"name,omitempty"`, true, false, false, tag{Name: "name", OmitEmpty: true}},
+		{`json:"-"`, true, false, false, tag{Ignore: true}},
+		{`json:",omitempty"`, true, false, false, tag{OmitEmpty: true}},
+		{`json:",string"`, true, false, false, tag{AsString: true}},
+		{`yaml:""`, false, true, false, tag{}},
+		{`yaml:"name"`, false, true, false, tag{Name: "name"}},
+		{`yaml:"name,omitempty"`, false, true, false, tag{Name: "name", OmitEmpty: true}},
+		{`yaml:"-"`, false, true, false, tag{Ignore: true}},
+		{`yaml:",omitempty"`, false, true, false, tag{OmitEmpty: true}},
+		{`yaml:",string"`, false, true, false, tag{AsString: true}},
+		{`dynamodbav:""`, false, false, true, tag{}},
+		{`dynamodbav:","`, false, false, true, tag{}},
+		{`dynamodbav:"name"`, false, false, true, tag{Name: "name"}},
+		{`dynamodbav:"name"`, false, false, true, tag{Name: "name"}},
+		{`dynamodbav:"-"`, false, false, true, tag{Ignore: true}},
+		{`dynamodbav:",omitempty"`, false, false, true, tag{OmitEmpty: true}},
+		{`dynamodbav:",omitemptyelem"`, false, false, true, tag{OmitEmptyElem: true}},
+		{`dynamodbav:",string"`, false, false, true, tag{AsString: true}},
+		{`dynamodbav:",binaryset"`, false, false, true, tag{AsBinSet: true}},
+		{`dynamodbav:",numberset"`, false, false, true, tag{AsNumSet: true}},
+		{`dynamodbav:",stringset"`, false, false, true, tag{AsStrSet: true}},
+		{`dynamodbav:",stringset,omitemptyelem"`, false, false, true, tag{AsStrSet: true, OmitEmptyElem: true}},
+		{`dynamodbav:"name,stringset,omitemptyelem"`, false, false, true, tag{Name: "name", AsStrSet: true, OmitEmptyElem: true}},
 	}
 
 	for i, c := range cases {
 		actual := tag{}
 		if c.json {
-			actual.parseJSONTag(c.in)
+			actual.parseStructTag("json", c.in)
+		}
+		if c.yaml {
+			actual.parseStructTag("yaml", c.in)
 		}
 		if c.av {
 			actual.parseAVTag(c.in)

--- a/service/dynamodb/dynamodbattribute/tag_test.go
+++ b/service/dynamodb/dynamodbattribute/tag_test.go
@@ -7,44 +7,35 @@ import (
 
 func TestTagParse(t *testing.T) {
 	cases := []struct {
-		in             reflect.StructTag
-		json, yaml, av bool
-		expect         tag
+		in       reflect.StructTag
+		json, av bool
+		expect   tag
 	}{
-		{`json:""`, true, false, false, tag{}},
-		{`json:"name"`, true, false, false, tag{Name: "name"}},
-		{`json:"name,omitempty"`, true, false, false, tag{Name: "name", OmitEmpty: true}},
-		{`json:"-"`, true, false, false, tag{Ignore: true}},
-		{`json:",omitempty"`, true, false, false, tag{OmitEmpty: true}},
-		{`json:",string"`, true, false, false, tag{AsString: true}},
-		{`yaml:""`, false, true, false, tag{}},
-		{`yaml:"name"`, false, true, false, tag{Name: "name"}},
-		{`yaml:"name,omitempty"`, false, true, false, tag{Name: "name", OmitEmpty: true}},
-		{`yaml:"-"`, false, true, false, tag{Ignore: true}},
-		{`yaml:",omitempty"`, false, true, false, tag{OmitEmpty: true}},
-		{`yaml:",string"`, false, true, false, tag{AsString: true}},
-		{`dynamodbav:""`, false, false, true, tag{}},
-		{`dynamodbav:","`, false, false, true, tag{}},
-		{`dynamodbav:"name"`, false, false, true, tag{Name: "name"}},
-		{`dynamodbav:"name"`, false, false, true, tag{Name: "name"}},
-		{`dynamodbav:"-"`, false, false, true, tag{Ignore: true}},
-		{`dynamodbav:",omitempty"`, false, false, true, tag{OmitEmpty: true}},
-		{`dynamodbav:",omitemptyelem"`, false, false, true, tag{OmitEmptyElem: true}},
-		{`dynamodbav:",string"`, false, false, true, tag{AsString: true}},
-		{`dynamodbav:",binaryset"`, false, false, true, tag{AsBinSet: true}},
-		{`dynamodbav:",numberset"`, false, false, true, tag{AsNumSet: true}},
-		{`dynamodbav:",stringset"`, false, false, true, tag{AsStrSet: true}},
-		{`dynamodbav:",stringset,omitemptyelem"`, false, false, true, tag{AsStrSet: true, OmitEmptyElem: true}},
-		{`dynamodbav:"name,stringset,omitemptyelem"`, false, false, true, tag{Name: "name", AsStrSet: true, OmitEmptyElem: true}},
+		{`json:""`, true, false, tag{}},
+		{`json:"name"`, true, false, tag{Name: "name"}},
+		{`json:"name,omitempty"`, true, false, tag{Name: "name", OmitEmpty: true}},
+		{`json:"-"`, true, false, tag{Ignore: true}},
+		{`json:",omitempty"`, true, false, tag{OmitEmpty: true}},
+		{`json:",string"`, true, false, tag{AsString: true}},
+		{`dynamodbav:""`, false, true, tag{}},
+		{`dynamodbav:","`, false, true, tag{}},
+		{`dynamodbav:"name"`, false, true, tag{Name: "name"}},
+		{`dynamodbav:"name"`, false, true, tag{Name: "name"}},
+		{`dynamodbav:"-"`, false, true, tag{Ignore: true}},
+		{`dynamodbav:",omitempty"`, false, true, tag{OmitEmpty: true}},
+		{`dynamodbav:",omitemptyelem"`, false, true, tag{OmitEmptyElem: true}},
+		{`dynamodbav:",string"`, false, true, tag{AsString: true}},
+		{`dynamodbav:",binaryset"`, false, true, tag{AsBinSet: true}},
+		{`dynamodbav:",numberset"`, false, true, tag{AsNumSet: true}},
+		{`dynamodbav:",stringset"`, false, true, tag{AsStrSet: true}},
+		{`dynamodbav:",stringset,omitemptyelem"`, false, true, tag{AsStrSet: true, OmitEmptyElem: true}},
+		{`dynamodbav:"name,stringset,omitemptyelem"`, false, true, tag{Name: "name", AsStrSet: true, OmitEmptyElem: true}},
 	}
 
 	for i, c := range cases {
 		actual := tag{}
 		if c.json {
 			actual.parseStructTag("json", c.in)
-		}
-		if c.yaml {
-			actual.parseStructTag("yaml", c.in)
 		}
 		if c.av {
 			actual.parseAVTag(c.in)


### PR DESCRIPTION
This allows structs defined with the `yaml` struct tag to be parsed in the same fashion as the `json` struct tag.

Where I work, we have many YAML configurations we map directly to DynamoDB tables. Being able to have the struct tags supported would be tremendously useful for us.