### PR TITLE
v1.14.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Release v1.14.30 (2018-07-19)
+===
+
+### Service Client Updates
+* `service/mediapackage`: Updates service API and documentation
+  * Adds support for DASH OriginEnpoints with multiple media presentation description periods triggered by presence of SCTE-35 ad markers in Channel input streams.
+
+### SDK Enhancements
+* `aws/default`: Add helper to get default provider chain list of credential providers ([#2059](https://github.com/aws/aws-sdk-go/issues/2051))
+  * Exports the default provider chain list of providers so it can be used to compose custom chains of credential providers.
+  * Fixes [#2051](https://github.com/aws/aws-sdk-go/issues/2051)
+
 Release v1.14.29 (2018-07-18)
 ===
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,8 +1,5 @@
 ### SDK Features
 
 ### SDK Enhancements
-* `aws/default`: Add helper to get default provider chain list of credential providers ([#2059](https://github.com/aws/aws-sdk-go/issues/2051))
-  * Exports the default provider chain list of providers so it can be used to compose custom chains of credential providers.
-  * Fixes [#2051](https://github.com/aws/aws-sdk-go/issues/2051)
 
 ### SDK Bugs

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.29"
+const SDKVersion = "1.14.30"

--- a/models/apis/mediapackage/2017-10-12/api-2.json
+++ b/models/apis/mediapackage/2017-10-12/api-2.json
@@ -701,7 +701,11 @@
         "MinUpdatePeriodSeconds": {
           "locationName": "minUpdatePeriodSeconds", 
           "shape": "__integer"
-        }, 
+        },
+        "PeriodTriggers": {
+          "locationName": "periodTriggers",
+          "shape": "__listOf__PeriodTriggersElement"
+        },
         "Profile": {
           "locationName": "profile", 
           "shape": "Profile"
@@ -1622,7 +1626,13 @@
         }
       }, 
       "type": "structure"
-    }, 
+    },
+    "__PeriodTriggersElement": {
+      "enum": [
+        "ADS"
+      ],
+      "type": "string"
+    },
     "__boolean": {
       "type": "boolean"
     }, 
@@ -1661,7 +1671,13 @@
         "shape": "OriginEndpoint"
       }, 
       "type": "list"
-    }, 
+    },
+    "__listOf__PeriodTriggersElement": {
+      "member": {
+        "shape": "__PeriodTriggersElement"
+      },
+      "type": "list"
+    },
     "__listOf__string": {
       "member": {
         "shape": "__string"

--- a/models/apis/mediapackage/2017-10-12/docs-2.json
+++ b/models/apis/mediapackage/2017-10-12/docs-2.json
@@ -190,6 +190,12 @@
         "MssPackage$StreamSelection" : null
       }
     },
+    "__PeriodTriggersElement" : {
+      "base" : null,
+      "refs" : {
+        "__listOf__PeriodTriggersElement$member" : null
+      }
+    },
     "__boolean" : {
       "base" : null,
       "refs" : {
@@ -260,6 +266,12 @@
       "base" : null,
       "refs" : {
         "OriginEndpointList$OriginEndpoints" : "A list of OriginEndpoint records."
+      }
+    },
+    "__listOf__PeriodTriggersElement" : {
+      "base" : null,
+      "refs" : {
+        "DashPackage$PeriodTriggers" : "A list of triggers that controls when the outgoing Dynamic Adaptive Streaming over HTTP (DASH)\nMedia Presentation Description (MPD) will be partitioned into multiple periods. If empty, the content will not\nbe partitioned into more than one period. If the list contains \"ADS\", new periods will be created where\nthe Channel source contains SCTE-35 ad markers.\n"
       }
     },
     "__listOf__string" : {

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -1773,6 +1773,13 @@ type DashPackage struct {
 	// Streaming over HTTP (DASH) Media Presentation Description (MPD).
 	MinUpdatePeriodSeconds *int64 `locationName:"minUpdatePeriodSeconds" type:"integer"`
 
+	// A list of triggers that controls when the outgoing Dynamic Adaptive Streaming
+	// over HTTP (DASH)Media Presentation Description (MPD) will be partitioned
+	// into multiple periods. If empty, the content will notbe partitioned into
+	// more than one period. If the list contains "ADS", new periods will be created
+	// wherethe Channel source contains SCTE-35 ad markers.
+	PeriodTriggers []*string `locationName:"periodTriggers" type:"list"`
+
 	// The Dynamic Adaptive Streaming over HTTP (DASH) profile type. When set to
 	// "HBBTV_1_5", HbbTV 1.5 compliant output is enabled.
 	Profile *string `locationName:"profile" type:"string" enum:"Profile"`
@@ -1834,6 +1841,12 @@ func (s *DashPackage) SetMinBufferTimeSeconds(v int64) *DashPackage {
 // SetMinUpdatePeriodSeconds sets the MinUpdatePeriodSeconds field's value.
 func (s *DashPackage) SetMinUpdatePeriodSeconds(v int64) *DashPackage {
 	s.MinUpdatePeriodSeconds = &v
+	return s
+}
+
+// SetPeriodTriggers sets the PeriodTriggers field's value.
+func (s *DashPackage) SetPeriodTriggers(v []*string) *DashPackage {
+	s.PeriodTriggers = v
 	return s
 }
 
@@ -3686,4 +3699,9 @@ const (
 
 	// StreamOrderVideoBitrateDescending is a StreamOrder enum value
 	StreamOrderVideoBitrateDescending = "VIDEO_BITRATE_DESCENDING"
+)
+
+const (
+	// __PeriodTriggersElementAds is a __PeriodTriggersElement enum value
+	__PeriodTriggersElementAds = "ADS"
 )


### PR DESCRIPTION
Release v1.14.30 (2018-07-19)
===

### Service Client Updates
* `service/mediapackage`: Updates service API and documentation
  * Adds support for DASH OriginEnpoints with multiple media presentation description periods triggered by presence of SCTE-35 ad markers in Channel input streams.

### SDK Enhancements
* `aws/default`: Add helper to get default provider chain list of credential providers ([#2059](https://github.com/aws/aws-sdk-go/issues/2051))
  * Exports the default provider chain list of providers so it can be used to compose custom chains of credential providers.
  * Fixes [#2051](https://github.com/aws/aws-sdk-go/issues/2051)

