### PR TITLE
Ignore whitespace changes in model generation checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,10 @@ ci-test-generate: get-deps
 
 ci-test-generate-validate:
 	@echo "CI test validate no generated code changes"
-	@gitstatus=`if [ \( -z "${SDK_GO_1_6}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  git status --porcelain; else echo "skipping validation"; fi`; \
+	@git add . -A
+	@gitstatus=`if [ \( -z "${SDK_GO_1_6}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  git diff --cached --ignore-space-change; else echo "skipping validation"; fi`; \
 	echo "$$gitstatus"; \
-	if [ "$$gitstatus" != "" ] && [ "$$gitstatus" != "skipping validation" ]; then git diff; exit 1; fi
+	if [ "$$gitstatus" != "" ] && [ "$$gitstatus" != "skipping validation" ]; then echo "$$gitstatus"; exit 1; fi
 
 integration: get-deps-tests integ-custom smoke-tests performance
 

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -274,7 +274,9 @@ func (a *API) renameCollidingFields() {
 
 func renameCollidingField(name string, v *Shape, field *ShapeRef) {
 	newName := name + "_"
-	fmt.Printf("Shape %s's field %q renamed to %q\n", v.ShapeName, name, newName)
+	if !(v.Exception && (name == "Code" || name == "Message")) {
+		fmt.Printf("Shape %s's field %q renamed to %q\n", v.ShapeName, name, newName)
+	}
 	delete(v.MemberRefs, name)
 	v.MemberRefs[newName] = field
 }


### PR DESCRIPTION
Fixes the SDK's CI validation of generated models to ignore whitespace changes. Addresses the issue with gofmt formatting differing between versions of Go