### PR TITLE
v1.14.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.14.32 (2018-07-24)
+===
+
+### Service Client Updates
+* `service/dynamodb`: Updates service API and documentation
+  * With this SDK update, APIs UpdateGlobalTableSettings and DescribeGlobalTableSettings now allow consistently configuring AutoScaling settings for a DynamoDB global table. Previously, they would only allow consistently setting IOPS. Now new APIs are being released, existing APIs are being extended.
+
 Release v1.14.31 (2018-07-20)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.31"
+const SDKVersion = "1.14.32"

--- a/models/apis/dynamodb/2012-08-10/api-2.json
+++ b/models/apis/dynamodb/2012-08-10/api-2.json
@@ -557,6 +557,77 @@
         "Action":{"shape":"AttributeAction"}
       }
     },
+    "AutoScalingPolicyDescription":{
+      "type":"structure",
+      "members":{
+        "PolicyName":{"shape":"AutoScalingPolicyName"},
+        "TargetTrackingScalingPolicyConfiguration":{"shape":"AutoScalingTargetTrackingScalingPolicyConfigurationDescription"}
+      }
+    },
+    "AutoScalingPolicyDescriptionList":{
+      "type":"list",
+      "member":{"shape":"AutoScalingPolicyDescription"}
+    },
+    "AutoScalingPolicyName":{
+      "type":"string",
+      "max":256,
+      "min":1,
+      "pattern":"\\p{Print}+"
+    },
+    "AutoScalingPolicyUpdate":{
+      "type":"structure",
+      "required":["TargetTrackingScalingPolicyConfiguration"],
+      "members":{
+        "PolicyName":{"shape":"AutoScalingPolicyName"},
+        "TargetTrackingScalingPolicyConfiguration":{"shape":"AutoScalingTargetTrackingScalingPolicyConfigurationUpdate"}
+      }
+    },
+    "AutoScalingRoleArn":{
+      "type":"string",
+      "max":1600,
+      "min":1,
+      "pattern":"[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "AutoScalingSettingsDescription":{
+      "type":"structure",
+      "members":{
+        "MinimumUnits":{"shape":"PositiveLongObject"},
+        "MaximumUnits":{"shape":"PositiveLongObject"},
+        "AutoScalingDisabled":{"shape":"BooleanObject"},
+        "AutoScalingRoleArn":{"shape":"String"},
+        "ScalingPolicies":{"shape":"AutoScalingPolicyDescriptionList"}
+      }
+    },
+    "AutoScalingSettingsUpdate":{
+      "type":"structure",
+      "members":{
+        "MinimumUnits":{"shape":"PositiveLongObject"},
+        "MaximumUnits":{"shape":"PositiveLongObject"},
+        "AutoScalingDisabled":{"shape":"BooleanObject"},
+        "AutoScalingRoleArn":{"shape":"AutoScalingRoleArn"},
+        "ScalingPolicyUpdate":{"shape":"AutoScalingPolicyUpdate"}
+      }
+    },
+    "AutoScalingTargetTrackingScalingPolicyConfigurationDescription":{
+      "type":"structure",
+      "required":["TargetValue"],
+      "members":{
+        "DisableScaleIn":{"shape":"BooleanObject"},
+        "ScaleInCooldown":{"shape":"IntegerObject"},
+        "ScaleOutCooldown":{"shape":"IntegerObject"},
+        "TargetValue":{"shape":"Double"}
+      }
+    },
+    "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate":{
+      "type":"structure",
+      "required":["TargetValue"],
+      "members":{
+        "DisableScaleIn":{"shape":"BooleanObject"},
+        "ScaleInCooldown":{"shape":"IntegerObject"},
+        "ScaleOutCooldown":{"shape":"IntegerObject"},
+        "TargetValue":{"shape":"Double"}
+      }
+    },
     "Backfilling":{"type":"boolean"},
     "BackupArn":{
       "type":"string",
@@ -1035,6 +1106,7 @@
         "TimeToLiveDescription":{"shape":"TimeToLiveDescription"}
       }
     },
+    "Double":{"type":"double"},
     "ErrorMessage":{"type":"string"},
     "ExpectedAttributeMap":{
       "type":"map",
@@ -1182,7 +1254,8 @@
       "required":["IndexName"],
       "members":{
         "IndexName":{"shape":"IndexName"},
-        "ProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"}
+        "ProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"},
+        "ProvisionedWriteCapacityAutoScalingSettingsUpdate":{"shape":"AutoScalingSettingsUpdate"}
       }
     },
     "GlobalTableGlobalSecondaryIndexSettingsUpdateList":{
@@ -1234,6 +1307,7 @@
       ]
     },
     "Integer":{"type":"integer"},
+    "IntegerObject":{"type":"integer"},
     "InternalServerError":{
       "type":"structure",
       "members":{
@@ -1677,7 +1751,9 @@
         "IndexName":{"shape":"IndexName"},
         "IndexStatus":{"shape":"IndexStatus"},
         "ProvisionedReadCapacityUnits":{"shape":"PositiveLongObject"},
-        "ProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"}
+        "ProvisionedReadCapacityAutoScalingSettings":{"shape":"AutoScalingSettingsDescription"},
+        "ProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"},
+        "ProvisionedWriteCapacityAutoScalingSettings":{"shape":"AutoScalingSettingsDescription"}
       }
     },
     "ReplicaGlobalSecondaryIndexSettingsDescriptionList":{
@@ -1689,7 +1765,8 @@
       "required":["IndexName"],
       "members":{
         "IndexName":{"shape":"IndexName"},
-        "ProvisionedReadCapacityUnits":{"shape":"PositiveLongObject"}
+        "ProvisionedReadCapacityUnits":{"shape":"PositiveLongObject"},
+        "ProvisionedReadCapacityAutoScalingSettingsUpdate":{"shape":"AutoScalingSettingsUpdate"}
       }
     },
     "ReplicaGlobalSecondaryIndexSettingsUpdateList":{
@@ -1716,7 +1793,9 @@
         "RegionName":{"shape":"RegionName"},
         "ReplicaStatus":{"shape":"ReplicaStatus"},
         "ReplicaProvisionedReadCapacityUnits":{"shape":"PositiveLongObject"},
+        "ReplicaProvisionedReadCapacityAutoScalingSettings":{"shape":"AutoScalingSettingsDescription"},
         "ReplicaProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"},
+        "ReplicaProvisionedWriteCapacityAutoScalingSettings":{"shape":"AutoScalingSettingsDescription"},
         "ReplicaGlobalSecondaryIndexSettings":{"shape":"ReplicaGlobalSecondaryIndexSettingsDescriptionList"}
       }
     },
@@ -1730,6 +1809,7 @@
       "members":{
         "RegionName":{"shape":"RegionName"},
         "ReplicaProvisionedReadCapacityUnits":{"shape":"PositiveLongObject"},
+        "ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate":{"shape":"AutoScalingSettingsUpdate"},
         "ReplicaGlobalSecondaryIndexSettingsUpdate":{"shape":"ReplicaGlobalSecondaryIndexSettingsUpdateList"}
       }
     },
@@ -2213,6 +2293,7 @@
       "members":{
         "GlobalTableName":{"shape":"TableName"},
         "GlobalTableProvisionedWriteCapacityUnits":{"shape":"PositiveLongObject"},
+        "GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate":{"shape":"AutoScalingSettingsUpdate"},
         "GlobalTableGlobalSecondaryIndexSettingsUpdate":{"shape":"GlobalTableGlobalSecondaryIndexSettingsUpdateList"},
         "ReplicaSettingsUpdate":{"shape":"ReplicaSettingsUpdateList"}
       }

--- a/models/apis/dynamodb/2012-08-10/docs-2.json
+++ b/models/apis/dynamodb/2012-08-10/docs-2.json
@@ -126,6 +126,67 @@
         "AttributeUpdates$value": null
       }
     },
+    "AutoScalingPolicyDescription": {
+      "base": "<p>Represents the properties of the scaling policy.</p>",
+      "refs": {
+        "AutoScalingPolicyDescriptionList$member": null
+      }
+    },
+    "AutoScalingPolicyDescriptionList": {
+      "base": null,
+      "refs": {
+        "AutoScalingSettingsDescription$ScalingPolicies": "<p>Information about the scaling policies.</p>"
+      }
+    },
+    "AutoScalingPolicyName": {
+      "base": null,
+      "refs": {
+        "AutoScalingPolicyDescription$PolicyName": "<p>The name of the scaling policy.</p>",
+        "AutoScalingPolicyUpdate$PolicyName": "<p>The name of the scaling policy.</p>"
+      }
+    },
+    "AutoScalingPolicyUpdate": {
+      "base": "<p>Represents the autoscaling policy to be modified.</p>",
+      "refs": {
+        "AutoScalingSettingsUpdate$ScalingPolicyUpdate": "<p>The scaling policy to apply for scaling target global table or global secondary index capacity units.</p>"
+      }
+    },
+    "AutoScalingRoleArn": {
+      "base": null,
+      "refs": {
+        "AutoScalingSettingsUpdate$AutoScalingRoleArn": "<p>Role ARN used for configuring autoscaling policy.</p>"
+      }
+    },
+    "AutoScalingSettingsDescription": {
+      "base": "<p>Represents the autoscaling settings for a global table or global secondary index.</p>",
+      "refs": {
+        "ReplicaGlobalSecondaryIndexSettingsDescription$ProvisionedReadCapacityAutoScalingSettings": "<p>Autoscaling settings for a global secondary index replica's read capacity units.</p>",
+        "ReplicaGlobalSecondaryIndexSettingsDescription$ProvisionedWriteCapacityAutoScalingSettings": "<p>AutoScaling settings for a global secondary index replica's write capacity units.</p>",
+        "ReplicaSettingsDescription$ReplicaProvisionedReadCapacityAutoScalingSettings": "<p>Autoscaling settings for a global table replica's read capacity units.</p>",
+        "ReplicaSettingsDescription$ReplicaProvisionedWriteCapacityAutoScalingSettings": "<p>AutoScaling settings for a global table replica's write capacity units.</p>"
+      }
+    },
+    "AutoScalingSettingsUpdate": {
+      "base": "<p>Represents the autoscaling settings to be modified for a global table or global secondary index.</p>",
+      "refs": {
+        "GlobalTableGlobalSecondaryIndexSettingsUpdate$ProvisionedWriteCapacityAutoScalingSettingsUpdate": "<p>AutoScaling settings for managing a global secondary index's write capacity units.</p>",
+        "ReplicaGlobalSecondaryIndexSettingsUpdate$ProvisionedReadCapacityAutoScalingSettingsUpdate": "<p>Autoscaling settings for managing a global secondary index replica's read capacity units.</p>",
+        "ReplicaSettingsUpdate$ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate": "<p>Autoscaling settings for managing a global table replica's read capacity units.</p>",
+        "UpdateGlobalTableSettingsInput$GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate": "<p>AutoScaling settings for managing provisioned write capacity for the global table.</p>"
+      }
+    },
+    "AutoScalingTargetTrackingScalingPolicyConfigurationDescription": {
+      "base": "<p>Represents the properties of a target tracking scaling policy.</p>",
+      "refs": {
+        "AutoScalingPolicyDescription$TargetTrackingScalingPolicyConfiguration": "<p>Represents a target tracking scaling policy configuration.</p>"
+      }
+    },
+    "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate": {
+      "base": "<p>Represents the settings of a target tracking scaling policy that will be modified.</p>",
+      "refs": {
+        "AutoScalingPolicyUpdate$TargetTrackingScalingPolicyConfiguration": "<p>Represents a target tracking scaling policy configuration.</p>"
+      }
+    },
     "Backfilling": {
       "base": null,
       "refs": {
@@ -278,6 +339,10 @@
     "BooleanObject": {
       "base": null,
       "refs": {
+        "AutoScalingSettingsDescription$AutoScalingDisabled": "<p>Disabled autoscaling for this global table or global secondary index.</p>",
+        "AutoScalingSettingsUpdate$AutoScalingDisabled": "<p>Disabled autoscaling for this global table or global secondary index.</p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationDescription$DisableScaleIn": "<p>Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is false.</p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate$DisableScaleIn": "<p>Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is false.</p>",
         "ExpectedAttributeValue$Exists": "<p>Causes DynamoDB to evaluate the value before attempting a conditional operation:</p> <ul> <li> <p>If <code>Exists</code> is <code>true</code>, DynamoDB will check to see if that attribute value already exists in the table. If it is found, then the operation succeeds. If it is not found, the operation fails with a <code>ConditionalCheckFailedException</code>.</p> </li> <li> <p>If <code>Exists</code> is <code>false</code>, DynamoDB assumes that the attribute value does not exist in the table. If in fact the value does not exist, then the assumption is valid and the operation succeeds. If the value is found, despite the assumption that it does not exist, the operation fails with a <code>ConditionalCheckFailedException</code>.</p> </li> </ul> <p>The default setting for <code>Exists</code> is <code>true</code>. If you supply a <code>Value</code> all by itself, DynamoDB assumes the attribute exists: You don't have to set <code>Exists</code> to <code>true</code>, because it is implied.</p> <p>DynamoDB returns a <code>ValidationException</code> if:</p> <ul> <li> <p> <code>Exists</code> is <code>true</code> but there is no <code>Value</code> to check. (You expect a value to exist, but don't specify what that value is.)</p> </li> <li> <p> <code>Exists</code> is <code>false</code> but you also provide a <code>Value</code>. (You cannot expect an attribute to have a value, while also expecting it not to exist.)</p> </li> </ul>",
         "PointInTimeRecoverySpecification$PointInTimeRecoveryEnabled": "<p>Indicates whether point in time recovery is enabled (true) or disabled (false) on the table.</p>",
         "QueryInput$ScanIndexForward": "<p>Specifies the order for index traversal: If <code>true</code> (default), the traversal is performed in ascending order; if <code>false</code>, the traversal is performed in descending order. </p> <p>Items with the same partition key value are stored in sorted order by sort key. If the sort key data type is Number, the results are stored in numeric order. For type String, the results are stored in order of UTF-8 bytes. For type Binary, DynamoDB treats each byte of the binary data as unsigned.</p> <p>If <code>ScanIndexForward</code> is <code>true</code>, DynamoDB returns the results in the order in which they are stored (by sort key value). This is the default behavior. If <code>ScanIndexForward</code> is <code>false</code>, DynamoDB reads the results in reverse order by sort key value, and then returns the results to the client.</p>",
@@ -556,6 +621,13 @@
       "refs": {
       }
     },
+    "Double": {
+      "base": null,
+      "refs": {
+        "AutoScalingTargetTrackingScalingPolicyConfigurationDescription$TargetValue": "<p>The target value for the metric. The range is 8.515920e-109 to 1.174271e+108 (Base 10) or 2e-360 to 2e360 (Base 2).</p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate$TargetValue": "<p>The target value for the metric. The range is 8.515920e-109 to 1.174271e+108 (Base 10) or 2e-360 to 2e360 (Base 2).</p>"
+      }
+    },
     "ErrorMessage": {
       "base": null,
       "refs": {
@@ -787,6 +859,15 @@
         "QueryOutput$ScannedCount": "<p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high <code>ScannedCount</code> value with few, or no, <code>Count</code> results indicates an inefficient <code>Query</code> operation. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same as <code>Count</code>.</p>",
         "ScanOutput$Count": "<p>The number of items in the response.</p> <p>If you set <code>ScanFilter</code> in the request, then <code>Count</code> is the number of items returned after the filter was applied, and <code>ScannedCount</code> is the number of matching items before the filter was applied.</p> <p>If you did not use a filter in the request, then <code>Count</code> is the same as <code>ScannedCount</code>.</p>",
         "ScanOutput$ScannedCount": "<p>The number of items evaluated, before any <code>ScanFilter</code> is applied. A high <code>ScannedCount</code> value with few, or no, <code>Count</code> results indicates an inefficient <code>Scan</code> operation. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same as <code>Count</code>.</p>"
+      }
+    },
+    "IntegerObject": {
+      "base": null,
+      "refs": {
+        "AutoScalingTargetTrackingScalingPolicyConfigurationDescription$ScaleInCooldown": "<p>The amount of time, in seconds, after a scale in activity completes before another scale in activity can start. The cooldown period is used to block subsequent scale in requests until it has expired. You should scale in conservatively to protect your application's availability. However, if another alarm triggers a scale out policy during the cooldown period after a scale-in, application autoscaling scales out your scalable target immediately. </p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationDescription$ScaleOutCooldown": "<p>The amount of time, in seconds, after a scale out activity completes before another scale out activity can start. While the cooldown period is in effect, the capacity that has been added by the previous scale out event that initiated the cooldown is calculated as part of the desired capacity for the next scale out. You should continuously (but not excessively) scale out.</p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate$ScaleInCooldown": "<p>The amount of time, in seconds, after a scale in activity completes before another scale in activity can start. The cooldown period is used to block subsequent scale in requests until it has expired. You should scale in conservatively to protect your application's availability. However, if another alarm triggers a scale out policy during the cooldown period after a scale-in, application autoscaling scales out your scalable target immediately. </p>",
+        "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate$ScaleOutCooldown": "<p>The amount of time, in seconds, after a scale out activity completes before another scale out activity can start. While the cooldown period is in effect, the capacity that has been added by the previous scale out event that initiated the cooldown is calculated as part of the desired capacity for the next scale out. You should continuously (but not excessively) scale out.</p>"
       }
     },
     "InternalServerError": {
@@ -1118,6 +1199,10 @@
     "PositiveLongObject": {
       "base": null,
       "refs": {
+        "AutoScalingSettingsDescription$MinimumUnits": "<p>The minimum capacity units that a global table or global secondary index should be scaled down to.</p>",
+        "AutoScalingSettingsDescription$MaximumUnits": "<p>The maximum capacity units that a global table or global secondary index should be scaled up to.</p>",
+        "AutoScalingSettingsUpdate$MinimumUnits": "<p>The minimum capacity units that a global table or global secondary index should be scaled down to.</p>",
+        "AutoScalingSettingsUpdate$MaximumUnits": "<p>The maximum capacity units that a global table or global secondary index should be scaled up to.</p>",
         "DescribeLimitsOutput$AccountMaxReadCapacityUnits": "<p>The maximum total read capacity units that your account allows you to provision across all of your tables in this region.</p>",
         "DescribeLimitsOutput$AccountMaxWriteCapacityUnits": "<p>The maximum total write capacity units that your account allows you to provision across all of your tables in this region.</p>",
         "DescribeLimitsOutput$TableMaxReadCapacityUnits": "<p>The maximum read capacity units that your account allows you to provision for a new table that you are creating in this region, including the read capacity units provisioned for its global secondary indexes (GSIs).</p>",
@@ -1530,6 +1615,7 @@
     "String": {
       "base": null,
       "refs": {
+        "AutoScalingSettingsDescription$AutoScalingRoleArn": "<p>Role ARN used for configuring autoScaling policy.</p>",
         "GlobalSecondaryIndexDescription$IndexArn": "<p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>",
         "LocalSecondaryIndexDescription$IndexArn": "<p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>",
         "TableDescription$TableArn": "<p>The Amazon Resource Name (ARN) that uniquely identifies the table.</p>",

--- a/models/apis/dynamodb/2012-08-10/smoke.json
+++ b/models/apis/dynamodb/2012-08-10/smoke.json
@@ -1,0 +1,20 @@
+{
+    "version": 1,
+    "defaultRegion": "us-west-2",
+    "testCases": [
+        {
+            "operationName": "ListTables",
+            "input": {
+                "Limit": 1
+            },
+            "errorExpectedFromService": false
+        },
+        {
+            "operationName": "DescribeTable",
+            "input": {
+                "TableName": "fake-table"
+            },
+            "errorExpectedFromService": true
+        }
+    ]
+}

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -4191,6 +4191,394 @@ func (s *AttributeValueUpdate) SetValue(v *AttributeValue) *AttributeValueUpdate
 	return s
 }
 
+// Represents the properties of the scaling policy.
+type AutoScalingPolicyDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the scaling policy.
+	PolicyName *string `min:"1" type:"string"`
+
+	// Represents a target tracking scaling policy configuration.
+	TargetTrackingScalingPolicyConfiguration *AutoScalingTargetTrackingScalingPolicyConfigurationDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s AutoScalingPolicyDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingPolicyDescription) GoString() string {
+	return s.String()
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AutoScalingPolicyDescription) SetPolicyName(v string) *AutoScalingPolicyDescription {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTargetTrackingScalingPolicyConfiguration sets the TargetTrackingScalingPolicyConfiguration field's value.
+func (s *AutoScalingPolicyDescription) SetTargetTrackingScalingPolicyConfiguration(v *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) *AutoScalingPolicyDescription {
+	s.TargetTrackingScalingPolicyConfiguration = v
+	return s
+}
+
+// Represents the autoscaling policy to be modified.
+type AutoScalingPolicyUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the scaling policy.
+	PolicyName *string `min:"1" type:"string"`
+
+	// Represents a target tracking scaling policy configuration.
+	//
+	// TargetTrackingScalingPolicyConfiguration is a required field
+	TargetTrackingScalingPolicyConfiguration *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingPolicyUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingPolicyUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingPolicyUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingPolicyUpdate"}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.TargetTrackingScalingPolicyConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetTrackingScalingPolicyConfiguration"))
+	}
+	if s.TargetTrackingScalingPolicyConfiguration != nil {
+		if err := s.TargetTrackingScalingPolicyConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("TargetTrackingScalingPolicyConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AutoScalingPolicyUpdate) SetPolicyName(v string) *AutoScalingPolicyUpdate {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTargetTrackingScalingPolicyConfiguration sets the TargetTrackingScalingPolicyConfiguration field's value.
+func (s *AutoScalingPolicyUpdate) SetTargetTrackingScalingPolicyConfiguration(v *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) *AutoScalingPolicyUpdate {
+	s.TargetTrackingScalingPolicyConfiguration = v
+	return s
+}
+
+// Represents the autoscaling settings for a global table or global secondary
+// index.
+type AutoScalingSettingsDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Disabled autoscaling for this global table or global secondary index.
+	AutoScalingDisabled *bool `type:"boolean"`
+
+	// Role ARN used for configuring autoScaling policy.
+	AutoScalingRoleArn *string `type:"string"`
+
+	// The maximum capacity units that a global table or global secondary index
+	// should be scaled up to.
+	MaximumUnits *int64 `min:"1" type:"long"`
+
+	// The minimum capacity units that a global table or global secondary index
+	// should be scaled down to.
+	MinimumUnits *int64 `min:"1" type:"long"`
+
+	// Information about the scaling policies.
+	ScalingPolicies []*AutoScalingPolicyDescription `type:"list"`
+}
+
+// String returns the string representation
+func (s AutoScalingSettingsDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingSettingsDescription) GoString() string {
+	return s.String()
+}
+
+// SetAutoScalingDisabled sets the AutoScalingDisabled field's value.
+func (s *AutoScalingSettingsDescription) SetAutoScalingDisabled(v bool) *AutoScalingSettingsDescription {
+	s.AutoScalingDisabled = &v
+	return s
+}
+
+// SetAutoScalingRoleArn sets the AutoScalingRoleArn field's value.
+func (s *AutoScalingSettingsDescription) SetAutoScalingRoleArn(v string) *AutoScalingSettingsDescription {
+	s.AutoScalingRoleArn = &v
+	return s
+}
+
+// SetMaximumUnits sets the MaximumUnits field's value.
+func (s *AutoScalingSettingsDescription) SetMaximumUnits(v int64) *AutoScalingSettingsDescription {
+	s.MaximumUnits = &v
+	return s
+}
+
+// SetMinimumUnits sets the MinimumUnits field's value.
+func (s *AutoScalingSettingsDescription) SetMinimumUnits(v int64) *AutoScalingSettingsDescription {
+	s.MinimumUnits = &v
+	return s
+}
+
+// SetScalingPolicies sets the ScalingPolicies field's value.
+func (s *AutoScalingSettingsDescription) SetScalingPolicies(v []*AutoScalingPolicyDescription) *AutoScalingSettingsDescription {
+	s.ScalingPolicies = v
+	return s
+}
+
+// Represents the autoscaling settings to be modified for a global table or
+// global secondary index.
+type AutoScalingSettingsUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Disabled autoscaling for this global table or global secondary index.
+	AutoScalingDisabled *bool `type:"boolean"`
+
+	// Role ARN used for configuring autoscaling policy.
+	AutoScalingRoleArn *string `min:"1" type:"string"`
+
+	// The maximum capacity units that a global table or global secondary index
+	// should be scaled up to.
+	MaximumUnits *int64 `min:"1" type:"long"`
+
+	// The minimum capacity units that a global table or global secondary index
+	// should be scaled down to.
+	MinimumUnits *int64 `min:"1" type:"long"`
+
+	// The scaling policy to apply for scaling target global table or global secondary
+	// index capacity units.
+	ScalingPolicyUpdate *AutoScalingPolicyUpdate `type:"structure"`
+}
+
+// String returns the string representation
+func (s AutoScalingSettingsUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingSettingsUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingSettingsUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingSettingsUpdate"}
+	if s.AutoScalingRoleArn != nil && len(*s.AutoScalingRoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingRoleArn", 1))
+	}
+	if s.MaximumUnits != nil && *s.MaximumUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaximumUnits", 1))
+	}
+	if s.MinimumUnits != nil && *s.MinimumUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MinimumUnits", 1))
+	}
+	if s.ScalingPolicyUpdate != nil {
+		if err := s.ScalingPolicyUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ScalingPolicyUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutoScalingDisabled sets the AutoScalingDisabled field's value.
+func (s *AutoScalingSettingsUpdate) SetAutoScalingDisabled(v bool) *AutoScalingSettingsUpdate {
+	s.AutoScalingDisabled = &v
+	return s
+}
+
+// SetAutoScalingRoleArn sets the AutoScalingRoleArn field's value.
+func (s *AutoScalingSettingsUpdate) SetAutoScalingRoleArn(v string) *AutoScalingSettingsUpdate {
+	s.AutoScalingRoleArn = &v
+	return s
+}
+
+// SetMaximumUnits sets the MaximumUnits field's value.
+func (s *AutoScalingSettingsUpdate) SetMaximumUnits(v int64) *AutoScalingSettingsUpdate {
+	s.MaximumUnits = &v
+	return s
+}
+
+// SetMinimumUnits sets the MinimumUnits field's value.
+func (s *AutoScalingSettingsUpdate) SetMinimumUnits(v int64) *AutoScalingSettingsUpdate {
+	s.MinimumUnits = &v
+	return s
+}
+
+// SetScalingPolicyUpdate sets the ScalingPolicyUpdate field's value.
+func (s *AutoScalingSettingsUpdate) SetScalingPolicyUpdate(v *AutoScalingPolicyUpdate) *AutoScalingSettingsUpdate {
+	s.ScalingPolicyUpdate = v
+	return s
+}
+
+// Represents the properties of a target tracking scaling policy.
+type AutoScalingTargetTrackingScalingPolicyConfigurationDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether scale in by the target tracking policy is disabled. If
+	// the value is true, scale in is disabled and the target tracking policy won't
+	// remove capacity from the scalable resource. Otherwise, scale in is enabled
+	// and the target tracking policy can remove capacity from the scalable resource.
+	// The default value is false.
+	DisableScaleIn *bool `type:"boolean"`
+
+	// The amount of time, in seconds, after a scale in activity completes before
+	// another scale in activity can start. The cooldown period is used to block
+	// subsequent scale in requests until it has expired. You should scale in conservatively
+	// to protect your application's availability. However, if another alarm triggers
+	// a scale out policy during the cooldown period after a scale-in, application
+	// autoscaling scales out your scalable target immediately.
+	ScaleInCooldown *int64 `type:"integer"`
+
+	// The amount of time, in seconds, after a scale out activity completes before
+	// another scale out activity can start. While the cooldown period is in effect,
+	// the capacity that has been added by the previous scale out event that initiated
+	// the cooldown is calculated as part of the desired capacity for the next scale
+	// out. You should continuously (but not excessively) scale out.
+	ScaleOutCooldown *int64 `type:"integer"`
+
+	// The target value for the metric. The range is 8.515920e-109 to 1.174271e+108
+	// (Base 10) or 2e-360 to 2e360 (Base 2).
+	//
+	// TargetValue is a required field
+	TargetValue *float64 `type:"double" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationDescription) GoString() string {
+	return s.String()
+}
+
+// SetDisableScaleIn sets the DisableScaleIn field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetDisableScaleIn(v bool) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.DisableScaleIn = &v
+	return s
+}
+
+// SetScaleInCooldown sets the ScaleInCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetScaleInCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.ScaleInCooldown = &v
+	return s
+}
+
+// SetScaleOutCooldown sets the ScaleOutCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetScaleOutCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.ScaleOutCooldown = &v
+	return s
+}
+
+// SetTargetValue sets the TargetValue field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetTargetValue(v float64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.TargetValue = &v
+	return s
+}
+
+// Represents the settings of a target tracking scaling policy that will be
+// modified.
+type AutoScalingTargetTrackingScalingPolicyConfigurationUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether scale in by the target tracking policy is disabled. If
+	// the value is true, scale in is disabled and the target tracking policy won't
+	// remove capacity from the scalable resource. Otherwise, scale in is enabled
+	// and the target tracking policy can remove capacity from the scalable resource.
+	// The default value is false.
+	DisableScaleIn *bool `type:"boolean"`
+
+	// The amount of time, in seconds, after a scale in activity completes before
+	// another scale in activity can start. The cooldown period is used to block
+	// subsequent scale in requests until it has expired. You should scale in conservatively
+	// to protect your application's availability. However, if another alarm triggers
+	// a scale out policy during the cooldown period after a scale-in, application
+	// autoscaling scales out your scalable target immediately.
+	ScaleInCooldown *int64 `type:"integer"`
+
+	// The amount of time, in seconds, after a scale out activity completes before
+	// another scale out activity can start. While the cooldown period is in effect,
+	// the capacity that has been added by the previous scale out event that initiated
+	// the cooldown is calculated as part of the desired capacity for the next scale
+	// out. You should continuously (but not excessively) scale out.
+	ScaleOutCooldown *int64 `type:"integer"`
+
+	// The target value for the metric. The range is 8.515920e-109 to 1.174271e+108
+	// (Base 10) or 2e-360 to 2e360 (Base 2).
+	//
+	// TargetValue is a required field
+	TargetValue *float64 `type:"double" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate"}
+	if s.TargetValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDisableScaleIn sets the DisableScaleIn field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetDisableScaleIn(v bool) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.DisableScaleIn = &v
+	return s
+}
+
+// SetScaleInCooldown sets the ScaleInCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetScaleInCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.ScaleInCooldown = &v
+	return s
+}
+
+// SetScaleOutCooldown sets the ScaleOutCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetScaleOutCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.ScaleOutCooldown = &v
+	return s
+}
+
+// SetTargetValue sets the TargetValue field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetTargetValue(v float64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.TargetValue = &v
+	return s
+}
+
 // Contains the description of the backup created for the table.
 type BackupDescription struct {
 	_ struct{} `type:"structure"`
@@ -7556,6 +7944,10 @@ type GlobalTableGlobalSecondaryIndexSettingsUpdate struct {
 	// IndexName is a required field
 	IndexName *string `min:"3" type:"string" required:"true"`
 
+	// AutoScaling settings for managing a global secondary index's write capacity
+	// units.
+	ProvisionedWriteCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
+
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
 	ProvisionedWriteCapacityUnits *int64 `min:"1" type:"long"`
@@ -7583,6 +7975,11 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) Validate() error {
 	if s.ProvisionedWriteCapacityUnits != nil && *s.ProvisionedWriteCapacityUnits < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProvisionedWriteCapacityUnits", 1))
 	}
+	if s.ProvisionedWriteCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ProvisionedWriteCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedWriteCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7593,6 +7990,12 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) Validate() error {
 // SetIndexName sets the IndexName field's value.
 func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetIndexName(v string) *GlobalTableGlobalSecondaryIndexSettingsUpdate {
 	s.IndexName = &v
+	return s
+}
+
+// SetProvisionedWriteCapacityAutoScalingSettingsUpdate sets the ProvisionedWriteCapacityAutoScalingSettingsUpdate field's value.
+func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetProvisionedWriteCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *GlobalTableGlobalSecondaryIndexSettingsUpdate {
+	s.ProvisionedWriteCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -9745,9 +10148,17 @@ type ReplicaGlobalSecondaryIndexSettingsDescription struct {
 	//    * ACTIVE - The global secondary index is ready for use.
 	IndexStatus *string `type:"string" enum:"IndexStatus"`
 
+	// Autoscaling settings for a global secondary index replica's read capacity
+	// units.
+	ProvisionedReadCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
+
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException.
 	ProvisionedReadCapacityUnits *int64 `min:"1" type:"long"`
+
+	// AutoScaling settings for a global secondary index replica's write capacity
+	// units.
+	ProvisionedWriteCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
 
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
@@ -9776,9 +10187,21 @@ func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetIndexStatus(v string
 	return s
 }
 
+// SetProvisionedReadCapacityAutoScalingSettings sets the ProvisionedReadCapacityAutoScalingSettings field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedReadCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaGlobalSecondaryIndexSettingsDescription {
+	s.ProvisionedReadCapacityAutoScalingSettings = v
+	return s
+}
+
 // SetProvisionedReadCapacityUnits sets the ProvisionedReadCapacityUnits field's value.
 func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedReadCapacityUnits(v int64) *ReplicaGlobalSecondaryIndexSettingsDescription {
 	s.ProvisionedReadCapacityUnits = &v
+	return s
+}
+
+// SetProvisionedWriteCapacityAutoScalingSettings sets the ProvisionedWriteCapacityAutoScalingSettings field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedWriteCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaGlobalSecondaryIndexSettingsDescription {
+	s.ProvisionedWriteCapacityAutoScalingSettings = v
 	return s
 }
 
@@ -9798,6 +10221,10 @@ type ReplicaGlobalSecondaryIndexSettingsUpdate struct {
 	//
 	// IndexName is a required field
 	IndexName *string `min:"3" type:"string" required:"true"`
+
+	// Autoscaling settings for managing a global secondary index replica's read
+	// capacity units.
+	ProvisionedReadCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
 
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException.
@@ -9826,6 +10253,11 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) Validate() error {
 	if s.ProvisionedReadCapacityUnits != nil && *s.ProvisionedReadCapacityUnits < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProvisionedReadCapacityUnits", 1))
 	}
+	if s.ProvisionedReadCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ProvisionedReadCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedReadCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9836,6 +10268,12 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) Validate() error {
 // SetIndexName sets the IndexName field's value.
 func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetIndexName(v string) *ReplicaGlobalSecondaryIndexSettingsUpdate {
 	s.IndexName = &v
+	return s
+}
+
+// SetProvisionedReadCapacityAutoScalingSettingsUpdate sets the ProvisionedReadCapacityAutoScalingSettingsUpdate field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetProvisionedReadCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *ReplicaGlobalSecondaryIndexSettingsUpdate {
+	s.ProvisionedReadCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -9857,11 +10295,17 @@ type ReplicaSettingsDescription struct {
 	// Replica global secondary index settings for the global table.
 	ReplicaGlobalSecondaryIndexSettings []*ReplicaGlobalSecondaryIndexSettingsDescription `type:"list"`
 
+	// Autoscaling settings for a global table replica's read capacity units.
+	ReplicaProvisionedReadCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
+
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException. For more information, see Specifying
 	// Read and Write Requirements (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput)
 	// in the Amazon DynamoDB Developer Guide.
 	ReplicaProvisionedReadCapacityUnits *int64 `min:"1" type:"long"`
+
+	// AutoScaling settings for a global table replica's write capacity units.
+	ReplicaProvisionedWriteCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
 
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException. For more information, see Specifying Read and Write
@@ -9903,9 +10347,21 @@ func (s *ReplicaSettingsDescription) SetReplicaGlobalSecondaryIndexSettings(v []
 	return s
 }
 
+// SetReplicaProvisionedReadCapacityAutoScalingSettings sets the ReplicaProvisionedReadCapacityAutoScalingSettings field's value.
+func (s *ReplicaSettingsDescription) SetReplicaProvisionedReadCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaSettingsDescription {
+	s.ReplicaProvisionedReadCapacityAutoScalingSettings = v
+	return s
+}
+
 // SetReplicaProvisionedReadCapacityUnits sets the ReplicaProvisionedReadCapacityUnits field's value.
 func (s *ReplicaSettingsDescription) SetReplicaProvisionedReadCapacityUnits(v int64) *ReplicaSettingsDescription {
 	s.ReplicaProvisionedReadCapacityUnits = &v
+	return s
+}
+
+// SetReplicaProvisionedWriteCapacityAutoScalingSettings sets the ReplicaProvisionedWriteCapacityAutoScalingSettings field's value.
+func (s *ReplicaSettingsDescription) SetReplicaProvisionedWriteCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaSettingsDescription {
+	s.ReplicaProvisionedWriteCapacityAutoScalingSettings = v
 	return s
 }
 
@@ -9933,6 +10389,10 @@ type ReplicaSettingsUpdate struct {
 	// Represents the settings of a global secondary index for a global table that
 	// will be modified.
 	ReplicaGlobalSecondaryIndexSettingsUpdate []*ReplicaGlobalSecondaryIndexSettingsUpdate `min:"1" type:"list"`
+
+	// Autoscaling settings for managing a global table replica's read capacity
+	// units.
+	ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
 
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException. For more information, see Specifying
@@ -9973,6 +10433,11 @@ func (s *ReplicaSettingsUpdate) Validate() error {
 			}
 		}
 	}
+	if s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9989,6 +10454,12 @@ func (s *ReplicaSettingsUpdate) SetRegionName(v string) *ReplicaSettingsUpdate {
 // SetReplicaGlobalSecondaryIndexSettingsUpdate sets the ReplicaGlobalSecondaryIndexSettingsUpdate field's value.
 func (s *ReplicaSettingsUpdate) SetReplicaGlobalSecondaryIndexSettingsUpdate(v []*ReplicaGlobalSecondaryIndexSettingsUpdate) *ReplicaSettingsUpdate {
 	s.ReplicaGlobalSecondaryIndexSettingsUpdate = v
+	return s
+}
+
+// SetReplicaProvisionedReadCapacityAutoScalingSettingsUpdate sets the ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate field's value.
+func (s *ReplicaSettingsUpdate) SetReplicaProvisionedReadCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *ReplicaSettingsUpdate {
+	s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -11955,6 +12426,10 @@ type UpdateGlobalTableSettingsInput struct {
 	// GlobalTableName is a required field
 	GlobalTableName *string `min:"3" type:"string" required:"true"`
 
+	// AutoScaling settings for managing provisioned write capacity for the global
+	// table.
+	GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
+
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
 	GlobalTableProvisionedWriteCapacityUnits *int64 `min:"1" type:"long"`
@@ -12001,6 +12476,11 @@ func (s *UpdateGlobalTableSettingsInput) Validate() error {
 			}
 		}
 	}
+	if s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.ReplicaSettingsUpdate != nil {
 		for i, v := range s.ReplicaSettingsUpdate {
 			if v == nil {
@@ -12027,6 +12507,12 @@ func (s *UpdateGlobalTableSettingsInput) SetGlobalTableGlobalSecondaryIndexSetti
 // SetGlobalTableName sets the GlobalTableName field's value.
 func (s *UpdateGlobalTableSettingsInput) SetGlobalTableName(v string) *UpdateGlobalTableSettingsInput {
 	s.GlobalTableName = &v
+	return s
+}
+
+// SetGlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate sets the GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate field's value.
+func (s *UpdateGlobalTableSettingsInput) SetGlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *UpdateGlobalTableSettingsInput {
+	s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 


### PR DESCRIPTION
Release v1.14.32 (2018-07-24)
===

### Service Client Updates
* `service/dynamodb`: Updates service API and documentation
  * With this SDK update, APIs UpdateGlobalTableSettings and DescribeGlobalTableSettings now allow consistently configuring AutoScaling settings for a DynamoDB global table. Previously, they would only allow consistently setting IOPS. Now new APIs are being released, existing APIs are being extended.

