### PR TITLE
private/model/api: Fix SDKs generation of APIs sharing input/output types

### DIFF
--- a/private/model/api/eventstream.go
+++ b/private/model/api/eventstream.go
@@ -127,7 +127,13 @@ func (a *API) setupEventStreams() {
 			Type:           "structure",
 			EventStreamAPI: op.EventStreamAPI,
 			IsEventStream:  true,
+			MemberRefs: map[string]*ShapeRef{
+				"Inbound": &ShapeRef{
+					ShapeName: inbound.Shape.ShapeName,
+				},
+			},
 		}
+		inbound.Shape.refs = append(inbound.Shape.refs, streamShape.MemberRefs["Inbound"])
 		streamShapeRef := &ShapeRef{
 			API:           a,
 			ShapeName:     streamShape.ShapeName,
@@ -837,7 +843,7 @@ var eventStreamTestTmpl = template.Must(
 		"ValueForType":               valueForType,
 		"HasNonBlobPayloadMembers":   eventHasNonBlobPayloadMembers,
 		"SetEventHeaderValueForType": setEventHeaderValueForType,
-		"Map":                        templateMap,
+		"Map": templateMap,
 		"OptionalAddInt": func(do bool, a, b int) int {
 			if !do {
 				return a

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -40,13 +40,11 @@ func (a *API) Setup() {
 	a.resolveReferences()
 	a.fixStutterNames()
 	a.renameExportable()
-	if !a.NoRenameToplevelShapes {
-		a.renameToplevelShapes()
-	}
+
+	a.createInputOutputShapes()
 
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()
-	a.createInputOutputShapes()
 	a.suppressHTTP2EventStreams()
 	a.setupEventStreams()
 	a.customizationPasses()

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -157,7 +157,7 @@ func TestUniqueInputAndOutputs(t *testing.T) {
 		}
 
 		a.fixStutterNames()
-		a.renameToplevelShapes()
+		a.createInputOutputShapes()
 		for k, v := range expected {
 			if a.Operations[k].InputRef.Shape.ShapeName != v[0] {
 				t.Errorf("Error %s case: Expected %q, but received %q", k, v[0], a.Operations[k].InputRef.Shape.ShapeName)


### PR DESCRIPTION
…Fixes the SDK's generation of API operation input and output types to
use types that are specific to the API operation. This fixes the SDK
incorrectly renaming input or output shapes based on the last API
operation to used the shared type.

Fix #2070


TODO:
* [ ] prevent existing wrongly renamed types from being "correctly" renamed (prevents further breaking change)
* [ ] Add testing of model reusing input/output across APIs.