### PR TITLE
check for error on iter.Next()

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -338,6 +338,11 @@ func (d *BatchDelete) Delete(ctx aws.Context, iter BatchDeleteIterator) error {
 		}
 	}
 
+	// iter.Next() could return false (above) plus populate iter.Err()
+	if iter.Err() != nil {
+		errs = append(errs, newError(iter.Err(), nil, nil))
+	}
+
 	if input != nil && len(input.Delete.Objects) > 0 {
 		if err := deleteBatch(ctx, d, input, objects); err != nil {
 			errs = append(errs, err...)


### PR DESCRIPTION
iter.Next() can run into a permissions issue (ie can't s3:ListBucket) and populate iter.Err() while returning false. currently the code will just silently eat the error and calls like NewBatchDeleteWithClient().Delete() will indicate success but leave later DeleteBucket() calls to fail because the bucket is not empty.

after exiting the iter.Next() loop, check for any error that might have been set. while the output is not ideal, some error is better than none. it now looks like:

BatchedDeleteIncomplete: some objects have failed to be deleted.                        
caused by: failed to perform batch operation on "" to "":
AccessDenied: Access Denied
        status code: 403, request id: REQUEST_ID, host id: HOST_ID


For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
