### PR TITLE
service/s3/s3manager: Document default behavior for Upload's MaxNumParts

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -241,6 +241,8 @@ type Uploader struct {
 	// E.g: 5GB file, with MaxUploadParts set to 100, will upload the file
 	// as 100, 50MB parts.
 	// With a limited of s3.MaxUploadParts (10,000 parts).
+	//
+	// Defaults to package const's MaxUploadParts value.
 	MaxUploadParts int
 
 	// The client to use when uploading to S3.
@@ -476,6 +478,9 @@ func (u *uploader) init() {
 	}
 	if u.cfg.PartSize == 0 {
 		u.cfg.PartSize = DefaultUploadPartSize
+	}
+	if u.cfg.MaxUploadParts == 0 {
+		u.cfg.MaxUploadParts = MaxUploadParts
 	}
 
 	u.bufferPool = sync.Pool{


### PR DESCRIPTION
Updates the S3 Upload Manager's default behavior for MaxNumParts, and
ensures that the Uploader.MaxNumPart's member value is initialized
properly if the type was created via struct initialization instead of
using the `NewUploader` function.

Fix #2015