### PR TITLE
private/protocol/xml/xmlutil: Fix SDK marshaling of empty types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,6 @@
   * Adds workaround to correct the endpoint for Application Autoscaling running in AWS China. This will allow your application to make API calls to Application Autoscaling service in AWS China.
   * Fixes [#2079](https://github.com/aws/aws-sdk-go/issues/2079)
   * Fixes [#1957](https://github.com/aws/aws-sdk-go/issues/1957)
+* `private/protocol/xml/xmlutil`: Fix SDK marshaling of empty types ([#2081](https://github.com/aws/aws-sdk-go/pull/2081))
+  * Fixes the SDK's marshaling of types without members. This corrects the issue where the SDK would not marshal an XML tag for a type, if that type did not have any exported members.
+  * Fixes [#2015](https://github.com/aws/aws-sdk-go/issues/2015)

--- a/private/protocol/xml/xmlutil/build.go
+++ b/private/protocol/xml/xmlutil/build.go
@@ -94,8 +94,6 @@ func (b *xmlBuilder) buildStruct(value reflect.Value, current *XMLNode, tag refl
 		return nil
 	}
 
-	fieldAdded := false
-
 	// unwrap payloads
 	if payload := tag.Get("payload"); payload != "" {
 		field, _ := value.Type().FieldByName(payload)
@@ -123,6 +121,8 @@ func (b *xmlBuilder) buildStruct(value reflect.Value, current *XMLNode, tag refl
 		child.Attr = append(child.Attr, ns)
 	}
 
+	var payloadFields, nonPayloadFields int
+
 	t := value.Type()
 	for i := 0; i < value.NumField(); i++ {
 		member := elemOf(value.Field(i))
@@ -137,8 +137,10 @@ func (b *xmlBuilder) buildStruct(value reflect.Value, current *XMLNode, tag refl
 
 		mTag := field.Tag
 		if mTag.Get("location") != "" { // skip non-body members
+			nonPayloadFields++
 			continue
 		}
+		payloadFields++
 
 		if protocol.CanSetIdempotencyToken(value.Field(i), field) {
 			token := protocol.GetIdempotencyToken()
@@ -153,11 +155,11 @@ func (b *xmlBuilder) buildStruct(value reflect.Value, current *XMLNode, tag refl
 		if err := b.buildValue(member, child, mTag); err != nil {
 			return err
 		}
-
-		fieldAdded = true
 	}
 
-	if fieldAdded { // only append this child if we have one ore more valid members
+	// Only case where the child shape is not added is if the shape only contains
+	// non-payload fields, e.g headers/query.
+	if !(payloadFields == 0 && nonPayloadFields > 0) {
 		current.AddChild(child)
 	}
 


### PR DESCRIPTION
Fixes the SDK's marshaling of types without members. This corrects the
issue where the SDK would not marshal an XML tag for a type, if that
type did not have any exported members.

Fix #2015