### PR TITLE
private/model/api: Improve error message for invalid doc model operation

### DIFF
--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -47,8 +47,13 @@ func (a *API) AttachDocs(filename string) {
 func (d *apiDocumentation) setup() {
 	d.API.Documentation = docstring(d.Service)
 
-	for op, doc := range d.Operations {
-		d.API.Operations[op].Documentation = docstring(doc)
+	for opName, doc := range d.Operations {
+		if _, ok := d.API.Operations[opName]; !ok {
+			panic(fmt.Sprintf("%s, doc op %q not found in API op set, %v",
+				d.API.name, opName, d.API.OperationNames()),
+			)
+		}
+		d.API.Operations[opName].Documentation = docstring(doc)
 	}
 
 	for shape, info := range d.Shapes {


### PR DESCRIPTION
Improves the error message generated when a service as invalid doc models referring to API operations not defined in the `api-2.json` file.