### PR TITLE
 service/dynamodb/dynamodbattribute: Add support marshalling and unmarshalling nil map/slice to empty map/slice

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -191,7 +191,7 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	case len(av.SS) != 0:
 		return d.decodeStringSet(av.SS, v)
 	}
-
+	d.decodeEmpty(fieldTag.NilAsEmpty, av, v)
 	return nil
 }
 
@@ -605,6 +605,16 @@ func (d *Decoder) decodeStringSet(ss []*string, v reflect.Value) error {
 	}
 
 	return nil
+}
+
+func (d *Decoder) decodeEmpty(nilAsEmpty bool, av *dynamodb.AttributeValue, v reflect.Value) {
+	if !nilAsEmpty {
+		return
+	}
+	switch {
+	case len(av.B) == 0, len(av.BS) == 0, len(av.NS) == 0, len(av.SS) == 0, len(av.L) == 0, len(av.M) == 0:
+		d.decodeNull(nilAsEmpty, v)
+	}
 }
 
 func decodeUnixTime(n string) (time.Time, error) {

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -620,3 +620,99 @@ func TestDecodeAliasedUnixTime(t *testing.T) {
 		t.Errorf("expect %v, got %v", expect, actual)
 	}
 }
+
+func TestUnmarshallNilMapAsEmpty(t *testing.T) {
+	input := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {NULL: aws.Bool(true)},
+		},
+	}
+	actual := &testNilAsEmptyElemMapStruct{}
+	expect := &testNilAsEmptyElemMapStruct{
+		Values: map[string]interface{}{},
+	}
+
+	err := Unmarshal(input, actual)
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestUnmarshallNilMapAsNil(t *testing.T) {
+	input := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {NULL: aws.Bool(true)},
+		},
+	}
+	actual := &testNilElemMapStruct{}
+	expect := &testNilElemMapStruct{
+		Values: nil,
+	}
+
+	err := Unmarshal(input, actual)
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestUnmarshallNilSliceAsEmpty(t *testing.T) {
+	input := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {NULL: aws.Bool(true)},
+			"StringSet": {NULL: aws.Bool(true)},
+			"NumberSet": {NULL: aws.Bool(true)},
+			"OtherList": {NULL: aws.Bool(true)},
+		},
+	}
+	actual := &testNilListIsEmptyStruct{}
+	expect := &testNilListIsEmptyStruct{
+		BinarySet: [][]byte{},
+		StringSet: []*string{},
+		NumberSet: []int{},
+		OtherList: []string{},
+	}
+
+	err := Unmarshal(input, actual)
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestUnmarshallNilSliceAsNil(t *testing.T) {
+	input := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {NULL: aws.Bool(true)},
+			"StringSet": {NULL: aws.Bool(true)},
+			"NumberSet": {NULL: aws.Bool(true)},
+			"OtherList": {NULL: aws.Bool(true)},
+		},
+	}
+
+	actual := &testNilListIsNilStruct{}
+
+	expect := &testNilListIsNilStruct{
+		BinarySet: nil,
+		StringSet: nil,
+		NumberSet: nil,
+		OtherList: nil,
+	}
+	err := Unmarshal(input, actual)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -737,14 +737,12 @@ func TestUnmarshalNilAsEmptyForEmptyInput(t *testing.T) {
 
 func tableTestUnmarshalAssertion(t *testing.T, tests []UnmarshalHelperStruct) {
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := Unmarshal(tt.input, tt.actual)
-			if err != nil {
-				t.Errorf("expect nil, got %v", err)
-			}
-			if e, a := tt.expect, tt.actual; !reflect.DeepEqual(e, a) {
-				t.Errorf("%s: expect %v, got %v", tt.name, e, a)
-			}
-		})
+		err := Unmarshal(tt.input, tt.actual)
+		if err != nil {
+			t.Errorf("expect nil, got %v", err)
+		}
+		if e, a := tt.expect, tt.actual; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expect %v, got %v", tt.name, e, a)
+		}
 	}
 }

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -357,7 +357,9 @@ func (e *Encoder) encodeMap(av *dynamodb.AttributeValue, v reflect.Value, fieldT
 
 		av.M[keyName] = elem
 	}
-	keepNilOrEmpty(av, reflect.Map, fieldTag.NilAsEmpty)
+	if len(av.M) == 0 {
+		keepNilOrEmpty(av, reflect.Map, fieldTag.NilAsEmpty)
+	}
 	return nil
 }
 
@@ -581,9 +583,6 @@ func tryMarshaler(av *dynamodb.AttributeValue, v reflect.Value) (bool, error) {
 }
 
 func keepNilOrEmpty(av *dynamodb.AttributeValue, kind reflect.Kind, nilAsEmpty bool) {
-	if len(av.M) != 0 {
-		return
-	}
 	if !nilAsEmpty {
 		encodeNull(av)
 		return

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -371,7 +371,7 @@ func (e *Encoder) encodeSlice(av *dynamodb.AttributeValue, v reflect.Value, fiel
 
 		b := slice.Bytes()
 		if len(b) == 0 {
-			encodeNull(av)
+			keepNilOrEmpty(av, reflect.Slice, fieldTag.NilAsEmpty)
 			return nil
 		}
 		av.B = append([]byte{}, b...)
@@ -416,7 +416,7 @@ func (e *Encoder) encodeSlice(av *dynamodb.AttributeValue, v reflect.Value, fiel
 		if n, err := e.encodeList(v, fieldTag, elemFn); err != nil {
 			return err
 		} else if n == 0 {
-			encodeNull(av)
+			keepNilOrEmpty(av, reflect.Slice, fieldTag.NilAsEmpty)
 		}
 	}
 
@@ -590,6 +590,8 @@ func keepNilOrEmpty(av *dynamodb.AttributeValue, kind reflect.Kind, nilAsEmpty b
 	switch kind {
 	case reflect.Map:
 		encodeEmptyMap(av)
+	case reflect.Slice:
+		return
 	default:
 		encodeNull(av)
 	}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -357,11 +357,18 @@ func (e *Encoder) encodeMap(av *dynamodb.AttributeValue, v reflect.Value, fieldT
 
 		av.M[keyName] = elem
 	}
-	if len(av.M) == 0 {
-		encodeNull(av)
-	}
-
+	keepNilOrEmpty(av, fieldTag)
 	return nil
+}
+
+func keepNilOrEmpty(av *dynamodb.AttributeValue, fieldTag tag) {
+	if len(av.M) == 0  {
+		if fieldTag.NilAsEmpty {
+			encodeEmptyMap(av)
+		} else {
+			encodeNull(av)
+		}
+	}
 }
 
 func (e *Encoder) encodeSlice(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
@@ -532,6 +539,10 @@ func encodeFloat(f float64) string {
 func encodeNull(av *dynamodb.AttributeValue) {
 	t := true
 	*av = dynamodb.AttributeValue{NULL: &t}
+}
+
+func encodeEmptyMap(av *dynamodb.AttributeValue) {
+	*av = dynamodb.AttributeValue{M: make(map[string]*dynamodb.AttributeValue)}
 }
 
 func valueElem(v reflect.Value) reflect.Value {

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -362,7 +362,7 @@ func (e *Encoder) encodeMap(av *dynamodb.AttributeValue, v reflect.Value, fieldT
 }
 
 func keepNilOrEmpty(av *dynamodb.AttributeValue, fieldTag tag) {
-	if len(av.M) == 0  {
+	if len(av.M) == 0 {
 		if fieldTag.NilAsEmpty {
 			encodeEmptyMap(av)
 		} else {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -406,14 +406,12 @@ func TestMarshalEmptyForEmptyOrNilInput(t *testing.T) {
 
 func tableTestMarshalAssertion(t *testing.T, tests []MarshalHelperStruct) {
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.actual, tt.err = Marshal(tt.input)
-			if tt.err != nil {
-				t.Errorf("expect nil, got %v", tt.err)
-			}
-			if e, a := tt.expect, tt.actual; !reflect.DeepEqual(e, a) {
-				t.Errorf("%s: expect %v, got %v", tt.name, e, a)
-			}
-		})
+		tt.actual, tt.err = Marshal(tt.input)
+		if tt.err != nil {
+			t.Errorf("expect nil, got %v", tt.err)
+		}
+		if e, a := tt.expect, tt.actual; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expect %v, got %v", tt.name, e, a)
+		}
 	}
 }

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -90,6 +90,10 @@ type testOmitEmptyElemMapStruct struct {
 	Values map[string]interface{} `dynamodbav:",omitemptyelem"`
 }
 
+type testNilAsEmptyElemMapStruct struct {
+	Values map[string]interface{} `dynamodbav:",omitemptyelem,nilasempty"`
+}
+
 func TestMarshalListOmitEmptyElem(t *testing.T) {
 	expect := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
@@ -126,6 +130,26 @@ func TestMarshalMapOmitEmptyElem(t *testing.T) {
 		"efg": nil,
 		"hij": "",
 		"klm": "abc",
+	}}
+
+	actual, err := Marshal(m)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestMarshalMapNilAsEmpty(t *testing.T) {
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {M: map[string]*dynamodb.AttributeValue{
+			}},
+		},
+	}
+
+	m := testNilAsEmptyElemMapStruct{Values: map[string]interface{}{
 	}}
 
 	actual, err := Marshal(m)

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -144,13 +144,11 @@ func TestMarshalMapOmitEmptyElem(t *testing.T) {
 func TestMarshalMapNilAsEmpty(t *testing.T) {
 	expect := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
-			"Values": {M: map[string]*dynamodb.AttributeValue{
-			}},
+			"Values": {M: map[string]*dynamodb.AttributeValue{}},
 		},
 	}
 
-	m := testNilAsEmptyElemMapStruct{Values: map[string]interface{}{
-	}}
+	m := testNilAsEmptyElemMapStruct{Values: map[string]interface{}{}}
 
 	actual, err := Marshal(m)
 	if err != nil {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -94,6 +94,10 @@ type testNilAsEmptyElemMapStruct struct {
 	Values map[string]interface{} `dynamodbav:",omitemptyelem,nilasempty"`
 }
 
+type testNilElemMapStruct struct {
+	Values map[string]interface{}
+}
+
 func TestMarshalListOmitEmptyElem(t *testing.T) {
 	expect := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
@@ -149,6 +153,24 @@ func TestMarshalMapNilAsEmpty(t *testing.T) {
 	}
 
 	m := testNilAsEmptyElemMapStruct{Values: map[string]interface{}{}}
+
+	actual, err := Marshal(m)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestMarshalMapNil(t *testing.T) {
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {NULL: aws.Bool(true)},
+		},
+	}
+
+	m := testNilElemMapStruct{Values: map[string]interface{}{}}
 
 	actual, err := Marshal(m)
 	if err != nil {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -313,3 +313,69 @@ func TestEncodeAliasedUnixTime(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
+
+type testNilListIsNilStruct struct {
+	BinarySet [][]byte  `dynamodbav:",binaryset"`
+	StringSet []*string `dynamodbav:",stringset"`
+	NumberSet []int     `dynamodbav:",numberset"`
+	OtherList []string
+}
+
+type testNilListIsEmptyStruct struct {
+	BinarySet [][]byte  `dynamodbav:",binaryset,nilasempty"`
+	StringSet []*string `dynamodbav:",stringset,nilasempty"`
+	NumberSet []int     `dynamodbav:",numberset,nilasempty"`
+	OtherList []string  `dynamodbav:",nilasempty"`
+}
+
+func TestNilSliceIsNilListIsNil(t *testing.T) {
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {NULL: aws.Bool(true)},
+			"StringSet": {NULL: aws.Bool(true)},
+			"NumberSet": {NULL: aws.Bool(true)},
+			"OtherList": {NULL: aws.Bool(true)},
+		},
+	}
+
+	m := testNilListIsNilStruct{
+		BinarySet: [][]byte{},
+		StringSet: []*string{},
+		NumberSet: []int{},
+		OtherList: []string{},
+	}
+
+	actual, err := Marshal(m)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestNilSliceIsEmpty(t *testing.T) {
+	expect := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {BS: [][]byte{}},
+			"StringSet": {SS: []*string{}},
+			"NumberSet": {NS: []*string{}},
+			"OtherList": {L: []*dynamodb.AttributeValue{}},
+		},
+	}
+
+	m := testNilListIsEmptyStruct{
+		BinarySet: [][]byte{},
+		StringSet: []*string{},
+		NumberSet: []int{},
+		OtherList: []string{},
+	}
+
+	actual, err := Marshal(m)
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := expect, actual; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}

--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -13,6 +13,7 @@ type tag struct {
 	AsString                     bool
 	AsBinSet, AsNumSet, AsStrSet bool
 	AsUnixTime                   bool
+	NilAsEmpty                   bool
 }
 
 func (t *tag) parseAVTag(structTag reflect.StructTag) {
@@ -63,6 +64,8 @@ func (t *tag) parseTagStr(tagStr string) {
 			t.AsStrSet = true
 		case "unixtime":
 			t.AsUnixTime = true
+		case "nilasempty":
+			t.NilAsEmpty = true
 		}
 	}
 }


### PR DESCRIPTION
#682 and aws/aws-sdk-go-v2#195 discusses a new feature to marshall maps as empty maps based on a tag. 
I have introduced `NilAsEmpty` tag, I have include code and tests for maps. If this approach is okay then I can do this for list too.
