### PR TITLE
example/service/s3/sync: Adding mimetype handling to the sync example

### DIFF
--- a/example/service/s3/sync/sync.go
+++ b/example/service/s3/sync/sync.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"

--- a/example/service/s3/sync/sync.go
+++ b/example/service/s3/sync/sync.go
@@ -70,8 +70,7 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 		iter.err = err
 	}
 
-	fileSplit := strings.Split(fi.key, ".")
-	extension := "." + fileSplit[len(fileSplit)-1]
+	extension := filepath.Ext(fi.key)
 	mimeType := mime.TypeByExtension(extension)
 
 	if mimeType == "" {
@@ -82,7 +81,7 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 		Bucket:      &iter.bucket,
 		Key:         &fi.key,
 		Body:        body,
-		ContentType: aws.String(mimeType),
+		ContentType: &mimeType,
 	}
 
 	return s3manager.BatchUploadObject{

--- a/example/service/s3/sync/sync.go
+++ b/example/service/s3/sync/sync.go
@@ -69,10 +69,19 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 		iter.err = err
 	}
 
+	fileSplit := strings.Split(fi.key, ".")
+	extension := "." + fileSplit[len(fileSplit)-1]
+	mimeType := mime.TypeByExtension(extension)
+
+	if mimeType == "" {
+		mimeType = "binary/octet-stream"
+	}
+
 	input := s3manager.UploadInput{
-		Bucket: &iter.bucket,
-		Key:    &fi.key,
-		Body:   body,
+		Bucket:      &iter.bucket,
+		Key:         &fi.key,
+		Body:        body,
+		ContentType: aws.String(mimeType),
 	}
 
 	return s3manager.BatchUploadObject{


### PR DESCRIPTION
Not sure if this is preferred, but I used this in some code for uploading some static HTML / CSS / JS, and S3 needed the ContentType to not just send the content as binary/octet-string. 

This will work when there's no file extension, as it will look up ".name".  This only gets funky if you have a file called "js", "html", etc.