### PR TITLE
v1.15.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+Release v1.15.14 (2018-08-16)
+===
+
+### Service Client Updates
+* `service/discovery`: Updates service API, documentation, and paginators
+  * The Application Discovery Service's Continuous Export APIs allow you to analyze your on-premises server inventory data, including system performance and network dependencies, in Amazon Athena.
+* `service/ec2`: Updates service API
+  * The 'Attribute' parameter DescribeVolumeAttribute request has been marked as required - the API has always required this parameter, but up until now this wasn't reflected appropriately in the SDK.
+* `service/mediaconvert`: Updates service API and documentation
+  * Added WriteSegmentTimelineInRepresentation option for Dash Outputs
+* `service/redshift`: Updates service API and documentation
+  * You can now resize your Amazon Redshift cluster quickly. With the new ResizeCluster action, your cluster is available for read and write operations within minutes
+* `service/ssm`: Updates service API and documentation
+  * AWS Systems Manager Inventory now supports groups to quickly see a count of which managed instances are and arent configured to collect one or more Inventory types
+
 Release v1.15.13 (2018-08-15)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.15.13"
+const SDKVersion = "1.15.14"

--- a/models/apis/discovery/2015-11-01/api-2.json
+++ b/models/apis/discovery/2015-11-01/api-2.json
@@ -119,6 +119,23 @@
         {"shape":"ServerInternalErrorException"}
       ]
     },
+    "DescribeContinuousExports":{
+      "name":"DescribeContinuousExports",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"DescribeContinuousExportsRequest"},
+      "output":{"shape":"DescribeContinuousExportsResponse"},
+      "errors":[
+        {"shape":"AuthorizationErrorException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ServerInternalErrorException"},
+        {"shape":"OperationNotPermittedException"},
+        {"shape":"ResourceNotFoundException"}
+      ]
+    },
     "DescribeExportConfigurations":{
       "name":"DescribeExportConfigurations",
       "http":{
@@ -244,6 +261,24 @@
         {"shape":"ServerInternalErrorException"}
       ]
     },
+    "StartContinuousExport":{
+      "name":"StartContinuousExport",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"StartContinuousExportRequest"},
+      "output":{"shape":"StartContinuousExportResponse"},
+      "errors":[
+        {"shape":"ConflictErrorException"},
+        {"shape":"AuthorizationErrorException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ServerInternalErrorException"},
+        {"shape":"OperationNotPermittedException"},
+        {"shape":"ResourceInUseException"}
+      ]
+    },
     "StartDataCollectionByAgentIds":{
       "name":"StartDataCollectionByAgentIds",
       "http":{
@@ -273,6 +308,24 @@
         {"shape":"InvalidParameterValueException"},
         {"shape":"ServerInternalErrorException"},
         {"shape":"OperationNotPermittedException"}
+      ]
+    },
+    "StopContinuousExport":{
+      "name":"StopContinuousExport",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"StopContinuousExportRequest"},
+      "output":{"shape":"StopContinuousExportResponse"},
+      "errors":[
+        {"shape":"AuthorizationErrorException"},
+        {"shape":"InvalidParameterException"},
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ServerInternalErrorException"},
+        {"shape":"OperationNotPermittedException"},
+        {"shape":"ResourceNotFoundException"},
+        {"shape":"ResourceInUseException"}
       ]
     },
     "StopDataCollectionByAgentIds":{
@@ -438,6 +491,46 @@
     },
     "ConfigurationsDownloadUrl":{"type":"string"},
     "ConfigurationsExportId":{"type":"string"},
+    "ConflictErrorException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"Message"}
+      },
+      "exception":true
+    },
+    "ContinuousExportDescription":{
+      "type":"structure",
+      "members":{
+        "exportId":{"shape":"ConfigurationsExportId"},
+        "status":{"shape":"ContinuousExportStatus"},
+        "statusDetail":{"shape":"StringMax255"},
+        "s3Bucket":{"shape":"S3Bucket"},
+        "startTime":{"shape":"TimeStamp"},
+        "stopTime":{"shape":"TimeStamp"},
+        "dataSource":{"shape":"DataSource"},
+        "schemaStorageConfig":{"shape":"SchemaStorageConfig"}
+      }
+    },
+    "ContinuousExportDescriptions":{
+      "type":"list",
+      "member":{"shape":"ContinuousExportDescription"}
+    },
+    "ContinuousExportIds":{
+      "type":"list",
+      "member":{"shape":"ConfigurationsExportId"}
+    },
+    "ContinuousExportStatus":{
+      "type":"string",
+      "enum":[
+        "START_IN_PROGRESS",
+        "START_FAILED",
+        "ACTIVE",
+        "ERROR",
+        "STOP_IN_PROGRESS",
+        "STOP_FAILED",
+        "INACTIVE"
+      ]
+    },
     "CreateApplicationRequest":{
       "type":"structure",
       "required":["name"],
@@ -510,6 +603,15 @@
         "unknownConnectors":{"shape":"Integer"}
       }
     },
+    "DataSource":{
+      "type":"string",
+      "enum":["AGENT"]
+    },
+    "DatabaseName":{
+      "type":"string",
+      "max":252,
+      "min":1
+    },
     "DeleteApplicationsRequest":{
       "type":"structure",
       "required":["configurationIds"],
@@ -571,6 +673,27 @@
       "type":"structure",
       "members":{
         "configurations":{"shape":"DescribeConfigurationsAttributes"}
+      }
+    },
+    "DescribeContinuousExportsMaxResults":{
+      "type":"integer",
+      "box":true,
+      "max":100,
+      "min":1
+    },
+    "DescribeContinuousExportsRequest":{
+      "type":"structure",
+      "members":{
+        "exportIds":{"shape":"ContinuousExportIds"},
+        "maxResults":{"shape":"DescribeContinuousExportsMaxResults"},
+        "nextToken":{"shape":"NextToken"}
+      }
+    },
+    "DescribeContinuousExportsResponse":{
+      "type":"structure",
+      "members":{
+        "descriptions":{"shape":"ContinuousExportDescriptions"},
+        "nextToken":{"shape":"NextToken"}
       }
     },
     "DescribeExportConfigurationsRequest":{
@@ -839,12 +962,25 @@
       "type":"list",
       "member":{"shape":"OrderByElement"}
     },
+    "ResourceInUseException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"Message"}
+      },
+      "exception":true
+    },
     "ResourceNotFoundException":{
       "type":"structure",
       "members":{
         "message":{"shape":"Message"}
       },
       "exception":true
+    },
+    "S3Bucket":{"type":"string"},
+    "SchemaStorageConfig":{
+      "type":"map",
+      "key":{"shape":"DatabaseName"},
+      "value":{"shape":"String"}
     },
     "ServerInternalErrorException":{
       "type":"structure",
@@ -853,6 +989,21 @@
       },
       "exception":true,
       "fault":true
+    },
+    "StartContinuousExportRequest":{
+      "type":"structure",
+      "members":{
+      }
+    },
+    "StartContinuousExportResponse":{
+      "type":"structure",
+      "members":{
+        "exportId":{"shape":"ConfigurationsExportId"},
+        "s3Bucket":{"shape":"S3Bucket"},
+        "startTime":{"shape":"TimeStamp"},
+        "dataSource":{"shape":"DataSource"},
+        "schemaStorageConfig":{"shape":"SchemaStorageConfig"}
+      }
     },
     "StartDataCollectionByAgentIdsRequest":{
       "type":"structure",
@@ -882,6 +1033,20 @@
         "exportId":{"shape":"ConfigurationsExportId"}
       }
     },
+    "StopContinuousExportRequest":{
+      "type":"structure",
+      "required":["exportId"],
+      "members":{
+        "exportId":{"shape":"ConfigurationsExportId"}
+      }
+    },
+    "StopContinuousExportResponse":{
+      "type":"structure",
+      "members":{
+        "startTime":{"shape":"TimeStamp"},
+        "stopTime":{"shape":"TimeStamp"}
+      }
+    },
     "StopDataCollectionByAgentIdsRequest":{
       "type":"structure",
       "required":["agentIds"],
@@ -896,6 +1061,11 @@
       }
     },
     "String":{"type":"string"},
+    "StringMax255":{
+      "type":"string",
+      "max":255,
+      "min":1
+    },
     "Tag":{
       "type":"structure",
       "required":[

--- a/models/apis/discovery/2015-11-01/docs-2.json
+++ b/models/apis/discovery/2015-11-01/docs-2.json
@@ -7,18 +7,21 @@
     "CreateTags": "<p>Creates one or more tags for configuration items. Tags are metadata that help you categorize IT assets. This API accepts a list of multiple configuration items.</p>",
     "DeleteApplications": "<p>Deletes a list of applications and their associations with configuration items.</p>",
     "DeleteTags": "<p>Deletes the association between configuration items and one or more tags. This API accepts a list of multiple configuration items.</p>",
-    "DescribeAgents": "<p>Lists agents or the Connector by ID or lists all agents/Connectors associated with your user account if you did not specify an ID.</p>",
-    "DescribeConfigurations": "<p>Retrieves attributes for a list of configuration item IDs. All of the supplied IDs must be for the same asset type (server, application, process, or connection). Output fields are specific to the asset type selected. For example, the output for a <i>server</i> configuration item includes a list of attributes about the server, such as host name, operating system, and number of network cards.</p> <p>For a complete list of outputs for each asset type, see <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html#DescribeConfigurations\">Using the DescribeConfigurations Action</a>.</p>",
-    "DescribeExportConfigurations": "<p>Deprecated. Use <code>DescribeExportTasks</code> instead.</p> <p>Retrieves the status of a given export process. You can retrieve status from a maximum of 100 processes.</p>",
+    "DescribeAgents": "<p>Lists agents or connectors as specified by ID or other filters. All agents/connectors associated with your user account can be listed if you call <code>DescribeAgents</code> as is without passing any parameters.</p>",
+    "DescribeConfigurations": "<p>Retrieves attributes for a list of configuration item IDs.</p> <note> <p>All of the supplied IDs must be for the same asset type from one of the follwoing:</p> <ul> <li> <p>server</p> </li> <li> <p>application</p> </li> <li> <p>process</p> </li> <li> <p>connection</p> </li> </ul> <p>Output fields are specific to the asset type specified. For example, the output for a <i>server</i> configuration item includes a list of attributes about the server, such as host name, operating system, number of network cards, etc.</p> <p>For a complete list of outputs for each asset type, see <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html#DescribeConfigurations\">Using the DescribeConfigurations Action</a>.</p> </note>",
+    "DescribeContinuousExports": "<p>Lists exports as specified by ID. All continuous exports associated with your user account can be listed if you call <code>DescribeContinuousExports</code> as is without passing any parameters.</p>",
+    "DescribeExportConfigurations": "<p> <code>DescribeExportConfigurations</code> is deprecated.</p> <p>Use instead <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html\"> <code>DescribeExportTasks</code> </a>.</p>",
     "DescribeExportTasks": "<p>Retrieve status of one or more export tasks. You can retrieve the status of up to 100 export tasks.</p>",
-    "DescribeTags": "<p>Retrieves a list of configuration items that are tagged with a specific tag. Or retrieves a list of all tags assigned to a specific configuration item.</p>",
+    "DescribeTags": "<p>Retrieves a list of configuration items that have tags as specified by the key-value pairs, name and value, passed to the optional parameter <code>filters</code>.</p> <p>There are three valid tag filter names:</p> <ul> <li> <p>tagKey</p> </li> <li> <p>tagValue</p> </li> <li> <p>configurationId</p> </li> </ul> <p>Also, all configuration items associated with your user account that have tags can be listed if you call <code>DescribeTags</code> as is without passing any parameters.</p>",
     "DisassociateConfigurationItemsFromApplication": "<p>Disassociates one or more configuration items from an application.</p>",
     "ExportConfigurations": "<p>Deprecated. Use <code>StartExportTask</code> instead.</p> <p>Exports all discovered configuration data to an Amazon S3 bucket or an application that enables you to view and evaluate the data. Data includes tags and tag associations, processes, connections, servers, and system performance. This API returns an export ID that you can query using the <i>DescribeExportConfigurations</i> API. The system imposes a limit of two configuration exports in six hours.</p>",
-    "GetDiscoverySummary": "<p>Retrieves a short summary of discovered assets.</p>",
-    "ListConfigurations": "<p>Retrieves a list of configuration items according to criteria that you specify in a filter. The filter criteria identifies the relationship requirements.</p>",
+    "GetDiscoverySummary": "<p>Retrieves a short summary of discovered assets.</p> <p>This API operation takes no request parameters and is called as is at the command prompt as shown in the example.</p>",
+    "ListConfigurations": "<p>Retrieves a list of configuration items as specified by the value passed to the required paramater <code>configurationType</code>. Optional filtering may be applied to refine search results.</p>",
     "ListServerNeighbors": "<p>Retrieves a list of servers that are one network hop away from a specified server.</p>",
+    "StartContinuousExport": "<p>Start the continuous flow of agent's discovered data into Amazon Athena.</p>",
     "StartDataCollectionByAgentIds": "<p>Instructs the specified agents or connectors to start collecting data.</p>",
     "StartExportTask": "<p> Begins the export of discovered data to an S3 bucket.</p> <p> If you specify <code>agentIds</code> in a filter, the task exports up to 72 hours of detailed data collected by the identified Application Discovery Agent, including network, process, and performance details. A time range for exported agent data may be set by using <code>startTime</code> and <code>endTime</code>. Export of detailed agent data is limited to five concurrently running exports. </p> <p> If you do not include an <code>agentIds</code> filter, summary data is exported that includes both AWS Agentless Discovery Connector data and summary data from AWS Discovery Agents. Export of summary data is limited to two exports per day. </p>",
+    "StopContinuousExport": "<p>Stop the continuous flow of agent's discovered data into Amazon Athena.</p>",
     "StopDataCollectionByAgentIds": "<p>Instructs the specified agents or connectors to stop collecting data.</p>",
     "UpdateApplication": "<p>Updates metadata about an application.</p>"
   },
@@ -193,10 +196,43 @@
     "ConfigurationsExportId": {
       "base": null,
       "refs": {
+        "ContinuousExportDescription$exportId": "<p>The unique ID assigned to this export.</p>",
+        "ContinuousExportIds$member": null,
         "ExportConfigurationsResponse$exportId": "<p>A unique identifier that you can use to query the export status.</p>",
         "ExportIds$member": null,
         "ExportInfo$exportId": "<p>A unique identifier used to query an export.</p>",
-        "StartExportTaskResponse$exportId": "<p>A unique identifier used to query the status of an export request.</p>"
+        "StartContinuousExportResponse$exportId": "<p>The unique ID assigned to this export.</p>",
+        "StartExportTaskResponse$exportId": "<p>A unique identifier used to query the status of an export request.</p>",
+        "StopContinuousExportRequest$exportId": "<p>The unique ID assigned to this export.</p>"
+      }
+    },
+    "ConflictErrorException": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
+    "ContinuousExportDescription": {
+      "base": "<p>A list of continuous export descriptions.</p>",
+      "refs": {
+        "ContinuousExportDescriptions$member": null
+      }
+    },
+    "ContinuousExportDescriptions": {
+      "base": null,
+      "refs": {
+        "DescribeContinuousExportsResponse$descriptions": "<p>A list of continuous export descriptions.</p>"
+      }
+    },
+    "ContinuousExportIds": {
+      "base": null,
+      "refs": {
+        "DescribeContinuousExportsRequest$exportIds": "<p>The unique IDs assigned to the exports.</p>"
+      }
+    },
+    "ContinuousExportStatus": {
+      "base": null,
+      "refs": {
+        "ContinuousExportDescription$status": "<p>Describes the status of the export. Can be one of the following values:</p> <ul> <li> <p>START_IN_PROGRESS - setting up resources to start continuous export.</p> </li> <li> <p>START_FAILED - an error occurred setting up continuous export. To recover, call start-continuous-export again.</p> </li> <li> <p>ACTIVE - data is being exported to the customer bucket.</p> </li> <li> <p>ERROR - an error occurred during export. To fix the issue, call stop-continuous-export and start-continuous-export.</p> </li> <li> <p>STOP_IN_PROGRESS - stopping the export.</p> </li> <li> <p>STOP_FAILED - an error occurred stopping the export. To recover, call stop-continuous-export again.</p> </li> <li> <p>INACTIVE - the continuous export has been stopped. Data is no longer being exported to the customer bucket.</p> </li> </ul>"
       }
     },
     "CreateApplicationRequest": {
@@ -229,6 +265,19 @@
       "base": "<p>Inventory data for installed discovery connectors.</p>",
       "refs": {
         "GetDiscoverySummaryResponse$connectorSummary": "<p>Details about discovered connectors, including connector status and health.</p>"
+      }
+    },
+    "DataSource": {
+      "base": null,
+      "refs": {
+        "ContinuousExportDescription$dataSource": "<p>The type of data collector used to gather this data (currently only offered for AGENT).</p>",
+        "StartContinuousExportResponse$dataSource": "<p>The type of data collector used to gather this data (currently only offered for AGENT).</p>"
+      }
+    },
+    "DatabaseName": {
+      "base": null,
+      "refs": {
+        "SchemaStorageConfig$key": null
       }
     },
     "DeleteApplicationsRequest": {
@@ -279,6 +328,22 @@
       }
     },
     "DescribeConfigurationsResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeContinuousExportsMaxResults": {
+      "base": null,
+      "refs": {
+        "DescribeContinuousExportsRequest$maxResults": "<p>A number between 1 and 100 specifying the maximum number of continuous export descriptions returned.</p>"
+      }
+    },
+    "DescribeContinuousExportsRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "DescribeContinuousExportsResponse": {
       "base": null,
       "refs": {
       }
@@ -356,7 +421,7 @@
     "ExportIds": {
       "base": null,
       "refs": {
-        "DescribeExportConfigurationsRequest$exportIds": "<p>A unique identifier that you can use to query the export status.</p>",
+        "DescribeExportConfigurationsRequest$exportIds": "<p>A list of continuous export ids to search for.</p>",
         "DescribeExportTasksRequest$exportIds": "<p>One or more unique identifiers used to query the status of an export request.</p>"
       }
     },
@@ -387,7 +452,7 @@
     "ExportsInfo": {
       "base": null,
       "refs": {
-        "DescribeExportConfigurationsResponse$exportsInfo": "<p>Returns export details. When the status is complete, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>",
+        "DescribeExportConfigurationsResponse$exportsInfo": "<p/>",
         "DescribeExportTasksResponse$exportsInfo": "<p>Contains one or more sets of export request details. When the status of a request is <code>SUCCEEDED</code>, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>"
       }
     },
@@ -453,7 +518,7 @@
         "CustomerConnectorInfo$totalConnectors": "<p>Total number of discovery connectors.</p>",
         "CustomerConnectorInfo$unknownConnectors": "<p>Number of unknown discovery connectors.</p>",
         "DescribeAgentsRequest$maxResults": "<p>The total number of agents/Connectors to return in a single page of output. The maximum value is 100.</p>",
-        "DescribeExportConfigurationsRequest$maxResults": "<p>The maximum number of results that you want to display as a part of the query.</p>",
+        "DescribeExportConfigurationsRequest$maxResults": "<p>A number between 1 and 100 specifying the maximum number of continuous export descriptions returned.</p>",
         "DescribeExportTasksRequest$maxResults": "<p>The maximum number of volume results returned by <code>DescribeExportTasks</code> in paginated output. When this parameter is used, <code>DescribeExportTasks</code> only returns <code>maxResults</code> results in a single page along with a <code>nextToken</code> response element.</p>",
         "DescribeTagsRequest$maxResults": "<p>The total number of items to return in a single page of output. The maximum value is 100.</p>",
         "ListConfigurationsRequest$maxResults": "<p>The total number of items to return. The maximum value is 100.</p>",
@@ -505,9 +570,11 @@
       "base": null,
       "refs": {
         "AuthorizationErrorException$message": null,
+        "ConflictErrorException$message": null,
         "InvalidParameterException$message": null,
         "InvalidParameterValueException$message": null,
         "OperationNotPermittedException$message": null,
+        "ResourceInUseException$message": null,
         "ResourceNotFoundException$message": null,
         "ServerInternalErrorException$message": null
       }
@@ -529,8 +596,10 @@
       "refs": {
         "DescribeAgentsRequest$nextToken": "<p>Token to retrieve the next set of results. For example, if you previously specified 100 IDs for <code>DescribeAgentsRequest$agentIds</code> but set <code>DescribeAgentsRequest$maxResults</code> to 10, you received a set of 10 results along with a token. Use that token in this query to get the next set of 10.</p>",
         "DescribeAgentsResponse$nextToken": "<p>Token to retrieve the next set of results. For example, if you specified 100 IDs for <code>DescribeAgentsRequest$agentIds</code> but set <code>DescribeAgentsRequest$maxResults</code> to 10, you received a set of 10 results along with this token. Use this token in the next query to retrieve the next set of 10.</p>",
-        "DescribeExportConfigurationsRequest$nextToken": "<p>A token to get the next set of results. For example, if you specify 100 IDs for <code>DescribeExportConfigurationsRequest$exportIds</code> but set <code>DescribeExportConfigurationsRequest$maxResults</code> to 10, you get results in a set of 10. Use the token in the query to get the next set of 10.</p>",
-        "DescribeExportConfigurationsResponse$nextToken": "<p>A token to get the next set of results. For example, if you specify 100 IDs for <code>DescribeExportConfigurationsRequest$exportIds</code> but set <code>DescribeExportConfigurationsRequest$maxResults</code> to 10, you get results in a set of 10. Use the token in the query to get the next set of 10.</p>",
+        "DescribeContinuousExportsRequest$nextToken": "<p>The token from the previous call to <code>DescribeExportTasks</code>.</p>",
+        "DescribeContinuousExportsResponse$nextToken": "<p>The token from the previous call to <code>DescribeExportTasks</code>.</p>",
+        "DescribeExportConfigurationsRequest$nextToken": "<p>The token from the previous call to describe-export-tasks.</p>",
+        "DescribeExportConfigurationsResponse$nextToken": "<p>The token from the previous call to describe-export-tasks.</p>",
         "DescribeExportTasksRequest$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated <code>DescribeExportTasks</code> request where <code>maxResults</code> was used and the results exceeded the value of that parameter. Pagination continues from the end of the previous results that returned the <code>nextToken</code> value. This value is null when there are no more results to return.</p>",
         "DescribeExportTasksResponse$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>DescribeExportTasks</code> request. When the results of a <code>DescribeExportTasks</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is null when there are no more results to return.</p>",
         "DescribeTagsRequest$nextToken": "<p>A token to start the list. Use this token to get the next set of results.</p>",
@@ -556,13 +625,42 @@
         "ListConfigurationsRequest$orderBy": "<p>Certain filter criteria return output that can be sorted in ascending or descending order. For a list of output characteristics for each filter, see <a href=\"http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html#ListConfigurations\">Using the ListConfigurations Action</a>.</p>"
       }
     },
+    "ResourceInUseException": {
+      "base": "<p/>",
+      "refs": {
+      }
+    },
     "ResourceNotFoundException": {
       "base": "<p>The specified configuration ID was not located. Verify the configuration ID and try again.</p>",
       "refs": {
       }
     },
+    "S3Bucket": {
+      "base": null,
+      "refs": {
+        "ContinuousExportDescription$s3Bucket": "<p>The name of the s3 bucket where the export data parquet files are stored.</p>",
+        "StartContinuousExportResponse$s3Bucket": "<p>The name of the s3 bucket where the export data parquet files are stored.</p>"
+      }
+    },
+    "SchemaStorageConfig": {
+      "base": null,
+      "refs": {
+        "ContinuousExportDescription$schemaStorageConfig": "<p>An object which describes how the data is stored.</p> <ul> <li> <p> <code>databaseName</code> - the name of the Glue database used to store the schema.</p> </li> </ul>",
+        "StartContinuousExportResponse$schemaStorageConfig": "<p>A dictionary which describes how the data is stored.</p> <ul> <li> <p> <code>databaseName</code> - the name of the Glue database used to store the schema.</p> </li> </ul>"
+      }
+    },
     "ServerInternalErrorException": {
       "base": "<p>The server experienced an internal error. Try again.</p>",
+      "refs": {
+      }
+    },
+    "StartContinuousExportRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "StartContinuousExportResponse": {
+      "base": null,
       "refs": {
       }
     },
@@ -582,6 +680,16 @@
       }
     },
     "StartExportTaskResponse": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "StopContinuousExportRequest": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "StopContinuousExportResponse": {
       "base": null,
       "refs": {
       }
@@ -622,8 +730,15 @@
         "ListServerNeighborsResponse$nextToken": "<p>Token to retrieve the next set of results. For example, if you specified 100 IDs for <code>ListServerNeighborsRequest$neighborConfigurationIds</code> but set <code>ListServerNeighborsRequest$maxResults</code> to 10, you received a set of 10 results along with this token. Use this token in the next query to retrieve the next set of 10.</p>",
         "NeighborConnectionDetail$transportProtocol": "<p>The network protocol used for the connection.</p>",
         "OrderByElement$fieldName": "<p>The field on which to order.</p>",
+        "SchemaStorageConfig$value": null,
         "UpdateApplicationRequest$name": "<p>New name of the application to be updated.</p>",
         "UpdateApplicationRequest$description": "<p>New description of the application to be updated.</p>"
+      }
+    },
+    "StringMax255": {
+      "base": null,
+      "refs": {
+        "ContinuousExportDescription$statusDetail": "<p>Contains information about any errors that may have occurred.</p>"
       }
     },
     "Tag": {
@@ -669,10 +784,15 @@
       "base": null,
       "refs": {
         "ConfigurationTag$timeOfCreation": "<p>The time the configuration tag was created in Coordinated Universal Time (UTC).</p>",
+        "ContinuousExportDescription$startTime": "<p>The timestamp representing when the continuous export was started.</p>",
+        "ContinuousExportDescription$stopTime": "<p>The timestamp that represents when this continuous export was stopped.</p>",
         "ExportInfo$requestedStartTime": "<p>The value of <code>startTime</code> parameter in the <code>StartExportTask</code> request. If no <code>startTime</code> was requested, this result does not appear in <code>ExportInfo</code>.</p>",
         "ExportInfo$requestedEndTime": "<p>The <code>endTime</code> used in the <code>StartExportTask</code> request. If no <code>endTime</code> was requested, this result does not appear in <code>ExportInfo</code>.</p>",
+        "StartContinuousExportResponse$startTime": "<p>The timestamp representing when the continuous export was started.</p>",
         "StartExportTaskRequest$startTime": "<p>The start timestamp for exported data from the single Application Discovery Agent selected in the filters. If no value is specified, data is exported starting from the first data collected by the agent.</p>",
-        "StartExportTaskRequest$endTime": "<p>The end timestamp for exported data from the single Application Discovery Agent selected in the filters. If no value is specified, exported data includes the most recent data collected by the agent.</p>"
+        "StartExportTaskRequest$endTime": "<p>The end timestamp for exported data from the single Application Discovery Agent selected in the filters. If no value is specified, exported data includes the most recent data collected by the agent.</p>",
+        "StopContinuousExportResponse$startTime": "<p>Timestamp that represents when this continuous export started collecting data.</p>",
+        "StopContinuousExportResponse$stopTime": "<p>Timestamp that represents when this continuous export was stopped.</p>"
       }
     },
     "UpdateApplicationRequest": {

--- a/models/apis/discovery/2015-11-01/paginators-1.json
+++ b/models/apis/discovery/2015-11-01/paginators-1.json
@@ -1,4 +1,9 @@
 {
   "pagination": {
+    "DescribeContinuousExports": {
+      "input_token": "nextToken",
+      "output_token": "nextToken",
+      "limit_key": "maxResults"
+    }
   }
 }

--- a/models/apis/discovery/2015-11-01/smoke.json
+++ b/models/apis/discovery/2015-11-01/smoke.json
@@ -1,0 +1,11 @@
+{
+    "version": 1,
+    "defaultRegion": "us-west-2",
+    "testCases": [
+        {
+            "operationName": "DescribeAgents",
+            "input": {},
+            "errorExpectedFromService": false
+        }
+    ]
+}

--- a/models/apis/ec2/2016-11-15/api-2.json
+++ b/models/apis/ec2/2016-11-15/api-2.json
@@ -7766,7 +7766,10 @@
     },
     "DescribeVolumeAttributeRequest":{
       "type":"structure",
-      "required":["VolumeId"],
+      "required":[
+        "Attribute",
+        "VolumeId"
+      ],
       "members":{
         "Attribute":{"shape":"VolumeAttributeName"},
         "VolumeId":{"shape":"String"},

--- a/models/apis/mediaconvert/2017-08-29/api-2.json
+++ b/models/apis/mediaconvert/2017-08-29/api-2.json
@@ -2092,6 +2092,10 @@
         "SegmentLength": {
           "shape": "__integerMin1Max2147483647",
           "locationName": "segmentLength"
+        },
+        "WriteSegmentTimelineInRepresentation": {
+          "shape": "DashIsoWriteSegmentTimelineInRepresentation",
+          "locationName": "writeSegmentTimelineInRepresentation"
         }
       },
       "required": [
@@ -2111,6 +2115,13 @@
       "enum": [
         "SINGLE_FILE",
         "SEGMENTED_FILES"
+      ]
+    },
+    "DashIsoWriteSegmentTimelineInRepresentation": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
       ]
     },
     "DeinterlaceAlgorithm": {

--- a/models/apis/mediaconvert/2017-08-29/docs-2.json
+++ b/models/apis/mediaconvert/2017-08-29/docs-2.json
@@ -522,6 +522,12 @@
         "DashIsoGroupSettings$SegmentControl": null
       }
     },
+    "DashIsoWriteSegmentTimelineInRepresentation": {
+      "base": "When ENABLED, segment durations are indicated in the manifest using SegmentTimeline and SegmentTimeline will be promoted down into Representation from AdaptationSet.",
+      "refs": {
+        "DashIsoGroupSettings$WriteSegmentTimelineInRepresentation": "When ENABLED, segment durations are indicated in the manifest using SegmentTimeline and SegmentTimeline will be promoted down into Representation from AdaptationSet."
+      }
+    },
     "DeinterlaceAlgorithm": {
       "base": "Only applies when you set Deinterlacer (DeinterlaceMode) to Deinterlace (DEINTERLACE) or Adaptive (ADAPTIVE). Motion adaptive interpolate (INTERPOLATE) produces sharper pictures, while blend (BLEND) produces smoother motion. Use (INTERPOLATE_TICKER) OR (BLEND_TICKER) if your source file includes a ticker, such as a scrolling headline at the bottom of the frame.",
       "refs": {

--- a/models/apis/redshift/2012-12-01/api-2.json
+++ b/models/apis/redshift/2012-12-01/api-2.json
@@ -1076,6 +1076,29 @@
         {"shape":"ClusterParameterGroupNotFoundFault"}
       ]
     },
+    "ResizeCluster":{
+      "name":"ResizeCluster",
+      "http":{
+        "method":"POST",
+        "requestUri":"/"
+      },
+      "input":{"shape":"ResizeClusterMessage"},
+      "output":{
+        "shape":"ResizeClusterResult",
+        "resultWrapper":"ResizeClusterResult"
+      },
+      "errors":[
+        {"shape":"InvalidClusterStateFault"},
+        {"shape":"ClusterNotFoundFault"},
+        {"shape":"NumberOfNodesQuotaExceededFault"},
+        {"shape":"NumberOfNodesPerClusterLimitExceededFault"},
+        {"shape":"InsufficientClusterCapacityFault"},
+        {"shape":"UnsupportedOptionFault"},
+        {"shape":"UnsupportedOperationFault"},
+        {"shape":"UnauthorizedOperation"},
+        {"shape":"LimitExceededFault"}
+      ]
+    },
     "RestoreFromClusterSnapshot":{
       "name":"RestoreFromClusterSnapshot",
       "http":{
@@ -1360,7 +1383,8 @@
         "EnhancedVpcRouting":{"shape":"Boolean"},
         "IamRoles":{"shape":"ClusterIamRoleList"},
         "PendingActions":{"shape":"PendingActionsList"},
-        "MaintenanceTrackName":{"shape":"String"}
+        "MaintenanceTrackName":{"shape":"String"},
+        "ElasticResizeNumberOfNodeOptions":{"shape":"String"}
       },
       "wrapper":true
     },
@@ -3462,6 +3486,26 @@
         "Parameters":{"shape":"ParametersList"}
       }
     },
+    "ResizeClusterMessage":{
+      "type":"structure",
+      "required":[
+        "ClusterIdentifier",
+        "NumberOfNodes"
+      ],
+      "members":{
+        "ClusterIdentifier":{"shape":"String"},
+        "ClusterType":{"shape":"String"},
+        "NodeType":{"shape":"String"},
+        "NumberOfNodes":{"shape":"Integer"},
+        "Classic":{"shape":"BooleanOptional"}
+      }
+    },
+    "ResizeClusterResult":{
+      "type":"structure",
+      "members":{
+        "Cluster":{"shape":"Cluster"}
+      }
+    },
     "ResizeNotFoundFault":{
       "type":"structure",
       "members":{
@@ -3487,7 +3531,9 @@
         "TotalResizeDataInMegaBytes":{"shape":"LongOptional"},
         "ProgressInMegaBytes":{"shape":"LongOptional"},
         "ElapsedTimeInSeconds":{"shape":"LongOptional"},
-        "EstimatedTimeToCompletionInSeconds":{"shape":"LongOptional"}
+        "EstimatedTimeToCompletionInSeconds":{"shape":"LongOptional"},
+        "ResizeType":{"shape":"String"},
+        "Message":{"shape":"String"}
       }
     },
     "ResourceNotFoundFault":{

--- a/models/apis/redshift/2012-12-01/docs-2.json
+++ b/models/apis/redshift/2012-12-01/docs-2.json
@@ -65,6 +65,7 @@
     "PurchaseReservedNodeOffering": "<p>Allows you to purchase reserved nodes. Amazon Redshift offers a predefined set of reserved node offerings. You can purchase one or more of the offerings. You can call the <a>DescribeReservedNodeOfferings</a> API to obtain the available reserved node offerings. You can call this API by providing a specific reserved node offering and the number of nodes you want to reserve. </p> <p> For more information about reserved node offerings, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/purchase-reserved-node-instance.html\">Purchasing Reserved Nodes</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>",
     "RebootCluster": "<p>Reboots a cluster. This action is taken as soon as possible. It results in a momentary outage to the cluster, during which the cluster status is set to <code>rebooting</code>. A cluster event is created when the reboot is completed. Any pending cluster modifications (see <a>ModifyCluster</a>) are applied at this reboot. For more information about managing clusters, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html\">Amazon Redshift Clusters</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
     "ResetClusterParameterGroup": "<p>Sets one or more parameters of the specified parameter group to their default values and sets the source values of the parameters to \"engine-default\". To reset the entire parameter group specify the <i>ResetAllParameters</i> parameter. For parameter changes to take effect you must reboot any associated clusters. </p>",
+    "ResizeCluster": "<p>Changes the cluster's type, node type, or number of nodes.</p>",
     "RestoreFromClusterSnapshot": "<p>Creates a new cluster from a snapshot. By default, Amazon Redshift creates the resulting cluster with the same configuration as the original cluster from which the snapshot was created, except that the new cluster is created with the default cluster security and parameter groups. After Amazon Redshift creates the cluster, you can use the <a>ModifyCluster</a> API to associate a different security group and different parameter group with the restored cluster. If you are using a DS node type, you can also choose to change to another DS node type of the same size during restore.</p> <p>If you restore a cluster into a VPC, you must provide a cluster subnet group where you want the cluster restored.</p> <p> For more information about working with snapshots, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-snapshots.html\">Amazon Redshift Snapshots</a> in the <i>Amazon Redshift Cluster Management Guide</i>.</p>",
     "RestoreTableFromClusterSnapshot": "<p>Creates a new table from a table in an Amazon Redshift cluster snapshot. You must create the new table within the Amazon Redshift cluster that the snapshot was taken from.</p> <p>You cannot use <code>RestoreTableFromClusterSnapshot</code> to restore a table with the same name as an existing table in an Amazon Redshift cluster. That is, you cannot overwrite an existing table in a cluster with a restored table. If you want to replace your original table with a new, restored table, then rename or drop your original table before you call <code>RestoreTableFromClusterSnapshot</code>. When you have renamed your original table, then you can pass the original name of the table as the <code>NewTableName</code> parameter value in the call to <code>RestoreTableFromClusterSnapshot</code>. This way, you can replace the original table with the table created from the snapshot.</p>",
     "RevokeClusterSecurityGroupIngress": "<p>Revokes an ingress rule in an Amazon Redshift security group for a previously authorized IP range or Amazon EC2 security group. To add an ingress rule, see <a>AuthorizeClusterSecurityGroupIngress</a>. For information about managing security groups, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-security-groups.html\">Amazon Redshift Cluster Security Groups</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
@@ -180,6 +181,7 @@
         "ModifyEventSubscriptionMessage$Enabled": "<p>A Boolean value indicating if the subscription is enabled. <code>true</code> indicates the subscription is enabled </p>",
         "PendingModifiedValues$PubliclyAccessible": "<p>The pending or in-progress change of the ability to connect to the cluster from the public network.</p>",
         "PendingModifiedValues$EnhancedVpcRouting": "<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>",
+        "ResizeClusterMessage$Classic": "<p>A boolean value indicating whether the resize operation is using the classic resize process.</p>",
         "RestoreFromClusterSnapshotMessage$AllowVersionUpgrade": "<p>If <code>true</code>, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. </p> <p>Default: <code>true</code> </p>",
         "RestoreFromClusterSnapshotMessage$PubliclyAccessible": "<p>If <code>true</code>, the cluster can be accessed from a public network. </p>",
         "RestoreFromClusterSnapshotMessage$EnhancedVpcRouting": "<p>An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html\">Enhanced VPC Routing</a> in the Amazon Redshift Cluster Management Guide.</p> <p>If this option is <code>true</code>, enhanced VPC routing is enabled. </p> <p>Default: false</p>"
@@ -203,6 +205,7 @@
         "ModifyClusterResult$Cluster": null,
         "ModifySnapshotCopyRetentionPeriodResult$Cluster": null,
         "RebootClusterResult$Cluster": null,
+        "ResizeClusterResult$Cluster": null,
         "RestoreFromClusterSnapshotResult$Cluster": null,
         "RotateEncryptionKeyResult$Cluster": null
       }
@@ -1106,6 +1109,7 @@
         "ReservedNode$Duration": "<p>The duration of the node reservation in seconds.</p>",
         "ReservedNode$NodeCount": "<p>The number of reserved compute nodes.</p>",
         "ReservedNodeOffering$Duration": "<p>The duration, in seconds, for which the offering will reserve the node.</p>",
+        "ResizeClusterMessage$NumberOfNodes": "<p>The new number of nodes for the cluster.</p>",
         "Snapshot$Port": "<p>The port that the cluster is listening on.</p>",
         "Snapshot$NumberOfNodes": "<p>The number of nodes in the cluster.</p>"
       }
@@ -1527,6 +1531,16 @@
       "refs": {
       }
     },
+    "ResizeClusterMessage": {
+      "base": null,
+      "refs": {
+      }
+    },
+    "ResizeClusterResult": {
+      "base": null,
+      "refs": {
+      }
+    },
     "ResizeNotFoundFault": {
       "base": "<p>A resize operation for the specified cluster is not found.</p>",
       "refs": {
@@ -1757,6 +1771,7 @@
         "Cluster$ClusterRevisionNumber": "<p>The specific revision number of the database in the cluster.</p>",
         "Cluster$KmsKeyId": "<p>The AWS Key Management Service (AWS KMS) key ID of the encryption key used to encrypt data in the cluster.</p>",
         "Cluster$MaintenanceTrackName": "<p>The name of the maintenance track for the cluster.</p>",
+        "Cluster$ElasticResizeNumberOfNodeOptions": "<p>Indicates the number of nodes the cluster can be resized to with the elastic resize method. </p>",
         "ClusterCredentials$DbUser": "<p>A database user name that is authorized to log on to the database <code>DbName</code> using the password <code>DbPassword</code>. If the specified DbUser exists in the database, the new user name has the same database privileges as the the user named in DbUser. By default, the user is added to PUBLIC. If the <code>DbGroups</code> parameter is specifed, <code>DbUser</code> is added to the listed groups for any sessions created using these credentials.</p>",
         "ClusterDbRevision$ClusterIdentifier": "<p>The unique identifier of the cluster.</p>",
         "ClusterDbRevision$CurrentDatabaseRevision": "<p>A string representing the current cluster version.</p>",
@@ -2021,9 +2036,14 @@
         "ReservedNodeOfferingsMessage$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
         "ReservedNodesMessage$Marker": "<p>A value that indicates the starting point for the next set of response records in a subsequent request. If a value is returned in a response, you can retrieve the next set of records by providing this returned marker value in the <code>Marker</code> parameter and retrying the command. If the <code>Marker</code> field is empty, all response records have been retrieved for the request. </p>",
         "ResetClusterParameterGroupMessage$ParameterGroupName": "<p>The name of the cluster parameter group to be reset.</p>",
+        "ResizeClusterMessage$ClusterIdentifier": "<p>The unique identifier for the cluster to resize.</p>",
+        "ResizeClusterMessage$ClusterType": "<p>The new cluster type for the specified cluster.</p>",
+        "ResizeClusterMessage$NodeType": "<p>The new node type for the nodes you are adding.</p>",
         "ResizeProgressMessage$TargetNodeType": "<p>The node type that the cluster will have after the resize operation is complete.</p>",
         "ResizeProgressMessage$TargetClusterType": "<p>The cluster type after the resize operation is complete.</p> <p>Valid Values: <code>multi-node</code> | <code>single-node</code> </p>",
         "ResizeProgressMessage$Status": "<p>The status of the resize operation.</p> <p>Valid Values: <code>NONE</code> | <code>IN_PROGRESS</code> | <code>FAILED</code> | <code>SUCCEEDED</code> </p>",
+        "ResizeProgressMessage$ResizeType": "<p>An enum with possible values of ClassicResize and ElasticResize. These values describe the type of resize operation being performed. </p>",
+        "ResizeProgressMessage$Message": "<p>An optional string to provide additional details about the resize action.</p>",
         "RestorableNodeTypeList$member": null,
         "RestoreFromClusterSnapshotMessage$ClusterIdentifier": "<p>The identifier of the cluster that will be created from restoring the snapshot.</p> <p>Constraints:</p> <ul> <li> <p>Must contain from 1 to 63 alphanumeric characters or hyphens.</p> </li> <li> <p>Alphabetic characters must be lowercase.</p> </li> <li> <p>First character must be a letter.</p> </li> <li> <p>Cannot end with a hyphen or contain two consecutive hyphens.</p> </li> <li> <p>Must be unique for all clusters within an AWS account.</p> </li> </ul>",
         "RestoreFromClusterSnapshotMessage$SnapshotIdentifier": "<p>The name of the snapshot from which to create the new cluster. This parameter isn't case sensitive.</p> <p>Example: <code>my-snapshot-id</code> </p>",

--- a/models/apis/ssm/2014-11-06/api-2.json
+++ b/models/apis/ssm/2014-11-06/api-2.json
@@ -791,8 +791,10 @@
       "errors":[
         {"shape":"InternalServerError"},
         {"shape":"InvalidFilter"},
+        {"shape":"InvalidInventoryGroupException"},
         {"shape":"InvalidNextToken"},
         {"shape":"InvalidTypeNameException"},
+        {"shape":"InvalidAggregatorException"},
         {"shape":"InvalidResultAttributeException"}
       ]
     },
@@ -2196,17 +2198,20 @@
       "enum":[
         "InvokedAfter",
         "InvokedBefore",
-        "Status"
+        "Status",
+        "ExecutionStage",
+        "DocumentName"
       ]
     },
     "CommandFilterList":{
       "type":"list",
       "member":{"shape":"CommandFilter"},
-      "max":3,
+      "max":5,
       "min":1
     },
     "CommandFilterValue":{
       "type":"string",
+      "max":128,
       "min":1
     },
     "CommandId":{
@@ -4450,6 +4455,13 @@
       },
       "exception":true
     },
+    "InvalidAggregatorException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"String"}
+      },
+      "exception":true
+    },
     "InvalidAllowedPatternException":{
       "type":"structure",
       "members":{
@@ -4585,6 +4597,13 @@
       "type":"structure",
       "members":{
         "message":{"shape":"String"}
+      },
+      "exception":true
+    },
+    "InvalidInventoryGroupException":{
+      "type":"structure",
+      "members":{
+        "Message":{"shape":"String"}
       },
       "exception":true
     },
@@ -4728,7 +4747,8 @@
       "type":"structure",
       "members":{
         "Expression":{"shape":"InventoryAggregatorExpression"},
-        "Aggregators":{"shape":"InventoryAggregatorList"}
+        "Aggregators":{"shape":"InventoryAggregatorList"},
+        "Groups":{"shape":"InventoryGroupList"}
       }
     },
     "InventoryAggregatorExpression":{
@@ -4823,7 +4843,29 @@
     "InventoryFilterValueList":{
       "type":"list",
       "member":{"shape":"InventoryFilterValue"},
-      "max":20,
+      "max":40,
+      "min":1
+    },
+    "InventoryGroup":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "Filters"
+      ],
+      "members":{
+        "Name":{"shape":"InventoryGroupName"},
+        "Filters":{"shape":"InventoryFilterList"}
+      }
+    },
+    "InventoryGroupList":{
+      "type":"list",
+      "member":{"shape":"InventoryGroup"},
+      "max":10,
+      "min":1
+    },
+    "InventoryGroupName":{
+      "type":"string",
+      "max":200,
       "min":1
     },
     "InventoryItem":{
@@ -4933,7 +4975,8 @@
         "NotEqual",
         "BeginWith",
         "LessThan",
-        "GreaterThan"
+        "GreaterThan",
+        "Exists"
       ]
     },
     "InventoryResultEntity":{

--- a/models/apis/ssm/2014-11-06/docs-2.json
+++ b/models/apis/ssm/2014-11-06/docs-2.json
@@ -5,8 +5,8 @@
     "AddTagsToResource": "<p>Adds or overwrites one or more tags for the specified resource. Tags are metadata that you can assign to your documents, managed instances, Maintenance Windows, Parameter Store parameters, and patch baselines. Tags enable you to categorize your resources in different ways, for example, by purpose, owner, or environment. Each tag consists of a key and an optional value, both of which you define. For example, you could define a set of tags for your account's managed instances that helps you track each instance's owner and stack level. For example: Key=Owner and Value=DbAdmin, SysAdmin, or Dev. Or Key=Stack and Value=Production, Pre-Production, or Test.</p> <p>Each resource can have a maximum of 50 tags. </p> <p>We recommend that you devise a set of tag keys that meets your needs for each resource type. Using a consistent set of tag keys makes it easier for you to manage your resources. You can search and filter the resources based on the tags you add. Tags don't have any semantic meaning to Amazon EC2 and are interpreted strictly as a string of characters. </p> <p>For more information about tags, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html\">Tagging Your Amazon EC2 Resources</a> in the <i>Amazon EC2 User Guide</i>.</p>",
     "CancelCommand": "<p>Attempts to cancel the command specified by the Command ID. There is no guarantee that the command will be terminated and the underlying process stopped.</p>",
     "CreateActivation": "<p>Registers your on-premises server or virtual machine with Amazon EC2 so that you can manage these resources using Run Command. An on-premises server or virtual machine that has been registered with EC2 is called a managed instance. For more information about activations, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-managedinstances.html\">Setting Up Systems Manager in Hybrid Environments</a>.</p>",
-    "CreateAssociation": "<p>Associates the specified Systems Manager document with the specified instances or targets.</p> <p>When you associate a document with one or more instances using instance IDs or tags, the SSM Agent running on the instance processes the document and configures the instance as specified.</p> <p>If you associate a document with an instance that already has an associated document, the system throws the AssociationAlreadyExists exception.</p>",
-    "CreateAssociationBatch": "<p>Associates the specified Systems Manager document with the specified instances or targets.</p> <p>When you associate a document with one or more instances using instance IDs or tags, the SSM Agent running on the instance processes the document and configures the instance as specified.</p> <p>If you associate a document with an instance that already has an associated document, the system throws the AssociationAlreadyExists exception.</p>",
+    "CreateAssociation": "<p>Associates the specified Systems Manager document with the specified instances or targets.</p> <p>When you associate a document with one or more instances using instance IDs or tags, SSM Agent running on the instance processes the document and configures the instance as specified.</p> <p>If you associate a document with an instance that already has an associated document, the system throws the AssociationAlreadyExists exception.</p>",
+    "CreateAssociationBatch": "<p>Associates the specified Systems Manager document with the specified instances or targets.</p> <p>When you associate a document with one or more instances using instance IDs or tags, SSM Agent running on the instance processes the document and configures the instance as specified.</p> <p>If you associate a document with an instance that already has an associated document, the system throws the AssociationAlreadyExists exception.</p>",
     "CreateDocument": "<p>Creates a Systems Manager document.</p> <p>After you create a document, you can use CreateAssociation to associate it with one or more running instances.</p>",
     "CreateMaintenanceWindow": "<p>Creates a new Maintenance Window.</p>",
     "CreatePatchBaseline": "<p>Creates a patch baseline.</p> <note> <p>For information about valid key and value pairs in <code>PatchFilters</code> for each supported operating system type, see <a href=\"http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PatchFilter.html\">PatchFilter</a>.</p> </note>",
@@ -2545,6 +2545,11 @@
       "refs": {
       }
     },
+    "InvalidAggregatorException": {
+      "base": "<p>The specified aggregator is not valid for inventory groups. Verify that the aggregator uses a valid inventory type such as <code>AWS:Application</code> or <code>AWS:InstanceInformation</code>.</p>",
+      "refs": {
+      }
+    },
     "InvalidAllowedPatternException": {
       "base": "<p>The request does not meet the regular expression requirement.</p>",
       "refs": {
@@ -2642,6 +2647,11 @@
     },
     "InvalidInstanceInformationFilterValue": {
       "base": "<p>The specified filter value is not valid.</p>",
+      "refs": {
+      }
+    },
+    "InvalidInventoryGroupException": {
+      "base": "<p>The specified inventory group is not valid.</p>",
       "refs": {
       }
     },
@@ -2849,6 +2859,7 @@
       "base": null,
       "refs": {
         "GetInventoryRequest$Filters": "<p>One or more filters. Use a filter to return a more specific list of results.</p>",
+        "InventoryGroup$Filters": "<p>Filters define the criteria for the group. The <code>matchingCount</code> field displays the number of resources that match the criteria. The <code>notMatchingCount</code> field displays the number of resources that don't match the criteria. </p>",
         "ListInventoryEntriesRequest$Filters": "<p>One or more filters. Use a filter to return a more specific list of results.</p>"
       }
     },
@@ -2862,6 +2873,24 @@
       "base": null,
       "refs": {
         "InventoryFilter$Values": "<p>Inventory filter values. Example: inventory filter where instance IDs are specified as values Key=AWS:InstanceInformation.InstanceId,Values= i-a12b3c4d5e6g, i-1a2b3c4d5e6,Type=Equal </p>"
+      }
+    },
+    "InventoryGroup": {
+      "base": "<p>A user-defined set of one or more filters on which to aggregate inventory data. Groups return a count of resources that match and don't match the specified criteria.</p>",
+      "refs": {
+        "InventoryGroupList$member": null
+      }
+    },
+    "InventoryGroupList": {
+      "base": null,
+      "refs": {
+        "InventoryAggregator$Groups": "<p>A user-defined set of one or more filters on which to aggregate inventory data. Groups return a count of resources that match and don't match the specified criteria.</p>"
+      }
+    },
+    "InventoryGroupName": {
+      "base": null,
+      "refs": {
+        "InventoryGroup$Name": "<p>The name of the group.</p>"
       }
     },
     "InventoryItem": {
@@ -5211,6 +5240,7 @@
         "InternalServerError$Message": null,
         "InvalidActivation$Message": null,
         "InvalidActivationId$Message": null,
+        "InvalidAggregatorException$Message": null,
         "InvalidAllowedPatternException$message": "<p>The request does not meet the regular expression requirement.</p>",
         "InvalidAssociation$Message": null,
         "InvalidAssociationVersion$Message": null,
@@ -5229,6 +5259,7 @@
         "InvalidFilterValue$Message": null,
         "InvalidInstanceId$Message": null,
         "InvalidInstanceInformationFilterValue$message": null,
+        "InvalidInventoryGroupException$Message": null,
         "InvalidInventoryItemContextException$Message": null,
         "InvalidInventoryRequestException$Message": null,
         "InvalidItemContentException$Message": null,

--- a/service/applicationdiscoveryservice/api.go
+++ b/service/applicationdiscoveryservice/api.go
@@ -517,8 +517,9 @@ func (c *ApplicationDiscoveryService) DescribeAgentsRequest(input *DescribeAgent
 
 // DescribeAgents API operation for AWS Application Discovery Service.
 //
-// Lists agents or the Connector by ID or lists all agents/Connectors associated
-// with your user account if you did not specify an ID.
+// Lists agents or connectors as specified by ID or other filters. All agents/connectors
+// associated with your user account can be listed if you call DescribeAgents
+// as is without passing any parameters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -608,11 +609,22 @@ func (c *ApplicationDiscoveryService) DescribeConfigurationsRequest(input *Descr
 
 // DescribeConfigurations API operation for AWS Application Discovery Service.
 //
-// Retrieves attributes for a list of configuration item IDs. All of the supplied
-// IDs must be for the same asset type (server, application, process, or connection).
-// Output fields are specific to the asset type selected. For example, the output
-// for a server configuration item includes a list of attributes about the server,
-// such as host name, operating system, and number of network cards.
+// Retrieves attributes for a list of configuration item IDs.
+//
+// All of the supplied IDs must be for the same asset type from one of the follwoing:
+//
+// server
+//
+// application
+//
+// process
+//
+// connection
+//
+// Output fields are specific to the asset type specified. For example, the
+// output for a server configuration item includes a list of attributes about
+// the server, such as host name, operating system, number of network cards,
+// etc.
 //
 // For a complete list of outputs for each asset type, see Using the DescribeConfigurations
 // Action (http://docs.aws.amazon.com/application-discovery/latest/APIReference/discovery-api-queries.html#DescribeConfigurations).
@@ -659,6 +671,161 @@ func (c *ApplicationDiscoveryService) DescribeConfigurationsWithContext(ctx aws.
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+const opDescribeContinuousExports = "DescribeContinuousExports"
+
+// DescribeContinuousExportsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeContinuousExports operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeContinuousExports for more information on using the DescribeContinuousExports
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeContinuousExportsRequest method.
+//    req, resp := client.DescribeContinuousExportsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/DescribeContinuousExports
+func (c *ApplicationDiscoveryService) DescribeContinuousExportsRequest(input *DescribeContinuousExportsInput) (req *request.Request, output *DescribeContinuousExportsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeContinuousExports,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"nextToken"},
+			OutputTokens:    []string{"nextToken"},
+			LimitToken:      "maxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &DescribeContinuousExportsInput{}
+	}
+
+	output = &DescribeContinuousExportsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeContinuousExports API operation for AWS Application Discovery Service.
+//
+// Lists exports as specified by ID. All continuous exports associated with
+// your user account can be listed if you call DescribeContinuousExports as
+// is without passing any parameters.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Application Discovery Service's
+// API operation DescribeContinuousExports for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeAuthorizationErrorException "AuthorizationErrorException"
+//   The AWS user account does not have permission to perform the action. Check
+//   the IAM policy associated with this account.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   One or more parameters are not valid. Verify the parameters and try again.
+//
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   The value of one or more parameters are either invalid or out of range. Verify
+//   the parameter values and try again.
+//
+//   * ErrCodeServerInternalErrorException "ServerInternalErrorException"
+//   The server experienced an internal error. Try again.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   This operation is not permitted.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified configuration ID was not located. Verify the configuration
+//   ID and try again.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/DescribeContinuousExports
+func (c *ApplicationDiscoveryService) DescribeContinuousExports(input *DescribeContinuousExportsInput) (*DescribeContinuousExportsOutput, error) {
+	req, out := c.DescribeContinuousExportsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeContinuousExportsWithContext is the same as DescribeContinuousExports with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeContinuousExports for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ApplicationDiscoveryService) DescribeContinuousExportsWithContext(ctx aws.Context, input *DescribeContinuousExportsInput, opts ...request.Option) (*DescribeContinuousExportsOutput, error) {
+	req, out := c.DescribeContinuousExportsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// DescribeContinuousExportsPages iterates over the pages of a DescribeContinuousExports operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See DescribeContinuousExports method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a DescribeContinuousExports operation.
+//    pageNum := 0
+//    err := client.DescribeContinuousExportsPages(params,
+//        func(page *DescribeContinuousExportsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ApplicationDiscoveryService) DescribeContinuousExportsPages(input *DescribeContinuousExportsInput, fn func(*DescribeContinuousExportsOutput, bool) bool) error {
+	return c.DescribeContinuousExportsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// DescribeContinuousExportsPagesWithContext same as DescribeContinuousExportsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ApplicationDiscoveryService) DescribeContinuousExportsPagesWithContext(ctx aws.Context, input *DescribeContinuousExportsInput, fn func(*DescribeContinuousExportsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *DescribeContinuousExportsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.DescribeContinuousExportsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*DescribeContinuousExportsOutput), !p.HasNextPage())
+	}
+	return p.Err()
 }
 
 const opDescribeExportConfigurations = "DescribeExportConfigurations"
@@ -708,10 +875,9 @@ func (c *ApplicationDiscoveryService) DescribeExportConfigurationsRequest(input 
 
 // DescribeExportConfigurations API operation for AWS Application Discovery Service.
 //
-// Deprecated. Use DescribeExportTasks instead.
+// DescribeExportConfigurations is deprecated.
 //
-// Retrieves the status of a given export process. You can retrieve status from
-// a maximum of 100 processes.
+// Use instead DescribeExportTasks (http://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -896,8 +1062,19 @@ func (c *ApplicationDiscoveryService) DescribeTagsRequest(input *DescribeTagsInp
 
 // DescribeTags API operation for AWS Application Discovery Service.
 //
-// Retrieves a list of configuration items that are tagged with a specific tag.
-// Or retrieves a list of all tags assigned to a specific configuration item.
+// Retrieves a list of configuration items that have tags as specified by the
+// key-value pairs, name and value, passed to the optional parameter filters.
+//
+// There are three valid tag filter names:
+//
+//    * tagKey
+//
+//    * tagValue
+//
+//    * configurationId
+//
+// Also, all configuration items associated with your user account that have
+// tags can be listed if you call DescribeTags as is without passing any parameters.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1185,6 +1362,9 @@ func (c *ApplicationDiscoveryService) GetDiscoverySummaryRequest(input *GetDisco
 //
 // Retrieves a short summary of discovered assets.
 //
+// This API operation takes no request parameters and is called as is at the
+// command prompt as shown in the example.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -1273,8 +1453,9 @@ func (c *ApplicationDiscoveryService) ListConfigurationsRequest(input *ListConfi
 
 // ListConfigurations API operation for AWS Application Discovery Service.
 //
-// Retrieves a list of configuration items according to criteria that you specify
-// in a filter. The filter criteria identifies the relationship requirements.
+// Retrieves a list of configuration items as specified by the value passed
+// to the required paramater configurationType. Optional filtering may be applied
+// to refine search results.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1410,6 +1591,103 @@ func (c *ApplicationDiscoveryService) ListServerNeighbors(input *ListServerNeigh
 // for more information on using Contexts.
 func (c *ApplicationDiscoveryService) ListServerNeighborsWithContext(ctx aws.Context, input *ListServerNeighborsInput, opts ...request.Option) (*ListServerNeighborsOutput, error) {
 	req, out := c.ListServerNeighborsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStartContinuousExport = "StartContinuousExport"
+
+// StartContinuousExportRequest generates a "aws/request.Request" representing the
+// client's request for the StartContinuousExport operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StartContinuousExport for more information on using the StartContinuousExport
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StartContinuousExportRequest method.
+//    req, resp := client.StartContinuousExportRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/StartContinuousExport
+func (c *ApplicationDiscoveryService) StartContinuousExportRequest(input *StartContinuousExportInput) (req *request.Request, output *StartContinuousExportOutput) {
+	op := &request.Operation{
+		Name:       opStartContinuousExport,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &StartContinuousExportInput{}
+	}
+
+	output = &StartContinuousExportOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StartContinuousExport API operation for AWS Application Discovery Service.
+//
+// Start the continuous flow of agent's discovered data into Amazon Athena.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Application Discovery Service's
+// API operation StartContinuousExport for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeConflictErrorException "ConflictErrorException"
+//
+//   * ErrCodeAuthorizationErrorException "AuthorizationErrorException"
+//   The AWS user account does not have permission to perform the action. Check
+//   the IAM policy associated with this account.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   One or more parameters are not valid. Verify the parameters and try again.
+//
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   The value of one or more parameters are either invalid or out of range. Verify
+//   the parameter values and try again.
+//
+//   * ErrCodeServerInternalErrorException "ServerInternalErrorException"
+//   The server experienced an internal error. Try again.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   This operation is not permitted.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/StartContinuousExport
+func (c *ApplicationDiscoveryService) StartContinuousExport(input *StartContinuousExportInput) (*StartContinuousExportOutput, error) {
+	req, out := c.StartContinuousExportRequest(input)
+	return out, req.Send()
+}
+
+// StartContinuousExportWithContext is the same as StartContinuousExport with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StartContinuousExport for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ApplicationDiscoveryService) StartContinuousExportWithContext(ctx aws.Context, input *StartContinuousExportInput, opts ...request.Option) (*StartContinuousExportOutput, error) {
+	req, out := c.StartContinuousExportRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1603,6 +1881,105 @@ func (c *ApplicationDiscoveryService) StartExportTask(input *StartExportTaskInpu
 // for more information on using Contexts.
 func (c *ApplicationDiscoveryService) StartExportTaskWithContext(ctx aws.Context, input *StartExportTaskInput, opts ...request.Option) (*StartExportTaskOutput, error) {
 	req, out := c.StartExportTaskRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStopContinuousExport = "StopContinuousExport"
+
+// StopContinuousExportRequest generates a "aws/request.Request" representing the
+// client's request for the StopContinuousExport operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StopContinuousExport for more information on using the StopContinuousExport
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StopContinuousExportRequest method.
+//    req, resp := client.StopContinuousExportRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/StopContinuousExport
+func (c *ApplicationDiscoveryService) StopContinuousExportRequest(input *StopContinuousExportInput) (req *request.Request, output *StopContinuousExportOutput) {
+	op := &request.Operation{
+		Name:       opStopContinuousExport,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &StopContinuousExportInput{}
+	}
+
+	output = &StopContinuousExportOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// StopContinuousExport API operation for AWS Application Discovery Service.
+//
+// Stop the continuous flow of agent's discovered data into Amazon Athena.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS Application Discovery Service's
+// API operation StopContinuousExport for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeAuthorizationErrorException "AuthorizationErrorException"
+//   The AWS user account does not have permission to perform the action. Check
+//   the IAM policy associated with this account.
+//
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   One or more parameters are not valid. Verify the parameters and try again.
+//
+//   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
+//   The value of one or more parameters are either invalid or out of range. Verify
+//   the parameter values and try again.
+//
+//   * ErrCodeServerInternalErrorException "ServerInternalErrorException"
+//   The server experienced an internal error. Try again.
+//
+//   * ErrCodeOperationNotPermittedException "OperationNotPermittedException"
+//   This operation is not permitted.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   The specified configuration ID was not located. Verify the configuration
+//   ID and try again.
+//
+//   * ErrCodeResourceInUseException "ResourceInUseException"
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/discovery-2015-11-01/StopContinuousExport
+func (c *ApplicationDiscoveryService) StopContinuousExport(input *StopContinuousExportInput) (*StopContinuousExportOutput, error) {
+	req, out := c.StopContinuousExportRequest(input)
+	return out, req.Send()
+}
+
+// StopContinuousExportWithContext is the same as StopContinuousExport with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StopContinuousExport for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ApplicationDiscoveryService) StopContinuousExportWithContext(ctx aws.Context, input *StopContinuousExportInput, opts ...request.Option) (*StopContinuousExportOutput, error) {
+	req, out := c.StopContinuousExportRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2103,6 +2480,114 @@ func (s *ConfigurationTag) SetTimeOfCreation(v time.Time) *ConfigurationTag {
 // SetValue sets the Value field's value.
 func (s *ConfigurationTag) SetValue(v string) *ConfigurationTag {
 	s.Value = &v
+	return s
+}
+
+// A list of continuous export descriptions.
+type ContinuousExportDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The type of data collector used to gather this data (currently only offered
+	// for AGENT).
+	DataSource *string `locationName:"dataSource" type:"string" enum:"DataSource"`
+
+	// The unique ID assigned to this export.
+	ExportId *string `locationName:"exportId" type:"string"`
+
+	// The name of the s3 bucket where the export data parquet files are stored.
+	S3Bucket *string `locationName:"s3Bucket" type:"string"`
+
+	// An object which describes how the data is stored.
+	//
+	//    * databaseName - the name of the Glue database used to store the schema.
+	SchemaStorageConfig map[string]*string `locationName:"schemaStorageConfig" type:"map"`
+
+	// The timestamp representing when the continuous export was started.
+	StartTime *time.Time `locationName:"startTime" type:"timestamp"`
+
+	// Describes the status of the export. Can be one of the following values:
+	//
+	//    * START_IN_PROGRESS - setting up resources to start continuous export.
+	//
+	//    * START_FAILED - an error occurred setting up continuous export. To recover,
+	//    call start-continuous-export again.
+	//
+	//    * ACTIVE - data is being exported to the customer bucket.
+	//
+	//    * ERROR - an error occurred during export. To fix the issue, call stop-continuous-export
+	//    and start-continuous-export.
+	//
+	//    * STOP_IN_PROGRESS - stopping the export.
+	//
+	//    * STOP_FAILED - an error occurred stopping the export. To recover, call
+	//    stop-continuous-export again.
+	//
+	//    * INACTIVE - the continuous export has been stopped. Data is no longer
+	//    being exported to the customer bucket.
+	Status *string `locationName:"status" type:"string" enum:"ContinuousExportStatus"`
+
+	// Contains information about any errors that may have occurred.
+	StatusDetail *string `locationName:"statusDetail" min:"1" type:"string"`
+
+	// The timestamp that represents when this continuous export was stopped.
+	StopTime *time.Time `locationName:"stopTime" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s ContinuousExportDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ContinuousExportDescription) GoString() string {
+	return s.String()
+}
+
+// SetDataSource sets the DataSource field's value.
+func (s *ContinuousExportDescription) SetDataSource(v string) *ContinuousExportDescription {
+	s.DataSource = &v
+	return s
+}
+
+// SetExportId sets the ExportId field's value.
+func (s *ContinuousExportDescription) SetExportId(v string) *ContinuousExportDescription {
+	s.ExportId = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *ContinuousExportDescription) SetS3Bucket(v string) *ContinuousExportDescription {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetSchemaStorageConfig sets the SchemaStorageConfig field's value.
+func (s *ContinuousExportDescription) SetSchemaStorageConfig(v map[string]*string) *ContinuousExportDescription {
+	s.SchemaStorageConfig = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ContinuousExportDescription) SetStartTime(v time.Time) *ContinuousExportDescription {
+	s.StartTime = &v
+	return s
+}
+
+// SetStatus sets the Status field's value.
+func (s *ContinuousExportDescription) SetStatus(v string) *ContinuousExportDescription {
+	s.Status = &v
+	return s
+}
+
+// SetStatusDetail sets the StatusDetail field's value.
+func (s *ContinuousExportDescription) SetStatusDetail(v string) *ContinuousExportDescription {
+	s.StatusDetail = &v
+	return s
+}
+
+// SetStopTime sets the StopTime field's value.
+func (s *ContinuousExportDescription) SetStopTime(v time.Time) *ContinuousExportDescription {
+	s.StopTime = &v
 	return s
 }
 
@@ -2744,19 +3229,104 @@ func (s *DescribeConfigurationsOutput) SetConfigurations(v []map[string]*string)
 	return s
 }
 
+type DescribeContinuousExportsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique IDs assigned to the exports.
+	ExportIds []*string `locationName:"exportIds" type:"list"`
+
+	// A number between 1 and 100 specifying the maximum number of continuous export
+	// descriptions returned.
+	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
+
+	// The token from the previous call to DescribeExportTasks.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeContinuousExportsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContinuousExportsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeContinuousExportsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeContinuousExportsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExportIds sets the ExportIds field's value.
+func (s *DescribeContinuousExportsInput) SetExportIds(v []*string) *DescribeContinuousExportsInput {
+	s.ExportIds = v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *DescribeContinuousExportsInput) SetMaxResults(v int64) *DescribeContinuousExportsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeContinuousExportsInput) SetNextToken(v string) *DescribeContinuousExportsInput {
+	s.NextToken = &v
+	return s
+}
+
+type DescribeContinuousExportsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A list of continuous export descriptions.
+	Descriptions []*ContinuousExportDescription `locationName:"descriptions" type:"list"`
+
+	// The token from the previous call to DescribeExportTasks.
+	NextToken *string `locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeContinuousExportsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContinuousExportsOutput) GoString() string {
+	return s.String()
+}
+
+// SetDescriptions sets the Descriptions field's value.
+func (s *DescribeContinuousExportsOutput) SetDescriptions(v []*ContinuousExportDescription) *DescribeContinuousExportsOutput {
+	s.Descriptions = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *DescribeContinuousExportsOutput) SetNextToken(v string) *DescribeContinuousExportsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type DescribeExportConfigurationsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier that you can use to query the export status.
+	// A list of continuous export ids to search for.
 	ExportIds []*string `locationName:"exportIds" type:"list"`
 
-	// The maximum number of results that you want to display as a part of the query.
+	// A number between 1 and 100 specifying the maximum number of continuous export
+	// descriptions returned.
 	MaxResults *int64 `locationName:"maxResults" type:"integer"`
 
-	// A token to get the next set of results. For example, if you specify 100 IDs
-	// for DescribeExportConfigurationsRequest$exportIds but set DescribeExportConfigurationsRequest$maxResults
-	// to 10, you get results in a set of 10. Use the token in the query to get
-	// the next set of 10.
+	// The token from the previous call to describe-export-tasks.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -2791,14 +3361,9 @@ func (s *DescribeExportConfigurationsInput) SetNextToken(v string) *DescribeExpo
 type DescribeExportConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Returns export details. When the status is complete, the response includes
-	// a URL for an Amazon S3 bucket where you can view the data in a CSV file.
 	ExportsInfo []*ExportInfo `locationName:"exportsInfo" type:"list"`
 
-	// A token to get the next set of results. For example, if you specify 100 IDs
-	// for DescribeExportConfigurationsRequest$exportIds but set DescribeExportConfigurationsRequest$maxResults
-	// to 10, you get results in a set of 10. Use the token in the query to get
-	// the next set of 10.
+	// The token from the previous call to describe-export-tasks.
 	NextToken *string `locationName:"nextToken" type:"string"`
 }
 
@@ -3850,6 +4415,82 @@ func (s *OrderByElement) SetSortOrder(v string) *OrderByElement {
 	return s
 }
 
+type StartContinuousExportInput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartContinuousExportInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartContinuousExportInput) GoString() string {
+	return s.String()
+}
+
+type StartContinuousExportOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The type of data collector used to gather this data (currently only offered
+	// for AGENT).
+	DataSource *string `locationName:"dataSource" type:"string" enum:"DataSource"`
+
+	// The unique ID assigned to this export.
+	ExportId *string `locationName:"exportId" type:"string"`
+
+	// The name of the s3 bucket where the export data parquet files are stored.
+	S3Bucket *string `locationName:"s3Bucket" type:"string"`
+
+	// A dictionary which describes how the data is stored.
+	//
+	//    * databaseName - the name of the Glue database used to store the schema.
+	SchemaStorageConfig map[string]*string `locationName:"schemaStorageConfig" type:"map"`
+
+	// The timestamp representing when the continuous export was started.
+	StartTime *time.Time `locationName:"startTime" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s StartContinuousExportOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StartContinuousExportOutput) GoString() string {
+	return s.String()
+}
+
+// SetDataSource sets the DataSource field's value.
+func (s *StartContinuousExportOutput) SetDataSource(v string) *StartContinuousExportOutput {
+	s.DataSource = &v
+	return s
+}
+
+// SetExportId sets the ExportId field's value.
+func (s *StartContinuousExportOutput) SetExportId(v string) *StartContinuousExportOutput {
+	s.ExportId = &v
+	return s
+}
+
+// SetS3Bucket sets the S3Bucket field's value.
+func (s *StartContinuousExportOutput) SetS3Bucket(v string) *StartContinuousExportOutput {
+	s.S3Bucket = &v
+	return s
+}
+
+// SetSchemaStorageConfig sets the SchemaStorageConfig field's value.
+func (s *StartContinuousExportOutput) SetSchemaStorageConfig(v map[string]*string) *StartContinuousExportOutput {
+	s.SchemaStorageConfig = v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *StartContinuousExportOutput) SetStartTime(v time.Time) *StartContinuousExportOutput {
+	s.StartTime = &v
+	return s
+}
+
 type StartDataCollectionByAgentIdsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -4018,6 +4659,77 @@ func (s StartExportTaskOutput) GoString() string {
 // SetExportId sets the ExportId field's value.
 func (s *StartExportTaskOutput) SetExportId(v string) *StartExportTaskOutput {
 	s.ExportId = &v
+	return s
+}
+
+type StopContinuousExportInput struct {
+	_ struct{} `type:"structure"`
+
+	// The unique ID assigned to this export.
+	//
+	// ExportId is a required field
+	ExportId *string `locationName:"exportId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s StopContinuousExportInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopContinuousExportInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopContinuousExportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopContinuousExportInput"}
+	if s.ExportId == nil {
+		invalidParams.Add(request.NewErrParamRequired("ExportId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetExportId sets the ExportId field's value.
+func (s *StopContinuousExportInput) SetExportId(v string) *StopContinuousExportInput {
+	s.ExportId = &v
+	return s
+}
+
+type StopContinuousExportOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Timestamp that represents when this continuous export started collecting
+	// data.
+	StartTime *time.Time `locationName:"startTime" type:"timestamp"`
+
+	// Timestamp that represents when this continuous export was stopped.
+	StopTime *time.Time `locationName:"stopTime" type:"timestamp"`
+}
+
+// String returns the string representation
+func (s StopContinuousExportOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopContinuousExportOutput) GoString() string {
+	return s.String()
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *StopContinuousExportOutput) SetStartTime(v time.Time) *StopContinuousExportOutput {
+	s.StartTime = &v
+	return s
+}
+
+// SetStopTime sets the StopTime field's value.
+func (s *StopContinuousExportOutput) SetStopTime(v time.Time) *StopContinuousExportOutput {
+	s.StopTime = &v
 	return s
 }
 
@@ -4292,6 +5004,34 @@ const (
 
 	// ConfigurationItemTypeApplication is a ConfigurationItemType enum value
 	ConfigurationItemTypeApplication = "APPLICATION"
+)
+
+const (
+	// ContinuousExportStatusStartInProgress is a ContinuousExportStatus enum value
+	ContinuousExportStatusStartInProgress = "START_IN_PROGRESS"
+
+	// ContinuousExportStatusStartFailed is a ContinuousExportStatus enum value
+	ContinuousExportStatusStartFailed = "START_FAILED"
+
+	// ContinuousExportStatusActive is a ContinuousExportStatus enum value
+	ContinuousExportStatusActive = "ACTIVE"
+
+	// ContinuousExportStatusError is a ContinuousExportStatus enum value
+	ContinuousExportStatusError = "ERROR"
+
+	// ContinuousExportStatusStopInProgress is a ContinuousExportStatus enum value
+	ContinuousExportStatusStopInProgress = "STOP_IN_PROGRESS"
+
+	// ContinuousExportStatusStopFailed is a ContinuousExportStatus enum value
+	ContinuousExportStatusStopFailed = "STOP_FAILED"
+
+	// ContinuousExportStatusInactive is a ContinuousExportStatus enum value
+	ContinuousExportStatusInactive = "INACTIVE"
+)
+
+const (
+	// DataSourceAgent is a DataSource enum value
+	DataSourceAgent = "AGENT"
 )
 
 const (

--- a/service/applicationdiscoveryservice/applicationdiscoveryserviceiface/interface.go
+++ b/service/applicationdiscoveryservice/applicationdiscoveryserviceiface/interface.go
@@ -88,6 +88,13 @@ type ApplicationDiscoveryServiceAPI interface {
 	DescribeConfigurationsWithContext(aws.Context, *applicationdiscoveryservice.DescribeConfigurationsInput, ...request.Option) (*applicationdiscoveryservice.DescribeConfigurationsOutput, error)
 	DescribeConfigurationsRequest(*applicationdiscoveryservice.DescribeConfigurationsInput) (*request.Request, *applicationdiscoveryservice.DescribeConfigurationsOutput)
 
+	DescribeContinuousExports(*applicationdiscoveryservice.DescribeContinuousExportsInput) (*applicationdiscoveryservice.DescribeContinuousExportsOutput, error)
+	DescribeContinuousExportsWithContext(aws.Context, *applicationdiscoveryservice.DescribeContinuousExportsInput, ...request.Option) (*applicationdiscoveryservice.DescribeContinuousExportsOutput, error)
+	DescribeContinuousExportsRequest(*applicationdiscoveryservice.DescribeContinuousExportsInput) (*request.Request, *applicationdiscoveryservice.DescribeContinuousExportsOutput)
+
+	DescribeContinuousExportsPages(*applicationdiscoveryservice.DescribeContinuousExportsInput, func(*applicationdiscoveryservice.DescribeContinuousExportsOutput, bool) bool) error
+	DescribeContinuousExportsPagesWithContext(aws.Context, *applicationdiscoveryservice.DescribeContinuousExportsInput, func(*applicationdiscoveryservice.DescribeContinuousExportsOutput, bool) bool, ...request.Option) error
+
 	DescribeExportConfigurations(*applicationdiscoveryservice.DescribeExportConfigurationsInput) (*applicationdiscoveryservice.DescribeExportConfigurationsOutput, error)
 	DescribeExportConfigurationsWithContext(aws.Context, *applicationdiscoveryservice.DescribeExportConfigurationsInput, ...request.Option) (*applicationdiscoveryservice.DescribeExportConfigurationsOutput, error)
 	DescribeExportConfigurationsRequest(*applicationdiscoveryservice.DescribeExportConfigurationsInput) (*request.Request, *applicationdiscoveryservice.DescribeExportConfigurationsOutput)
@@ -120,6 +127,10 @@ type ApplicationDiscoveryServiceAPI interface {
 	ListServerNeighborsWithContext(aws.Context, *applicationdiscoveryservice.ListServerNeighborsInput, ...request.Option) (*applicationdiscoveryservice.ListServerNeighborsOutput, error)
 	ListServerNeighborsRequest(*applicationdiscoveryservice.ListServerNeighborsInput) (*request.Request, *applicationdiscoveryservice.ListServerNeighborsOutput)
 
+	StartContinuousExport(*applicationdiscoveryservice.StartContinuousExportInput) (*applicationdiscoveryservice.StartContinuousExportOutput, error)
+	StartContinuousExportWithContext(aws.Context, *applicationdiscoveryservice.StartContinuousExportInput, ...request.Option) (*applicationdiscoveryservice.StartContinuousExportOutput, error)
+	StartContinuousExportRequest(*applicationdiscoveryservice.StartContinuousExportInput) (*request.Request, *applicationdiscoveryservice.StartContinuousExportOutput)
+
 	StartDataCollectionByAgentIds(*applicationdiscoveryservice.StartDataCollectionByAgentIdsInput) (*applicationdiscoveryservice.StartDataCollectionByAgentIdsOutput, error)
 	StartDataCollectionByAgentIdsWithContext(aws.Context, *applicationdiscoveryservice.StartDataCollectionByAgentIdsInput, ...request.Option) (*applicationdiscoveryservice.StartDataCollectionByAgentIdsOutput, error)
 	StartDataCollectionByAgentIdsRequest(*applicationdiscoveryservice.StartDataCollectionByAgentIdsInput) (*request.Request, *applicationdiscoveryservice.StartDataCollectionByAgentIdsOutput)
@@ -127,6 +138,10 @@ type ApplicationDiscoveryServiceAPI interface {
 	StartExportTask(*applicationdiscoveryservice.StartExportTaskInput) (*applicationdiscoveryservice.StartExportTaskOutput, error)
 	StartExportTaskWithContext(aws.Context, *applicationdiscoveryservice.StartExportTaskInput, ...request.Option) (*applicationdiscoveryservice.StartExportTaskOutput, error)
 	StartExportTaskRequest(*applicationdiscoveryservice.StartExportTaskInput) (*request.Request, *applicationdiscoveryservice.StartExportTaskOutput)
+
+	StopContinuousExport(*applicationdiscoveryservice.StopContinuousExportInput) (*applicationdiscoveryservice.StopContinuousExportOutput, error)
+	StopContinuousExportWithContext(aws.Context, *applicationdiscoveryservice.StopContinuousExportInput, ...request.Option) (*applicationdiscoveryservice.StopContinuousExportOutput, error)
+	StopContinuousExportRequest(*applicationdiscoveryservice.StopContinuousExportInput) (*request.Request, *applicationdiscoveryservice.StopContinuousExportOutput)
 
 	StopDataCollectionByAgentIds(*applicationdiscoveryservice.StopDataCollectionByAgentIdsInput) (*applicationdiscoveryservice.StopDataCollectionByAgentIdsOutput, error)
 	StopDataCollectionByAgentIdsWithContext(aws.Context, *applicationdiscoveryservice.StopDataCollectionByAgentIdsInput, ...request.Option) (*applicationdiscoveryservice.StopDataCollectionByAgentIdsOutput, error)

--- a/service/applicationdiscoveryservice/errors.go
+++ b/service/applicationdiscoveryservice/errors.go
@@ -11,6 +11,10 @@ const (
 	// the IAM policy associated with this account.
 	ErrCodeAuthorizationErrorException = "AuthorizationErrorException"
 
+	// ErrCodeConflictErrorException for service response error code
+	// "ConflictErrorException".
+	ErrCodeConflictErrorException = "ConflictErrorException"
+
 	// ErrCodeInvalidParameterException for service response error code
 	// "InvalidParameterException".
 	//
@@ -29,6 +33,10 @@ const (
 	//
 	// This operation is not permitted.
 	ErrCodeOperationNotPermittedException = "OperationNotPermittedException"
+
+	// ErrCodeResourceInUseException for service response error code
+	// "ResourceInUseException".
+	ErrCodeResourceInUseException = "ResourceInUseException"
 
 	// ErrCodeResourceNotFoundException for service response error code
 	// "ResourceNotFoundException".

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -41876,7 +41876,9 @@ type DescribeVolumeAttributeInput struct {
 	_ struct{} `type:"structure"`
 
 	// The attribute of the volume. This parameter is required.
-	Attribute *string `type:"string" enum:"VolumeAttributeName"`
+	//
+	// Attribute is a required field
+	Attribute *string `type:"string" required:"true" enum:"VolumeAttributeName"`
 
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -41903,6 +41905,9 @@ func (s DescribeVolumeAttributeInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DescribeVolumeAttributeInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeVolumeAttributeInput"}
+	if s.Attribute == nil {
+		invalidParams.Add(request.NewErrParamRequired("Attribute"))
+	}
 	if s.VolumeId == nil {
 		invalidParams.Add(request.NewErrParamRequired("VolumeId"))
 	}

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -4900,6 +4900,10 @@ type DashIsoGroupSettings struct {
 	//
 	// SegmentLength is a required field
 	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer" required:"true"`
+
+	// When ENABLED, segment durations are indicated in the manifest using SegmentTimeline
+	// and SegmentTimeline will be promoted down into Representation from AdaptationSet.
+	WriteSegmentTimelineInRepresentation *string `locationName:"writeSegmentTimelineInRepresentation" type:"string" enum:"DashIsoWriteSegmentTimelineInRepresentation"`
 }
 
 // String returns the string representation
@@ -4984,6 +4988,12 @@ func (s *DashIsoGroupSettings) SetSegmentControl(v string) *DashIsoGroupSettings
 // SetSegmentLength sets the SegmentLength field's value.
 func (s *DashIsoGroupSettings) SetSegmentLength(v int64) *DashIsoGroupSettings {
 	s.SegmentLength = &v
+	return s
+}
+
+// SetWriteSegmentTimelineInRepresentation sets the WriteSegmentTimelineInRepresentation field's value.
+func (s *DashIsoGroupSettings) SetWriteSegmentTimelineInRepresentation(v string) *DashIsoGroupSettings {
+	s.WriteSegmentTimelineInRepresentation = &v
 	return s
 }
 
@@ -15145,6 +15155,16 @@ const (
 
 	// DashIsoSegmentControlSegmentedFiles is a DashIsoSegmentControl enum value
 	DashIsoSegmentControlSegmentedFiles = "SEGMENTED_FILES"
+)
+
+// When ENABLED, segment durations are indicated in the manifest using SegmentTimeline
+// and SegmentTimeline will be promoted down into Representation from AdaptationSet.
+const (
+	// DashIsoWriteSegmentTimelineInRepresentationEnabled is a DashIsoWriteSegmentTimelineInRepresentation enum value
+	DashIsoWriteSegmentTimelineInRepresentationEnabled = "ENABLED"
+
+	// DashIsoWriteSegmentTimelineInRepresentationDisabled is a DashIsoWriteSegmentTimelineInRepresentation enum value
+	DashIsoWriteSegmentTimelineInRepresentationDisabled = "DISABLED"
 )
 
 // Only applies when you set Deinterlacer (DeinterlaceMode) to Deinterlace (DEINTERLACE)

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -6861,6 +6861,112 @@ func (c *Redshift) ResetClusterParameterGroupWithContext(ctx aws.Context, input 
 	return out, req.Send()
 }
 
+const opResizeCluster = "ResizeCluster"
+
+// ResizeClusterRequest generates a "aws/request.Request" representing the
+// client's request for the ResizeCluster operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ResizeCluster for more information on using the ResizeCluster
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ResizeClusterRequest method.
+//    req, resp := client.ResizeClusterRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ResizeCluster
+func (c *Redshift) ResizeClusterRequest(input *ResizeClusterInput) (req *request.Request, output *ResizeClusterOutput) {
+	op := &request.Operation{
+		Name:       opResizeCluster,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ResizeClusterInput{}
+	}
+
+	output = &ResizeClusterOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ResizeCluster API operation for Amazon Redshift.
+//
+// Changes the cluster's type, node type, or number of nodes.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Redshift's
+// API operation ResizeCluster for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidClusterStateFault "InvalidClusterState"
+//   The specified cluster is not in the available state.
+//
+//   * ErrCodeClusterNotFoundFault "ClusterNotFound"
+//   The ClusterIdentifier parameter does not refer to an existing cluster.
+//
+//   * ErrCodeNumberOfNodesQuotaExceededFault "NumberOfNodesQuotaExceeded"
+//   The operation would exceed the number of nodes allotted to the account. For
+//   information about increasing your quota, go to Limits in Amazon Redshift
+//   (http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html)
+//   in the Amazon Redshift Cluster Management Guide.
+//
+//   * ErrCodeNumberOfNodesPerClusterLimitExceededFault "NumberOfNodesPerClusterLimitExceeded"
+//   The operation would exceed the number of nodes allowed for a cluster.
+//
+//   * ErrCodeInsufficientClusterCapacityFault "InsufficientClusterCapacity"
+//   The number of nodes specified exceeds the allotted capacity of the cluster.
+//
+//   * ErrCodeUnsupportedOptionFault "UnsupportedOptionFault"
+//   A request option was specified that is not supported.
+//
+//   * ErrCodeUnsupportedOperationFault "UnsupportedOperation"
+//   The requested operation isn't supported.
+//
+//   * ErrCodeUnauthorizedOperation "UnauthorizedOperation"
+//   Your account is not authorized to perform the requested operation.
+//
+//   * ErrCodeLimitExceededFault "LimitExceededFault"
+//   The encryption key has exceeded its grant limit in AWS KMS.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/redshift-2012-12-01/ResizeCluster
+func (c *Redshift) ResizeCluster(input *ResizeClusterInput) (*ResizeClusterOutput, error) {
+	req, out := c.ResizeClusterRequest(input)
+	return out, req.Send()
+}
+
+// ResizeClusterWithContext is the same as ResizeCluster with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ResizeCluster for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Redshift) ResizeClusterWithContext(ctx aws.Context, input *ResizeClusterInput, opts ...request.Option) (*ResizeClusterOutput, error) {
+	req, out := c.ResizeClusterRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opRestoreFromClusterSnapshot = "RestoreFromClusterSnapshot"
 
 // RestoreFromClusterSnapshotRequest generates a "aws/request.Request" representing the
@@ -7832,6 +7938,10 @@ type Cluster struct {
 	// The status of the elastic IP (EIP) address.
 	ElasticIpStatus *ElasticIpStatus `type:"structure"`
 
+	// Indicates the number of nodes the cluster can be resized to with the elastic
+	// resize method.
+	ElasticResizeNumberOfNodeOptions *string `type:"string"`
+
 	// A Boolean value that, if true, indicates that data in the cluster is encrypted
 	// at rest.
 	Encrypted *bool `type:"boolean"`
@@ -8015,6 +8125,12 @@ func (s *Cluster) SetDBName(v string) *Cluster {
 // SetElasticIpStatus sets the ElasticIpStatus field's value.
 func (s *Cluster) SetElasticIpStatus(v *ElasticIpStatus) *Cluster {
 	s.ElasticIpStatus = v
+	return s
+}
+
+// SetElasticResizeNumberOfNodeOptions sets the ElasticResizeNumberOfNodeOptions field's value.
+func (s *Cluster) SetElasticResizeNumberOfNodeOptions(v string) *Cluster {
+	s.ElasticResizeNumberOfNodeOptions = &v
 	return s
 }
 
@@ -13107,12 +13223,19 @@ type DescribeResizeOutput struct {
 	// Valid Values: List of table names
 	ImportTablesNotStarted []*string `type:"list"`
 
+	// An optional string to provide additional details about the resize action.
+	Message *string `type:"string"`
+
 	// While the resize operation is in progress, this value shows the current amount
 	// of data, in megabytes, that has been processed so far. When the resize operation
 	// is complete, this value shows the total amount of data, in megabytes, on
 	// the cluster, which may be more or less than TotalResizeDataInMegaBytes (the
 	// estimated total amount of data before resize).
 	ProgressInMegaBytes *int64 `type:"long"`
+
+	// An enum with possible values of ClassicResize and ElasticResize. These values
+	// describe the type of resize operation being performed.
+	ResizeType *string `type:"string"`
 
 	// The status of the resize operation.
 	//
@@ -13182,9 +13305,21 @@ func (s *DescribeResizeOutput) SetImportTablesNotStarted(v []*string) *DescribeR
 	return s
 }
 
+// SetMessage sets the Message field's value.
+func (s *DescribeResizeOutput) SetMessage(v string) *DescribeResizeOutput {
+	s.Message = &v
+	return s
+}
+
 // SetProgressInMegaBytes sets the ProgressInMegaBytes field's value.
 func (s *DescribeResizeOutput) SetProgressInMegaBytes(v int64) *DescribeResizeOutput {
 	s.ProgressInMegaBytes = &v
+	return s
+}
+
+// SetResizeType sets the ResizeType field's value.
+func (s *DescribeResizeOutput) SetResizeType(v string) *DescribeResizeOutput {
+	s.ResizeType = &v
 	return s
 }
 
@@ -16550,6 +16685,109 @@ func (s *ResetClusterParameterGroupInput) SetParameters(v []*Parameter) *ResetCl
 // SetResetAllParameters sets the ResetAllParameters field's value.
 func (s *ResetClusterParameterGroupInput) SetResetAllParameters(v bool) *ResetClusterParameterGroupInput {
 	s.ResetAllParameters = &v
+	return s
+}
+
+type ResizeClusterInput struct {
+	_ struct{} `type:"structure"`
+
+	// A boolean value indicating whether the resize operation is using the classic
+	// resize process.
+	Classic *bool `type:"boolean"`
+
+	// The unique identifier for the cluster to resize.
+	//
+	// ClusterIdentifier is a required field
+	ClusterIdentifier *string `type:"string" required:"true"`
+
+	// The new cluster type for the specified cluster.
+	ClusterType *string `type:"string"`
+
+	// The new node type for the nodes you are adding.
+	NodeType *string `type:"string"`
+
+	// The new number of nodes for the cluster.
+	//
+	// NumberOfNodes is a required field
+	NumberOfNodes *int64 `type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s ResizeClusterInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResizeClusterInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResizeClusterInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResizeClusterInput"}
+	if s.ClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("ClusterIdentifier"))
+	}
+	if s.NumberOfNodes == nil {
+		invalidParams.Add(request.NewErrParamRequired("NumberOfNodes"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClassic sets the Classic field's value.
+func (s *ResizeClusterInput) SetClassic(v bool) *ResizeClusterInput {
+	s.Classic = &v
+	return s
+}
+
+// SetClusterIdentifier sets the ClusterIdentifier field's value.
+func (s *ResizeClusterInput) SetClusterIdentifier(v string) *ResizeClusterInput {
+	s.ClusterIdentifier = &v
+	return s
+}
+
+// SetClusterType sets the ClusterType field's value.
+func (s *ResizeClusterInput) SetClusterType(v string) *ResizeClusterInput {
+	s.ClusterType = &v
+	return s
+}
+
+// SetNodeType sets the NodeType field's value.
+func (s *ResizeClusterInput) SetNodeType(v string) *ResizeClusterInput {
+	s.NodeType = &v
+	return s
+}
+
+// SetNumberOfNodes sets the NumberOfNodes field's value.
+func (s *ResizeClusterInput) SetNumberOfNodes(v int64) *ResizeClusterInput {
+	s.NumberOfNodes = &v
+	return s
+}
+
+type ResizeClusterOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Describes a cluster.
+	Cluster *Cluster `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResizeClusterOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResizeClusterOutput) GoString() string {
+	return s.String()
+}
+
+// SetCluster sets the Cluster field's value.
+func (s *ResizeClusterOutput) SetCluster(v *Cluster) *ResizeClusterOutput {
+	s.Cluster = v
 	return s
 }
 

--- a/service/redshift/redshiftiface/interface.go
+++ b/service/redshift/redshiftiface/interface.go
@@ -357,6 +357,10 @@ type RedshiftAPI interface {
 	ResetClusterParameterGroupWithContext(aws.Context, *redshift.ResetClusterParameterGroupInput, ...request.Option) (*redshift.ClusterParameterGroupNameMessage, error)
 	ResetClusterParameterGroupRequest(*redshift.ResetClusterParameterGroupInput) (*request.Request, *redshift.ClusterParameterGroupNameMessage)
 
+	ResizeCluster(*redshift.ResizeClusterInput) (*redshift.ResizeClusterOutput, error)
+	ResizeClusterWithContext(aws.Context, *redshift.ResizeClusterInput, ...request.Option) (*redshift.ResizeClusterOutput, error)
+	ResizeClusterRequest(*redshift.ResizeClusterInput) (*request.Request, *redshift.ResizeClusterOutput)
+
 	RestoreFromClusterSnapshot(*redshift.RestoreFromClusterSnapshotInput) (*redshift.RestoreFromClusterSnapshotOutput, error)
 	RestoreFromClusterSnapshotWithContext(aws.Context, *redshift.RestoreFromClusterSnapshotInput, ...request.Option) (*redshift.RestoreFromClusterSnapshotOutput, error)
 	RestoreFromClusterSnapshotRequest(*redshift.RestoreFromClusterSnapshotInput) (*request.Request, *redshift.RestoreFromClusterSnapshotOutput)

--- a/service/ssm/errors.go
+++ b/service/ssm/errors.go
@@ -196,6 +196,13 @@ const (
 	// or ActivationCode and try again.
 	ErrCodeInvalidActivationId = "InvalidActivationId"
 
+	// ErrCodeInvalidAggregatorException for service response error code
+	// "InvalidAggregatorException".
+	//
+	// The specified aggregator is not valid for inventory groups. Verify that the
+	// aggregator uses a valid inventory type such as AWS:Application or AWS:InstanceInformation.
+	ErrCodeInvalidAggregatorException = "InvalidAggregatorException"
+
 	// ErrCodeInvalidAllowedPatternException for service response error code
 	// "InvalidAllowedPatternException".
 	//
@@ -334,6 +341,12 @@ const (
 	//
 	// The specified filter value is not valid.
 	ErrCodeInvalidInstanceInformationFilterValue = "InvalidInstanceInformationFilterValue"
+
+	// ErrCodeInvalidInventoryGroupException for service response error code
+	// "InvalidInventoryGroupException".
+	//
+	// The specified inventory group is not valid.
+	ErrCodeInvalidInventoryGroupException = "InvalidInventoryGroupException"
 
 	// ErrCodeInvalidInventoryItemContextException for service response error code
 	// "InvalidInventoryItemContextException".


### PR DESCRIPTION
Release v1.15.14 (2018-08-16)
===

### Service Client Updates
* `service/discovery`: Updates service API, documentation, and paginators
  * The Application Discovery Service's Continuous Export APIs allow you to analyze your on-premises server inventory data, including system performance and network dependencies, in Amazon Athena.
* `service/ec2`: Updates service API
  * The 'Attribute' parameter DescribeVolumeAttribute request has been marked as required - the API has always required this parameter, but up until now this wasn't reflected appropriately in the SDK.
* `service/mediaconvert`: Updates service API and documentation
  * Added WriteSegmentTimelineInRepresentation option for Dash Outputs
* `service/redshift`: Updates service API and documentation
  * You can now resize your Amazon Redshift cluster quickly. With the new ResizeCluster action, your cluster is available for read and write operations within minutes
* `service/ssm`: Updates service API and documentation
  * AWS Systems Manager Inventory now supports groups to quickly see a count of which managed instances are and arent configured to collect one or more Inventory types

