### PR TITLE
v1.15.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Release v1.15.16 (2018-08-20)
+===
+
+### Service Client Updates
+* `service/dynamodb`: Updates service API and documentation
+  * Added SSESpecification block to update-table command which allows users to modify table Server-Side Encryption. Added two new fields (SSEType and KMSMasterKeyId) to SSESpecification block used by create-table and update-table commands. Added new SSEDescription Status value UPDATING.
+* `service/mediaconvert`: Updates service API
+  * This release fixes backward-incompatible changes from a previous release. That previous release changed non-required job settings to required, which prevented jobs and job templates from merging correctly. The current change removes validation of required settings from the SDK and instead centralizes the validation in the service API. For information on required settings, see the Resources chapter of the AWS Elemental MediaConvert API Reference https://docs.aws.amazon.com/mediaconvert/latest/apireference/resources.html
+
 Release v1.15.15 (2018-08-17)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.15.15"
+const SDKVersion = "1.15.16"

--- a/models/apis/dynamodb/2012-08-10/api-2.json
+++ b/models/apis/dynamodb/2012-08-10/api-2.json
@@ -1385,6 +1385,7 @@
       "member":{"shape":"AttributeMap"}
     },
     "KMSMasterKeyArn":{"type":"string"},
+    "KMSMasterKeyId":{"type":"string"},
     "Key":{
       "type":"map",
       "key":{"shape":"AttributeName"},
@@ -1965,9 +1966,10 @@
     "SSEEnabled":{"type":"boolean"},
     "SSESpecification":{
       "type":"structure",
-      "required":["Enabled"],
       "members":{
-        "Enabled":{"shape":"SSEEnabled"}
+        "Enabled":{"shape":"SSEEnabled"},
+        "SSEType":{"shape":"SSEType"},
+        "KMSMasterKeyId":{"shape":"KMSMasterKeyId"}
       }
     },
     "SSEStatus":{
@@ -1976,7 +1978,8 @@
         "ENABLING",
         "ENABLED",
         "DISABLING",
-        "DISABLED"
+        "DISABLED",
+        "UPDATING"
       ]
     },
     "SSEType":{
@@ -2363,7 +2366,8 @@
         "TableName":{"shape":"TableName"},
         "ProvisionedThroughput":{"shape":"ProvisionedThroughput"},
         "GlobalSecondaryIndexUpdates":{"shape":"GlobalSecondaryIndexUpdateList"},
-        "StreamSpecification":{"shape":"StreamSpecification"}
+        "StreamSpecification":{"shape":"StreamSpecification"},
+        "SSESpecification":{"shape":"SSESpecification"}
       }
     },
     "UpdateTableOutput":{

--- a/models/apis/dynamodb/2012-08-10/docs-2.json
+++ b/models/apis/dynamodb/2012-08-10/docs-2.json
@@ -274,14 +274,14 @@
     "BackupType": {
       "base": null,
       "refs": {
-        "BackupDetails$BackupType": "<p>BackupType:</p> <ul> <li> <p> <code>USER</code> - On demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On demand backup automatically created by DynamoDB.</p> </li> </ul>",
-        "BackupSummary$BackupType": "<p>BackupType:</p> <ul> <li> <p> <code>USER</code> - On demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On demand backup automatically created by DynamoDB.</p> </li> </ul>"
+        "BackupDetails$BackupType": "<p>BackupType:</p> <ul> <li> <p> <code>USER</code> - On-demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On-demand backup automatically created by DynamoDB.</p> </li> </ul>",
+        "BackupSummary$BackupType": "<p>BackupType:</p> <ul> <li> <p> <code>USER</code> - On-demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On-demand backup automatically created by DynamoDB.</p> </li> </ul>"
       }
     },
     "BackupTypeFilter": {
       "base": null,
       "refs": {
-        "ListBackupsInput$BackupType": "<p>The backups from the table specified by BackupType are listed.</p> <p>Where BackupType can be:</p> <ul> <li> <p> <code>USER</code> - On demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On demand backup automatically created by DynamoDB.</p> </li> <li> <p> <code>ALL</code> - All types of on demand backups (USER and SYSTEM).</p> </li> </ul>"
+        "ListBackupsInput$BackupType": "<p>The backups from the table specified by <code>BackupType</code> are listed.</p> <p>Where <code>BackupType</code> can be:</p> <ul> <li> <p> <code>USER</code> - On-demand backup created by you.</p> </li> <li> <p> <code>SYSTEM</code> - On-demand backup automatically created by DynamoDB.</p> </li> <li> <p> <code>ALL</code> - All types of on-demand backups (USER and SYSTEM).</p> </li> </ul>"
       }
     },
     "BackupsInputLimit": {
@@ -453,7 +453,7 @@
     "ContinuousBackupsStatus": {
       "base": null,
       "refs": {
-        "ContinuousBackupsDescription$ContinuousBackupsStatus": "<p> <code>ContinuousBackupsStatus</code> can be one of the following states : ENABLED, DISABLED</p>"
+        "ContinuousBackupsDescription$ContinuousBackupsStatus": "<p> <code>ContinuousBackupsStatus</code> can be one of the following states: ENABLED, DISABLED</p>"
       }
     },
     "ContinuousBackupsUnavailableException": {
@@ -506,8 +506,8 @@
     "Date": {
       "base": null,
       "refs": {
-        "BackupDetails$BackupExpiryDateTime": "<p>Time at which the automatic on demand backup created by DynamoDB will expire. This <code>SYSTEM</code> on demand backup expires automatically 35 days after its creation.</p>",
-        "BackupSummary$BackupExpiryDateTime": "<p>Time at which the automatic on demand backup created by DynamoDB will expire. This <code>SYSTEM</code> on demand backup expires automatically 35 days after its creation.</p>",
+        "BackupDetails$BackupExpiryDateTime": "<p>Time at which the automatic on-demand backup created by DynamoDB will expire. This <code>SYSTEM</code> on-demand backup expires automatically 35 days after its creation.</p>",
+        "BackupSummary$BackupExpiryDateTime": "<p>Time at which the automatic on-demand backup created by DynamoDB will expire. This <code>SYSTEM</code> on-demand backup expires automatically 35 days after its creation.</p>",
         "GlobalTableDescription$CreationDateTime": "<p>The creation time of the global table.</p>",
         "PointInTimeRecoveryDescription$EarliestRestorableDateTime": "<p>Specifies the earliest point in time you can restore your table to. It You can restore your table to any point in time during the last 35 days. </p>",
         "PointInTimeRecoveryDescription$LatestRestorableDateTime": "<p> <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time. </p>",
@@ -957,6 +957,12 @@
       "base": null,
       "refs": {
         "SSEDescription$KMSMasterKeyArn": "<p>The KMS master key ARN used for the KMS encryption.</p>"
+      }
+    },
+    "KMSMasterKeyId": {
+      "base": null,
+      "refs": {
+        "SSESpecification$KMSMasterKeyId": "<p>The KMS Master Key (CMK) which should be used for the KMS encryption. To specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB KMS Master Key alias/aws/dynamodb.</p>"
       }
     },
     "Key": {
@@ -1531,19 +1537,21 @@
     "SSESpecification": {
       "base": "<p>Represents the settings used to enable server-side encryption.</p>",
       "refs": {
-        "CreateTableInput$SSESpecification": "<p>Represents the settings used to enable server-side encryption.</p>"
+        "CreateTableInput$SSESpecification": "<p>Represents the settings used to enable server-side encryption.</p>",
+        "UpdateTableInput$SSESpecification": "<p>The new server-side encryption settings for the specified table.</p>"
       }
     },
     "SSEStatus": {
       "base": null,
       "refs": {
-        "SSEDescription$Status": "<p>The current state of server-side encryption:</p> <ul> <li> <p> <code>ENABLING</code> - Server-side encryption is being enabled.</p> </li> <li> <p> <code>ENABLED</code> - Server-side encryption is enabled.</p> </li> <li> <p> <code>DISABLING</code> - Server-side encryption is being disabled.</p> </li> <li> <p> <code>DISABLED</code> - Server-side encryption is disabled.</p> </li> </ul>"
+        "SSEDescription$Status": "<p>The current state of server-side encryption:</p> <ul> <li> <p> <code>ENABLING</code> - Server-side encryption is being enabled.</p> </li> <li> <p> <code>ENABLED</code> - Server-side encryption is enabled.</p> </li> <li> <p> <code>DISABLING</code> - Server-side encryption is being disabled.</p> </li> <li> <p> <code>DISABLED</code> - Server-side encryption is disabled.</p> </li> <li> <p> <code>UPDATING</code> - Server-side encryption is being updated.</p> </li> </ul>"
       }
     },
     "SSEType": {
       "base": null,
       "refs": {
-        "SSEDescription$SSEType": "<p>Server-side encryption type:</p> <ul> <li> <p> <code>AES256</code> - Server-side encryption which uses the AES256 algorithm.</p> </li> <li> <p> <code>KMS</code> - Server-side encryption which uses AWS Key Management Service.</p> </li> </ul>"
+        "SSEDescription$SSEType": "<p>Server-side encryption type:</p> <ul> <li> <p> <code>AES256</code> - Server-side encryption which uses the AES256 algorithm.</p> </li> <li> <p> <code>KMS</code> - Server-side encryption which uses AWS Key Management Service.</p> </li> </ul>",
+        "SSESpecification$SSEType": "<p>Server-side encryption type:</p> <ul> <li> <p> <code>AES256</code> - Server-side encryption which uses the AES256 algorithm.</p> </li> <li> <p> <code>KMS</code> - Server-side encryption which uses AWS Key Management Service. (default)</p> </li> </ul>"
       }
     },
     "ScalarAttributeType": {
@@ -1716,7 +1724,7 @@
         "GlobalTable$GlobalTableName": "<p>The global table name.</p>",
         "GlobalTableDescription$GlobalTableName": "<p>The global table name.</p>",
         "ItemCollectionMetricsPerTable$key": null,
-        "ListBackupsInput$TableName": "<p>The backups from the table specified by TableName are listed. </p>",
+        "ListBackupsInput$TableName": "<p>The backups from the table specified by <code>TableName</code> are listed. </p>",
         "ListGlobalTablesInput$ExclusiveStartGlobalTableName": "<p>The first global table name that this operation will evaluate.</p>",
         "ListGlobalTablesOutput$LastEvaluatedGlobalTableName": "<p>Last evaluated global table name.</p>",
         "ListTablesInput$ExclusiveStartTableName": "<p>The first table name that this operation will evaluate. Use the value that was returned for <code>LastEvaluatedTableName</code> in a previous operation, so that you can obtain the next page of results.</p>",

--- a/models/apis/mediaconvert/2017-08-29/api-2.json
+++ b/models/apis/mediaconvert/2017-08-29/api-2.json
@@ -874,11 +874,7 @@
           "shape": "AacVbrQuality",
           "locationName": "vbrQuality"
         }
-      },
-      "required": [
-        "CodingMode",
-        "SampleRate"
-      ]
+      }
     },
     "AacSpecification": {
       "type": "string",
@@ -1060,10 +1056,7 @@
           "shape": "WavSettings",
           "locationName": "wavSettings"
         }
-      },
-      "required": [
-        "Codec"
-      ]
+      }
     },
     "AudioDefaultSelection": {
       "type": "string",
@@ -1115,10 +1108,7 @@
           "shape": "__stringPatternWS",
           "locationName": "streamName"
         }
-      },
-      "required": [
-        "CodecSettings"
-      ]
+      }
     },
     "AudioLanguageCodeControl": {
       "type": "string",
@@ -1236,10 +1226,7 @@
           "shape": "__listOf__stringMin1",
           "locationName": "audioSelectorNames"
         }
-      },
-      "required": [
-        "AudioSelectorNames"
-      ]
+      }
     },
     "AudioSelectorType": {
       "type": "string",
@@ -1345,13 +1332,7 @@
           "shape": "__integerMin0Max2147483647",
           "locationName": "yPosition"
         }
-      },
-      "required": [
-        "OutlineColor",
-        "Alignment",
-        "OutlineSize",
-        "FontOpacity"
-      ]
+      }
     },
     "BurninSubtitleAlignment": {
       "type": "string",
@@ -1446,11 +1427,7 @@
           "shape": "__string",
           "locationName": "languageDescription"
         }
-      },
-      "required": [
-        "DestinationSettings",
-        "CaptionSelectorName"
-      ]
+      }
     },
     "CaptionDescriptionPreset": {
       "type": "structure",
@@ -1471,10 +1448,7 @@
           "shape": "__string",
           "locationName": "languageDescription"
         }
-      },
-      "required": [
-        "DestinationSettings"
-      ]
+      }
     },
     "CaptionDestinationSettings": {
       "type": "structure",
@@ -1503,10 +1477,7 @@
           "shape": "TtmlDestinationSettings",
           "locationName": "ttmlDestinationSettings"
         }
-      },
-      "required": [
-        "DestinationType"
-      ]
+      }
     },
     "CaptionDestinationType": {
       "type": "string",
@@ -1536,10 +1507,7 @@
           "shape": "CaptionSourceSettings",
           "locationName": "sourceSettings"
         }
-      },
-      "required": [
-        "SourceSettings"
-      ]
+      }
     },
     "CaptionSourceSettings": {
       "type": "structure",
@@ -1568,10 +1536,7 @@
           "shape": "TeletextSourceSettings",
           "locationName": "teletextSourceSettings"
         }
-      },
-      "required": [
-        "SourceType"
-      ]
+      }
     },
     "CaptionSourceType": {
       "type": "string",
@@ -1594,10 +1559,7 @@
           "shape": "__listOfOutputChannelMapping",
           "locationName": "outputChannels"
         }
-      },
-      "required": [
-        "OutputChannels"
-      ]
+      }
     },
     "CmafClientCache": {
       "type": "string",
@@ -1636,10 +1598,7 @@
           "shape": "CmafKeyProviderType",
           "locationName": "type"
         }
-      },
-      "required": [
-        "Type"
-      ]
+      }
     },
     "CmafEncryptionType": {
       "type": "string",
@@ -1710,11 +1669,7 @@
           "shape": "CmafWriteHLSManifest",
           "locationName": "writeHlsManifest"
         }
-      },
-      "required": [
-        "FragmentLength",
-        "SegmentLength"
-      ]
+      }
     },
     "CmafInitializationVectorInManifest": {
       "type": "string",
@@ -1874,10 +1829,7 @@
           "shape": "Mp4Settings",
           "locationName": "mp4Settings"
         }
-      },
-      "required": [
-        "Container"
-      ]
+      }
     },
     "ContainerType": {
       "type": "string",
@@ -2053,10 +2005,7 @@
           "shape": "SpekeKeyProvider",
           "locationName": "spekeKeyProvider"
         }
-      },
-      "required": [
-        "SpekeKeyProvider"
-      ]
+      }
     },
     "DashIsoGroupSettings": {
       "type": "structure",
@@ -2097,11 +2046,7 @@
           "shape": "DashIsoWriteSegmentTimelineInRepresentation",
           "locationName": "writeSegmentTimelineInRepresentation"
         }
-      },
-      "required": [
-        "SegmentLength",
-        "FragmentLength"
-      ]
+      }
     },
     "DashIsoHbbtvCompliance": {
       "type": "string",
@@ -2267,12 +2212,7 @@
           "shape": "__integerMin25Max10000",
           "locationName": "nitInterval"
         }
-      },
-      "required": [
-        "NetworkName",
-        "NitInterval",
-        "NetworkId"
-      ]
+      }
     },
     "DvbSdtSettings": {
       "type": "structure",
@@ -2362,13 +2302,7 @@
           "shape": "__integerMin0Max2147483647",
           "locationName": "yPosition"
         }
-      },
-      "required": [
-        "OutlineColor",
-        "Alignment",
-        "OutlineSize",
-        "FontOpacity"
-      ]
+      }
     },
     "DvbSubSourceSettings": {
       "type": "structure",
@@ -2438,10 +2372,7 @@
           "shape": "__integerMin1000Max30000",
           "locationName": "tdtInterval"
         }
-      },
-      "required": [
-        "TdtInterval"
-      ]
+      }
     },
     "Eac3AttenuationControl": {
       "type": "string",
@@ -2735,10 +2666,7 @@
           "shape": "__integerMinNegative2147483648Max2147483647",
           "locationName": "timeDelta"
         }
-      },
-      "required": [
-        "SourceFile"
-      ]
+      }
     },
     "ForbiddenException": {
       "type": "structure",
@@ -2998,10 +2926,7 @@
           "shape": "__integerMin1Max10",
           "locationName": "qvbrQualityLevel"
         }
-      },
-      "required": [
-        "QvbrQualityLevel"
-      ]
+      }
     },
     "H264RateControlMode": {
       "type": "string",
@@ -3357,10 +3282,7 @@
           "shape": "__integerMin1Max10",
           "locationName": "qvbrQualityLevel"
         }
-      },
-      "required": [
-        "QvbrQualityLevel"
-      ]
+      }
     },
     "H265RateControlMode": {
       "type": "string",
@@ -3654,11 +3576,7 @@
           "shape": "__integerMin0Max50000",
           "locationName": "whitePointY"
         }
-      },
-      "required": [
-        "MaxContentLightLevel",
-        "MaxFrameAverageLightLevel"
-      ]
+      }
     },
     "HlsAdMarkers": {
       "type": "string",
@@ -3753,10 +3671,7 @@
           "shape": "HlsKeyProviderType",
           "locationName": "type"
         }
-      },
-      "required": [
-        "Type"
-      ]
+      }
     },
     "HlsEncryptionType": {
       "type": "string",
@@ -3860,11 +3775,7 @@
           "shape": "__integerMinNegative2147483648Max2147483647",
           "locationName": "timestampDeltaMilliseconds"
         }
-      },
-      "required": [
-        "MinSegmentLength",
-        "SegmentLength"
-      ]
+      }
     },
     "HlsIFrameOnlyManifest": {
       "type": "string",
@@ -3973,11 +3884,7 @@
           "shape": "__stringPattern010920405090509092",
           "locationName": "timecode"
         }
-      },
-      "required": [
-        "Timecode",
-        "Id3"
-      ]
+      }
     },
     "ImageInserter": {
       "type": "structure",
@@ -3986,10 +3893,7 @@
           "shape": "__listOfInsertableImage",
           "locationName": "insertableImages"
         }
-      },
-      "required": [
-        "InsertableImages"
-      ]
+      }
     },
     "Input": {
       "type": "structure",
@@ -4046,10 +3950,7 @@
           "shape": "VideoSelector",
           "locationName": "videoSelector"
         }
-      },
-      "required": [
-        "FileInput"
-      ]
+      }
     },
     "InputClipping": {
       "type": "structure",
@@ -4201,14 +4102,7 @@
           "shape": "__integerMinNegative2147483648Max2147483647",
           "locationName": "width"
         }
-      },
-      "required": [
-        "ImageY",
-        "ImageX",
-        "ImageInserterInput",
-        "Opacity",
-        "Layer"
-      ]
+      }
     },
     "InternalServerErrorException": {
       "type": "structure",
@@ -4315,11 +4209,7 @@
           "shape": "TimedMetadataInsertion",
           "locationName": "timedMetadataInsertion"
         }
-      },
-      "required": [
-        "OutputGroups",
-        "Inputs"
-      ]
+      }
     },
     "JobStatus": {
       "type": "string",
@@ -4415,10 +4305,7 @@
           "shape": "TimedMetadataInsertion",
           "locationName": "timedMetadataInsertion"
         }
-      },
-      "required": [
-        "OutputGroups"
-      ]
+      }
     },
     "LanguageCode": {
       "type": "string",
@@ -5517,10 +5404,7 @@
           "shape": "SpekeKeyProvider",
           "locationName": "spekeKeyProvider"
         }
-      },
-      "required": [
-        "SpekeKeyProvider"
-      ]
+      }
     },
     "MsSmoothGroupSettings": {
       "type": "structure",
@@ -5545,10 +5429,7 @@
           "shape": "MsSmoothManifestEncoding",
           "locationName": "manifestEncoding"
         }
-      },
-      "required": [
-        "FragmentLength"
-      ]
+      }
     },
     "MsSmoothManifestEncoding": {
       "type": "string",
@@ -5585,10 +5466,7 @@
           "shape": "NoiseReducerSpatialFilterSettings",
           "locationName": "spatialFilterSettings"
         }
-      },
-      "required": [
-        "Filter"
-      ]
+      }
     },
     "NoiseReducerFilter": {
       "type": "string",
@@ -5692,10 +5570,7 @@
           "shape": "__listOf__integerMinNegative60Max6",
           "locationName": "inputChannels"
         }
-      },
-      "required": [
-        "InputChannels"
-      ]
+      }
     },
     "OutputDetail": {
       "type": "structure",
@@ -5729,11 +5604,7 @@
           "shape": "__listOfOutput",
           "locationName": "outputs"
         }
-      },
-      "required": [
-        "Outputs",
-        "OutputGroupSettings"
-      ]
+      }
     },
     "OutputGroupDetail": {
       "type": "structure",
@@ -5771,10 +5642,7 @@
           "shape": "OutputGroupType",
           "locationName": "type"
         }
-      },
-      "required": [
-        "Type"
-      ]
+      }
     },
     "OutputGroupType": {
       "type": "string",
@@ -6054,13 +5922,7 @@
           "shape": "__integerMin0Max2147483647",
           "locationName": "y"
         }
-      },
-      "required": [
-        "X",
-        "Y",
-        "Height",
-        "Width"
-      ]
+      }
     },
     "RemixSettings": {
       "type": "structure",
@@ -6077,12 +5939,7 @@
           "shape": "__integerMin1Max8",
           "locationName": "channelsOut"
         }
-      },
-      "required": [
-        "ChannelsOut",
-        "ChannelMapping",
-        "ChannelsIn"
-      ]
+      }
     },
     "ResourceTags": {
       "type": "structure",
@@ -6145,12 +6002,7 @@
           "shape": "__stringPatternHttps",
           "locationName": "url"
         }
-      },
-      "required": [
-        "ResourceId",
-        "SystemIds",
-        "Url"
-      ]
+      }
     },
     "StaticKeyProvider": {
       "type": "structure",
@@ -6171,11 +6023,7 @@
           "shape": "__string",
           "locationName": "url"
         }
-      },
-      "required": [
-        "Url",
-        "StaticKeyValue"
-      ]
+      }
     },
     "TagResourceRequest": {
       "type": "structure",
@@ -6291,10 +6139,7 @@
           "shape": "__listOfId3Insertion",
           "locationName": "id3Insertions"
         }
-      },
-      "required": [
-        "Id3Insertions"
-      ]
+      }
     },
     "Timing": {
       "type": "structure",
@@ -6506,10 +6351,7 @@
           "shape": "ProresSettings",
           "locationName": "proresSettings"
         }
-      },
-      "required": [
-        "Codec"
-      ]
+      }
     },
     "VideoDescription": {
       "type": "structure",
@@ -6574,10 +6416,7 @@
           "shape": "__integerMin32Max4096",
           "locationName": "width"
         }
-      },
-      "required": [
-        "CodecSettings"
-      ]
+      }
     },
     "VideoDetail": {
       "type": "structure",

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -4636,8 +4636,8 @@ type BackupDetails struct {
 	// BackupCreationDateTime is a required field
 	BackupCreationDateTime *time.Time `type:"timestamp" required:"true"`
 
-	// Time at which the automatic on demand backup created by DynamoDB will expire.
-	// This SYSTEM on demand backup expires automatically 35 days after its creation.
+	// Time at which the automatic on-demand backup created by DynamoDB will expire.
+	// This SYSTEM on-demand backup expires automatically 35 days after its creation.
 	BackupExpiryDateTime *time.Time `type:"timestamp"`
 
 	// Name of the requested backup.
@@ -4655,9 +4655,9 @@ type BackupDetails struct {
 
 	// BackupType:
 	//
-	//    * USER - On demand backup created by you.
+	//    * USER - On-demand backup created by you.
 	//
-	//    * SYSTEM - On demand backup automatically created by DynamoDB.
+	//    * SYSTEM - On-demand backup automatically created by DynamoDB.
 	//
 	// BackupType is a required field
 	BackupType *string `type:"string" required:"true" enum:"BackupType"`
@@ -4725,8 +4725,8 @@ type BackupSummary struct {
 	// Time at which the backup was created.
 	BackupCreationDateTime *time.Time `type:"timestamp"`
 
-	// Time at which the automatic on demand backup created by DynamoDB will expire.
-	// This SYSTEM on demand backup expires automatically 35 days after its creation.
+	// Time at which the automatic on-demand backup created by DynamoDB will expire.
+	// This SYSTEM on-demand backup expires automatically 35 days after its creation.
 	BackupExpiryDateTime *time.Time `type:"timestamp"`
 
 	// Name of the specified backup.
@@ -4740,9 +4740,9 @@ type BackupSummary struct {
 
 	// BackupType:
 	//
-	//    * USER - On demand backup created by you.
+	//    * USER - On-demand backup created by you.
 	//
-	//    * SYSTEM - On demand backup automatically created by DynamoDB.
+	//    * SYSTEM - On-demand backup automatically created by DynamoDB.
 	BackupType *string `type:"string" enum:"BackupType"`
 
 	// ARN associated with the table.
@@ -5436,7 +5436,7 @@ func (s *ConsumedCapacity) SetTableName(v string) *ConsumedCapacity {
 type ContinuousBackupsDescription struct {
 	_ struct{} `type:"structure"`
 
-	// ContinuousBackupsStatus can be one of the following states : ENABLED, DISABLED
+	// ContinuousBackupsStatus can be one of the following states: ENABLED, DISABLED
 	//
 	// ContinuousBackupsStatus is a required field
 	ContinuousBackupsStatus *string `type:"string" required:"true" enum:"ContinuousBackupsStatus"`
@@ -6006,11 +6006,6 @@ func (s *CreateTableInput) Validate() error {
 	if s.ProvisionedThroughput != nil {
 		if err := s.ProvisionedThroughput.Validate(); err != nil {
 			invalidParams.AddNested("ProvisionedThroughput", err.(request.ErrInvalidParams))
-		}
-	}
-	if s.SSESpecification != nil {
-		if err := s.SSESpecification.Validate(); err != nil {
-			invalidParams.AddNested("SSESpecification", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -8318,11 +8313,11 @@ type ListBackupsInput struct {
 	//
 	// Where BackupType can be:
 	//
-	//    * USER - On demand backup created by you.
+	//    * USER - On-demand backup created by you.
 	//
-	//    * SYSTEM - On demand backup automatically created by DynamoDB.
+	//    * SYSTEM - On-demand backup automatically created by DynamoDB.
 	//
-	//    * ALL - All types of on demand backups (USER and SYSTEM).
+	//    * ALL - All types of on-demand backups (USER and SYSTEM).
 	BackupType *string `type:"string" enum:"BackupTypeFilter"`
 
 	// LastEvaluatedBackupArn is the ARN of the backup last evaluated when the current
@@ -10852,6 +10847,8 @@ type SSEDescription struct {
 	//    * DISABLING - Server-side encryption is being disabled.
 	//
 	//    * DISABLED - Server-side encryption is disabled.
+	//
+	//    * UPDATING - Server-side encryption is being updated.
 	Status *string `type:"string" enum:"SSEStatus"`
 }
 
@@ -10889,9 +10886,21 @@ type SSESpecification struct {
 
 	// Indicates whether server-side encryption is enabled (true) or disabled (false)
 	// on the table.
+	Enabled *bool `type:"boolean"`
+
+	// The KMS Master Key (CMK) which should be used for the KMS encryption. To
+	// specify a CMK, use its key ID, Amazon Resource Name (ARN), alias name, or
+	// alias ARN. Note that you should only provide this parameter if the key is
+	// different from the default DynamoDB KMS Master Key alias/aws/dynamodb.
+	KMSMasterKeyId *string `type:"string"`
+
+	// Server-side encryption type:
 	//
-	// Enabled is a required field
-	Enabled *bool `type:"boolean" required:"true"`
+	//    * AES256 - Server-side encryption which uses the AES256 algorithm.
+	//
+	//    * KMS - Server-side encryption which uses AWS Key Management Service.
+	//    (default)
+	SSEType *string `type:"string" enum:"SSEType"`
 }
 
 // String returns the string representation
@@ -10904,22 +10913,21 @@ func (s SSESpecification) GoString() string {
 	return s.String()
 }
 
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *SSESpecification) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "SSESpecification"}
-	if s.Enabled == nil {
-		invalidParams.Add(request.NewErrParamRequired("Enabled"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
-}
-
 // SetEnabled sets the Enabled field's value.
 func (s *SSESpecification) SetEnabled(v bool) *SSESpecification {
 	s.Enabled = &v
+	return s
+}
+
+// SetKMSMasterKeyId sets the KMSMasterKeyId field's value.
+func (s *SSESpecification) SetKMSMasterKeyId(v string) *SSESpecification {
+	s.KMSMasterKeyId = &v
+	return s
+}
+
+// SetSSEType sets the SSEType field's value.
+func (s *SSESpecification) SetSSEType(v string) *SSESpecification {
+	s.SSEType = &v
 	return s
 }
 
@@ -13057,6 +13065,9 @@ type UpdateTableInput struct {
 	// The new provisioned throughput settings for the specified table or index.
 	ProvisionedThroughput *ProvisionedThroughput `type:"structure"`
 
+	// The new server-side encryption settings for the specified table.
+	SSESpecification *SSESpecification `type:"structure"`
+
 	// Represents the DynamoDB Streams configuration for the table.
 	//
 	// You will receive a ResourceInUseException if you attempt to enable a stream
@@ -13136,6 +13147,12 @@ func (s *UpdateTableInput) SetGlobalSecondaryIndexUpdates(v []*GlobalSecondaryIn
 // SetProvisionedThroughput sets the ProvisionedThroughput field's value.
 func (s *UpdateTableInput) SetProvisionedThroughput(v *ProvisionedThroughput) *UpdateTableInput {
 	s.ProvisionedThroughput = v
+	return s
+}
+
+// SetSSESpecification sets the SSESpecification field's value.
+func (s *UpdateTableInput) SetSSESpecification(v *SSESpecification) *UpdateTableInput {
+	s.SSESpecification = v
 	return s
 }
 
@@ -13526,6 +13543,9 @@ const (
 
 	// SSEStatusDisabled is a SSEStatus enum value
 	SSEStatusDisabled = "DISABLED"
+
+	// SSEStatusUpdating is a SSEStatus enum value
+	SSEStatusUpdating = "UPDATING"
 )
 
 const (

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -2085,9 +2085,7 @@ type AacSettings struct {
 	// Mix)" setting receives a stereo description plus control track and emits
 	// a mono AAC encode of the description track, with control data emitted in
 	// the PES header as per ETSI TS 101 154 Annex E.
-	//
-	// CodingMode is a required field
-	CodingMode *string `locationName:"codingMode" type:"string" required:"true" enum:"AacCodingMode"`
+	CodingMode *string `locationName:"codingMode" type:"string" enum:"AacCodingMode"`
 
 	// Rate Control Mode.
 	RateControlMode *string `locationName:"rateControlMode" type:"string" enum:"AacRateControlMode"`
@@ -2097,9 +2095,7 @@ type AacSettings struct {
 	RawFormat *string `locationName:"rawFormat" type:"string" enum:"AacRawFormat"`
 
 	// Sample rate in Hz. Valid values depend on rate control mode and profile.
-	//
-	// SampleRate is a required field
-	SampleRate *int64 `locationName:"sampleRate" min:"8000" type:"integer" required:"true"`
+	SampleRate *int64 `locationName:"sampleRate" min:"8000" type:"integer"`
 
 	// Use MPEG-2 AAC instead of MPEG-4 AAC audio for raw or MPEG-2 Transport Stream
 	// containers.
@@ -2124,12 +2120,6 @@ func (s *AacSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "AacSettings"}
 	if s.Bitrate != nil && *s.Bitrate < 6000 {
 		invalidParams.Add(request.NewErrParamMinValue("Bitrate", 6000))
-	}
-	if s.CodingMode == nil {
-		invalidParams.Add(request.NewErrParamRequired("CodingMode"))
-	}
-	if s.SampleRate == nil {
-		invalidParams.Add(request.NewErrParamRequired("SampleRate"))
 	}
 	if s.SampleRate != nil && *s.SampleRate < 8000 {
 		invalidParams.Add(request.NewErrParamMinValue("SampleRate", 8000))
@@ -2438,9 +2428,7 @@ type AudioCodecSettings struct {
 	AiffSettings *AiffSettings `locationName:"aiffSettings" type:"structure"`
 
 	// Type of Audio codec.
-	//
-	// Codec is a required field
-	Codec *string `locationName:"codec" type:"string" required:"true" enum:"AudioCodec"`
+	Codec *string `locationName:"codec" type:"string" enum:"AudioCodec"`
 
 	// Required when you set (Codec) under (AudioDescriptions)>(CodecSettings) to
 	// the value EAC3.
@@ -2468,9 +2456,6 @@ func (s AudioCodecSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *AudioCodecSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "AudioCodecSettings"}
-	if s.Codec == nil {
-		invalidParams.Add(request.NewErrParamRequired("Codec"))
-	}
 	if s.AacSettings != nil {
 		if err := s.AacSettings.Validate(); err != nil {
 			invalidParams.AddNested("AacSettings", err.(request.ErrInvalidParams))
@@ -2588,9 +2573,7 @@ type AudioDescription struct {
 	// enum you choose, define the corresponding settings object. The following
 	// lists the codec enum, settings object pairs. * AAC, AacSettings * MP2, Mp2Settings
 	// * WAV, WavSettings * AIFF, AiffSettings * AC3, Ac3Settings * EAC3, Eac3Settings
-	//
-	// CodecSettings is a required field
-	CodecSettings *AudioCodecSettings `locationName:"codecSettings" type:"structure" required:"true"`
+	CodecSettings *AudioCodecSettings `locationName:"codecSettings" type:"structure"`
 
 	// Specify the language for this audio output track, using the ISO 639-2 or
 	// ISO 639-3 three-letter language code. The language specified will be used
@@ -2633,9 +2616,6 @@ func (s AudioDescription) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *AudioDescription) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "AudioDescription"}
-	if s.CodecSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("CodecSettings"))
-	}
 	if s.CustomLanguageCode != nil && len(*s.CustomLanguageCode) < 3 {
 		invalidParams.Add(request.NewErrParamMinLen("CustomLanguageCode", 3))
 	}
@@ -2965,9 +2945,7 @@ type AudioSelectorGroup struct {
 	// Audio selector names are standardized, based on their order within the input
 	// (e.g., "Audio Selector 1"). The audio selector name parameter can be repeated
 	// to add any number of audio selectors to the group.
-	//
-	// AudioSelectorNames is a required field
-	AudioSelectorNames []*string `locationName:"audioSelectorNames" type:"list" required:"true"`
+	AudioSelectorNames []*string `locationName:"audioSelectorNames" type:"list"`
 }
 
 // String returns the string representation
@@ -2978,19 +2956,6 @@ func (s AudioSelectorGroup) String() string {
 // GoString returns the string representation
 func (s AudioSelectorGroup) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *AudioSelectorGroup) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "AudioSelectorGroup"}
-	if s.AudioSelectorNames == nil {
-		invalidParams.Add(request.NewErrParamRequired("AudioSelectorNames"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetAudioSelectorNames sets the AudioSelectorNames field's value.
@@ -3049,9 +3014,7 @@ type BurninDestinationSettings struct {
 	// This option is not valid for source captions that are STL, 608/embedded or
 	// teletext. These source settings are already pre-defined by the caption stream.
 	// All burn-in and DVB-Sub font settings must match.
-	//
-	// Alignment is a required field
-	Alignment *string `locationName:"alignment" type:"string" required:"true" enum:"BurninSubtitleAlignment"`
+	Alignment *string `locationName:"alignment" type:"string" enum:"BurninSubtitleAlignment"`
 
 	// Specifies the color of the rectangle behind the captions.All burn-in and
 	// DVB-Sub font settings must match.
@@ -3070,9 +3033,7 @@ type BurninDestinationSettings struct {
 
 	// Specifies the opacity of the burned-in captions. 255 is opaque; 0 is transparent.All
 	// burn-in and DVB-Sub font settings must match.
-	//
-	// FontOpacity is a required field
-	FontOpacity *int64 `locationName:"fontOpacity" type:"integer" required:"true"`
+	FontOpacity *int64 `locationName:"fontOpacity" type:"integer"`
 
 	// Font resolution in DPI (dots per inch); default is 96 dpi.All burn-in and
 	// DVB-Sub font settings must match.
@@ -3087,17 +3048,13 @@ type BurninDestinationSettings struct {
 	// that are either 608/embedded or teletext. These source settings are already
 	// pre-defined by the caption stream. All burn-in and DVB-Sub font settings
 	// must match.
-	//
-	// OutlineColor is a required field
-	OutlineColor *string `locationName:"outlineColor" type:"string" required:"true" enum:"BurninSubtitleOutlineColor"`
+	OutlineColor *string `locationName:"outlineColor" type:"string" enum:"BurninSubtitleOutlineColor"`
 
 	// Specifies font outline size in pixels. This option is not valid for source
 	// captions that are either 608/embedded or teletext. These source settings
 	// are already pre-defined by the caption stream. All burn-in and DVB-Sub font
 	// settings must match.
-	//
-	// OutlineSize is a required field
-	OutlineSize *int64 `locationName:"outlineSize" type:"integer" required:"true"`
+	OutlineSize *int64 `locationName:"outlineSize" type:"integer"`
 
 	// Specifies the color of the shadow cast by the captions.All burn-in and DVB-Sub
 	// font settings must match.
@@ -3157,20 +3114,8 @@ func (s BurninDestinationSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *BurninDestinationSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "BurninDestinationSettings"}
-	if s.Alignment == nil {
-		invalidParams.Add(request.NewErrParamRequired("Alignment"))
-	}
-	if s.FontOpacity == nil {
-		invalidParams.Add(request.NewErrParamRequired("FontOpacity"))
-	}
 	if s.FontResolution != nil && *s.FontResolution < 96 {
 		invalidParams.Add(request.NewErrParamMinValue("FontResolution", 96))
-	}
-	if s.OutlineColor == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutlineColor"))
-	}
-	if s.OutlineSize == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutlineSize"))
 	}
 	if s.ShadowXOffset != nil && *s.ShadowXOffset < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("ShadowXOffset", -2.147483648e+09))
@@ -3343,9 +3288,7 @@ type CaptionDescription struct {
 	// input when generating captions. The name should be of the format "Caption
 	// Selector ", which denotes that the Nth Caption Selector will be used from
 	// each input.
-	//
-	// CaptionSelectorName is a required field
-	CaptionSelectorName *string `locationName:"captionSelectorName" min:"1" type:"string" required:"true"`
+	CaptionSelectorName *string `locationName:"captionSelectorName" min:"1" type:"string"`
 
 	// Indicates the language of the caption output track, using the ISO 639-2 or
 	// ISO 639-3 three-letter language code
@@ -3353,9 +3296,7 @@ type CaptionDescription struct {
 
 	// Specific settings required by destination type. Note that burnin_destination_settings
 	// are not available if the source of the caption data is Embedded or Teletext.
-	//
-	// DestinationSettings is a required field
-	DestinationSettings *CaptionDestinationSettings `locationName:"destinationSettings" type:"structure" required:"true"`
+	DestinationSettings *CaptionDestinationSettings `locationName:"destinationSettings" type:"structure"`
 
 	// Indicates the language of the caption output track.
 	LanguageCode *string `locationName:"languageCode" type:"string" enum:"LanguageCode"`
@@ -3379,17 +3320,11 @@ func (s CaptionDescription) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CaptionDescription) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CaptionDescription"}
-	if s.CaptionSelectorName == nil {
-		invalidParams.Add(request.NewErrParamRequired("CaptionSelectorName"))
-	}
 	if s.CaptionSelectorName != nil && len(*s.CaptionSelectorName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("CaptionSelectorName", 1))
 	}
 	if s.CustomLanguageCode != nil && len(*s.CustomLanguageCode) < 3 {
 		invalidParams.Add(request.NewErrParamMinLen("CustomLanguageCode", 3))
-	}
-	if s.DestinationSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("DestinationSettings"))
 	}
 	if s.DestinationSettings != nil {
 		if err := s.DestinationSettings.Validate(); err != nil {
@@ -3443,9 +3378,7 @@ type CaptionDescriptionPreset struct {
 
 	// Specific settings required by destination type. Note that burnin_destination_settings
 	// are not available if the source of the caption data is Embedded or Teletext.
-	//
-	// DestinationSettings is a required field
-	DestinationSettings *CaptionDestinationSettings `locationName:"destinationSettings" type:"structure" required:"true"`
+	DestinationSettings *CaptionDestinationSettings `locationName:"destinationSettings" type:"structure"`
 
 	// Indicates the language of the caption output track.
 	LanguageCode *string `locationName:"languageCode" type:"string" enum:"LanguageCode"`
@@ -3471,9 +3404,6 @@ func (s *CaptionDescriptionPreset) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CaptionDescriptionPreset"}
 	if s.CustomLanguageCode != nil && len(*s.CustomLanguageCode) < 3 {
 		invalidParams.Add(request.NewErrParamMinLen("CustomLanguageCode", 3))
-	}
-	if s.DestinationSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("DestinationSettings"))
 	}
 	if s.DestinationSettings != nil {
 		if err := s.DestinationSettings.Validate(); err != nil {
@@ -3521,9 +3451,7 @@ type CaptionDestinationSettings struct {
 
 	// Type of Caption output, including Burn-In, Embedded, SCC, SRT, TTML, WebVTT,
 	// DVB-Sub, Teletext.
-	//
-	// DestinationType is a required field
-	DestinationType *string `locationName:"destinationType" type:"string" required:"true" enum:"CaptionDestinationType"`
+	DestinationType *string `locationName:"destinationType" type:"string" enum:"CaptionDestinationType"`
 
 	// DVB-Sub Destination Settings
 	DvbSubDestinationSettings *DvbSubDestinationSettings `locationName:"dvbSubDestinationSettings" type:"structure"`
@@ -3552,9 +3480,6 @@ func (s CaptionDestinationSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CaptionDestinationSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CaptionDestinationSettings"}
-	if s.DestinationType == nil {
-		invalidParams.Add(request.NewErrParamRequired("DestinationType"))
-	}
 	if s.BurninDestinationSettings != nil {
 		if err := s.BurninDestinationSettings.Validate(); err != nil {
 			invalidParams.AddNested("BurninDestinationSettings", err.(request.ErrInvalidParams))
@@ -3636,9 +3561,7 @@ type CaptionSelector struct {
 
 	// Source settings (SourceSettings) contains the group of settings for captions
 	// in the input.
-	//
-	// SourceSettings is a required field
-	SourceSettings *CaptionSourceSettings `locationName:"sourceSettings" type:"structure" required:"true"`
+	SourceSettings *CaptionSourceSettings `locationName:"sourceSettings" type:"structure"`
 }
 
 // String returns the string representation
@@ -3656,9 +3579,6 @@ func (s *CaptionSelector) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CaptionSelector"}
 	if s.CustomLanguageCode != nil && len(*s.CustomLanguageCode) < 3 {
 		invalidParams.Add(request.NewErrParamMinLen("CustomLanguageCode", 3))
-	}
-	if s.SourceSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("SourceSettings"))
 	}
 	if s.SourceSettings != nil {
 		if err := s.SourceSettings.Validate(); err != nil {
@@ -3709,9 +3629,7 @@ type CaptionSourceSettings struct {
 
 	// Use Source (SourceType) to identify the format of your input captions. The
 	// service cannot auto-detect caption format.
-	//
-	// SourceType is a required field
-	SourceType *string `locationName:"sourceType" type:"string" required:"true" enum:"CaptionSourceType"`
+	SourceType *string `locationName:"sourceType" type:"string" enum:"CaptionSourceType"`
 
 	// Settings specific to Teletext caption sources, including Page number.
 	TeletextSourceSettings *TeletextSourceSettings `locationName:"teletextSourceSettings" type:"structure"`
@@ -3730,9 +3648,6 @@ func (s CaptionSourceSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CaptionSourceSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CaptionSourceSettings"}
-	if s.SourceType == nil {
-		invalidParams.Add(request.NewErrParamRequired("SourceType"))
-	}
 	if s.AncillarySourceSettings != nil {
 		if err := s.AncillarySourceSettings.Validate(); err != nil {
 			invalidParams.AddNested("AncillarySourceSettings", err.(request.ErrInvalidParams))
@@ -3809,9 +3724,7 @@ type ChannelMapping struct {
 	_ struct{} `type:"structure"`
 
 	// List of output channels
-	//
-	// OutputChannels is a required field
-	OutputChannels []*OutputChannelMapping `locationName:"outputChannels" type:"list" required:"true"`
+	OutputChannels []*OutputChannelMapping `locationName:"outputChannels" type:"list"`
 }
 
 // String returns the string representation
@@ -3822,29 +3735,6 @@ func (s ChannelMapping) String() string {
 // GoString returns the string representation
 func (s ChannelMapping) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *ChannelMapping) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "ChannelMapping"}
-	if s.OutputChannels == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutputChannels"))
-	}
-	if s.OutputChannels != nil {
-		for i, v := range s.OutputChannels {
-			if v == nil {
-				continue
-			}
-			if err := v.Validate(); err != nil {
-				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OutputChannels", i), err.(request.ErrInvalidParams))
-			}
-		}
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetOutputChannels sets the OutputChannels field's value.
@@ -3875,9 +3765,7 @@ type CmafEncryptionSettings struct {
 	StaticKeyProvider *StaticKeyProvider `locationName:"staticKeyProvider" type:"structure"`
 
 	// Indicates which type of key provider is used for encryption.
-	//
-	// Type is a required field
-	Type *string `locationName:"type" type:"string" required:"true" enum:"CmafKeyProviderType"`
+	Type *string `locationName:"type" type:"string" enum:"CmafKeyProviderType"`
 }
 
 // String returns the string representation
@@ -3895,14 +3783,6 @@ func (s *CmafEncryptionSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CmafEncryptionSettings"}
 	if s.ConstantInitializationVector != nil && len(*s.ConstantInitializationVector) < 32 {
 		invalidParams.Add(request.NewErrParamMinLen("ConstantInitializationVector", 32))
-	}
-	if s.Type == nil {
-		invalidParams.Add(request.NewErrParamRequired("Type"))
-	}
-	if s.StaticKeyProvider != nil {
-		if err := s.StaticKeyProvider.Validate(); err != nil {
-			invalidParams.AddNested("StaticKeyProvider", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3976,9 +3856,7 @@ type CmafGroupSettings struct {
 	// Emit Single File is checked, the fragmentation is internal to a single output
 	// file and it does not cause the creation of many output files as in other
 	// output types.
-	//
-	// FragmentLength is a required field
-	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer" required:"true"`
+	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer"`
 
 	// When set to GZIP, compresses HLS playlist.
 	ManifestCompression *string `locationName:"manifestCompression" type:"string" enum:"CmafManifestCompression"`
@@ -4017,9 +3895,7 @@ type CmafGroupSettings struct {
 	// puts the content of each output in a single file that has metadata that marks
 	// these segments. If you set it to segmented files, the service creates multiple
 	// files for each output, each with the content of one segment.
-	//
-	// SegmentLength is a required field
-	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer" required:"true"`
+	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer"`
 
 	// Include or exclude RESOLUTION attribute for video in EXT-X-STREAM-INF tag
 	// of variant manifest.
@@ -4045,14 +3921,8 @@ func (s CmafGroupSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CmafGroupSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CmafGroupSettings"}
-	if s.FragmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("FragmentLength"))
-	}
 	if s.FragmentLength != nil && *s.FragmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("FragmentLength", 1))
-	}
-	if s.SegmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("SegmentLength"))
 	}
 	if s.SegmentLength != nil && *s.SegmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("SegmentLength", 1))
@@ -4217,11 +4087,6 @@ func (s *ColorCorrector) Validate() error {
 	if s.Saturation != nil && *s.Saturation < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Saturation", 1))
 	}
-	if s.Hdr10Metadata != nil {
-		if err := s.Hdr10Metadata.Validate(); err != nil {
-			invalidParams.AddNested("Hdr10Metadata", err.(request.ErrInvalidParams))
-		}
-	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4271,9 +4136,7 @@ type ContainerSettings struct {
 
 	// Container for this output. Some containers require a container settings object.
 	// If not specified, the default object will be created.
-	//
-	// Container is a required field
-	Container *string `locationName:"container" type:"string" required:"true" enum:"ContainerType"`
+	Container *string `locationName:"container" type:"string" enum:"ContainerType"`
 
 	// Settings for F4v container
 	F4vSettings *F4vSettings `locationName:"f4vSettings" type:"structure"`
@@ -4304,9 +4167,6 @@ func (s ContainerSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ContainerSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ContainerSettings"}
-	if s.Container == nil {
-		invalidParams.Add(request.NewErrParamRequired("Container"))
-	}
 	if s.M2tsSettings != nil {
 		if err := s.M2tsSettings.Validate(); err != nil {
 			invalidParams.AddNested("M2tsSettings", err.(request.ErrInvalidParams))
@@ -4811,9 +4671,7 @@ type DashIsoEncryptionSettings struct {
 	_ struct{} `type:"structure"`
 
 	// Settings for use with a SPEKE key provider
-	//
-	// SpekeKeyProvider is a required field
-	SpekeKeyProvider *SpekeKeyProvider `locationName:"spekeKeyProvider" type:"structure" required:"true"`
+	SpekeKeyProvider *SpekeKeyProvider `locationName:"spekeKeyProvider" type:"structure"`
 }
 
 // String returns the string representation
@@ -4824,24 +4682,6 @@ func (s DashIsoEncryptionSettings) String() string {
 // GoString returns the string representation
 func (s DashIsoEncryptionSettings) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *DashIsoEncryptionSettings) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "DashIsoEncryptionSettings"}
-	if s.SpekeKeyProvider == nil {
-		invalidParams.Add(request.NewErrParamRequired("SpekeKeyProvider"))
-	}
-	if s.SpekeKeyProvider != nil {
-		if err := s.SpekeKeyProvider.Validate(); err != nil {
-			invalidParams.AddNested("SpekeKeyProvider", err.(request.ErrInvalidParams))
-		}
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetSpekeKeyProvider sets the SpekeKeyProvider field's value.
@@ -4876,9 +4716,7 @@ type DashIsoGroupSettings struct {
 	// Emit Single File is checked, the fragmentation is internal to a single output
 	// file and it does not cause the creation of many output files as in other
 	// output types.
-	//
-	// FragmentLength is a required field
-	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer" required:"true"`
+	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer"`
 
 	// Supports HbbTV specification as indicated
 	HbbtvCompliance *string `locationName:"hbbtvCompliance" type:"string" enum:"DashIsoHbbtvCompliance"`
@@ -4897,9 +4735,7 @@ type DashIsoGroupSettings struct {
 	// may be longer. When Emit Single File is checked, the segmentation is internal
 	// to a single output file and it does not cause the creation of many output
 	// files as in other output types.
-	//
-	// SegmentLength is a required field
-	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer" required:"true"`
+	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer"`
 
 	// When ENABLED, segment durations are indicated in the manifest using SegmentTimeline
 	// and SegmentTimeline will be promoted down into Representation from AdaptationSet.
@@ -4919,22 +4755,11 @@ func (s DashIsoGroupSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DashIsoGroupSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DashIsoGroupSettings"}
-	if s.FragmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("FragmentLength"))
-	}
 	if s.FragmentLength != nil && *s.FragmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("FragmentLength", 1))
 	}
-	if s.SegmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("SegmentLength"))
-	}
 	if s.SegmentLength != nil && *s.SegmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("SegmentLength", 1))
-	}
-	if s.Encryption != nil {
-		if err := s.Encryption.Validate(); err != nil {
-			invalidParams.AddNested("Encryption", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5293,21 +5118,15 @@ type DvbNitSettings struct {
 	_ struct{} `type:"structure"`
 
 	// The numeric value placed in the Network Information Table (NIT).
-	//
-	// NetworkId is a required field
-	NetworkId *int64 `locationName:"networkId" type:"integer" required:"true"`
+	NetworkId *int64 `locationName:"networkId" type:"integer"`
 
 	// The network name text placed in the network_name_descriptor inside the Network
 	// Information Table. Maximum length is 256 characters.
-	//
-	// NetworkName is a required field
-	NetworkName *string `locationName:"networkName" min:"1" type:"string" required:"true"`
+	NetworkName *string `locationName:"networkName" min:"1" type:"string"`
 
 	// The number of milliseconds between instances of this table in the output
 	// transport stream.
-	//
-	// NitInterval is a required field
-	NitInterval *int64 `locationName:"nitInterval" min:"25" type:"integer" required:"true"`
+	NitInterval *int64 `locationName:"nitInterval" min:"25" type:"integer"`
 }
 
 // String returns the string representation
@@ -5323,17 +5142,8 @@ func (s DvbNitSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DvbNitSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DvbNitSettings"}
-	if s.NetworkId == nil {
-		invalidParams.Add(request.NewErrParamRequired("NetworkId"))
-	}
-	if s.NetworkName == nil {
-		invalidParams.Add(request.NewErrParamRequired("NetworkName"))
-	}
 	if s.NetworkName != nil && len(*s.NetworkName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("NetworkName", 1))
-	}
-	if s.NitInterval == nil {
-		invalidParams.Add(request.NewErrParamRequired("NitInterval"))
 	}
 	if s.NitInterval != nil && *s.NitInterval < 25 {
 		invalidParams.Add(request.NewErrParamMinValue("NitInterval", 25))
@@ -5454,9 +5264,7 @@ type DvbSubDestinationSettings struct {
 	// This option is not valid for source captions that are STL, 608/embedded or
 	// teletext. These source settings are already pre-defined by the caption stream.
 	// All burn-in and DVB-Sub font settings must match.
-	//
-	// Alignment is a required field
-	Alignment *string `locationName:"alignment" type:"string" required:"true" enum:"DvbSubtitleAlignment"`
+	Alignment *string `locationName:"alignment" type:"string" enum:"DvbSubtitleAlignment"`
 
 	// Specifies the color of the rectangle behind the captions.All burn-in and
 	// DVB-Sub font settings must match.
@@ -5475,9 +5283,7 @@ type DvbSubDestinationSettings struct {
 
 	// Specifies the opacity of the burned-in captions. 255 is opaque; 0 is transparent.All
 	// burn-in and DVB-Sub font settings must match.
-	//
-	// FontOpacity is a required field
-	FontOpacity *int64 `locationName:"fontOpacity" type:"integer" required:"true"`
+	FontOpacity *int64 `locationName:"fontOpacity" type:"integer"`
 
 	// Font resolution in DPI (dots per inch); default is 96 dpi.All burn-in and
 	// DVB-Sub font settings must match.
@@ -5492,17 +5298,13 @@ type DvbSubDestinationSettings struct {
 	// that are either 608/embedded or teletext. These source settings are already
 	// pre-defined by the caption stream. All burn-in and DVB-Sub font settings
 	// must match.
-	//
-	// OutlineColor is a required field
-	OutlineColor *string `locationName:"outlineColor" type:"string" required:"true" enum:"DvbSubtitleOutlineColor"`
+	OutlineColor *string `locationName:"outlineColor" type:"string" enum:"DvbSubtitleOutlineColor"`
 
 	// Specifies font outline size in pixels. This option is not valid for source
 	// captions that are either 608/embedded or teletext. These source settings
 	// are already pre-defined by the caption stream. All burn-in and DVB-Sub font
 	// settings must match.
-	//
-	// OutlineSize is a required field
-	OutlineSize *int64 `locationName:"outlineSize" type:"integer" required:"true"`
+	OutlineSize *int64 `locationName:"outlineSize" type:"integer"`
 
 	// Specifies the color of the shadow cast by the captions.All burn-in and DVB-Sub
 	// font settings must match.
@@ -5562,20 +5364,8 @@ func (s DvbSubDestinationSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DvbSubDestinationSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DvbSubDestinationSettings"}
-	if s.Alignment == nil {
-		invalidParams.Add(request.NewErrParamRequired("Alignment"))
-	}
-	if s.FontOpacity == nil {
-		invalidParams.Add(request.NewErrParamRequired("FontOpacity"))
-	}
 	if s.FontResolution != nil && *s.FontResolution < 96 {
 		invalidParams.Add(request.NewErrParamMinValue("FontResolution", 96))
-	}
-	if s.OutlineColor == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutlineColor"))
-	}
-	if s.OutlineSize == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutlineSize"))
 	}
 	if s.ShadowXOffset != nil && *s.ShadowXOffset < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("ShadowXOffset", -2.147483648e+09))
@@ -5731,9 +5521,7 @@ type DvbTdtSettings struct {
 
 	// The number of milliseconds between instances of this table in the output
 	// transport stream.
-	//
-	// TdtInterval is a required field
-	TdtInterval *int64 `locationName:"tdtInterval" min:"1000" type:"integer" required:"true"`
+	TdtInterval *int64 `locationName:"tdtInterval" min:"1000" type:"integer"`
 }
 
 // String returns the string representation
@@ -5749,9 +5537,6 @@ func (s DvbTdtSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *DvbTdtSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DvbTdtSettings"}
-	if s.TdtInterval == nil {
-		invalidParams.Add(request.NewErrParamRequired("TdtInterval"))
-	}
 	if s.TdtInterval != nil && *s.TdtInterval < 1000 {
 		invalidParams.Add(request.NewErrParamMinValue("TdtInterval", 1000))
 	}
@@ -6162,9 +5947,7 @@ type FileSourceSettings struct {
 
 	// External caption file used for loading captions. Accepted file extensions
 	// are 'scc', 'ttml', 'dfxp', 'stl', 'srt', and 'smi'.
-	//
-	// SourceFile is a required field
-	SourceFile *string `locationName:"sourceFile" min:"14" type:"string" required:"true"`
+	SourceFile *string `locationName:"sourceFile" min:"14" type:"string"`
 
 	// Specifies a time delta in seconds to offset the captions from the source
 	// file.
@@ -6184,9 +5967,6 @@ func (s FileSourceSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *FileSourceSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "FileSourceSettings"}
-	if s.SourceFile == nil {
-		invalidParams.Add(request.NewErrParamRequired("SourceFile"))
-	}
 	if s.SourceFile != nil && len(*s.SourceFile) < 14 {
 		invalidParams.Add(request.NewErrParamMinLen("SourceFile", 14))
 	}
@@ -6580,9 +6360,7 @@ type H264QvbrSettings struct {
 	// 1 to 10. Use higher numbers for greater quality. Level 10 results in nearly
 	// lossless compression. The quality level for most broadcast-quality transcodes
 	// is between 6 and 9.
-	//
-	// QvbrQualityLevel is a required field
-	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer" required:"true"`
+	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer"`
 }
 
 // String returns the string representation
@@ -6600,9 +6378,6 @@ func (s *H264QvbrSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "H264QvbrSettings"}
 	if s.MaxAverageBitrate != nil && *s.MaxAverageBitrate < 1000 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxAverageBitrate", 1000))
-	}
-	if s.QvbrQualityLevel == nil {
-		invalidParams.Add(request.NewErrParamRequired("QvbrQualityLevel"))
 	}
 	if s.QvbrQualityLevel != nil && *s.QvbrQualityLevel < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("QvbrQualityLevel", 1))
@@ -7119,9 +6894,7 @@ type H265QvbrSettings struct {
 	// 1 to 10. Use higher numbers for greater quality. Level 10 results in nearly
 	// lossless compression. The quality level for most broadcast-quality transcodes
 	// is between 6 and 9.
-	//
-	// QvbrQualityLevel is a required field
-	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer" required:"true"`
+	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer"`
 }
 
 // String returns the string representation
@@ -7139,9 +6912,6 @@ func (s *H265QvbrSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "H265QvbrSettings"}
 	if s.MaxAverageBitrate != nil && *s.MaxAverageBitrate < 1000 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxAverageBitrate", 1000))
-	}
-	if s.QvbrQualityLevel == nil {
-		invalidParams.Add(request.NewErrParamRequired("QvbrQualityLevel"))
 	}
 	if s.QvbrQualityLevel != nil && *s.QvbrQualityLevel < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("QvbrQualityLevel", 1))
@@ -7677,15 +7447,11 @@ type Hdr10Metadata struct {
 
 	// Maximum light level among all samples in the coded video sequence, in units
 	// of candelas per square meter.
-	//
-	// MaxContentLightLevel is a required field
-	MaxContentLightLevel *int64 `locationName:"maxContentLightLevel" type:"integer" required:"true"`
+	MaxContentLightLevel *int64 `locationName:"maxContentLightLevel" type:"integer"`
 
 	// Maximum average light level of any frame in the coded video sequence, in
 	// units of candelas per square meter.
-	//
-	// MaxFrameAverageLightLevel is a required field
-	MaxFrameAverageLightLevel *int64 `locationName:"maxFrameAverageLightLevel" type:"integer" required:"true"`
+	MaxFrameAverageLightLevel *int64 `locationName:"maxFrameAverageLightLevel" type:"integer"`
 
 	// Nominal maximum mastering display luminance in units of of 0.0001 candelas
 	// per square meter.
@@ -7724,22 +7490,6 @@ func (s Hdr10Metadata) String() string {
 // GoString returns the string representation
 func (s Hdr10Metadata) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *Hdr10Metadata) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "Hdr10Metadata"}
-	if s.MaxContentLightLevel == nil {
-		invalidParams.Add(request.NewErrParamRequired("MaxContentLightLevel"))
-	}
-	if s.MaxFrameAverageLightLevel == nil {
-		invalidParams.Add(request.NewErrParamRequired("MaxFrameAverageLightLevel"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetBluePrimaryX sets the BluePrimaryX field's value.
@@ -7907,9 +7657,7 @@ type HlsEncryptionSettings struct {
 	StaticKeyProvider *StaticKeyProvider `locationName:"staticKeyProvider" type:"structure"`
 
 	// Indicates which type of key provider is used for encryption.
-	//
-	// Type is a required field
-	Type *string `locationName:"type" type:"string" required:"true" enum:"HlsKeyProviderType"`
+	Type *string `locationName:"type" type:"string" enum:"HlsKeyProviderType"`
 }
 
 // String returns the string representation
@@ -7927,19 +7675,6 @@ func (s *HlsEncryptionSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "HlsEncryptionSettings"}
 	if s.ConstantInitializationVector != nil && len(*s.ConstantInitializationVector) < 32 {
 		invalidParams.Add(request.NewErrParamMinLen("ConstantInitializationVector", 32))
-	}
-	if s.Type == nil {
-		invalidParams.Add(request.NewErrParamRequired("Type"))
-	}
-	if s.SpekeKeyProvider != nil {
-		if err := s.SpekeKeyProvider.Validate(); err != nil {
-			invalidParams.AddNested("SpekeKeyProvider", err.(request.ErrInvalidParams))
-		}
-	}
-	if s.StaticKeyProvider != nil {
-		if err := s.StaticKeyProvider.Validate(); err != nil {
-			invalidParams.AddNested("StaticKeyProvider", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8056,9 +7791,7 @@ type HlsGroupSettings struct {
 	// When set, Minimum Segment Size is enforced by looking ahead and back within
 	// the specified range for a nearby avail and extending the segment size if
 	// needed.
-	//
-	// MinSegmentLength is a required field
-	MinSegmentLength *int64 `locationName:"minSegmentLength" type:"integer" required:"true"`
+	MinSegmentLength *int64 `locationName:"minSegmentLength" type:"integer"`
 
 	// Indicates whether the .m3u8 manifest file should be generated for this HLS
 	// output group.
@@ -8080,9 +7813,7 @@ type HlsGroupSettings struct {
 	// Length of MPEG-2 Transport Stream segments to create (in seconds). Note that
 	// segments will end on the next keyframe after this number of seconds, so actual
 	// segment length may be longer.
-	//
-	// SegmentLength is a required field
-	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer" required:"true"`
+	SegmentLength *int64 `locationName:"segmentLength" min:"1" type:"integer"`
 
 	// Number of segments to write to a subdirectory before starting a new one.
 	// directoryStructure must be SINGLE_DIRECTORY for this setting to have an effect.
@@ -8115,12 +7846,6 @@ func (s HlsGroupSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *HlsGroupSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "HlsGroupSettings"}
-	if s.MinSegmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("MinSegmentLength"))
-	}
-	if s.SegmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("SegmentLength"))
-	}
 	if s.SegmentLength != nil && *s.SegmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("SegmentLength", 1))
 	}
@@ -8373,14 +8098,10 @@ type Id3Insertion struct {
 	_ struct{} `type:"structure"`
 
 	// Use ID3 tag (Id3) to provide a tag value in base64-encode format.
-	//
-	// Id3 is a required field
-	Id3 *string `locationName:"id3" type:"string" required:"true"`
+	Id3 *string `locationName:"id3" type:"string"`
 
 	// Provide a Timecode (TimeCode) in HH:MM:SS:FF or HH:MM:SS;FF format.
-	//
-	// Timecode is a required field
-	Timecode *string `locationName:"timecode" type:"string" required:"true"`
+	Timecode *string `locationName:"timecode" type:"string"`
 }
 
 // String returns the string representation
@@ -8391,22 +8112,6 @@ func (s Id3Insertion) String() string {
 // GoString returns the string representation
 func (s Id3Insertion) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *Id3Insertion) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "Id3Insertion"}
-	if s.Id3 == nil {
-		invalidParams.Add(request.NewErrParamRequired("Id3"))
-	}
-	if s.Timecode == nil {
-		invalidParams.Add(request.NewErrParamRequired("Timecode"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetId3 sets the Id3 field's value.
@@ -8429,9 +8134,7 @@ type ImageInserter struct {
 
 	// Image to insert. Must be 32 bit windows BMP, PNG, or TGA file. Must not be
 	// larger than the output frames.
-	//
-	// InsertableImages is a required field
-	InsertableImages []*InsertableImage `locationName:"insertableImages" type:"list" required:"true"`
+	InsertableImages []*InsertableImage `locationName:"insertableImages" type:"list"`
 }
 
 // String returns the string representation
@@ -8447,9 +8150,6 @@ func (s ImageInserter) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ImageInserter) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ImageInserter"}
-	if s.InsertableImages == nil {
-		invalidParams.Add(request.NewErrParamRequired("InsertableImages"))
-	}
 	if s.InsertableImages != nil {
 		for i, v := range s.InsertableImages {
 			if v == nil {
@@ -8505,9 +8205,7 @@ type Input struct {
 	// Use Input (fileInput) to define the source file used in the transcode job.
 	// There can be multiple inputs in a job. These inputs are concantenated, in
 	// the order they are specified in the job, to create the output.
-	//
-	// FileInput is a required field
-	FileInput *string `locationName:"fileInput" type:"string" required:"true"`
+	FileInput *string `locationName:"fileInput" type:"string"`
 
 	// Use Filter enable (InputFilterEnable) to specify how the transcoding service
 	// applies the denoise and deblock filters. You must also enable the filters
@@ -8567,24 +8265,11 @@ func (s Input) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *Input) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "Input"}
-	if s.FileInput == nil {
-		invalidParams.Add(request.NewErrParamRequired("FileInput"))
-	}
 	if s.FilterStrength != nil && *s.FilterStrength < -5 {
 		invalidParams.Add(request.NewErrParamMinValue("FilterStrength", -5))
 	}
 	if s.ProgramNumber != nil && *s.ProgramNumber < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProgramNumber", 1))
-	}
-	if s.AudioSelectorGroups != nil {
-		for i, v := range s.AudioSelectorGroups {
-			if v == nil {
-				continue
-			}
-			if err := v.Validate(); err != nil {
-				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AudioSelectorGroups", i), err.(request.ErrInvalidParams))
-			}
-		}
 	}
 	if s.AudioSelectors != nil {
 		for i, v := range s.AudioSelectors {
@@ -8839,16 +8524,6 @@ func (s *InputTemplate) Validate() error {
 	if s.ProgramNumber != nil && *s.ProgramNumber < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProgramNumber", 1))
 	}
-	if s.AudioSelectorGroups != nil {
-		for i, v := range s.AudioSelectorGroups {
-			if v == nil {
-				continue
-			}
-			if err := v.Validate(); err != nil {
-				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "AudioSelectorGroups", i), err.(request.ErrInvalidParams))
-			}
-		}
-	}
 	if s.AudioSelectors != nil {
 		for i, v := range s.AudioSelectors {
 			if v == nil {
@@ -8979,35 +8654,25 @@ type InsertableImage struct {
 	// Use Image location (imageInserterInput) to specify the Amazon S3 location
 	// of the image to be inserted into the output. Use a 32 bit BMP, PNG, or TGA
 	// file that fits inside the video frame.
-	//
-	// ImageInserterInput is a required field
-	ImageInserterInput *string `locationName:"imageInserterInput" min:"14" type:"string" required:"true"`
+	ImageInserterInput *string `locationName:"imageInserterInput" min:"14" type:"string"`
 
 	// Use Left (ImageX) to set the distance, in pixels, between the inserted image
 	// and the left edge of the frame. Required for BMP, PNG and TGA input.
-	//
-	// ImageX is a required field
-	ImageX *int64 `locationName:"imageX" type:"integer" required:"true"`
+	ImageX *int64 `locationName:"imageX" type:"integer"`
 
 	// Use Top (ImageY) to set the distance, in pixels, between the inserted image
 	// and the top edge of the video frame. Required for BMP, PNG and TGA input.
-	//
-	// ImageY is a required field
-	ImageY *int64 `locationName:"imageY" type:"integer" required:"true"`
+	ImageY *int64 `locationName:"imageY" type:"integer"`
 
 	// Use Layer (Layer) to specify how overlapping inserted images appear. Images
 	// with higher values of layer appear on top of images with lower values of
 	// layer.
-	//
-	// Layer is a required field
-	Layer *int64 `locationName:"layer" type:"integer" required:"true"`
+	Layer *int64 `locationName:"layer" type:"integer"`
 
 	// Use Opacity (Opacity) to specify how much of the underlying video shows through
 	// the inserted image. 0 is transparent and 100 is fully opaque. Default is
 	// 50.
-	//
-	// Opacity is a required field
-	Opacity *int64 `locationName:"opacity" type:"integer" required:"true"`
+	Opacity *int64 `locationName:"opacity" type:"integer"`
 
 	// Use Start time (StartTime) to specify the video timecode when the image is
 	// inserted in the output. This must be in timecode (HH:MM:SS:FF or HH:MM:SS;FF)
@@ -9045,29 +8710,14 @@ func (s *InsertableImage) Validate() error {
 	if s.Height != nil && *s.Height < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("Height", -2.147483648e+09))
 	}
-	if s.ImageInserterInput == nil {
-		invalidParams.Add(request.NewErrParamRequired("ImageInserterInput"))
-	}
 	if s.ImageInserterInput != nil && len(*s.ImageInserterInput) < 14 {
 		invalidParams.Add(request.NewErrParamMinLen("ImageInserterInput", 14))
-	}
-	if s.ImageX == nil {
-		invalidParams.Add(request.NewErrParamRequired("ImageX"))
 	}
 	if s.ImageX != nil && *s.ImageX < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("ImageX", -2.147483648e+09))
 	}
-	if s.ImageY == nil {
-		invalidParams.Add(request.NewErrParamRequired("ImageY"))
-	}
 	if s.ImageY != nil && *s.ImageY < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("ImageY", -2.147483648e+09))
-	}
-	if s.Layer == nil {
-		invalidParams.Add(request.NewErrParamRequired("Layer"))
-	}
-	if s.Opacity == nil {
-		invalidParams.Add(request.NewErrParamRequired("Opacity"))
 	}
 	if s.Width != nil && *s.Width < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("Width", -2.147483648e+09))
@@ -9304,9 +8954,7 @@ type JobSettings struct {
 	// Use Inputs (inputs) to define source file used in the transcode job. There
 	// can be multiple inputs add in a job. These inputs will be concantenated together
 	// to create the output.
-	//
-	// Inputs is a required field
-	Inputs []*Input `locationName:"inputs" type:"list" required:"true"`
+	Inputs []*Input `locationName:"inputs" type:"list"`
 
 	// Settings for Nielsen Configuration
 	NielsenConfiguration *NielsenConfiguration `locationName:"nielsenConfiguration" type:"structure"`
@@ -9320,9 +8968,7 @@ type JobSettings struct {
 	// * HLS_GROUP_SETTINGS, HlsGroupSettings * DASH_ISO_GROUP_SETTINGS, DashIsoGroupSettings
 	// * MS_SMOOTH_GROUP_SETTINGS, MsSmoothGroupSettings * CMAF_GROUP_SETTINGS,
 	// CmafGroupSettings
-	//
-	// OutputGroups is a required field
-	OutputGroups []*OutputGroup `locationName:"outputGroups" type:"list" required:"true"`
+	OutputGroups []*OutputGroup `locationName:"outputGroups" type:"list"`
 
 	// Contains settings used to acquire and adjust timecode information from inputs.
 	TimecodeConfig *TimecodeConfig `locationName:"timecodeConfig" type:"structure"`
@@ -9350,12 +8996,6 @@ func (s *JobSettings) Validate() error {
 	if s.AdAvailOffset != nil && *s.AdAvailOffset < -1000 {
 		invalidParams.Add(request.NewErrParamMinValue("AdAvailOffset", -1000))
 	}
-	if s.Inputs == nil {
-		invalidParams.Add(request.NewErrParamRequired("Inputs"))
-	}
-	if s.OutputGroups == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutputGroups"))
-	}
 	if s.AvailBlanking != nil {
 		if err := s.AvailBlanking.Validate(); err != nil {
 			invalidParams.AddNested("AvailBlanking", err.(request.ErrInvalidParams))
@@ -9379,11 +9019,6 @@ func (s *JobSettings) Validate() error {
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OutputGroups", i), err.(request.ErrInvalidParams))
 			}
-		}
-	}
-	if s.TimedMetadataInsertion != nil {
-		if err := s.TimedMetadataInsertion.Validate(); err != nil {
-			invalidParams.AddNested("TimedMetadataInsertion", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -9570,9 +9205,7 @@ type JobTemplateSettings struct {
 	// * HLS_GROUP_SETTINGS, HlsGroupSettings * DASH_ISO_GROUP_SETTINGS, DashIsoGroupSettings
 	// * MS_SMOOTH_GROUP_SETTINGS, MsSmoothGroupSettings * CMAF_GROUP_SETTINGS,
 	// CmafGroupSettings
-	//
-	// OutputGroups is a required field
-	OutputGroups []*OutputGroup `locationName:"outputGroups" type:"list" required:"true"`
+	OutputGroups []*OutputGroup `locationName:"outputGroups" type:"list"`
 
 	// Contains settings used to acquire and adjust timecode information from inputs.
 	TimecodeConfig *TimecodeConfig `locationName:"timecodeConfig" type:"structure"`
@@ -9600,9 +9233,6 @@ func (s *JobTemplateSettings) Validate() error {
 	if s.AdAvailOffset != nil && *s.AdAvailOffset < -1000 {
 		invalidParams.Add(request.NewErrParamMinValue("AdAvailOffset", -1000))
 	}
-	if s.OutputGroups == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutputGroups"))
-	}
 	if s.AvailBlanking != nil {
 		if err := s.AvailBlanking.Validate(); err != nil {
 			invalidParams.AddNested("AvailBlanking", err.(request.ErrInvalidParams))
@@ -9626,11 +9256,6 @@ func (s *JobTemplateSettings) Validate() error {
 			if err := v.Validate(); err != nil {
 				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "OutputGroups", i), err.(request.ErrInvalidParams))
 			}
-		}
-	}
-	if s.TimedMetadataInsertion != nil {
-		if err := s.TimedMetadataInsertion.Validate(); err != nil {
-			invalidParams.AddNested("TimedMetadataInsertion", err.(request.ErrInvalidParams))
 		}
 	}
 
@@ -11390,9 +11015,7 @@ type MsSmoothEncryptionSettings struct {
 	_ struct{} `type:"structure"`
 
 	// Settings for use with a SPEKE key provider
-	//
-	// SpekeKeyProvider is a required field
-	SpekeKeyProvider *SpekeKeyProvider `locationName:"spekeKeyProvider" type:"structure" required:"true"`
+	SpekeKeyProvider *SpekeKeyProvider `locationName:"spekeKeyProvider" type:"structure"`
 }
 
 // String returns the string representation
@@ -11403,24 +11026,6 @@ func (s MsSmoothEncryptionSettings) String() string {
 // GoString returns the string representation
 func (s MsSmoothEncryptionSettings) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *MsSmoothEncryptionSettings) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "MsSmoothEncryptionSettings"}
-	if s.SpekeKeyProvider == nil {
-		invalidParams.Add(request.NewErrParamRequired("SpekeKeyProvider"))
-	}
-	if s.SpekeKeyProvider != nil {
-		if err := s.SpekeKeyProvider.Validate(); err != nil {
-			invalidParams.AddNested("SpekeKeyProvider", err.(request.ErrInvalidParams))
-		}
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetSpekeKeyProvider sets the SpekeKeyProvider field's value.
@@ -11451,9 +11056,7 @@ type MsSmoothGroupSettings struct {
 
 	// Use Fragment length (FragmentLength) to specify the mp4 fragment sizes in
 	// seconds. Fragment length must be compatible with GOP size and framerate.
-	//
-	// FragmentLength is a required field
-	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer" required:"true"`
+	FragmentLength *int64 `locationName:"fragmentLength" min:"1" type:"integer"`
 
 	// Use Manifest encoding (MsSmoothManifestEncoding) to specify the encoding
 	// format for the server and client manifest. Valid options are utf8 and utf16.
@@ -11473,16 +11076,8 @@ func (s MsSmoothGroupSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *MsSmoothGroupSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "MsSmoothGroupSettings"}
-	if s.FragmentLength == nil {
-		invalidParams.Add(request.NewErrParamRequired("FragmentLength"))
-	}
 	if s.FragmentLength != nil && *s.FragmentLength < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("FragmentLength", 1))
-	}
-	if s.Encryption != nil {
-		if err := s.Encryption.Validate(); err != nil {
-			invalidParams.AddNested("Encryption", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11570,9 +11165,7 @@ type NoiseReducer struct {
 	// filter. * Mean (softest), Gaussian, Lanczos, and Sharpen (sharpest) are convolution
 	// filters. * Conserve is a min/max noise reduction filter. * Spatial is a frequency-domain
 	// filter based on JND principles.
-	//
-	// Filter is a required field
-	Filter *string `locationName:"filter" type:"string" required:"true" enum:"NoiseReducerFilter"`
+	Filter *string `locationName:"filter" type:"string" enum:"NoiseReducerFilter"`
 
 	// Settings for a noise reducer filter
 	FilterSettings *NoiseReducerFilterSettings `locationName:"filterSettings" type:"structure"`
@@ -11594,9 +11187,6 @@ func (s NoiseReducer) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *NoiseReducer) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "NoiseReducer"}
-	if s.Filter == nil {
-		invalidParams.Add(request.NewErrParamRequired("Filter"))
-	}
 	if s.SpatialFilterSettings != nil {
 		if err := s.SpatialFilterSettings.Validate(); err != nil {
 			invalidParams.AddNested("SpatialFilterSettings", err.(request.ErrInvalidParams))
@@ -11864,9 +11454,7 @@ type OutputChannelMapping struct {
 	_ struct{} `type:"structure"`
 
 	// List of input channels
-	//
-	// InputChannels is a required field
-	InputChannels []*int64 `locationName:"inputChannels" type:"list" required:"true"`
+	InputChannels []*int64 `locationName:"inputChannels" type:"list"`
 }
 
 // String returns the string representation
@@ -11877,19 +11465,6 @@ func (s OutputChannelMapping) String() string {
 // GoString returns the string representation
 func (s OutputChannelMapping) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *OutputChannelMapping) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "OutputChannelMapping"}
-	if s.InputChannels == nil {
-		invalidParams.Add(request.NewErrParamRequired("InputChannels"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetInputChannels sets the InputChannels field's value.
@@ -11945,15 +11520,11 @@ type OutputGroup struct {
 	Name *string `locationName:"name" type:"string"`
 
 	// Output Group settings, including type
-	//
-	// OutputGroupSettings is a required field
-	OutputGroupSettings *OutputGroupSettings `locationName:"outputGroupSettings" type:"structure" required:"true"`
+	OutputGroupSettings *OutputGroupSettings `locationName:"outputGroupSettings" type:"structure"`
 
 	// This object holds groups of encoding settings, one group of settings per
 	// output.
-	//
-	// Outputs is a required field
-	Outputs []*Output `locationName:"outputs" type:"list" required:"true"`
+	Outputs []*Output `locationName:"outputs" type:"list"`
 }
 
 // String returns the string representation
@@ -11969,12 +11540,6 @@ func (s OutputGroup) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *OutputGroup) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "OutputGroup"}
-	if s.OutputGroupSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutputGroupSettings"))
-	}
-	if s.Outputs == nil {
-		invalidParams.Add(request.NewErrParamRequired("Outputs"))
-	}
 	if s.OutputGroupSettings != nil {
 		if err := s.OutputGroupSettings.Validate(); err != nil {
 			invalidParams.AddNested("OutputGroupSettings", err.(request.ErrInvalidParams))
@@ -12072,9 +11637,7 @@ type OutputGroupSettings struct {
 
 	// Type of output group (File group, Apple HLS, DASH ISO, Microsoft Smooth Streaming,
 	// CMAF)
-	//
-	// Type is a required field
-	Type *string `locationName:"type" type:"string" required:"true" enum:"OutputGroupType"`
+	Type *string `locationName:"type" type:"string" enum:"OutputGroupType"`
 }
 
 // String returns the string representation
@@ -12090,9 +11653,6 @@ func (s OutputGroupSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *OutputGroupSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "OutputGroupSettings"}
-	if s.Type == nil {
-		invalidParams.Add(request.NewErrParamRequired("Type"))
-	}
 	if s.CmafGroupSettings != nil {
 		if err := s.CmafGroupSettings.Validate(); err != nil {
 			invalidParams.AddNested("CmafGroupSettings", err.(request.ErrInvalidParams))
@@ -12646,26 +12206,18 @@ type Rectangle struct {
 	_ struct{} `type:"structure"`
 
 	// Height of rectangle in pixels. Specify only even numbers.
-	//
-	// Height is a required field
-	Height *int64 `locationName:"height" min:"2" type:"integer" required:"true"`
+	Height *int64 `locationName:"height" min:"2" type:"integer"`
 
 	// Width of rectangle in pixels. Specify only even numbers.
-	//
-	// Width is a required field
-	Width *int64 `locationName:"width" min:"2" type:"integer" required:"true"`
+	Width *int64 `locationName:"width" min:"2" type:"integer"`
 
 	// The distance, in pixels, between the rectangle and the left edge of the video
 	// frame. Specify only even numbers.
-	//
-	// X is a required field
-	X *int64 `locationName:"x" type:"integer" required:"true"`
+	X *int64 `locationName:"x" type:"integer"`
 
 	// The distance, in pixels, between the rectangle and the top edge of the video
 	// frame. Specify only even numbers.
-	//
-	// Y is a required field
-	Y *int64 `locationName:"y" type:"integer" required:"true"`
+	Y *int64 `locationName:"y" type:"integer"`
 }
 
 // String returns the string representation
@@ -12681,23 +12233,11 @@ func (s Rectangle) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *Rectangle) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "Rectangle"}
-	if s.Height == nil {
-		invalidParams.Add(request.NewErrParamRequired("Height"))
-	}
 	if s.Height != nil && *s.Height < 2 {
 		invalidParams.Add(request.NewErrParamMinValue("Height", 2))
 	}
-	if s.Width == nil {
-		invalidParams.Add(request.NewErrParamRequired("Width"))
-	}
 	if s.Width != nil && *s.Width < 2 {
 		invalidParams.Add(request.NewErrParamMinValue("Width", 2))
-	}
-	if s.X == nil {
-		invalidParams.Add(request.NewErrParamRequired("X"))
-	}
-	if s.Y == nil {
-		invalidParams.Add(request.NewErrParamRequired("Y"))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12740,22 +12280,16 @@ type RemixSettings struct {
 	// remixing value for each channel. Units are in dB. Acceptable values are within
 	// the range from -60 (mute) through 6. A setting of 0 passes the input channel
 	// unchanged to the output channel (no attenuation or amplification).
-	//
-	// ChannelMapping is a required field
-	ChannelMapping *ChannelMapping `locationName:"channelMapping" type:"structure" required:"true"`
+	ChannelMapping *ChannelMapping `locationName:"channelMapping" type:"structure"`
 
 	// Specify the number of audio channels from your input that you want to use
 	// in your output. With remixing, you might combine or split the data in these
 	// channels, so the number of channels in your final output might be different.
-	//
-	// ChannelsIn is a required field
-	ChannelsIn *int64 `locationName:"channelsIn" min:"1" type:"integer" required:"true"`
+	ChannelsIn *int64 `locationName:"channelsIn" min:"1" type:"integer"`
 
 	// Specify the number of channels in this output after remixing. Valid values:
 	// 1, 2, 4, 6, 8
-	//
-	// ChannelsOut is a required field
-	ChannelsOut *int64 `locationName:"channelsOut" min:"1" type:"integer" required:"true"`
+	ChannelsOut *int64 `locationName:"channelsOut" min:"1" type:"integer"`
 }
 
 // String returns the string representation
@@ -12771,25 +12305,11 @@ func (s RemixSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *RemixSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "RemixSettings"}
-	if s.ChannelMapping == nil {
-		invalidParams.Add(request.NewErrParamRequired("ChannelMapping"))
-	}
-	if s.ChannelsIn == nil {
-		invalidParams.Add(request.NewErrParamRequired("ChannelsIn"))
-	}
 	if s.ChannelsIn != nil && *s.ChannelsIn < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ChannelsIn", 1))
 	}
-	if s.ChannelsOut == nil {
-		invalidParams.Add(request.NewErrParamRequired("ChannelsOut"))
-	}
 	if s.ChannelsOut != nil && *s.ChannelsOut < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ChannelsOut", 1))
-	}
-	if s.ChannelMapping != nil {
-		if err := s.ChannelMapping.Validate(); err != nil {
-			invalidParams.AddNested("ChannelMapping", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12883,21 +12403,15 @@ type SpekeKeyProvider struct {
 	_ struct{} `type:"structure"`
 
 	// The SPEKE-compliant server uses Resource ID (ResourceId) to identify content.
-	//
-	// ResourceId is a required field
-	ResourceId *string `locationName:"resourceId" type:"string" required:"true"`
+	ResourceId *string `locationName:"resourceId" type:"string"`
 
 	// Relates to SPEKE implementation. DRM system identifiers. DASH output groups
 	// support a max of two system ids. Other group types support one system id.
-	//
-	// SystemIds is a required field
-	SystemIds []*string `locationName:"systemIds" type:"list" required:"true"`
+	SystemIds []*string `locationName:"systemIds" type:"list"`
 
 	// Use URL (Url) to specify the SPEKE-compliant server that will provide keys
 	// for content.
-	//
-	// Url is a required field
-	Url *string `locationName:"url" type:"string" required:"true"`
+	Url *string `locationName:"url" type:"string"`
 }
 
 // String returns the string representation
@@ -12908,25 +12422,6 @@ func (s SpekeKeyProvider) String() string {
 // GoString returns the string representation
 func (s SpekeKeyProvider) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *SpekeKeyProvider) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "SpekeKeyProvider"}
-	if s.ResourceId == nil {
-		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
-	}
-	if s.SystemIds == nil {
-		invalidParams.Add(request.NewErrParamRequired("SystemIds"))
-	}
-	if s.Url == nil {
-		invalidParams.Add(request.NewErrParamRequired("Url"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetResourceId sets the ResourceId field's value.
@@ -12962,15 +12457,11 @@ type StaticKeyProvider struct {
 
 	// Relates to DRM implementation. Use a 32-character hexidecimal string to specify
 	// Key Value (StaticKeyValue).
-	//
-	// StaticKeyValue is a required field
-	StaticKeyValue *string `locationName:"staticKeyValue" type:"string" required:"true"`
+	StaticKeyValue *string `locationName:"staticKeyValue" type:"string"`
 
 	// Relates to DRM implementation. The location of the license server used for
 	// protecting content.
-	//
-	// Url is a required field
-	Url *string `locationName:"url" type:"string" required:"true"`
+	Url *string `locationName:"url" type:"string"`
 }
 
 // String returns the string representation
@@ -12981,22 +12472,6 @@ func (s StaticKeyProvider) String() string {
 // GoString returns the string representation
 func (s StaticKeyProvider) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *StaticKeyProvider) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "StaticKeyProvider"}
-	if s.StaticKeyValue == nil {
-		invalidParams.Add(request.NewErrParamRequired("StaticKeyValue"))
-	}
-	if s.Url == nil {
-		invalidParams.Add(request.NewErrParamRequired("Url"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetKeyFormat sets the KeyFormat field's value.
@@ -13323,9 +12798,7 @@ type TimedMetadataInsertion struct {
 	_ struct{} `type:"structure"`
 
 	// Id3Insertions contains the array of Id3Insertion instances.
-	//
-	// Id3Insertions is a required field
-	Id3Insertions []*Id3Insertion `locationName:"id3Insertions" type:"list" required:"true"`
+	Id3Insertions []*Id3Insertion `locationName:"id3Insertions" type:"list"`
 }
 
 // String returns the string representation
@@ -13336,29 +12809,6 @@ func (s TimedMetadataInsertion) String() string {
 // GoString returns the string representation
 func (s TimedMetadataInsertion) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *TimedMetadataInsertion) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "TimedMetadataInsertion"}
-	if s.Id3Insertions == nil {
-		invalidParams.Add(request.NewErrParamRequired("Id3Insertions"))
-	}
-	if s.Id3Insertions != nil {
-		for i, v := range s.Id3Insertions {
-			if v == nil {
-				continue
-			}
-			if err := v.Validate(); err != nil {
-				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Id3Insertions", i), err.(request.ErrInvalidParams))
-			}
-		}
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetId3Insertions sets the Id3Insertions field's value.
@@ -13791,9 +13241,7 @@ type VideoCodecSettings struct {
 	_ struct{} `type:"structure"`
 
 	// Type of video codec
-	//
-	// Codec is a required field
-	Codec *string `locationName:"codec" type:"string" required:"true" enum:"VideoCodec"`
+	Codec *string `locationName:"codec" type:"string" enum:"VideoCodec"`
 
 	// Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
 	// the value FRAME_CAPTURE.
@@ -13828,9 +13276,6 @@ func (s VideoCodecSettings) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *VideoCodecSettings) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "VideoCodecSettings"}
-	if s.Codec == nil {
-		invalidParams.Add(request.NewErrParamRequired("Codec"))
-	}
 	if s.FrameCaptureSettings != nil {
 		if err := s.FrameCaptureSettings.Validate(); err != nil {
 			invalidParams.AddNested("FrameCaptureSettings", err.(request.ErrInvalidParams))
@@ -13923,9 +13368,7 @@ type VideoDescription struct {
 	// lists the codec enum, settings object pairs. * H_264, H264Settings * H_265,
 	// H265Settings * MPEG2, Mpeg2Settings * PRORES, ProresSettings * FRAME_CAPTURE,
 	// FrameCaptureSettings
-	//
-	// CodecSettings is a required field
-	CodecSettings *VideoCodecSettings `locationName:"codecSettings" type:"structure" required:"true"`
+	CodecSettings *VideoCodecSettings `locationName:"codecSettings" type:"structure"`
 
 	// Enable Insert color metadata (ColorMetadata) to include color metadata in
 	// this output. This setting is enabled by default.
@@ -14020,9 +13463,6 @@ func (s VideoDescription) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *VideoDescription) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "VideoDescription"}
-	if s.CodecSettings == nil {
-		invalidParams.Add(request.NewErrParamRequired("CodecSettings"))
-	}
 	if s.Height != nil && *s.Height < 32 {
 		invalidParams.Add(request.NewErrParamMinValue("Height", 32))
 	}
@@ -14340,11 +13780,6 @@ func (s *VideoSelector) Validate() error {
 	}
 	if s.ProgramNumber != nil && *s.ProgramNumber < -2.147483648e+09 {
 		invalidParams.Add(request.NewErrParamMinValue("ProgramNumber", -2.147483648e+09))
-	}
-	if s.Hdr10Metadata != nil {
-		if err := s.Hdr10Metadata.Validate(); err != nil {
-			invalidParams.AddNested("Hdr10Metadata", err.(request.ErrInvalidParams))
-		}
 	}
 
 	if invalidParams.Len() > 0 {


### PR DESCRIPTION
Release v1.15.16 (2018-08-20)
===

### Service Client Updates
* `service/dynamodb`: Updates service API and documentation
  * Added SSESpecification block to update-table command which allows users to modify table Server-Side Encryption. Added two new fields (SSEType and KMSMasterKeyId) to SSESpecification block used by create-table and update-table commands. Added new SSEDescription Status value UPDATING.
* `service/mediaconvert`: Updates service API
  * This release fixes backward-incompatible changes from a previous release. That previous release changed non-required job settings to required, which prevented jobs and job templates from merging correctly. The current change removes validation of required settings from the SDK and instead centralizes the validation in the service API. For information on required settings, see the Resources chapter of the AWS Elemental MediaConvert API Reference https://docs.aws.amazon.com/mediaconvert/latest/apireference/resources.html

