### PR TITLE
v1.15.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Release v1.15.18 (2018-08-22)
+===
+
+### Service Client Updates
+* `service/snowball`: Updates service API
+  * Snowball job states allow customers to track the status of the Snowball job. We are launching a new Snowball job state "WithSortingFacility"!  When customer returns the Snowball to AWS, the device first goes to a sorting facility before it reaches an AWS data center.  Many customers have requested us to add a new state to reflect the presence of the device at the sorting facility for better tracking. Today when a customer returns  the Snowball, the state first changes from "InTransitToAWS" to "WithAWS". With the addition of new state, the device will move from "InTransitToAWS" to "WithAWSSortingFacility", and then to "WithAWS".  There are no other changes to the API at this time besides adding this new state.
+
 Release v1.15.17 (2018-08-21)
 ===
 

--- a/aws/version.go
+++ b/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.15.17"
+const SDKVersion = "1.15.18"

--- a/models/apis/snowball/2016-06-30/api-2.json
+++ b/models/apis/snowball/2016-06-30/api-2.json
@@ -683,6 +683,7 @@
         "InTransitToCustomer",
         "WithCustomer",
         "InTransitToAWS",
+        "WithAWSSortingFacility",
         "WithAWS",
         "InProgress",
         "Complete",

--- a/service/snowball/api.go
+++ b/service/snowball/api.go
@@ -4752,6 +4752,9 @@ const (
 	// JobStateInTransitToAws is a JobState enum value
 	JobStateInTransitToAws = "InTransitToAWS"
 
+	// JobStateWithAwssortingFacility is a JobState enum value
+	JobStateWithAwssortingFacility = "WithAWSSortingFacility"
+
 	// JobStateWithAws is a JobState enum value
 	JobStateWithAws = "WithAWS"
 


### PR DESCRIPTION
Release v1.15.18 (2018-08-22)
===

### Service Client Updates
* `service/snowball`: Updates service API
  * Snowball job states allow customers to track the status of the Snowball job. We are launching a new Snowball job state "WithSortingFacility"!  When customer returns the Snowball to AWS, the device first goes to a sorting facility before it reaches an AWS data center.  Many customers have requested us to add a new state to reflect the presence of the device at the sorting facility for better tracking. Today when a customer returns  the Snowball, the state first changes from "InTransitToAWS" to "WithAWS". With the addition of new state, the device will move from "InTransitToAWS" to "WithAWSSortingFacility", and then to "WithAWS".  There are no other changes to the API at this time besides adding this new state.

