### PR TITLE
 private/protocol/json/jsonutil: Use json.Decoder to decrease memory allocation

### DIFF
--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"time"
 
@@ -17,16 +16,10 @@ import (
 func UnmarshalJSON(v interface{}, stream io.Reader) error {
 	var out interface{}
 
-	b, err := ioutil.ReadAll(stream)
-	if err != nil {
-		return err
-	}
-
-	if len(b) == 0 {
-		return nil
-	}
-
-	if err := json.Unmarshal(b, &out); err != nil {
+	if err := json.NewDecoder(stream).Decode(&out); err != nil {
+		if err == io.EOF {
+			return nil
+		}
 		return err
 	}
 

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -16,10 +16,10 @@ import (
 func UnmarshalJSON(v interface{}, stream io.Reader) error {
 	var out interface{}
 
-	if err := json.NewDecoder(stream).Decode(&out); err != nil {
-		if err == io.EOF {
-			return nil
-		}
+	err := json.NewDecoder(stream).Decode(&out)
+	if err == io.EOF {
+		return nil
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
closed: #2114 

https://gist.github.com/atsushi-ishibashi/2d7d13cf1df9a84251ed175816a04b14
The below shows that the new `UnmarshalJSON` decrease memory capacity by 50%.
```
//current
BenchmarkUnmarshalJSON-4    	 1000000	      2122 ns/op	    2928 B/op	      18 allocs/op
//new one
BenchmarkUnmarshalJSON2-4   	 1000000	      1654 ns/op	    1480 B/op	      17 allocs/op
```