### PR TITLE
Update example for CreateRole to not mention encoding

### DIFF
--- a/service/iam/examples_test.go
+++ b/service/iam/examples_test.go
@@ -515,11 +515,11 @@ func ExampleIAM_CreateOpenIDConnectProvider_shared00() {
 // To create an IAM role
 //
 // The following command creates a role named Test-Role and attaches a trust policy
-// to it that is provided as a URL-encoded JSON string.
+// to it that is provided as a JSON string.
 func ExampleIAM_CreateRole_shared00() {
 	svc := iam.New(session.New())
 	input := &iam.CreateRoleInput{
-		AssumeRolePolicyDocument: aws.String("<URL-encoded-JSON>"),
+		AssumeRolePolicyDocument: aws.String("<JSON>"),
 		Path:     aws.String("/"),
 		RoleName: aws.String("Test-Role"),
 	}


### PR DESCRIPTION
URL Encoding is not only NOT required but causes the error
```
{"level":"error","message":"MalformedPolicyDocument: This policy contains invalid Json\n\tstatus code: 400, request id: 8bbb46fa-a9f8-11e8-8137-d3ca37fba8d9"}
```

Users of the SDK should be instructed to pass in a string containing the JSON. Hopefully, this update will prevent future confusion...