### PR TITLE
 service/s3/s3manager: Fixing doc for BatchDownloadObject in s3manager

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -215,14 +215,14 @@ func (d Downloader) DownloadWithContext(ctx aws.Context, w io.WriterAt, input *s
 //
 //	objects := []s3manager.BatchDownloadObject {
 //		{
-//			Input: &s3.GetObjectInput {
+//			Object: &s3.GetObjectInput {
 //				Bucket: aws.String("bucket"),
 //				Key: aws.String("foo"),
 //			},
 //			Writer: fooFile,
 //		},
 //		{
-//			Input: &s3.GetObjectInput {
+//			Object: &s3.GetObjectInput {
 //				Bucket: aws.String("bucket"),
 //				Key: aws.String("bar"),
 //			},


### PR DESCRIPTION
While following comments on how to interact with s3 BatchDownloadObject, I realized there's one place the comment was incorrect on the object structure `BatchDownloadObject`. 

Hopefully this is a straightforward PR!
