### PR TITLE
private/protocol: wrapping serialization errors 

### DIFF
--- a/private/protocol/ec2query/unmarshal.go
+++ b/private/protocol/ec2query/unmarshal.go
@@ -30,7 +30,7 @@ func Unmarshal(r *request.Request) {
 			r.Error = awserr.NewRequestFailure(
 				awserr.New("SerializationError", "failed decoding EC2 Query response", err),
 				r.HTTPResponse.StatusCode,
-				"",
+				r.RequestID,
 			)
 			return
 		}
@@ -59,7 +59,7 @@ func UnmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed decoding EC2 Query error response", err),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 	} else {
 		r.Error = awserr.NewRequestFailure(

--- a/private/protocol/ec2query/unmarshal.go
+++ b/private/protocol/ec2query/unmarshal.go
@@ -27,7 +27,11 @@ func Unmarshal(r *request.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, "")
 		if err != nil {
-			r.Error = awserr.New("SerializationError", "failed decoding EC2 Query response", err)
+			r.Error = awserr.NewRequestFailure(
+				awserr.New("SerializationError", "failed decoding EC2 Query response", err),
+				r.HTTPResponse.StatusCode,
+				"",
+			)
 			return
 		}
 	}
@@ -52,7 +56,11 @@ func UnmarshalError(r *request.Request) {
 	resp := &xmlErrorResponse{}
 	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
 	if err != nil && err != io.EOF {
-		r.Error = awserr.New("SerializationError", "failed decoding EC2 Query error response", err)
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed decoding EC2 Query error response", err),
+			r.HTTPResponse.StatusCode,
+			"",
+		)
 	} else {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(resp.Code, resp.Message, nil),

--- a/private/protocol/jsonrpc/jsonrpc.go
+++ b/private/protocol/jsonrpc/jsonrpc.go
@@ -67,7 +67,7 @@ func Unmarshal(req *request.Request) {
 			req.Error = awserr.NewRequestFailure(
 				awserr.New("SerializationError", "failed decoding JSON RPC response", err),
 				req.HTTPResponse.StatusCode,
-				"",
+				req.RequestID,
 			)
 		}
 	}
@@ -87,7 +87,7 @@ func UnmarshalError(req *request.Request) {
 		req.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed reading JSON RPC error response", err),
 			req.HTTPResponse.StatusCode,
-			"",
+			req.RequestID,
 		)
 		return
 	}
@@ -95,7 +95,7 @@ func UnmarshalError(req *request.Request) {
 		req.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", req.HTTPResponse.Status, nil),
 			req.HTTPResponse.StatusCode,
-			"",
+			req.RequestID,
 		)
 		return
 	}
@@ -104,7 +104,7 @@ func UnmarshalError(req *request.Request) {
 		req.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed decoding JSON RPC error response", err),
 			req.HTTPResponse.StatusCode,
-			"",
+			req.RequestID,
 		)
 		return
 	}

--- a/private/protocol/jsonrpc/jsonrpc.go
+++ b/private/protocol/jsonrpc/jsonrpc.go
@@ -64,7 +64,11 @@ func Unmarshal(req *request.Request) {
 	if req.DataFilled() {
 		err := jsonutil.UnmarshalJSON(req.Data, req.HTTPResponse.Body)
 		if err != nil {
-			req.Error = awserr.New("SerializationError", "failed decoding JSON RPC response", err)
+			req.Error = awserr.NewRequestFailure(
+				awserr.New("SerializationError", "failed decoding JSON RPC response", err),
+				req.HTTPResponse.StatusCode,
+				"",
+			)
 		}
 	}
 	return
@@ -80,7 +84,11 @@ func UnmarshalError(req *request.Request) {
 	defer req.HTTPResponse.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(req.HTTPResponse.Body)
 	if err != nil {
-		req.Error = awserr.New("SerializationError", "failed reading JSON RPC error response", err)
+		req.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed reading JSON RPC error response", err),
+			req.HTTPResponse.StatusCode,
+			"",
+		)
 		return
 	}
 	if len(bodyBytes) == 0 {
@@ -93,7 +101,11 @@ func UnmarshalError(req *request.Request) {
 	}
 	var jsonErr jsonErrorResponse
 	if err := json.Unmarshal(bodyBytes, &jsonErr); err != nil {
-		req.Error = awserr.New("SerializationError", "failed decoding JSON RPC error response", err)
+		req.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed decoding JSON RPC error response", err),
+			req.HTTPResponse.StatusCode,
+			"",
+		)
 		return
 	}
 

--- a/private/protocol/query/unmarshal.go
+++ b/private/protocol/query/unmarshal.go
@@ -26,7 +26,7 @@ func Unmarshal(r *request.Request) {
 			r.Error = awserr.NewRequestFailure(
 				awserr.New("SerializationError", "failed decoding Query response", err),
 				r.HTTPResponse.StatusCode,
-				"",
+				r.RequestID,
 			)
 			return
 		}

--- a/private/protocol/query/unmarshal.go
+++ b/private/protocol/query/unmarshal.go
@@ -23,7 +23,11 @@ func Unmarshal(r *request.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, r.Operation.Name+"Result")
 		if err != nil {
-			r.Error = awserr.New("SerializationError", "failed decoding Query response", err)
+			r.Error = awserr.NewRequestFailure(
+				awserr.New("SerializationError", "failed decoding Query response", err),
+				r.HTTPResponse.StatusCode,
+				"",
+			)
 			return
 		}
 	}

--- a/private/protocol/query/unmarshal_error.go
+++ b/private/protocol/query/unmarshal_error.go
@@ -28,7 +28,11 @@ func UnmarshalError(r *request.Request) {
 
 	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
-		r.Error = awserr.New("SerializationError", "failed to read from query HTTP response body", err)
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed to read from query HTTP response body", err),
+			r.HTTPResponse.StatusCode,
+			r.RequestID,
+		)
 		return
 	}
 
@@ -61,6 +65,10 @@ func UnmarshalError(r *request.Request) {
 	}
 
 	// Failed to retrieve any error message from the response body
-	r.Error = awserr.New("SerializationError",
-		"failed to decode query XML error response", decodeErr)
+	r.Error = awserr.NewRequestFailure(
+		awserr.New("SerializationError",
+			"failed to decode query XML error response", decodeErr),
+		r.HTTPResponse.StatusCode,
+		r.RequestID,
+	)
 }

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -60,7 +60,7 @@ func UnmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed reading REST JSON error response", err),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 		return
 	}
@@ -68,7 +68,7 @@ func UnmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", r.HTTPResponse.Status, nil),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 		return
 	}
@@ -77,7 +77,7 @@ func UnmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed decoding REST JSON error response", err),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 		return
 	}

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -57,7 +57,11 @@ func UnmarshalError(r *request.Request) {
 	code := r.HTTPResponse.Header.Get("X-Amzn-Errortype")
 	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
-		r.Error = awserr.New("SerializationError", "failed reading REST JSON error response", err)
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed reading REST JSON error response", err),
+			r.HTTPResponse.StatusCode,
+			"",
+		)
 		return
 	}
 	if len(bodyBytes) == 0 {
@@ -70,7 +74,11 @@ func UnmarshalError(r *request.Request) {
 	}
 	var jsonErr jsonErrorResponse
 	if err := json.Unmarshal(bodyBytes, &jsonErr); err != nil {
-		r.Error = awserr.New("SerializationError", "failed decoding REST JSON error response", err)
+		r.Error = awserr.NewRequestFailure(
+			awserr.New("SerializationError", "failed decoding REST JSON error response", err),
+			r.HTTPResponse.StatusCode,
+			"",
+		)
 		return
 	}
 

--- a/private/protocol/restxml/restxml.go
+++ b/private/protocol/restxml/restxml.go
@@ -36,7 +36,11 @@ func Build(r *request.Request) {
 		var buf bytes.Buffer
 		err := xmlutil.BuildXML(r.Params, xml.NewEncoder(&buf))
 		if err != nil {
-			r.Error = awserr.New("SerializationError", "failed to encode rest XML request", err)
+			r.Error = awserr.NewRequestFailure(
+				awserr.New("SerializationError", "failed to encode rest XML request", err),
+				r.HTTPResponse.StatusCode,
+				"",
+			)
 			return
 		}
 		r.SetBufferBody(buf.Bytes())
@@ -50,7 +54,11 @@ func Unmarshal(r *request.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, "")
 		if err != nil {
-			r.Error = awserr.New("SerializationError", "failed to decode REST XML response", err)
+			r.Error = awserr.NewRequestFailure(
+				awserr.New("SerializationError", "failed to decode REST XML response", err),
+				r.HTTPResponse.StatusCode,
+				"",
+			)
 			return
 		}
 	} else {

--- a/private/protocol/restxml/restxml.go
+++ b/private/protocol/restxml/restxml.go
@@ -39,7 +39,7 @@ func Build(r *request.Request) {
 			r.Error = awserr.NewRequestFailure(
 				awserr.New("SerializationError", "failed to encode rest XML request", err),
 				r.HTTPResponse.StatusCode,
-				"",
+				r.RequestID,
 			)
 			return
 		}
@@ -57,7 +57,7 @@ func Unmarshal(r *request.Request) {
 			r.Error = awserr.NewRequestFailure(
 				awserr.New("SerializationError", "failed to decode REST XML response", err),
 				r.HTTPResponse.StatusCode,
-				"",
+				r.RequestID,
 			)
 			return
 		}

--- a/private/protocol/unmarshal_test.go
+++ b/private/protocol/unmarshal_test.go
@@ -46,11 +46,12 @@ func TestUnmarshalDrainBodyNoBody(t *testing.T) {
 	assert.NoError(t, r.Error)
 }
 
-type testOutput struct {
-	_ struct{}
-}
-
 func TestUnmarshalSeriaizationError(t *testing.T) {
+
+	type testOutput struct {
+		_ struct{}
+	}
+
 	cases := []struct {
 		name          string
 		r             request.Request

--- a/private/protocol/unmarshal_test.go
+++ b/private/protocol/unmarshal_test.go
@@ -1,12 +1,19 @@
 package protocol_test
 
 import (
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/ec2query"
+	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
+	"github.com/aws/aws-sdk-go/private/protocol/query"
+	"github.com/aws/aws-sdk-go/private/protocol/restjson"
+	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,4 +44,114 @@ func TestUnmarshalDrainBodyNoBody(t *testing.T) {
 
 	protocol.UnmarshalDiscardBody(r)
 	assert.NoError(t, r.Error)
+}
+
+type testOutput struct {
+	_ struct{}
+}
+
+func TestUnmarshalSeriaizationError(t *testing.T) {
+	cases := []struct {
+		name          string
+		r             request.Request
+		unmarshalFn   func(*request.Request)
+		expectedError awserr.RequestFailure
+	}{
+		{
+			name: "jsonrpc",
+			r: request.Request{
+				Data: &testOutput{},
+				HTTPResponse: &http.Response{
+					StatusCode: 502,
+					Body:       ioutil.NopCloser(strings.NewReader("invalid json")),
+				},
+			},
+			unmarshalFn: jsonrpc.Unmarshal,
+			expectedError: awserr.NewRequestFailure(
+				awserr.New("SerializationError", "", nil),
+				502,
+				"",
+			),
+		},
+		{
+			name: "ec2query",
+			r: request.Request{
+				Data: &testOutput{},
+				HTTPResponse: &http.Response{
+					StatusCode: 111,
+					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+				},
+			},
+			unmarshalFn: ec2query.Unmarshal,
+			expectedError: awserr.NewRequestFailure(
+				awserr.New("SerializationError", "", nil),
+				111,
+				"",
+			),
+		},
+		{
+			name: "query",
+			r: request.Request{
+				Operation: &request.Operation{
+					Name: "Foo",
+				},
+				Data: &testOutput{},
+				HTTPResponse: &http.Response{
+					StatusCode: 1,
+					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+				},
+			},
+			unmarshalFn: query.Unmarshal,
+			expectedError: awserr.NewRequestFailure(
+				awserr.New("SerializationError", "", nil),
+				1,
+				"",
+			),
+		},
+		{
+			name: "restjson",
+			r: request.Request{
+				Data: &testOutput{},
+				HTTPResponse: &http.Response{
+					StatusCode: 123,
+					Body:       ioutil.NopCloser(strings.NewReader("invalid json")),
+				},
+			},
+			unmarshalFn: restjson.Unmarshal,
+			expectedError: awserr.NewRequestFailure(
+				awserr.New("SerializationError", "", nil),
+				123,
+				"",
+			),
+		},
+		{
+			name: "restxml",
+			r: request.Request{
+				Data: &testOutput{},
+				HTTPResponse: &http.Response{
+					StatusCode: 456,
+					Body:       ioutil.NopCloser(strings.NewReader("<<>>>>>>")),
+				},
+			},
+			unmarshalFn: restxml.Unmarshal,
+			expectedError: awserr.NewRequestFailure(
+				awserr.New("SerializationError", "", nil),
+				456,
+				"",
+			),
+		},
+	}
+
+	for _, c := range cases {
+		c.unmarshalFn(&c.r)
+
+		rfErr, ok := c.r.Error.(awserr.RequestFailure)
+		if !ok {
+			t.Errorf("%s: expected awserr.RequestFailure, but received %T", c.name, c.r.Error)
+		}
+
+		if e, a := c.expectedError.StatusCode(), rfErr.StatusCode(); e != a {
+			t.Errorf("%s: expected %v, but received %v", c.name, e, a)
+		}
+	}
 }


### PR DESCRIPTION
This change will allow serialization errors that were being returned during unmarshaling to be wrapped in a `awserr.RequestFailure` instead. This allows for custom retryers to get at the status code more easily.