### PR TITLE
aws/default: Add Authorization header support for endpoint credential provider

### DIFF
--- a/aws/credentials/endpointcreds/provider.go
+++ b/aws/credentials/endpointcreds/provider.go
@@ -65,6 +65,10 @@ type Provider struct {
 	//
 	// If ExpiryWindow is 0 or less it will be ignored.
 	ExpiryWindow time.Duration
+
+	// Optional authorization token value if set will be used as the value of
+	// the Authorization header of the endpoint credential request.
+	AuthorizationToken string
 }
 
 // NewProviderClient returns a credentials Provider for retrieving AWS credentials
@@ -152,6 +156,9 @@ func (p *Provider) getCredentials() (*getCredentialsOutput, error) {
 	out := &getCredentialsOutput{}
 	req := p.Client.NewRequest(op, nil, out)
 	req.HTTPRequest.Header.Set("Accept", "application/json")
+	if authToken := p.AuthorizationToken; len(authToken) != 0 {
+		req.HTTPRequest.Header.Set("Authorization", authToken)
+	}
 
 	return out, req.Send()
 }

--- a/aws/credentials/endpointcreds/provider_test.go
+++ b/aws/credentials/endpointcreds/provider_test.go
@@ -154,3 +154,65 @@ func TestFailedRetrieveCredentials(t *testing.T) {
 		t.Errorf("expect expired, wasn't")
 	}
 }
+
+func TestAuthorizationToken(t *testing.T) {
+	const expectAuthToken = "Basic abc123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if e, a := "/path/to/endpoint", r.URL.Path; e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "application/json", r.Header.Get("Accept"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := expectAuthToken, r.Header.Get("Authorization"); e != a {
+			t.Fatalf("expect %v, got %v", e, a)
+		}
+
+		encoder := json.NewEncoder(w)
+		err := encoder.Encode(map[string]interface{}{
+			"AccessKeyID":     "AKID",
+			"SecretAccessKey": "SECRET",
+			"Token":           "TOKEN",
+			"Expiration":      time.Now().Add(1 * time.Hour),
+		})
+
+		if err != nil {
+			fmt.Println("failed to write out creds", err)
+		}
+	}))
+
+	client := endpointcreds.NewProviderClient(*unit.Session.Config,
+		unit.Session.Handlers,
+		server.URL+"/path/to/endpoint?something=else",
+		func(p *endpointcreds.Provider) {
+			p.AuthorizationToken = expectAuthToken
+		},
+	)
+	creds, err := client.Retrieve()
+
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
+
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "TOKEN", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if client.IsExpired() {
+		t.Errorf("expect not expired, was")
+	}
+
+	client.(*endpointcreds.Provider).CurrentTime = func() time.Time {
+		return time.Now().Add(2 * time.Hour)
+	}
+
+	if !client.IsExpired() {
+		t.Errorf("expect expired, wasn't")
+	}
+}

--- a/aws/credentials/endpointcreds/provider_test.go
+++ b/aws/credentials/endpointcreds/provider_test.go
@@ -11,14 +11,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRetrieveRefreshableCredentials(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/path/to/endpoint", r.URL.Path)
-		assert.Equal(t, "application/json", r.Header.Get("Accept"))
-		assert.Equal(t, "else", r.URL.Query().Get("something"))
+		if e, a := "/path/to/endpoint", r.URL.Path; e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "application/json", r.Header.Get("Accept"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "else", r.URL.Query().Get("something"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
 
 		encoder := json.NewEncoder(w)
 		err := encoder.Encode(map[string]interface{}{
@@ -39,18 +44,30 @@ func TestRetrieveRefreshableCredentials(t *testing.T) {
 	)
 	creds, err := client.Retrieve()
 
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
 
-	assert.Equal(t, "AKID", creds.AccessKeyID)
-	assert.Equal(t, "SECRET", creds.SecretAccessKey)
-	assert.Equal(t, "TOKEN", creds.SessionToken)
-	assert.False(t, client.IsExpired())
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "TOKEN", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if client.IsExpired() {
+		t.Errorf("expect not expired, was")
+	}
 
 	client.(*endpointcreds.Provider).CurrentTime = func() time.Time {
 		return time.Now().Add(2 * time.Hour)
 	}
 
-	assert.True(t, client.IsExpired())
+	if !client.IsExpired() {
+		t.Errorf("expect expired, wasn't")
+	}
 }
 
 func TestRetrieveStaticCredentials(t *testing.T) {
@@ -69,12 +86,22 @@ func TestRetrieveStaticCredentials(t *testing.T) {
 	client := endpointcreds.NewProviderClient(*unit.Session.Config, unit.Session.Handlers, server.URL)
 	creds, err := client.Retrieve()
 
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
 
-	assert.Equal(t, "AKID", creds.AccessKeyID)
-	assert.Equal(t, "SECRET", creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
-	assert.False(t, client.IsExpired())
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect no SessionToken, got %#v", v)
+	}
+	if client.IsExpired() {
+		t.Errorf("expect not expired, was")
+	}
 }
 
 func TestFailedRetrieveCredentials(t *testing.T) {
@@ -94,18 +121,36 @@ func TestFailedRetrieveCredentials(t *testing.T) {
 	client := endpointcreds.NewProviderClient(*unit.Session.Config, unit.Session.Handlers, server.URL)
 	creds, err := client.Retrieve()
 
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error, got none")
+	}
 	aerr := err.(awserr.Error)
 
-	assert.Equal(t, "CredentialsEndpointError", aerr.Code())
-	assert.Equal(t, "failed to load credentials", aerr.Message())
+	if e, a := "CredentialsEndpointError", aerr.Code(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "failed to load credentials", aerr.Message(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	aerr = aerr.OrigErr().(awserr.Error)
-	assert.Equal(t, "Error", aerr.Code())
-	assert.Equal(t, "Message", aerr.Message())
+	if e, a := "Error", aerr.Code(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "Message", aerr.Message(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
-	assert.Empty(t, creds.AccessKeyID)
-	assert.Empty(t, creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
-	assert.True(t, client.IsExpired())
+	if v := creds.AccessKeyID; len(v) != 0 {
+		t.Errorf("expect empty, got %#v", v)
+	}
+	if v := creds.SecretAccessKey; len(v) != 0 {
+		t.Errorf("expect empty, got %#v", v)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("expect empty, got %#v", v)
+	}
+	if !client.IsExpired() {
+		t.Errorf("expect expired, wasn't")
+	}
 }

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -112,8 +112,9 @@ func CredProviders(cfg *aws.Config, handlers request.Handlers) []credentials.Pro
 }
 
 const (
-	httpProviderEnvVar     = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
-	ecsCredsProviderEnvVar = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+	httpProviderAuthorizationEnvVar = "AWS_CONTAINER_AUTHORIZATION_TOKEN"
+	httpProviderEnvVar              = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
+	ecsCredsProviderEnvVar          = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 )
 
 // RemoteCredProvider returns a credentials provider for the default remote
@@ -187,6 +188,7 @@ func httpCredProvider(cfg aws.Config, handlers request.Handlers, u string) crede
 	return endpointcreds.NewProviderClient(cfg, handlers, u,
 		func(p *endpointcreds.Provider) {
 			p.ExpiryWindow = 5 * time.Minute
+			p.AuthorizationToken = os.Getenv(httpProviderAuthorizationEnvVar)
 		},
 	)
 }

--- a/aws/defaults/defaults_test.go
+++ b/aws/defaults/defaults_test.go
@@ -37,16 +37,18 @@ func TestHTTPCredProvider(t *testing.T) {
 	}
 
 	cases := []struct {
-		Host string
-		Fail bool
+		Host      string
+		AuthToken string
+		Fail      bool
 	}{
-		{"localhost", false},
-		{"actuallylocal", false},
-		{"127.0.0.1", false},
-		{"127.1.1.1", false},
-		{"[::1]", false},
-		{"www.example.com", true},
-		{"169.254.170.2", true},
+		{Host: "localhost", Fail: false},
+		{Host: "actuallylocal", Fail: false},
+		{Host: "127.0.0.1", Fail: false},
+		{Host: "127.1.1.1", Fail: false},
+		{Host: "[::1]", Fail: false},
+		{Host: "www.example.com", Fail: true},
+		{Host: "169.254.170.2", Fail: true},
+		{Host: "localhost", Fail: false, AuthToken: "Basic abc123"},
 	}
 
 	defer os.Clearenv()
@@ -54,6 +56,7 @@ func TestHTTPCredProvider(t *testing.T) {
 	for i, c := range cases {
 		u := fmt.Sprintf("http://%s/abc/123", c.Host)
 		os.Setenv(httpProviderEnvVar, u)
+		os.Setenv(httpProviderAuthorizationEnvVar, c.AuthToken)
 
 		provider := RemoteCredProvider(aws.Config{}, request.Handlers{})
 		if provider == nil {
@@ -77,6 +80,9 @@ func TestHTTPCredProvider(t *testing.T) {
 			httpProvider := provider.(*endpointcreds.Provider)
 			if e, a := u, httpProvider.Client.Endpoint; e != a {
 				t.Errorf("%d, expect %q endpoint, got %q", i, e, a)
+			}
+			if e, a := c.AuthToken, httpProvider.AuthorizationToken; e != a {
+				t.Errorf("%d, expect %q auth token, got %q", i, e, a)
 			}
 		}
 	}


### PR DESCRIPTION
Updates the endpoint credential provider support for specifying an
AuthorizationToken value that will be used as the `Authorization` HTTP
header.

Add support for the AWS_CONTAINER_AUTHORIZATION_TOKEN environment
variable to specify the Authorization token for ECS Container
and generic HTTP credential providers.

This fix allows applications written with the Go SDK to retrieve
credentials while running within the AWS Greengrass platform.