### PR TITLE
private/model/api: Use modeled service signing version in code generation

### DIFF
--- a/service/s3/service.go
+++ b/service/s3/service.go
@@ -67,7 +67,9 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 	}
 
 	// Handlers
-	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Sign.PushBackNamed(v4.BuildNamedHandler(v4.SignRequestHandler.Name, func(s *v4.Signer) {
+		s.DisableURIPathEscaping = true
+	}))
 	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
 	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
 	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)


### PR DESCRIPTION
Updates the SDK's code generate to make use of the model's service
signature version when generating the client for the service. This
allows the SDK to generate a client using the correct signature version,
e.g v4 vs s3v4 without the need for additional customizations.