### PR TITLE
fix typo in Config struct documentation

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -18,7 +18,7 @@ const UseServiceDefaultRetries = -1
 type RequestRetryer interface{}
 
 // A Config provides service configuration for service clients. By default,
-// all clients will use the defaults.DefaultConfig tructure.
+// all clients will use the defaults.DefaultConfig structure.
 //
 //     // Create Session with MaxRetry configuration to be shared by multiple
 //     // service clients.


### PR DESCRIPTION
fix typo in `Config struct` documentation in [aws-sdk-go/aws/config.go](https://github.com/aws/aws-sdk-go/blob/2c6fb0737fb299300b5f082701aac627244ab28a/aws/config.go#L21)