### PR TITLE
private/protocol: Add domain host name label validation

### DIFF
--- a/aws/request/validation.go
+++ b/aws/request/validation.go
@@ -17,6 +17,10 @@ const (
 	ParamMinValueErrCode = "ParamMinValueError"
 	// ParamMinLenErrCode is the error code for fields without enough elements.
 	ParamMinLenErrCode = "ParamMinLenError"
+
+	// ParamFormatErrCode is the error code for a field with invalid
+	// format or characters.
+	ParamFormatErrCode = "ParamFormatInvalidError"
 )
 
 // Validator provides a way for types to perform validation logic on their
@@ -231,4 +235,27 @@ func NewErrParamMinLen(field string, min int) *ErrParamMinLen {
 // MinLen returns the field's required minimum length.
 func (e *ErrParamMinLen) MinLen() int {
 	return e.min
+}
+
+// An ErrParamFormat represents a invalid format parameter error.
+type ErrParamFormat struct {
+	errInvalidParam
+	format string
+}
+
+// NewErrParamFormat creates a new invalid format parameter error.
+func NewErrParamFormat(field string, format, value string) *ErrParamFormat {
+	return &ErrParamFormat{
+		errInvalidParam: errInvalidParam{
+			code:  ParamFormatErrCode,
+			field: field,
+			msg:   fmt.Sprintf("format %v, %v", format, value),
+		},
+		format: format,
+	}
+}
+
+// Format returns the field's required format.
+func (e *ErrParamFormat) Format() string {
+	return e.format
 }

--- a/private/protocol/host.go
+++ b/private/protocol/host.go
@@ -1,0 +1,21 @@
+package protocol
+
+// ValidHostLabel returns if the label is a valid RFC 1123 Section 2.1 domain
+// host label name.
+func ValidHostLabel(label string) bool {
+	if l := len(label); l == 0 || l > 63 {
+		return false
+	}
+	for _, r := range label {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+
+	return true
+}

--- a/private/protocol/host_test.go
+++ b/private/protocol/host_test.go
@@ -1,0 +1,35 @@
+// +build go1.7
+
+package protocol
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestValidHostLabel(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{Input: "abc123", Valid: true},
+		{Input: "123", Valid: true},
+		{Input: "abc", Valid: true},
+		{Input: "123-abc", Valid: true},
+		{Input: "{thing}-abc", Valid: false},
+		{Input: "abc.123", Valid: false},
+		{Input: "abc/123", Valid: false},
+		{Input: "012345678901234567890123456789012345678901234567890123456789123", Valid: true},
+		{Input: "0123456789012345678901234567890123456789012345678901234567891234", Valid: false},
+		{Input: "", Valid: false},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			valid := ValidHostLabel(c.Input)
+			if e, a := c.Valid, valid; e != a {
+				t.Errorf("expect valid %v, got %v", e, a)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds support for validation of host domain name labels based on RFC 1123
specification.