### PR TITLE
aws/csm: adding MaxRetriesExceeded metric

### DIFF
--- a/aws/csm/metric.go
+++ b/aws/csm/metric.go
@@ -48,4 +48,6 @@ type metric struct {
 	DNSLatency               *int `json:"DnsLatency,omitempty"`
 	TCPLatency               *int `json:"TcpLatency,omitempty"`
 	SSLLatency               *int `json:"SslLatency,omitempty"`
+
+	MaxRetriesExceeded *int `json:"MaxRetriesExceeded,omitempty"`
 }

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -112,15 +112,16 @@ func (rep *Reporter) sendAPICallMetric(r *request.Request) {
 
 	now := time.Now()
 	m := metric{
-		ClientID:      aws.String(rep.clientID),
-		API:           aws.String(r.Operation.Name),
-		Service:       aws.String(r.ClientInfo.ServiceID),
-		Timestamp:     (*metricTime)(&now),
-		Type:          aws.String("ApiCall"),
-		AttemptCount:  aws.Int(r.RetryCount + 1),
-		Region:        r.Config.Region,
-		Latency:       aws.Int(int(time.Now().Sub(r.Time) / time.Millisecond)),
-		XAmzRequestID: aws.String(r.RequestID),
+		ClientID:           aws.String(rep.clientID),
+		API:                aws.String(r.Operation.Name),
+		Service:            aws.String(r.ClientInfo.ServiceID),
+		Timestamp:          (*metricTime)(&now),
+		Type:               aws.String("ApiCall"),
+		AttemptCount:       aws.Int(r.RetryCount + 1),
+		Region:             r.Config.Region,
+		Latency:            aws.Int(int(time.Now().Sub(r.Time) / time.Millisecond)),
+		XAmzRequestID:      aws.String(r.RequestID),
+		MaxRetriesExceeded: aws.Int(boolIntValue(r.RetryCount >= r.MaxRetries())),
 	}
 
 	// TODO: Probably want to figure something out for logging dropped
@@ -229,4 +230,13 @@ func (rep *Reporter) InjectHandlers(handlers *request.Handlers) {
 	handlers.Complete.PushFrontNamed(apiCallAttemptHandler)
 
 	handlers.AfterRetry.PushFrontNamed(apiCallAttemptHandler)
+}
+
+// boolIntValue return 1 for true and 0 for false.
+func boolIntValue(b bool) int {
+	if b {
+		return 1
+	}
+
+	return 0
 }

--- a/aws/csm/reporter_internal_test.go
+++ b/aws/csm/reporter_internal_test.go
@@ -1,0 +1,72 @@
+package csm
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/client/metadata"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestMaxRetriesExceeded(t *testing.T) {
+	md := metadata.ClientInfo{
+		Endpoint: "http://127.0.0.1",
+	}
+
+	cfg := aws.Config{
+		Region:      aws.String("foo"),
+		Credentials: credentials.NewStaticCredentials("", "", ""),
+	}
+
+	op := &request.Operation{}
+	cases := []struct {
+		name                    string
+		httpStatusCode          int
+		expectedMaxRetriesValue int
+		expectedMetrics         int
+	}{
+		{
+			name:                    "max retry reached",
+			httpStatusCode:          http.StatusBadGateway,
+			expectedMaxRetriesValue: 1,
+		},
+		{
+			name:                    "status ok",
+			httpStatusCode:          http.StatusOK,
+			expectedMaxRetriesValue: 0,
+		},
+	}
+
+	for _, c := range cases {
+		r := request.New(cfg, md, defaults.Handlers(), client.DefaultRetryer{NumMaxRetries: 2}, op, nil, nil)
+		reporter := newReporter("", "")
+		r.Handlers.Send.Clear()
+		reporter.InjectHandlers(&r.Handlers)
+
+		r.Handlers.Send.PushBack(func(r *request.Request) {
+			r.HTTPResponse = &http.Response{
+				StatusCode: c.httpStatusCode,
+			}
+		})
+		r.Send()
+
+		for {
+			m := <-reporter.metricsCh.ch
+
+			if *m.Type != "ApiCall" {
+				// ignore non-ApiCall metrics since MaxRetriesExceeded is only on ApiCall events
+				continue
+			}
+
+			if val := *m.MaxRetriesExceeded; val != c.expectedMaxRetriesValue {
+				t.Errorf("%s: expected %d, but received %d", c.name, c.expectedMaxRetriesValue, val)
+			}
+
+			break
+		}
+	}
+}

--- a/aws/csm/reporter_test.go
+++ b/aws/csm/reporter_test.go
@@ -2,7 +2,6 @@ package csm_test
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,41 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
-
-func startUDPServer(done chan struct{}, fn func([]byte)) (string, error) {
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		return "", err
-	}
-
-	conn, err := net.ListenUDP("udp", addr)
-	if err != nil {
-		return "", err
-	}
-
-	buf := make([]byte, 1024)
-	i := 0
-	go func() {
-		defer conn.Close()
-		for {
-			i++
-			select {
-			case <-done:
-				return
-			default:
-			}
-
-			n, _, err := conn.ReadFromUDP(buf)
-			fn(buf[:n])
-
-			if err != nil {
-				panic(err)
-			}
-		}
-	}()
-
-	return conn.LocalAddr().String(), nil
-}
 
 func TestReportingMetrics(t *testing.T) {
 	reporter := csm.Get()


### PR DESCRIPTION
Adds an additional metric, `MaxRetriesExceeded`. This will compare the `request.RetryCount` with the `request.Config.MaxRetries` and will set `1` is retry count is at least the `MaxRetries` and `0` otherwise.
