### PR TITLE
Update SDKs Makefile to use golang.org/x/lint/golint pkg rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ get-deps-tests:
 
 get-deps-verify:
 	@echo "go get SDK verification utilities"
-	@if [ \( -z "${SDK_GO_1_4}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  go get github.com/golang/lint/golint; else echo "skipped getting golint"; fi
+	@if [ \( -z "${SDK_GO_1_4}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  go get golang.org/x/lint/golint; else echo "skipped getting golint"; fi
 
 bench:
 	@echo "go bench SDK packages"


### PR DESCRIPTION
Updates the SDK's Makefile to use `golang.org/x/lint/golint` instead of `github.com/golang/lint/golint`. lint package was updated to use `golang.org/x` root in golang/lint@9a272034