### PR TITLE
adding ci-test-no-verify in make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: go
 matrix:
     allow_failures:
         - go: tip
-        - go: 1.6.x
-          os: linux
     include:
         - os: linux
           sudo: required
@@ -46,11 +44,12 @@ matrix:
           go: tip
 
 script:
-  - if [ $TRAVIS_GO_VERSION == "1.7.x" ] ||
-    [ $TRAVIS_GO_VERSION == "1.8.x" ]; then
-    make ci-test-no-verify;
-    else
+  - if [ $TRAVIS_GO_VERSION == "tip" ] ||
+    [ $TRAVIS_GO_VERSION == "1.11.x" ] || 
+    [ $TRAVIS_GO_VERSION == "1.10.x" ]; then
     make ci-test;
+    else
+    make ci-test-no-verify;
     fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,12 @@ matrix:
           go: tip
 
 script:
-  - make ci-test
+  - if [ $TRAVIS_GO_VERSION == "1.7.x" ] ||
+    [ $TRAVIS_GO_VERSION == "1.8.x" ]; then
+    make ci-test-no-verify;
+    else
+    make ci-test;
+    fi
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,12 @@ unit-with-race-cover: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
 	@go test -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 $(SDK_UNIT_TEST_ONLY_PKGS)
 
+unit-with-race-cover-no-verify: get-deps-tests build
+	@echo "go test SDK and vendor packages"
+	@go test -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 $(SDK_UNIT_TEST_ONLY_PKGS)
+
+ci-test-no-verify: unit-with-race-cover-no-verify
+
 ci-test: ci-test-generate unit-with-race-cover ci-test-generate-validate
 
 ci-test-generate: get-deps

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ UNIT_TEST_TAGS="example codegen awsinclude"
 SDK_WITH_VENDOR_PKGS=$(shell go list -tags ${UNIT_TEST_TAGS} ./... | grep -v "/vendor/src")
 SDK_ONLY_PKGS=$(shell go list ./... | grep -v "/vendor/")
 SDK_UNIT_TEST_ONLY_PKGS=$(shell go list -tags ${UNIT_TEST_TAGS} ./... | grep -v "/vendor/")
-SDK_GO_1_4=$(shell go version | grep "go1.4")
-SDK_GO_1_5=$(shell go version | grep "go1.5")
-SDK_GO_1_6=$(shell go version | grep "go1.6")
 SDK_GO_VERSION=$(shell go version | awk '''{print $$3}''' | tr -d '''\n''')
 
 all: get-deps generate unit
@@ -69,22 +66,22 @@ unit-with-race-cover: get-deps-tests build verify
 	@echo "go test SDK and vendor packages"
 	@go test -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 $(SDK_UNIT_TEST_ONLY_PKGS)
 
-unit-with-race-cover-no-verify: get-deps-tests build
-	@echo "go test SDK and vendor packages"
-	@go test -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 $(SDK_UNIT_TEST_ONLY_PKGS)
+unit-test-sdk-packages: get-deps-tests build
+	@echo "go test SDK only packages"
+	@go test -race -cpu=1,2,4 $(SDK_ONLY_PKGS)
 
-ci-test-no-verify: unit-with-race-cover-no-verify
+ci-test-no-verify: unit-test-sdk-packages
 
 ci-test: ci-test-generate unit-with-race-cover ci-test-generate-validate
 
 ci-test-generate: get-deps
 	@echo "CI test generated code"
-	@if [ \( -z "${SDK_GO_1_6}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  make generate; else echo "skipping generate"; fi
+	make generate
 
 ci-test-generate-validate:
 	@echo "CI test validate no generated code changes"
 	@git add . -A
-	@gitstatus=`if [ \( -z "${SDK_GO_1_6}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  git diff --cached --ignore-space-change; else echo "skipping validation"; fi`; \
+	@gitstatus=`git diff --cached --ignore-space-change`; \
 	echo "$$gitstatus"; \
 	if [ "$$gitstatus" != "" ] && [ "$$gitstatus" != "skipping validation" ]; then echo "$$gitstatus"; exit 1; fi
 
@@ -175,19 +172,13 @@ verify: get-deps-verify lint vet
 
 lint:
 	@echo "go lint SDK and vendor packages"
-	@lint=`if [ \( -z "${SDK_GO_1_4}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  golint ./...; else echo "skipping golint"; fi`; \
+	@lint=`golint ./...`; \
 	lint=`echo "$$lint" | grep -E -v -e ${LINTIGNOREDOT} -e ${LINTIGNOREDOC} -e ${LINTIGNORECONST} -e ${LINTIGNORESTUTTER} -e ${LINTIGNOREINFLECT} -e ${LINTIGNOREDEPS} -e ${LINTIGNOREINFLECTS3UPLOAD} -e ${LINTIGNOREPKGCOMMENT} -e ${LINTIGNOREENDPOINTS}`; \
 	echo "$$lint"; \
-	if [ "$$lint" != "" ] && [ "$$lint" != "skipping golint" ]; then exit 1; fi
+	if [ "$$lint" != "" ]; then exit 1; fi
 
 SDK_BASE_FOLDERS=$(shell ls -d */ | grep -v vendor | grep -v awsmigrate)
-ifneq (,$(findstring go1.4, ${SDK_GO_VERSION}))
-	GO_VET_CMD=echo skipping go vet, ${SDK_GO_VERSION}
-else ifneq (,$(findstring go1.6, ${SDK_GO_VERSION}))
-	GO_VET_CMD=go tool vet --all -shadow -example=false
-else
-	GO_VET_CMD=go tool vet --all -shadow
-endif
+GO_VET_CMD=go tool vet --all -shadow
 
 vet:
 	${GO_VET_CMD} ${SDK_BASE_FOLDERS}
@@ -206,7 +197,7 @@ get-deps-tests:
 
 get-deps-verify:
 	@echo "go get SDK verification utilities"
-	@if [ \( -z "${SDK_GO_1_4}" \) -a \( -z "${SDK_GO_1_5}" \) ]; then  go get golang.org/x/lint/golint; else echo "skipped getting golint"; fi
+	go get golang.org/x/lint/golint
 
 bench:
 	@echo "go bench SDK packages"


### PR DESCRIPTION
Golang version 1.7 and 1.8 were failing in Travis. This now will skip the verify test which runs vet and lint.
