### PR TITLE
internal/ini: fixing bug where '//' was assumed to be a comment

### DIFF
--- a/internal/ini/comment_token.go
+++ b/internal/ini/comment_token.go
@@ -12,10 +12,6 @@ func isComment(b []rune) bool {
 		return true
 	case '#':
 		return true
-	case '/':
-		if len(b) > 1 {
-			return b[1] == '/'
-		}
 	}
 
 	return false

--- a/internal/ini/doc.go
+++ b/internal/ini/doc.go
@@ -24,7 +24,6 @@
 //
 //	SkipState will skip (NL WS)+
 //
-//	comment -> # comment' | ; comment' | / comment_slash
-//	comment_slash -> / comment'
+//	comment -> # comment' | ; comment'
 //	comment' -> epsilon | value
 package ini

--- a/internal/ini/ini_parser.go
+++ b/internal/ini/ini_parser.go
@@ -25,8 +25,7 @@ const (
 	// SkipTokenState will skip any token and push the previous
 	// state onto the stack.
 	SkipTokenState
-	// comment -> # comment' | ; comment' | / comment_slash
-	// comment_slash -> / comment'
+	// comment -> # comment' | ; comment'
 	// comment' -> MarkComplete | value
 	CommentState
 	// MarkComplete state will complete statements and move that
@@ -157,6 +156,12 @@ loop:
 
 		step := parseTable[k.Kind][tok.Type()]
 		if s.ShouldSkip(tok) {
+			// being in a skip state with no tokens will break out of
+			// the parse loop since there is nothing left to process.
+			if len(tokens) == 0 {
+				break loop
+			}
+
 			step = SkipTokenState
 		}
 

--- a/internal/ini/skipper.go
+++ b/internal/ini/skipper.go
@@ -5,10 +5,10 @@ package ini
 // files. See example below
 //
 //	[ foo ]
-//	nested = // this section will be skipped
+//	nested = ; this section will be skipped
 //		a=b
 //		c=d
-//	bar=baz // this will be included
+//	bar=baz ; this will be included
 type skipper struct {
 	shouldSkip bool
 	TokenSet   bool
@@ -22,7 +22,10 @@ func newSkipper() skipper {
 }
 
 func (s *skipper) ShouldSkip(tok Token) bool {
-	if s.shouldSkip && s.prevTok.Type() == TokenNL && tok.Type() != TokenWS {
+	if s.shouldSkip &&
+		s.prevTok.Type() == TokenNL &&
+		tok.Type() != TokenWS {
+
 		s.Continue()
 		return false
 	}

--- a/internal/ini/statement.go
+++ b/internal/ini/statement.go
@@ -18,9 +18,8 @@ func newExprStatement(ast AST) AST {
 // CommentStatement represents a comment in the ini defintion.
 //
 //	grammar:
-//	comment -> #comment' | ;comment' | /comment_slash
-//	comment_slash -> /comment'
-//	comment' -> value
+//	comment -> #comment' | ;comment'
+//	comment' -> epsilon | value
 func newCommentStatement(tok Token) AST {
 	return newAST(ASTKindCommentStatement, newExpression(tok))
 }


### PR DESCRIPTION
This change fixes a bug where `//` were parsed to be comments which was not previously supported. In addition, fixed the skipper to break out of the parse loop if there are no tokens left to parse and we are in a skip state which was discovered to be a bug during updating of the `//` comment tests.

Fixes #2239 