### PR TITLE
internal/ini: allowing LHS of equal expression to contain spaces

### DIFF
--- a/internal/ini/testdata/valid/space_lhs
+++ b/internal/ini/testdata/valid/space_lhs
@@ -1,0 +1,2 @@
+[ hyphen-profile-name ]
+aws region = "foo-region"

--- a/internal/ini/testdata/valid/space_lhs_expected
+++ b/internal/ini/testdata/valid/space_lhs_expected
@@ -1,0 +1,5 @@
+{
+    "hyphen-profile-name": {
+        "aws region": "foo-region"
+    }
+}


### PR DESCRIPTION
Fixes #2263 

The LHS of equal expression did not allow for spaces unless they were quoted. This is was supported previously and this PR is to maintain that.