### PR TITLE
Update http request host when force host style

### DIFF
--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -64,6 +64,7 @@ func updateEndpointForHostStyle(r *request.Request) {
 	}
 
 	moveBucketToHost(r.HTTPRequest.URL, bucket)
+	r.HTTPRequest.Host = r.HTTPRequest.URL.Host
 }
 
 var (
@@ -107,6 +108,7 @@ func updateEndpointForAccelerate(r *request.Request) {
 	r.HTTPRequest.URL.Host = strings.Join(parts, ".")
 
 	moveBucketToHost(r.HTTPRequest.URL, bucket)
+	r.HTTPRequest.Host = r.HTTPRequest.URL.Host
 }
 
 // Attempts to retrieve the bucket name from the request input parameters.


### PR DESCRIPTION
This PR aims to improve host style request. When using host-style, both http request host and http request URL host should format to `[BucketName].s3.amazonaws.com`. So, after run `moveBucketToHost`, it should re-set `HTTPRequest.Host`.
