### PR TITLE
s3manageriface: add missing methods

### DIFF
--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -13,7 +13,7 @@ import (
 type DownloaderAPI interface {
 	Download(io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
 	DownloadWithContext(aws.Context, io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
-	DownloadWithIterator(ctx aws.Context, iter s3manager.BatchDownloadIterator, opts ...func(*s3manager.Downloader)) error
+	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
 
 var _ DownloaderAPI = (*s3manager.Downloader)(nil)
@@ -22,14 +22,14 @@ var _ DownloaderAPI = (*s3manager.Downloader)(nil)
 type UploaderAPI interface {
 	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 	UploadWithContext(aws.Context, *s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
-	UploadWithIterator(ctx aws.Context, iter s3manager.BatchUploadIterator, opts ...func(*s3manager.Uploader)) error
+	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
 
 // BatchDeleteAPI is the interface type for s3manager.BatchDelete.
 type BatchDeleteAPI interface {
-	Delete(ctx aws.Context, iter s3manager.BatchDeleteIterator) error
+	Delete(aws.Context, s3manager.BatchDeleteIterator) error
 }
 
 var _ BatchDeleteAPI = (*s3manager.BatchDelete)(nil)

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -13,6 +13,7 @@ import (
 type DownloaderAPI interface {
 	Download(io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
 	DownloadWithContext(aws.Context, io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
+	DownloadWithIterator(ctx aws.Context, iter s3manager.BatchDownloadIterator, opts ...func(*s3manager.Downloader)) error
 }
 
 var _ DownloaderAPI = (*s3manager.Downloader)(nil)
@@ -21,6 +22,14 @@ var _ DownloaderAPI = (*s3manager.Downloader)(nil)
 type UploaderAPI interface {
 	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 	UploadWithContext(aws.Context, *s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadWithIterator(ctx aws.Context, iter s3manager.BatchUploadIterator, opts ...func(*s3manager.Uploader)) error
 }
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
+
+// BatchDeleteAPI is the interface type for s3manager.BatchDelete.
+type BatchDeleteAPI interface {
+	Delete(ctx aws.Context, iter s3manager.BatchDeleteIterator) error
+}
+
+var _ BatchDeleteAPI = (*s3manager.BatchDelete)(nil)


### PR DESCRIPTION
`UploadWithIterator`, `DownloadWithIterator`, as well as BatchDelete's `Delete` are all missing from s3manageriface. Minor oversight? 