### PR TITLE
internal/ini: trimming rhs spaces issue

### DIFF
--- a/internal/ini/ini_parser.go
+++ b/internal/ini/ini_parser.go
@@ -335,13 +335,12 @@ func trimSpaces(k AST) AST {
 	}
 
 	// trim right hand side of spaces
-	for i := len(k.Root.raw) - 1; i > 0; i-- {
+	for i := len(k.Root.raw) - 1; i >= 0; i-- {
 		if !isWhitespace(k.Root.raw[i]) {
 			break
 		}
 
 		k.Root.raw = k.Root.raw[:len(k.Root.raw)-1]
-		i--
 	}
 
 	return k

--- a/internal/ini/testdata/valid/issue_2281
+++ b/internal/ini/testdata/valid/issue_2281
@@ -1,0 +1,7 @@
+[foo-profile]
+aws_access_key_id        = accesskey
+aws_secret_access_key    = secret
+aws_session_token        = token
+aws_security_token       = sectoken
+x_principal_arn          = arn:aws:sts::myarn
+x_security_token_expires = time

--- a/internal/ini/testdata/valid/issue_2281_expected
+++ b/internal/ini/testdata/valid/issue_2281_expected
@@ -1,0 +1,10 @@
+{
+	"foo-profile": {
+		"aws_access_key_id": "accesskey",
+		"aws_secret_access_key": "secret",
+		"aws_session_token": "token",
+		"aws_security_token": "sectoken",
+		"x_principal_arn": "arn:aws:sts::myarn",
+		"x_security_token_expires": "time"
+	}
+}

--- a/internal/ini/trim_spaces_test.go
+++ b/internal/ini/trim_spaces_test.go
@@ -1,0 +1,75 @@
+package ini
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTrimSpaces(t *testing.T) {
+	cases := []struct {
+		name         string
+		node         AST
+		expectedNode AST
+	}{
+		{
+			name: "simple case",
+			node: AST{
+				Root: Token{
+					raw: []rune("foo"),
+				},
+			},
+			expectedNode: AST{
+				Root: Token{
+					raw: []rune("foo"),
+				},
+			},
+		},
+		{
+			name: "LHS case",
+			node: AST{
+				Root: Token{
+					raw: []rune("         foo"),
+				},
+			},
+			expectedNode: AST{
+				Root: Token{
+					raw: []rune("foo"),
+				},
+			},
+		},
+		{
+			name: "RHS case",
+			node: AST{
+				Root: Token{
+					raw: []rune("foo     "),
+				},
+			},
+			expectedNode: AST{
+				Root: Token{
+					raw: []rune("foo"),
+				},
+			},
+		},
+		{
+			name: "both sides case",
+			node: AST{
+				Root: Token{
+					raw: []rune(" foo "),
+				},
+			},
+			expectedNode: AST{
+				Root: Token{
+					raw: []rune("foo"),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		node := trimSpaces(c.node)
+
+		if e, a := c.expectedNode, node; !reflect.DeepEqual(e, a) {
+			t.Errorf("%s: expected %v, but received %v", c.name, e, a)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2281 

Copy pasta bug. Do not need to decrement i twice when trimming RHS.