### PR TITLE
aws/session: Fix formatting bug in doc.

### DIFF
--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -99,7 +99,7 @@ handler logs every request and its payload made by a service client:
 
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
-		logger.Println("Request: %s/%s, Payload: %s",
+		logger.Printf("Request: %s/%s, Payload: %s",
 			r.ClientInfo.ServiceName, r.Operation, r.Params)
 	})
 


### PR DESCRIPTION
This PR fixes a minor issue in `aws/session/doc.go` where the developer mistakenly used format specifiers in `logger.Println`.

Changes committed:
	modified:   aws/session/doc.go

Signed-off-by: Abhishek Kashyap <avskksyp@gmail.com>
<!--
For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

If there is an existing bug or feature this PR is answers please reference it here.
-->