### PR TITLE
aws/request: Add additional throttle error code

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -40,6 +40,7 @@ var throttleCodes = map[string]struct{}{
 	"RequestThrottled":                       {},
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
+	"TransactionInProgressException":         {},
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials


### PR DESCRIPTION
Adds a new throttle error code the SDK should react to when determining if
a request should be throttled.