### PR TITLE
Fixup endpoint discovery unit test to be stable

### DIFF
--- a/aws/crr/cache.go
+++ b/aws/crr/cache.go
@@ -38,6 +38,15 @@ func (c *EndpointCache) get(endpointKey string) (Endpoint, bool) {
 	return endpoint.(Endpoint), true
 }
 
+// Has returns if the enpoint cache contains a valid entry for the endpoint key
+// provided.
+func (c *EndpointCache) Has(endpointKey string) bool {
+	endpoint, ok := c.get(endpointKey)
+	_, found := endpoint.GetValidAddress()
+
+	return ok && found
+}
+
 // Get will retrieve a weighted address  based off of the endpoint key. If an endpoint
 // should be retrieved, due to not existing or the current endpoint has expired
 // the Discoverer object that was passed in will attempt to discover a new endpoint

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/aws/aws-sdk-go
 
-require (
-	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
-)
+require github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,2 @@
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/endpoint_discovery_test.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/endpoint_discovery_test.go
@@ -80,12 +80,17 @@ func TestAsyncEndpointDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for s := time.Now().Add(1 * time.Second); s.After(time.Now()); {
+	var cacheUpdated bool
+	for s := time.Now().Add(10 * time.Second); s.After(time.Now()); {
 		// Wait for the cache to be updated before making second request.
 		if svc.endpointCache.Has(req.Operation.Name) {
+			cacheUpdated = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if !cacheUpdated {
+		t.Fatalf("expect endpoint cache to be updated, was not")
 	}
 
 	req, _ = svc.TestDiscoveryOptionalRequest(&TestDiscoveryOptionalInput{

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/endpoint_discovery_test.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/endpoint_discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -47,6 +48,8 @@ func TestEndpointDiscovery(t *testing.T) {
 }
 
 func TestAsyncEndpointDiscovery(t *testing.T) {
+	t.Parallel()
+
 	svc := New(unit.Session, &aws.Config{
 		EnableEndpointDiscovery: aws.Bool(true),
 	})
@@ -54,20 +57,12 @@ func TestAsyncEndpointDiscovery(t *testing.T) {
 
 	var firstAsyncReq sync.WaitGroup
 	firstAsyncReq.Add(1)
-	svc.Handlers.Send.PushBack(func(r *request.Request) {
+	svc.Handlers.Build.PushBack(func(r *request.Request) {
 		if r.Operation.Name == opDescribeEndpoints {
 			firstAsyncReq.Wait()
 		}
 	})
 	svc.Handlers.Send.PushBack(mockSendDescEndpoint)
-
-	var descWg sync.WaitGroup
-	descWg.Add(1)
-	svc.Handlers.Complete.PushBack(func(r *request.Request) {
-		if r.Operation.Name == opDescribeEndpoints {
-			descWg.Done()
-		}
-	})
 
 	req, _ := svc.TestDiscoveryOptionalRequest(&TestDiscoveryOptionalInput{
 		Sdk: aws.String("sdk"),
@@ -78,12 +73,20 @@ func TestAsyncEndpointDiscovery(t *testing.T) {
 			t.Errorf("expected %q, but received %q", e, a)
 		}
 	})
+	req.Handlers.Complete.PushBack(func(r *request.Request) {
+		firstAsyncReq.Done()
+	})
 	if err := req.Send(); err != nil {
 		t.Fatal(err)
 	}
 
-	firstAsyncReq.Done()
-	descWg.Wait()
+	for s := time.Now().Add(1 * time.Second); s.After(time.Now()); {
+		// Wait for the cache to be updated before making second request.
+		if svc.endpointCache.Has(req.Operation.Name) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	req, _ = svc.TestDiscoveryOptionalRequest(&TestDiscoveryOptionalInput{
 		Sdk: aws.String("sdk"),


### PR DESCRIPTION
Fixes the SDK's endpoint discovery async unit test to be stable, and
produce consistent unit test results.