### PR TITLE
service/s3: Update S3 operations to autofill Content-MD5 header

### DIFF
--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -33,6 +33,7 @@ func defaultInitRequestFn(r *request.Request) {
 	switch r.Operation.Name {
 	case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy,
 		opPutBucketTagging, opDeleteObjects, opPutBucketLifecycleConfiguration,
+		opPutObjectLegalHold, opPutObjectRetention, opPutObjectLockConfiguration,
 		opPutBucketReplication:
 		// These S3 operations require Content-MD5 to be set
 		r.Handlers.Build.PushBack(contentMD5)


### PR DESCRIPTION
Updates the S3 client to autofill the Content-MD5 header for the
PutObjectLegalHold, PutObjectRetention, and PutObjectLockConfiguration
operations.