### PR TITLE
private/mode/api: Update SDK to require URI path members not be empty

### DIFF
--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -1754,6 +1754,9 @@
     "shapes": {
       "InputShape": {
         "type": "structure",
+        "required": [
+            "URIFooEnum"
+        ],
         "members": {
           "HeaderEnum": {
             "shape": "EnumType",
@@ -1824,14 +1827,15 @@
           },
           "http": {
             "method": "POST",
-            "requestUri": "/path"
+            "requestUri": "/Enum/{URIEnum}"
           },
           "name": "OperationName"
         },
         "params": {
+          "URIFooEnum": "bar"
         },
         "serialized": {
-          "uri": "/path",
+          "uri": "/Enum/bar",
           "headers": {}
         }
       }

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -114,11 +114,13 @@ type Shape struct {
 
 // CanBeEmpty returns if the shape value can sent request as an empty value.
 // String, blob, list, and map are types must not be empty when the member is
-// decorated with HostLabel.
+// serialized to the uri path, or decorated with HostLabel.
 func (ref *ShapeRef) CanBeEmpty() bool {
 	switch ref.Shape.Type {
 	case "string":
-		return !ref.HostLabel
+		return !(ref.Location == "uri" || ref.HostLabel)
+	case "blob", "map", "list":
+		return !(ref.Location == "uri")
 	default:
 		return true
 	}
@@ -789,7 +791,7 @@ func (s *Shape) IsEnum() bool {
 }
 
 // IsRequired returns if member is a required field. Required fields are fields
-// marked as required, or hostLabels.
+// marked as required, hostLabels, or location of uri path.
 func (s *Shape) IsRequired(member string) bool {
 	ref, ok := s.MemberRefs[member]
 	if !ok {
@@ -798,7 +800,7 @@ func (s *Shape) IsRequired(member string) bool {
 			s.ShapeName, member,
 		))
 	}
-	if ref.HostLabel {
+	if ref.Location == "uri" || ref.HostLabel {
 		return true
 	}
 	for _, n := range s.Required {

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -317,7 +317,24 @@ func (c *InputService2ProtocolTest) InputService2TestCaseOperation1WithContext(c
 type InputService2TestShapeInputService2TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	PipelineId *string `location:"uri" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService2TestShapeInputService2TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService2TestShapeInputService2TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetPipelineId sets the PipelineId field's value.
@@ -464,7 +481,24 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1WithContext(c
 type InputService3TestShapeInputService3TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	Foo *string `location:"uri" locationName:"PipelineId" type:"string"`
+	// Foo is a required field
+	Foo *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService3TestShapeInputService3TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService3TestShapeInputService3TestCaseOperation1Input"}
+	if s.Foo == nil {
+		invalidParams.Add(request.NewErrParamRequired("Foo"))
+	}
+	if s.Foo != nil && len(*s.Foo) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Foo", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetFoo sets the Foo field's value.
@@ -758,9 +792,26 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1WithContext(c
 type InputService5TestShapeInputService5TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	PipelineId *string `location:"uri" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" type:"string" required:"true"`
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService5TestShapeInputService5TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService5TestShapeInputService5TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetPipelineId sets the PipelineId field's value.
@@ -913,9 +964,26 @@ func (c *InputService6ProtocolTest) InputService6TestCaseOperation1WithContext(c
 type InputService6TestShapeInputService6TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	PipelineId *string `location:"uri" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" type:"string" required:"true"`
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService6TestShapeInputService6TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService6TestShapeInputService6TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetPipelineId sets the PipelineId field's value.
@@ -1306,7 +1374,24 @@ type InputService8TestShapeInputService8TestCaseOperation1Input struct {
 
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService8TestShapeInputService8TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService8TestShapeInputService8TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetAscending sets the Ascending field's value.
@@ -1471,7 +1556,24 @@ type InputService9TestShapeInputService9TestCaseOperation1Input struct {
 
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService9TestShapeInputService9TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService9TestShapeInputService9TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetAscending sets the Ascending field's value.
@@ -1664,7 +1766,24 @@ type InputService10TestShapeInputService10TestCaseOperation1Input struct {
 
 	PageToken *string `location:"querystring" locationName:"PageToken" type:"string"`
 
-	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" locationName:"PipelineId" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService10TestShapeInputService10TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService10TestShapeInputService10TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetAscending sets the Ascending field's value.
@@ -1869,6 +1988,9 @@ func (s *InputService11TestShapeInputService11TestCaseOperation1Input) Validate(
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
 	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2044,6 +2166,9 @@ func (s *InputService12TestShapeInputService12TestCaseOperation1Input) Validate(
 	invalidParams := request.ErrInvalidParams{Context: "InputService12TestShapeInputService12TestCaseOperation1Input"}
 	if s.Foo == nil {
 		invalidParams.Add(request.NewErrParamRequired("Foo"))
+	}
+	if s.Foo != nil && len(*s.Foo) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Foo", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -5383,7 +5383,7 @@ func (c *InputService25ProtocolTest) InputService25TestCaseOperation2Request(inp
 	op := &request.Operation{
 		Name:       opInputService25TestCaseOperation2,
 		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		HTTPPath:   "/Enum/{URIEnum}",
 	}
 
 	if input == nil {
@@ -7008,7 +7008,9 @@ func TestInputService25ProtocolTestEnumCase1(t *testing.T) {
 
 func TestInputService25ProtocolTestEnumCase2(t *testing.T) {
 	svc := NewInputService25ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
-	input := &InputService25TestShapeInputService25TestCaseOperation2Input{}
+	input := &InputService25TestShapeInputService25TestCaseOperation2Input{
+		URIFooEnum: aws.String("bar"),
+	}
 	req, _ := svc.InputService25TestCaseOperation2Request(input)
 	r := req.HTTPRequest
 
@@ -7019,7 +7021,7 @@ func TestInputService25ProtocolTestEnumCase2(t *testing.T) {
 	}
 
 	// assert URL
-	awstesting.AssertURL(t, "https://test/path", r.URL.String())
+	awstesting.AssertURL(t, "https://test/Enum/bar", r.URL.String())
 
 	// assert headers
 

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -2535,9 +2535,26 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1WithContext
 type InputService14TestShapeInputService14TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	PipelineId *string `location:"uri" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" type:"string" required:"true"`
 
 	QueryDoc map[string]*string `location:"querystring" type:"map"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService14TestShapeInputService14TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService14TestShapeInputService14TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetPipelineId sets the PipelineId field's value.
@@ -2690,9 +2707,26 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext
 type InputService15TestShapeInputService15TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	PipelineId *string `location:"uri" type:"string"`
+	// PipelineId is a required field
+	PipelineId *string `location:"uri" type:"string" required:"true"`
 
 	QueryDoc map[string][]*string `location:"querystring" type:"map"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService15TestShapeInputService15TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService15TestShapeInputService15TestCaseOperation1Input"}
+	if s.PipelineId == nil {
+		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
+	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetPipelineId sets the PipelineId field's value.
@@ -4059,9 +4093,33 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1WithContext
 type InputService21TestShapeInputService21TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 
-	Bucket *string `location:"uri" type:"string"`
+	// Bucket is a required field
+	Bucket *string `location:"uri" type:"string" required:"true"`
 
-	Key *string `location:"uri" type:"string"`
+	// Key is a required field
+	Key *string `location:"uri" type:"string" required:"true"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService21TestShapeInputService21TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService21TestShapeInputService21TestCaseOperation1Input"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetBucket sets the Bucket field's value.
@@ -5377,9 +5435,26 @@ type InputService25TestShapeInputService25TestCaseOperation1Input struct {
 
 	ListEnums []*string `type:"list"`
 
-	URIFooEnum *string `location:"uri" locationName:"URIEnum" type:"string" enum:"InputService25TestShapeEnumType"`
+	// URIFooEnum is a required field
+	URIFooEnum *string `location:"uri" locationName:"URIEnum" type:"string" required:"true" enum:"InputService25TestShapeEnumType"`
 
 	URIListEnums []*string `location:"querystring" locationName:"ListEnums" type:"list"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService25TestShapeInputService25TestCaseOperation1Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService25TestShapeInputService25TestCaseOperation1Input"}
+	if s.URIFooEnum == nil {
+		invalidParams.Add(request.NewErrParamRequired("URIFooEnum"))
+	}
+	if s.URIFooEnum != nil && len(*s.URIFooEnum) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("URIFooEnum", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetFooEnum sets the FooEnum field's value.
@@ -5425,9 +5500,26 @@ type InputService25TestShapeInputService25TestCaseOperation2Input struct {
 
 	ListEnums []*string `type:"list"`
 
-	URIFooEnum *string `location:"uri" locationName:"URIEnum" type:"string" enum:"InputService25TestShapeEnumType"`
+	// URIFooEnum is a required field
+	URIFooEnum *string `location:"uri" locationName:"URIEnum" type:"string" required:"true" enum:"InputService25TestShapeEnumType"`
 
 	URIListEnums []*string `location:"querystring" locationName:"ListEnums" type:"list"`
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InputService25TestShapeInputService25TestCaseOperation2Input) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InputService25TestShapeInputService25TestCaseOperation2Input"}
+	if s.URIFooEnum == nil {
+		invalidParams.Add(request.NewErrParamRequired("URIFooEnum"))
+	}
+	if s.URIFooEnum != nil && len(*s.URIFooEnum) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("URIFooEnum", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetFooEnum sets the FooEnum field's value.

--- a/service/amplify/api.go
+++ b/service/amplify/api.go
@@ -3052,6 +3052,9 @@ func (s *DeleteDomainAssociationInput) Validate() error {
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
 	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3144,6 +3147,9 @@ func (s *DeleteJobInput) Validate() error {
 	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3478,6 +3484,9 @@ func (s *GetDomainAssociationInput) Validate() error {
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
 	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3570,6 +3579,9 @@ func (s *GetJobInput) Validate() error {
 	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4503,6 +4515,9 @@ func (s *StopJobInput) Validate() error {
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
 	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5057,6 +5072,9 @@ func (s *UpdateDomainAssociationInput) Validate() error {
 	}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 	if s.SubDomainSettings == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubDomainSettings"))

--- a/service/apigateway/api.go
+++ b/service/apigateway/api.go
@@ -12094,6 +12094,9 @@ func (s *CreateAuthorizerInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
 	}
@@ -12206,6 +12209,9 @@ func (s *CreateBasePathMappingInput) Validate() error {
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
 	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
@@ -12293,6 +12299,9 @@ func (s *CreateDeploymentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12400,6 +12409,9 @@ func (s *CreateDocumentationPartInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.Location != nil {
 		if err := s.Location.Validate(); err != nil {
 			invalidParams.AddNested("Location", err.(request.ErrInvalidParams))
@@ -12469,6 +12481,9 @@ func (s *CreateDocumentationVersionInput) Validate() error {
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12676,6 +12691,9 @@ func (s *CreateModelInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12750,6 +12768,9 @@ func (s *CreateRequestValidatorInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12817,11 +12838,17 @@ func (s *CreateResourceInput) Validate() error {
 	if s.ParentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ParentId"))
 	}
+	if s.ParentId != nil && len(*s.ParentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ParentId", 1))
+	}
 	if s.PathPart == nil {
 		invalidParams.Add(request.NewErrParamRequired("PathPart"))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13037,6 +13064,9 @@ func (s *CreateStageInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
 	}
@@ -13234,6 +13264,9 @@ func (s *CreateUsagePlanKeyInput) Validate() error {
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
 	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13352,6 +13385,9 @@ func (s *DeleteApiKeyInput) Validate() error {
 	if s.ApiKey == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
 	}
+	if s.ApiKey != nil && len(*s.ApiKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiKey", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13410,8 +13446,14 @@ func (s *DeleteAuthorizerInput) Validate() error {
 	if s.AuthorizerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
 	}
+	if s.AuthorizerId != nil && len(*s.AuthorizerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13477,8 +13519,14 @@ func (s *DeleteBasePathMappingInput) Validate() error {
 	if s.BasePath == nil {
 		invalidParams.Add(request.NewErrParamRequired("BasePath"))
 	}
+	if s.BasePath != nil && len(*s.BasePath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BasePath", 1))
+	}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13539,6 +13587,9 @@ func (s *DeleteClientCertificateInput) Validate() error {
 	if s.ClientCertificateId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
 	}
+	if s.ClientCertificateId != nil && len(*s.ClientCertificateId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientCertificateId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13597,8 +13648,14 @@ func (s *DeleteDeploymentInput) Validate() error {
 	if s.DeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
 	}
+	if s.DeploymentId != nil && len(*s.DeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13664,8 +13721,14 @@ func (s *DeleteDocumentationPartInput) Validate() error {
 	if s.DocumentationPartId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationPartId"))
 	}
+	if s.DocumentationPartId != nil && len(*s.DocumentationPartId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationPartId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13731,8 +13794,14 @@ func (s *DeleteDocumentationVersionInput) Validate() error {
 	if s.DocumentationVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationVersion"))
 	}
+	if s.DocumentationVersion != nil && len(*s.DocumentationVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationVersion", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13792,6 +13861,9 @@ func (s *DeleteDomainNameInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteDomainNameInput"}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13872,8 +13944,14 @@ func (s *DeleteGatewayResponseInput) Validate() error {
 	if s.ResponseType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResponseType"))
 	}
+	if s.ResponseType != nil && len(*s.ResponseType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResponseType", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13944,11 +14022,20 @@ func (s *DeleteIntegrationInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14030,14 +14117,26 @@ func (s *DeleteIntegrationResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14120,11 +14219,20 @@ func (s *DeleteMethodInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14206,14 +14314,26 @@ func (s *DeleteMethodResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14291,8 +14411,14 @@ func (s *DeleteModelInput) Validate() error {
 	if s.ModelName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ModelName"))
 	}
+	if s.ModelName != nil && len(*s.ModelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ModelName", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14358,8 +14484,14 @@ func (s *DeleteRequestValidatorInput) Validate() error {
 	if s.RequestValidatorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RequestValidatorId"))
 	}
+	if s.RequestValidatorId != nil && len(*s.RequestValidatorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RequestValidatorId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14425,8 +14557,14 @@ func (s *DeleteResourceInput) Validate() error {
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14487,6 +14625,9 @@ func (s *DeleteRestApiInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14545,8 +14686,14 @@ func (s *DeleteStageInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14607,6 +14754,9 @@ func (s *DeleteUsagePlanInput) Validate() error {
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
 	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14653,8 +14803,14 @@ func (s *DeleteUsagePlanKeyInput) Validate() error {
 	if s.KeyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("KeyId"))
 	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
+	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14729,6 +14885,9 @@ func (s *DeleteVpcLinkInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteVpcLinkInput"}
 	if s.VpcLinkId == nil {
 		invalidParams.Add(request.NewErrParamRequired("VpcLinkId"))
+	}
+	if s.VpcLinkId != nil && len(*s.VpcLinkId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VpcLinkId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15282,8 +15441,14 @@ func (s *FlushStageAuthorizersCacheInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15349,8 +15514,14 @@ func (s *FlushStageCacheInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15453,6 +15624,9 @@ func (s *GetApiKeyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetApiKeyInput"}
 	if s.ApiKey == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
+	}
+	if s.ApiKey != nil && len(*s.ApiKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiKey", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15611,8 +15785,14 @@ func (s *GetAuthorizerInput) Validate() error {
 	if s.AuthorizerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
 	}
+	if s.AuthorizerId != nil && len(*s.AuthorizerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15665,6 +15845,9 @@ func (s *GetAuthorizersInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetAuthorizersInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15759,8 +15942,14 @@ func (s *GetBasePathMappingInput) Validate() error {
 	if s.BasePath == nil {
 		invalidParams.Add(request.NewErrParamRequired("BasePath"))
 	}
+	if s.BasePath != nil && len(*s.BasePath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BasePath", 1))
+	}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15813,6 +16002,9 @@ func (s *GetBasePathMappingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBasePathMappingsInput"}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15898,6 +16090,9 @@ func (s *GetClientCertificateInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetClientCertificateInput"}
 	if s.ClientCertificateId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
+	}
+	if s.ClientCertificateId != nil && len(*s.ClientCertificateId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientCertificateId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16020,8 +16215,14 @@ func (s *GetDeploymentInput) Validate() error {
 	if s.DeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
 	}
+	if s.DeploymentId != nil && len(*s.DeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16080,6 +16281,9 @@ func (s *GetDeploymentsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDeploymentsInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16180,8 +16384,14 @@ func (s *GetDocumentationPartInput) Validate() error {
 	if s.DocumentationPartId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationPartId"))
 	}
+	if s.DocumentationPartId != nil && len(*s.DocumentationPartId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationPartId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16249,6 +16459,9 @@ func (s *GetDocumentationPartsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDocumentationPartsInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16364,8 +16577,14 @@ func (s *GetDocumentationVersionInput) Validate() error {
 	if s.DocumentationVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationVersion"))
 	}
+	if s.DocumentationVersion != nil && len(*s.DocumentationVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationVersion", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16418,6 +16637,9 @@ func (s *GetDocumentationVersionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDocumentationVersionsInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16507,6 +16729,9 @@ func (s *GetDomainNameInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDomainNameInput"}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16640,11 +16865,20 @@ func (s *GetExportInput) Validate() error {
 	if s.ExportType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ExportType"))
 	}
+	if s.ExportType != nil && len(*s.ExportType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ExportType", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16777,8 +17011,14 @@ func (s *GetGatewayResponseInput) Validate() error {
 	if s.ResponseType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResponseType"))
 	}
+	if s.ResponseType != nil && len(*s.ResponseType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResponseType", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16836,6 +17076,9 @@ func (s *GetGatewayResponsesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetGatewayResponsesInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17089,11 +17332,20 @@ func (s *GetIntegrationInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17161,14 +17413,26 @@ func (s *GetIntegrationResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17237,11 +17501,20 @@ func (s *GetMethodInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17309,14 +17582,26 @@ func (s *GetMethodResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17385,8 +17670,14 @@ func (s *GetModelInput) Validate() error {
 	if s.ModelName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ModelName"))
 	}
+	if s.ModelName != nil && len(*s.ModelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ModelName", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17444,8 +17735,14 @@ func (s *GetModelTemplateInput) Validate() error {
 	if s.ModelName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ModelName"))
 	}
+	if s.ModelName != nil && len(*s.ModelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ModelName", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17525,6 +17822,9 @@ func (s *GetModelsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetModelsInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17616,8 +17916,14 @@ func (s *GetRequestValidatorInput) Validate() error {
 	if s.RequestValidatorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RequestValidatorId"))
 	}
+	if s.RequestValidatorId != nil && len(*s.RequestValidatorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RequestValidatorId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17670,6 +17976,9 @@ func (s *GetRequestValidatorsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetRequestValidatorsInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17773,8 +18082,14 @@ func (s *GetResourceInput) Validate() error {
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17841,6 +18156,9 @@ func (s *GetResourcesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetResourcesInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17932,6 +18250,9 @@ func (s *GetRestApiInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetRestApiInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18059,11 +18380,20 @@ func (s *GetSdkInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.SdkType == nil {
 		invalidParams.Add(request.NewErrParamRequired("SdkType"))
 	}
+	if s.SdkType != nil && len(*s.SdkType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SdkType", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18163,6 +18493,9 @@ func (s *GetSdkTypeInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetSdkTypeInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18274,8 +18607,14 @@ func (s *GetStageInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18324,6 +18663,9 @@ func (s *GetStagesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetStagesInput"}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18404,6 +18746,9 @@ func (s *GetTagsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetTagsInput"}
 	if s.ResourceArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18507,6 +18852,9 @@ func (s *GetUsageInput) Validate() error {
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
 	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -18576,6 +18924,9 @@ func (s *GetUsagePlanInput) Validate() error {
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
 	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -18622,8 +18973,14 @@ func (s *GetUsagePlanKeyInput) Validate() error {
 	if s.KeyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("KeyId"))
 	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
+	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18681,6 +19038,9 @@ func (s *GetUsagePlanKeysInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetUsagePlanKeysInput"}
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
+	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18851,6 +19211,9 @@ func (s *GetVpcLinkInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetVpcLinkInput"}
 	if s.VpcLinkId == nil {
 		invalidParams.Add(request.NewErrParamRequired("VpcLinkId"))
+	}
+	if s.VpcLinkId != nil && len(*s.VpcLinkId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VpcLinkId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -19077,6 +19440,9 @@ func (s *ImportDocumentationPartsInput) Validate() error {
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -20300,8 +20666,14 @@ func (s *PutGatewayResponseInput) Validate() error {
 	if s.ResponseType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResponseType"))
 	}
+	if s.ResponseType != nil && len(*s.ResponseType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResponseType", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -20477,11 +20849,20 @@ func (s *PutIntegrationInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
@@ -20662,14 +21043,26 @@ func (s *PutIntegrationResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -20813,11 +21206,20 @@ func (s *PutMethodInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -20951,14 +21353,26 @@ func (s *PutMethodResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -21053,6 +21467,9 @@ func (s *PutRestApiInput) Validate() error {
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -21738,6 +22155,9 @@ func (s *TagResourceInput) Validate() error {
 	if s.ResourceArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
 	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
 	if s.Tags == nil {
 		invalidParams.Add(request.NewErrParamRequired("Tags"))
 	}
@@ -21829,8 +22249,14 @@ func (s *TestInvokeAuthorizerInput) Validate() error {
 	if s.AuthorizerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
 	}
+	if s.AuthorizerId != nil && len(*s.AuthorizerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22026,11 +22452,20 @@ func (s *TestInvokeMethodInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22231,6 +22666,9 @@ func (s *UntagResourceInput) Validate() error {
 	if s.ResourceArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
 	}
+	if s.ResourceArn != nil && len(*s.ResourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceArn", 1))
+	}
 	if s.TagKeys == nil {
 		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
 	}
@@ -22322,6 +22760,9 @@ func (s *UpdateApiKeyInput) Validate() error {
 	if s.ApiKey == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiKey"))
 	}
+	if s.ApiKey != nil && len(*s.ApiKey) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiKey", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -22376,8 +22817,14 @@ func (s *UpdateAuthorizerInput) Validate() error {
 	if s.AuthorizerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AuthorizerId"))
 	}
+	if s.AuthorizerId != nil && len(*s.AuthorizerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AuthorizerId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22439,8 +22886,14 @@ func (s *UpdateBasePathMappingInput) Validate() error {
 	if s.BasePath == nil {
 		invalidParams.Add(request.NewErrParamRequired("BasePath"))
 	}
+	if s.BasePath != nil && len(*s.BasePath) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BasePath", 1))
+	}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22497,6 +22950,9 @@ func (s *UpdateClientCertificateInput) Validate() error {
 	if s.ClientCertificateId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClientCertificateId"))
 	}
+	if s.ClientCertificateId != nil && len(*s.ClientCertificateId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientCertificateId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -22552,8 +23008,14 @@ func (s *UpdateDeploymentInput) Validate() error {
 	if s.DeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
 	}
+	if s.DeploymentId != nil && len(*s.DeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22615,8 +23077,14 @@ func (s *UpdateDocumentationPartInput) Validate() error {
 	if s.DocumentationPartId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationPartId"))
 	}
+	if s.DocumentationPartId != nil && len(*s.DocumentationPartId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationPartId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22678,8 +23146,14 @@ func (s *UpdateDocumentationVersionInput) Validate() error {
 	if s.DocumentationVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("DocumentationVersion"))
 	}
+	if s.DocumentationVersion != nil && len(*s.DocumentationVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DocumentationVersion", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22735,6 +23209,9 @@ func (s *UpdateDomainNameInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateDomainNameInput"}
 	if s.DomainName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -22810,8 +23287,14 @@ func (s *UpdateGatewayResponseInput) Validate() error {
 	if s.ResponseType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResponseType"))
 	}
+	if s.ResponseType != nil && len(*s.ResponseType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResponseType", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23002,11 +23485,20 @@ func (s *UpdateIntegrationInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23084,14 +23576,26 @@ func (s *UpdateIntegrationResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23170,11 +23674,20 @@ func (s *UpdateMethodInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23252,14 +23765,26 @@ func (s *UpdateMethodResponseInput) Validate() error {
 	if s.HttpMethod == nil {
 		invalidParams.Add(request.NewErrParamRequired("HttpMethod"))
 	}
+	if s.HttpMethod != nil && len(*s.HttpMethod) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HttpMethod", 1))
+	}
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
+	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
 	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StatusCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("StatusCode"))
+	}
+	if s.StatusCode != nil && len(*s.StatusCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StatusCode", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23333,8 +23858,14 @@ func (s *UpdateModelInput) Validate() error {
 	if s.ModelName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ModelName"))
 	}
+	if s.ModelName != nil && len(*s.ModelName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ModelName", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23396,8 +23927,14 @@ func (s *UpdateRequestValidatorInput) Validate() error {
 	if s.RequestValidatorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RequestValidatorId"))
 	}
+	if s.RequestValidatorId != nil && len(*s.RequestValidatorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RequestValidatorId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23520,8 +24057,14 @@ func (s *UpdateResourceInput) Validate() error {
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
+	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23578,6 +24121,9 @@ func (s *UpdateRestApiInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -23632,8 +24178,14 @@ func (s *UpdateStageInput) Validate() error {
 	if s.RestApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("RestApiId"))
 	}
+	if s.RestApiId != nil && len(*s.RestApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RestApiId", 1))
+	}
 	if s.StageName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StageName"))
+	}
+	if s.StageName != nil && len(*s.StageName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StageName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23697,8 +24249,14 @@ func (s *UpdateUsageInput) Validate() error {
 	if s.KeyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("KeyId"))
 	}
+	if s.KeyId != nil && len(*s.KeyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("KeyId", 1))
+	}
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
+	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -23755,6 +24313,9 @@ func (s *UpdateUsagePlanInput) Validate() error {
 	if s.UsagePlanId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UsagePlanId"))
 	}
+	if s.UsagePlanId != nil && len(*s.UsagePlanId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UsagePlanId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -23804,6 +24365,9 @@ func (s *UpdateVpcLinkInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateVpcLinkInput"}
 	if s.VpcLinkId == nil {
 		invalidParams.Add(request.NewErrParamRequired("VpcLinkId"))
+	}
+	if s.VpcLinkId != nil && len(*s.VpcLinkId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VpcLinkId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/appsync/api.go
+++ b/service/appsync/api.go
@@ -3252,6 +3252,9 @@ func (s *CreateApiKeyInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3356,6 +3359,9 @@ func (s *CreateDataSourceInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateDataSourceInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
@@ -3525,6 +3531,9 @@ func (s *CreateFunctionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateFunctionInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.DataSourceName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DataSourceName"))
@@ -3797,6 +3806,9 @@ func (s *CreateResolverInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FieldName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FieldName"))
 	}
@@ -3811,6 +3823,9 @@ func (s *CreateResolverInput) Validate() error {
 	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3926,6 +3941,9 @@ func (s *CreateTypeInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateTypeInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.Definition == nil {
 		invalidParams.Add(request.NewErrParamRequired("Definition"))
@@ -4133,8 +4151,14 @@ func (s *DeleteApiKeyInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4199,8 +4223,14 @@ func (s *DeleteDataSourceInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4265,8 +4295,14 @@ func (s *DeleteFunctionInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FunctionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionId"))
+	}
+	if s.FunctionId != nil && len(*s.FunctionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4325,6 +4361,9 @@ func (s *DeleteGraphqlApiInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteGraphqlApiInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4388,11 +4427,20 @@ func (s *DeleteResolverInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FieldName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FieldName"))
 	}
+	if s.FieldName != nil && len(*s.FieldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FieldName", 1))
+	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4463,8 +4511,14 @@ func (s *DeleteTypeInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4734,8 +4788,14 @@ func (s *GetDataSourceInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4809,8 +4869,14 @@ func (s *GetFunctionInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FunctionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionId"))
+	}
+	if s.FunctionId != nil && len(*s.FunctionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4879,6 +4945,9 @@ func (s *GetGraphqlApiInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4944,6 +5013,9 @@ func (s *GetIntrospectionSchemaInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetIntrospectionSchemaInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
@@ -5027,11 +5099,20 @@ func (s *GetResolverInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FieldName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FieldName"))
 	}
+	if s.FieldName != nil && len(*s.FieldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FieldName", 1))
+	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5105,6 +5186,9 @@ func (s *GetSchemaCreationStatusInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetSchemaCreationStatusInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5187,11 +5271,17 @@ func (s *GetTypeInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
 	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5450,6 +5540,9 @@ func (s *ListApiKeysInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5540,6 +5633,9 @@ func (s *ListDataSourcesInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5629,6 +5725,9 @@ func (s *ListFunctionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListFunctionsInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5791,8 +5890,14 @@ func (s *ListResolversByFunctionInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FunctionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionId"))
+	}
+	if s.FunctionId != nil && len(*s.FunctionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5894,8 +5999,14 @@ func (s *ListResolversInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5997,6 +6108,9 @@ func (s *ListTypesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListTypesInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
@@ -6453,6 +6567,9 @@ func (s *StartSchemaCreationInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Definition == nil {
 		invalidParams.Add(request.NewErrParamRequired("Definition"))
 	}
@@ -6596,8 +6713,14 @@ func (s *UpdateApiKeyInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6709,8 +6832,14 @@ func (s *UpdateDataSourceInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
@@ -6883,11 +7012,17 @@ func (s *UpdateFunctionInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.DataSourceName == nil {
 		invalidParams.Add(request.NewErrParamRequired("DataSourceName"))
 	}
 	if s.FunctionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionId"))
+	}
+	if s.FunctionId != nil && len(*s.FunctionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionId", 1))
 	}
 	if s.FunctionVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionVersion"))
@@ -7023,6 +7158,9 @@ func (s *UpdateGraphqlApiInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateGraphqlApiInput"}
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
+	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
 	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
@@ -7168,8 +7306,14 @@ func (s *UpdateResolverInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.FieldName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FieldName"))
+	}
+	if s.FieldName != nil && len(*s.FieldName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FieldName", 1))
 	}
 	if s.RequestMappingTemplate == nil {
 		invalidParams.Add(request.NewErrParamRequired("RequestMappingTemplate"))
@@ -7182,6 +7326,9 @@ func (s *UpdateResolverInput) Validate() error {
 	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7299,11 +7446,17 @@ func (s *UpdateTypeInput) Validate() error {
 	if s.ApiId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApiId"))
 	}
+	if s.ApiId != nil && len(*s.ApiId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApiId", 1))
+	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
 	}
 	if s.TypeName == nil {
 		invalidParams.Add(request.NewErrParamRequired("TypeName"))
+	}
+	if s.TypeName != nil && len(*s.TypeName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TypeName", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/chime/api.go
+++ b/service/chime/api.go
@@ -1915,6 +1915,9 @@ func (s *BatchSuspendUserInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserIdList == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserIdList"))
 	}
@@ -1992,6 +1995,9 @@ func (s *BatchUnsuspendUserInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserIdList == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserIdList"))
 	}
@@ -2068,6 +2074,9 @@ func (s *BatchUpdateUserInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "BatchUpdateUserInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 	if s.UpdateUserRequestItems == nil {
 		invalidParams.Add(request.NewErrParamRequired("UpdateUserRequestItems"))
@@ -2215,6 +2224,9 @@ func (s *DeleteAccountInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2266,6 +2278,9 @@ func (s *GetAccountInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetAccountInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2327,6 +2342,9 @@ func (s *GetAccountSettingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetAccountSettingsInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2394,8 +2412,14 @@ func (s *GetUserInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2520,6 +2544,9 @@ func (s *InviteUsersInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "InviteUsersInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 	if s.UserEmailList == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserEmailList"))
@@ -2698,6 +2725,9 @@ func (s *ListUsersInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
 	}
@@ -2794,8 +2824,14 @@ func (s *LogoutUserInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2860,8 +2896,14 @@ func (s *ResetPersonalPINInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2932,6 +2974,9 @@ func (s *UpdateAccountInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateAccountInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 	if s.Name != nil && len(*s.Name) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
@@ -3008,6 +3053,9 @@ func (s *UpdateAccountSettingsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.AccountSettings == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountSettings"))
 	}
@@ -3078,8 +3126,14 @@ func (s *UpdateUserInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -6215,6 +6215,9 @@ func (s *CreateInvalidationInput) Validate() error {
 	if s.DistributionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
 	}
+	if s.DistributionId != nil && len(*s.DistributionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DistributionId", 1))
+	}
 	if s.InvalidationBatch == nil {
 		invalidParams.Add(request.NewErrParamRequired("InvalidationBatch"))
 	}
@@ -7193,6 +7196,9 @@ func (s *DeleteCloudFrontOriginAccessIdentityInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7290,6 +7296,9 @@ func (s *DeleteDistributionInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7351,6 +7360,9 @@ func (s *DeleteFieldLevelEncryptionConfigInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteFieldLevelEncryptionConfigInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7414,6 +7426,9 @@ func (s *DeleteFieldLevelEncryptionProfileInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7475,6 +7490,9 @@ func (s *DeletePublicKeyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeletePublicKeyInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7538,6 +7556,9 @@ func (s *DeleteStreamingDistributionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteStreamingDistributionInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9529,6 +9550,9 @@ func (s *GetCloudFrontOriginAccessIdentityConfigInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9600,6 +9624,9 @@ func (s *GetCloudFrontOriginAccessIdentityInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetCloudFrontOriginAccessIdentityInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9674,6 +9701,9 @@ func (s *GetDistributionConfigInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9746,6 +9776,9 @@ func (s *GetDistributionInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9816,6 +9849,9 @@ func (s *GetFieldLevelEncryptionConfigInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetFieldLevelEncryptionConfigInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9888,6 +9924,9 @@ func (s *GetFieldLevelEncryptionInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9959,6 +9998,9 @@ func (s *GetFieldLevelEncryptionProfileConfigInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10029,6 +10071,9 @@ func (s *GetFieldLevelEncryptionProfileInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetFieldLevelEncryptionProfileInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10106,8 +10151,14 @@ func (s *GetInvalidationInput) Validate() error {
 	if s.DistributionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
 	}
+	if s.DistributionId != nil && len(*s.DistributionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DistributionId", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10178,6 +10229,9 @@ func (s *GetPublicKeyConfigInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10247,6 +10301,9 @@ func (s *GetPublicKeyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetPublicKeyInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10319,6 +10376,9 @@ func (s *GetStreamingDistributionConfigInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10390,6 +10450,9 @@ func (s *GetStreamingDistributionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetStreamingDistributionInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11092,6 +11155,9 @@ func (s *ListDistributionsByWebACLIdInput) Validate() error {
 	if s.WebACLId == nil {
 		invalidParams.Add(request.NewErrParamRequired("WebACLId"))
 	}
+	if s.WebACLId != nil && len(*s.WebACLId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("WebACLId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11363,6 +11429,9 @@ func (s *ListInvalidationsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListInvalidationsInput"}
 	if s.DistributionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DistributionId"))
+	}
+	if s.DistributionId != nil && len(*s.DistributionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DistributionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14410,6 +14479,9 @@ func (s *UpdateCloudFrontOriginAccessIdentityInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.CloudFrontOriginAccessIdentityConfig != nil {
 		if err := s.CloudFrontOriginAccessIdentityConfig.Validate(); err != nil {
 			invalidParams.AddNested("CloudFrontOriginAccessIdentityConfig", err.(request.ErrInvalidParams))
@@ -14511,6 +14583,9 @@ func (s *UpdateDistributionInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.DistributionConfig != nil {
 		if err := s.DistributionConfig.Validate(); err != nil {
 			invalidParams.AddNested("DistributionConfig", err.(request.ErrInvalidParams))
@@ -14610,6 +14685,9 @@ func (s *UpdateFieldLevelEncryptionConfigInput) Validate() error {
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 	if s.FieldLevelEncryptionConfig != nil {
 		if err := s.FieldLevelEncryptionConfig.Validate(); err != nil {
@@ -14711,6 +14789,9 @@ func (s *UpdateFieldLevelEncryptionProfileInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.FieldLevelEncryptionProfileConfig != nil {
 		if err := s.FieldLevelEncryptionProfileConfig.Validate(); err != nil {
 			invalidParams.AddNested("FieldLevelEncryptionProfileConfig", err.(request.ErrInvalidParams))
@@ -14806,6 +14887,9 @@ func (s *UpdatePublicKeyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdatePublicKeyInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 	if s.PublicKeyConfig == nil {
 		invalidParams.Add(request.NewErrParamRequired("PublicKeyConfig"))
@@ -14906,6 +14990,9 @@ func (s *UpdateStreamingDistributionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateStreamingDistributionInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 	if s.StreamingDistributionConfig == nil {
 		invalidParams.Add(request.NewErrParamRequired("StreamingDistributionConfig"))

--- a/service/connect/api.go
+++ b/service/connect/api.go
@@ -2404,6 +2404,9 @@ func (s *DeleteUserInput) Validate() error {
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
 	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2470,6 +2473,9 @@ func (s *DescribeUserHierarchyGroupInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeUserHierarchyGroupInput"}
 	if s.HierarchyGroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HierarchyGroupId"))
+	}
+	if s.HierarchyGroupId != nil && len(*s.HierarchyGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HierarchyGroupId", 1))
 	}
 	if s.InstanceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InstanceId"))
@@ -2626,6 +2632,9 @@ func (s *DescribeUserInput) Validate() error {
 	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4682,6 +4691,9 @@ func (s *UpdateUserHierarchyInput) Validate() error {
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
 	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4768,6 +4780,9 @@ func (s *UpdateUserIdentityInfoInput) Validate() error {
 	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 	if s.IdentityInfo != nil {
 		if err := s.IdentityInfo.Validate(); err != nil {
@@ -4862,6 +4877,9 @@ func (s *UpdateUserPhoneConfigInput) Validate() error {
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
 	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
+	}
 	if s.PhoneConfig != nil {
 		if err := s.PhoneConfig.Validate(); err != nil {
 			invalidParams.AddNested("PhoneConfig", err.(request.ErrInvalidParams))
@@ -4954,6 +4972,9 @@ func (s *UpdateUserRoutingProfileInput) Validate() error {
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
 	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5043,6 +5064,9 @@ func (s *UpdateUserSecurityProfilesInput) Validate() error {
 	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/dlm/api.go
+++ b/service/dlm/api.go
@@ -650,6 +650,9 @@ func (s *DeleteLifecyclePolicyInput) Validate() error {
 	if s.PolicyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyId"))
 	}
+	if s.PolicyId != nil && len(*s.PolicyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -806,6 +809,9 @@ func (s *GetLifecyclePolicyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetLifecyclePolicyInput"}
 	if s.PolicyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyId"))
+	}
+	if s.PolicyId != nil && len(*s.PolicyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1269,6 +1275,9 @@ func (s *UpdateLifecyclePolicyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateLifecyclePolicyInput"}
 	if s.PolicyId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyId"))
+	}
+	if s.PolicyId != nil && len(*s.PolicyId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyId", 1))
 	}
 	if s.PolicyDetails != nil {
 		if err := s.PolicyDetails.Validate(); err != nil {

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -1637,6 +1637,9 @@ func (s *CreateTagsInput) Validate() error {
 	if s.FileSystemId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
 	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
+	}
 	if s.Tags == nil {
 		invalidParams.Add(request.NewErrParamRequired("Tags"))
 	}
@@ -1708,6 +1711,9 @@ func (s *DeleteFileSystemInput) Validate() error {
 	if s.FileSystemId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
 	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1759,6 +1765,9 @@ func (s *DeleteMountTargetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteMountTargetInput"}
 	if s.MountTargetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
+	}
+	if s.MountTargetId != nil && len(*s.MountTargetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MountTargetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1816,6 +1825,9 @@ func (s *DeleteTagsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteTagsInput"}
 	if s.FileSystemId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
 	}
 	if s.TagKeys == nil {
 		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
@@ -1993,6 +2005,9 @@ func (s *DescribeMountTargetSecurityGroupsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeMountTargetSecurityGroupsInput"}
 	if s.MountTargetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
+	}
+	if s.MountTargetId != nil && len(*s.MountTargetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MountTargetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2178,6 +2193,9 @@ func (s *DescribeTagsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeTagsInput"}
 	if s.FileSystemId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
 	}
 	if s.MaxItems != nil && *s.MaxItems < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
@@ -2493,6 +2511,9 @@ func (s *ModifyMountTargetSecurityGroupsInput) Validate() error {
 	if s.MountTargetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("MountTargetId"))
 	}
+	if s.MountTargetId != nil && len(*s.MountTargetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("MountTargetId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2704,6 +2725,9 @@ func (s *UpdateFileSystemInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateFileSystemInput"}
 	if s.FileSystemId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/eks/api.go
+++ b/service/eks/api.go
@@ -725,6 +725,9 @@ func (s *DeleteClusterInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -785,6 +788,9 @@ func (s *DescribeClusterInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeClusterInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -220,14 +220,14 @@ func ExampleElastiCache_CreateCacheCluster_shared00() {
 func ExampleElastiCache_CreateCacheCluster_shared01() {
 	svc := elasticache.New(session.New())
 	input := &elasticache.CreateCacheClusterInput{
-		AutoMinorVersionUpgrade: aws.Bool(true),
-		CacheClusterId:          aws.String("my-redis"),
-		CacheNodeType:           aws.String("cache.r3.larage"),
-		CacheSubnetGroupName:    aws.String("default"),
-		Engine:                  aws.String("redis"),
-		EngineVersion:           aws.String("3.2.4"),
-		NumCacheNodes:           aws.Int64(1),
-		Port:                    aws.Int64(6379),
+		AutoMinorVersionUpgrade:   aws.Bool(true),
+		CacheClusterId:            aws.String("my-redis"),
+		CacheNodeType:             aws.String("cache.r3.larage"),
+		CacheSubnetGroupName:      aws.String("default"),
+		Engine:                    aws.String("redis"),
+		EngineVersion:             aws.String("3.2.4"),
+		NumCacheNodes:             aws.Int64(1),
+		Port:                      aws.Int64(6379),
 		PreferredAvailabilityZone: aws.String("us-east-1c"),
 		SnapshotRetentionLimit:    aws.Int64(7),
 	}

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -3363,8 +3363,14 @@ func (s *DescribeElasticsearchInstanceTypeLimitsInput) Validate() error {
 	if s.ElasticsearchVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("ElasticsearchVersion"))
 	}
+	if s.ElasticsearchVersion != nil && len(*s.ElasticsearchVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ElasticsearchVersion", 1))
+	}
 	if s.InstanceType == nil {
 		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+	if s.InstanceType != nil && len(*s.InstanceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InstanceType", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4718,6 +4724,9 @@ func (s *ListElasticsearchInstanceTypesInput) Validate() error {
 	}
 	if s.ElasticsearchVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("ElasticsearchVersion"))
+	}
+	if s.ElasticsearchVersion != nil && len(*s.ElasticsearchVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ElasticsearchVersion", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -2324,6 +2324,9 @@ func (s *CancelJobInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3728,6 +3731,9 @@ func (s *DeletePipelineInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3781,6 +3787,9 @@ func (s *DeletePresetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeletePresetInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5038,6 +5047,9 @@ func (s *ListJobsByPipelineInput) Validate() error {
 	if s.PipelineId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PipelineId"))
 	}
+	if s.PipelineId != nil && len(*s.PipelineId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PipelineId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5133,6 +5145,9 @@ func (s *ListJobsByStatusInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListJobsByStatusInput"}
 	if s.Status == nil {
 		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.Status != nil && len(*s.Status) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Status", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6427,6 +6442,9 @@ func (s *ReadJobInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6489,6 +6507,9 @@ func (s *ReadPipelineInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ReadPipelineInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6566,6 +6587,9 @@ func (s *ReadPresetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ReadPresetInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7156,6 +7180,9 @@ func (s *UpdatePipelineInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.Name != nil && len(*s.Name) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
@@ -7277,6 +7304,9 @@ func (s *UpdatePipelineNotificationsInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.Notifications == nil {
 		invalidParams.Add(request.NewErrParamRequired("Notifications"))
 	}
@@ -7397,6 +7427,9 @@ func (s *UpdatePipelineStatusInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdatePipelineStatusInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 	if s.Status == nil {
 		invalidParams.Add(request.NewErrParamRequired("Status"))

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -3766,11 +3766,20 @@ func (s *AbortMultipartUploadInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UploadId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UploadId"))
 	}
+	if s.UploadId != nil && len(*s.UploadId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UploadId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3847,8 +3856,14 @@ func (s *AbortVaultLockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3922,8 +3937,14 @@ func (s *AddTagsToVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4200,11 +4221,20 @@ func (s *CompleteMultipartUploadInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UploadId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UploadId"))
 	}
+	if s.UploadId != nil && len(*s.UploadId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UploadId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4284,11 +4314,20 @@ func (s *CompleteVaultLockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.LockId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LockId"))
 	}
+	if s.LockId != nil && len(*s.LockId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LockId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4365,8 +4404,14 @@ func (s *CreateVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4515,11 +4560,20 @@ func (s *DeleteArchiveInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.ArchiveId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ArchiveId"))
 	}
+	if s.ArchiveId != nil && len(*s.ArchiveId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ArchiveId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4595,8 +4649,14 @@ func (s *DeleteVaultAccessPolicyInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4666,8 +4726,14 @@ func (s *DeleteVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4724,8 +4790,14 @@ func (s *DeleteVaultNotificationsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4814,11 +4886,20 @@ func (s *DescribeJobInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
 	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4880,8 +4961,14 @@ func (s *DescribeVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5056,6 +5143,9 @@ func (s *GetDataRetrievalPolicyInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5164,11 +5254,20 @@ func (s *GetJobOutputInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
 	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5336,8 +5435,14 @@ func (s *GetVaultAccessPolicyInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5417,8 +5522,14 @@ func (s *GetVaultLockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5528,8 +5639,14 @@ func (s *GetVaultNotificationsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5735,8 +5852,14 @@ func (s *InitiateJobInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 	if s.JobParameters != nil {
 		if err := s.JobParameters.Validate(); err != nil {
@@ -5857,8 +5980,14 @@ func (s *InitiateMultipartUploadInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5964,8 +6093,14 @@ func (s *InitiateVaultLockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6606,8 +6741,14 @@ func (s *ListJobsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6735,8 +6876,14 @@ func (s *ListMultipartUploadsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6857,11 +7004,20 @@ func (s *ListPartsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UploadId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UploadId"))
 	}
+	if s.UploadId != nil && len(*s.UploadId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UploadId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7013,6 +7169,9 @@ func (s *ListProvisionedCapacityInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7084,8 +7243,14 @@ func (s *ListTagsForVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7170,6 +7335,9 @@ func (s *ListVaultsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListVaultsInput"}
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7401,6 +7569,9 @@ func (s *PurchaseProvisionedCapacityInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7475,8 +7646,14 @@ func (s *RemoveTagsFromVaultInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7711,6 +7888,9 @@ func (s *SetDataRetrievalPolicyInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7782,8 +7962,14 @@ func (s *SetVaultAccessPolicyInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7863,8 +8049,14 @@ func (s *SetVaultNotificationsInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7949,8 +8141,14 @@ func (s *UploadArchiveInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8104,11 +8302,20 @@ func (s *UploadMultipartPartInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.UploadId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UploadId"))
 	}
+	if s.UploadId != nil && len(*s.UploadId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UploadId", 1))
+	}
 	if s.VaultName == nil {
 		invalidParams.Add(request.NewErrParamRequired("VaultName"))
+	}
+	if s.VaultName != nil && len(*s.VaultName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VaultName", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -6951,6 +6951,9 @@ func (s *AssociateRoleToGroupInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7763,6 +7766,9 @@ func (s *CreateCoreDefinitionVersionInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7869,6 +7875,9 @@ func (s *CreateDeploymentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateDeploymentInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8074,6 +8083,9 @@ func (s *CreateDeviceDefinitionVersionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateDeviceDefinitionVersionInput"}
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
+	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8285,6 +8297,9 @@ func (s *CreateFunctionDefinitionVersionInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8386,6 +8401,9 @@ func (s *CreateGroupCertificateAuthorityInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateGroupCertificateAuthorityInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8576,6 +8594,9 @@ func (s *CreateGroupVersionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateGroupVersionInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8820,6 +8841,9 @@ func (s *CreateLoggerDefinitionVersionInput) Validate() error {
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
 	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9026,6 +9050,9 @@ func (s *CreateResourceDefinitionVersionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateResourceDefinitionVersionInput"}
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
+	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9346,6 +9373,9 @@ func (s *CreateSubscriptionDefinitionVersionInput) Validate() error {
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
 	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9568,6 +9598,9 @@ func (s *DeleteCoreDefinitionInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9617,6 +9650,9 @@ func (s *DeleteDeviceDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteDeviceDefinitionInput"}
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
+	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9668,6 +9704,9 @@ func (s *DeleteFunctionDefinitionInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9717,6 +9756,9 @@ func (s *DeleteGroupInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteGroupInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9768,6 +9810,9 @@ func (s *DeleteLoggerDefinitionInput) Validate() error {
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
 	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9818,6 +9863,9 @@ func (s *DeleteResourceDefinitionInput) Validate() error {
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
 	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9867,6 +9915,9 @@ func (s *DeleteSubscriptionDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteSubscriptionDefinitionInput"}
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
+	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10055,6 +10106,9 @@ func (s *DisassociateRoleFromGroupInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DisassociateRoleFromGroupInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10543,6 +10597,9 @@ func (s *GetAssociatedRoleInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10610,6 +10667,9 @@ func (s *GetBulkDeploymentStatusInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBulkDeploymentStatusInput"}
 	if s.BulkDeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BulkDeploymentId"))
+	}
+	if s.BulkDeploymentId != nil && len(*s.BulkDeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BulkDeploymentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10706,6 +10766,9 @@ func (s *GetConnectivityInfoInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetConnectivityInfoInput"}
 	if s.ThingName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11009,6 +11072,9 @@ func (s *GetCoreDefinitionInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11118,8 +11184,14 @@ func (s *GetCoreDefinitionVersionInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 	if s.CoreDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionVersionId"))
+	}
+	if s.CoreDefinitionVersionId != nil && len(*s.CoreDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11236,8 +11308,14 @@ func (s *GetDeploymentStatusInput) Validate() error {
 	if s.DeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeploymentId"))
 	}
+	if s.DeploymentId != nil && len(*s.DeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeploymentId", 1))
+	}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11342,6 +11420,9 @@ func (s *GetDeviceDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDeviceDefinitionInput"}
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
+	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11454,8 +11535,14 @@ func (s *GetDeviceDefinitionVersionInput) Validate() error {
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
 	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
+	}
 	if s.DeviceDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionVersionId"))
+	}
+	if s.DeviceDefinitionVersionId != nil && len(*s.DeviceDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11575,6 +11662,9 @@ func (s *GetFunctionDefinitionInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11686,8 +11776,14 @@ func (s *GetFunctionDefinitionVersionInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 	if s.FunctionDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionVersionId"))
+	}
+	if s.FunctionDefinitionVersionId != nil && len(*s.FunctionDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11811,8 +11907,14 @@ func (s *GetGroupCertificateAuthorityInput) Validate() error {
 	if s.CertificateAuthorityId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CertificateAuthorityId"))
 	}
+	if s.CertificateAuthorityId != nil && len(*s.CertificateAuthorityId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CertificateAuthorityId", 1))
+	}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11898,6 +12000,9 @@ func (s *GetGroupCertificateConfigurationInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11971,6 +12076,9 @@ func (s *GetGroupInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetGroupInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12081,8 +12189,14 @@ func (s *GetGroupVersionInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 	if s.GroupVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupVersionId"))
+	}
+	if s.GroupVersionId != nil && len(*s.GroupVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12185,6 +12299,9 @@ func (s *GetLoggerDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetLoggerDefinitionInput"}
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
+	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12297,8 +12414,14 @@ func (s *GetLoggerDefinitionVersionInput) Validate() error {
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
 	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
+	}
 	if s.LoggerDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionVersionId"))
+	}
+	if s.LoggerDefinitionVersionId != nil && len(*s.LoggerDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12409,6 +12532,9 @@ func (s *GetResourceDefinitionInput) Validate() error {
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
 	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12518,8 +12644,14 @@ func (s *GetResourceDefinitionVersionInput) Validate() error {
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
 	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
+	}
 	if s.ResourceDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionVersionId"))
+	}
+	if s.ResourceDefinitionVersionId != nil && len(*s.ResourceDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12670,6 +12802,9 @@ func (s *GetSubscriptionDefinitionInput) Validate() error {
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
 	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12781,8 +12916,14 @@ func (s *GetSubscriptionDefinitionVersionInput) Validate() error {
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
 	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
+	}
 	if s.SubscriptionDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionVersionId"))
+	}
+	if s.SubscriptionDefinitionVersionId != nil && len(*s.SubscriptionDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13132,6 +13273,9 @@ func (s *ListBulkDeploymentDetailedReportsInput) Validate() error {
 	if s.BulkDeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BulkDeploymentId"))
 	}
+	if s.BulkDeploymentId != nil && len(*s.BulkDeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BulkDeploymentId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13422,6 +13566,9 @@ func (s *ListCoreDefinitionVersionsInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13564,6 +13711,9 @@ func (s *ListDeploymentsInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13648,6 +13798,9 @@ func (s *ListDeviceDefinitionVersionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListDeviceDefinitionVersionsInput"}
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
+	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13791,6 +13944,9 @@ func (s *ListFunctionDefinitionVersionsInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13929,6 +14085,9 @@ func (s *ListGroupCertificateAuthoritiesInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13991,6 +14150,9 @@ func (s *ListGroupVersionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListGroupVersionsInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14137,6 +14299,9 @@ func (s *ListLoggerDefinitionVersionsInput) Validate() error {
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
 	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14279,6 +14444,9 @@ func (s *ListResourceDefinitionVersionsInput) Validate() error {
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
 	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14420,6 +14588,9 @@ func (s *ListSubscriptionDefinitionVersionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListSubscriptionDefinitionVersionsInput"}
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
+	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14729,6 +14900,9 @@ func (s *ResetDeploymentsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ResetDeploymentsInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15167,6 +15341,9 @@ func (s *StopBulkDeploymentInput) Validate() error {
 	if s.BulkDeploymentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BulkDeploymentId"))
 	}
+	if s.BulkDeploymentId != nil && len(*s.BulkDeploymentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BulkDeploymentId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15299,6 +15476,9 @@ func (s *UpdateConnectivityInfoInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateConnectivityInfoInput"}
 	if s.ThingName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThingName"))
+	}
+	if s.ThingName != nil && len(*s.ThingName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThingName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15434,6 +15614,9 @@ func (s *UpdateCoreDefinitionInput) Validate() error {
 	if s.CoreDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CoreDefinitionId"))
 	}
+	if s.CoreDefinitionId != nil && len(*s.CoreDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CoreDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15491,6 +15674,9 @@ func (s *UpdateDeviceDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateDeviceDefinitionInput"}
 	if s.DeviceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceDefinitionId"))
+	}
+	if s.DeviceDefinitionId != nil && len(*s.DeviceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15550,6 +15736,9 @@ func (s *UpdateFunctionDefinitionInput) Validate() error {
 	if s.FunctionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("FunctionDefinitionId"))
 	}
+	if s.FunctionDefinitionId != nil && len(*s.FunctionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FunctionDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15608,6 +15797,9 @@ func (s *UpdateGroupCertificateConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateGroupCertificateConfigurationInput"}
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
+	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15691,6 +15883,9 @@ func (s *UpdateGroupInput) Validate() error {
 	if s.GroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("GroupId"))
 	}
+	if s.GroupId != nil && len(*s.GroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("GroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15748,6 +15943,9 @@ func (s *UpdateLoggerDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateLoggerDefinitionInput"}
 	if s.LoggerDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("LoggerDefinitionId"))
+	}
+	if s.LoggerDefinitionId != nil && len(*s.LoggerDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("LoggerDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15807,6 +16005,9 @@ func (s *UpdateResourceDefinitionInput) Validate() error {
 	if s.ResourceDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceDefinitionId"))
 	}
+	if s.ResourceDefinitionId != nil && len(*s.ResourceDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15864,6 +16065,9 @@ func (s *UpdateSubscriptionDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateSubscriptionDefinitionInput"}
 	if s.SubscriptionDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SubscriptionDefinitionId"))
+	}
+	if s.SubscriptionDefinitionId != nil && len(*s.SubscriptionDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SubscriptionDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/greengrass/api.go
+++ b/service/greengrass/api.go
@@ -7559,6 +7559,9 @@ func (s *CreateConnectorDefinitionVersionInput) Validate() error {
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
 	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9548,6 +9551,9 @@ func (s *DeleteConnectorDefinitionInput) Validate() error {
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
 	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10839,6 +10845,9 @@ func (s *GetConnectorDefinitionInput) Validate() error {
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
 	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10950,8 +10959,14 @@ func (s *GetConnectorDefinitionVersionInput) Validate() error {
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
 	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
+	}
 	if s.ConnectorDefinitionVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionVersionId"))
+	}
+	if s.ConnectorDefinitionVersionId != nil && len(*s.ConnectorDefinitionVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionVersionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13424,6 +13439,9 @@ func (s *ListConnectorDefinitionVersionsInput) Validate() error {
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
 	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15555,6 +15573,9 @@ func (s *UpdateConnectorDefinitionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateConnectorDefinitionInput"}
 	if s.ConnectorDefinitionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConnectorDefinitionId"))
+	}
+	if s.ConnectorDefinitionId != nil && len(*s.ConnectorDefinitionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectorDefinitionId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/guardduty/api.go
+++ b/service/guardduty/api.go
@@ -3906,6 +3906,9 @@ func (s *AcceptInvitationInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.InvitationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InvitationId"))
 	}
@@ -4144,6 +4147,9 @@ func (s *ArchiveFindingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ArchiveFindingsInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 	if s.FindingIds == nil {
 		invalidParams.Add(request.NewErrParamRequired("FindingIds"))
@@ -4503,6 +4509,9 @@ func (s *CreateFilterInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FindingCriteria == nil {
 		invalidParams.Add(request.NewErrParamRequired("FindingCriteria"))
 	}
@@ -4635,6 +4644,9 @@ func (s *CreateIPSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
 	}
@@ -4744,6 +4756,9 @@ func (s *CreateMembersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.AccountDetails != nil {
 		for i, v := range s.AccountDetails {
 			if v == nil {
@@ -4824,6 +4839,9 @@ func (s *CreateSampleFindingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateSampleFindingsInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4909,6 +4927,9 @@ func (s *CreateThreatIntelSetInput) Validate() error {
 	}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 	if s.Format == nil {
 		invalidParams.Add(request.NewErrParamRequired("Format"))
@@ -5074,6 +5095,9 @@ func (s *DeleteDetectorInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5127,8 +5151,14 @@ func (s *DeleteFilterInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FilterName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5189,8 +5219,14 @@ func (s *DeleteIPSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.IpSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("IpSetId"))
+	}
+	if s.IpSetId != nil && len(*s.IpSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IpSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5322,6 +5358,9 @@ func (s *DeleteMembersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5392,8 +5431,14 @@ func (s *DeleteThreatIntelSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.ThreatIntelSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThreatIntelSetId"))
+	}
+	if s.ThreatIntelSetId != nil && len(*s.ThreatIntelSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThreatIntelSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5450,6 +5495,9 @@ func (s *DisassociateFromMasterAccountInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DisassociateFromMasterAccountInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5510,6 +5558,9 @@ func (s *DisassociateMembersInput) Validate() error {
 	}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5872,6 +5923,9 @@ func (s *GetDetectorInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5971,8 +6025,14 @@ func (s *GetFilterInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FilterName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6087,6 +6147,9 @@ func (s *GetFindingsInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FindingIds == nil {
 		invalidParams.Add(request.NewErrParamRequired("FindingIds"))
 	}
@@ -6171,6 +6234,9 @@ func (s *GetFindingsStatisticsInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FindingStatisticTypes == nil {
 		invalidParams.Add(request.NewErrParamRequired("FindingStatisticTypes"))
 	}
@@ -6249,8 +6315,14 @@ func (s *GetIPSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.IpSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("IpSetId"))
+	}
+	if s.IpSetId != nil && len(*s.IpSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IpSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6385,6 +6457,9 @@ func (s *GetMasterAccountInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6453,6 +6528,9 @@ func (s *GetMembersInput) Validate() error {
 	}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6533,8 +6611,14 @@ func (s *GetThreatIntelSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.ThreatIntelSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThreatIntelSetId"))
+	}
+	if s.ThreatIntelSetId != nil && len(*s.ThreatIntelSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThreatIntelSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6856,6 +6940,9 @@ func (s *InviteMembersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7022,6 +7109,9 @@ func (s *ListFiltersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
 	}
@@ -7125,6 +7215,9 @@ func (s *ListFindingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListFindingsInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -7230,6 +7323,9 @@ func (s *ListIPSetsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListIPSetsInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -7407,6 +7503,9 @@ func (s *ListMembersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
 	}
@@ -7505,6 +7604,9 @@ func (s *ListThreatIntelSetsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListThreatIntelSetsInput"}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -8435,6 +8537,9 @@ func (s *StartMonitoringMembersInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8511,6 +8616,9 @@ func (s *StopMonitoringMembersInput) Validate() error {
 	}
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
+	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8618,6 +8726,9 @@ func (s *UnarchiveFindingsInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FindingIds == nil {
 		invalidParams.Add(request.NewErrParamRequired("FindingIds"))
 	}
@@ -8723,6 +8834,9 @@ func (s *UpdateDetectorInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8803,8 +8917,14 @@ func (s *UpdateFilterInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.FilterName == nil {
 		invalidParams.Add(request.NewErrParamRequired("FilterName"))
+	}
+	if s.FilterName != nil && len(*s.FilterName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FilterName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8910,6 +9030,9 @@ func (s *UpdateFindingsFeedbackInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.Feedback == nil {
 		invalidParams.Add(request.NewErrParamRequired("Feedback"))
 	}
@@ -8997,8 +9120,14 @@ func (s *UpdateIPSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.IpSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("IpSetId"))
+	}
+	if s.IpSetId != nil && len(*s.IpSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IpSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9089,8 +9218,14 @@ func (s *UpdateThreatIntelSetInput) Validate() error {
 	if s.DetectorId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DetectorId"))
 	}
+	if s.DetectorId != nil && len(*s.DetectorId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DetectorId", 1))
+	}
 	if s.ThreatIntelSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThreatIntelSetId"))
+	}
+	if s.ThreatIntelSetId != nil && len(*s.ThreatIntelSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ThreatIntelSetId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/iam/examples_test.go
+++ b/service/iam/examples_test.go
@@ -520,8 +520,8 @@ func ExampleIAM_CreateRole_shared00() {
 	svc := iam.New(session.New())
 	input := &iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String("<URL-encoded-JSON>"),
-		Path:     aws.String("/"),
-		RoleName: aws.String("Test-Role"),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String("Test-Role"),
 	}
 
 	result, err := svc.CreateRole(input)

--- a/service/iot/api.go
+++ b/service/iot/api.go
@@ -20931,6 +20931,9 @@ func (s *DeletePolicyVersionInput) Validate() error {
 	if s.PolicyVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
 	}
+	if s.PolicyVersionId != nil && len(*s.PolicyVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyVersionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -23207,6 +23210,9 @@ func (s *DescribeThingRegistrationTaskInput) Validate() error {
 	if s.TaskId == nil {
 		invalidParams.Add(request.NewErrParamRequired("TaskId"))
 	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -24943,6 +24949,9 @@ func (s *GetPolicyVersionInput) Validate() error {
 	if s.PolicyVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
 	}
+	if s.PolicyVersionId != nil && len(*s.PolicyVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyVersionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -26362,6 +26371,9 @@ func (s *ListAttachedPoliciesInput) Validate() error {
 	}
 	if s.Target == nil {
 		invalidParams.Add(request.NewErrParamRequired("Target"))
+	}
+	if s.Target != nil && len(*s.Target) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Target", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -29222,6 +29234,9 @@ func (s *ListThingRegistrationTaskReportsInput) Validate() error {
 	}
 	if s.TaskId == nil {
 		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -32481,6 +32496,9 @@ func (s *SetDefaultPolicyVersionInput) Validate() error {
 	if s.PolicyVersionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PolicyVersionId"))
 	}
+	if s.PolicyVersionId != nil && len(*s.PolicyVersionId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyVersionId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -33193,6 +33211,9 @@ func (s *StopThingRegistrationTaskInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "StopThingRegistrationTaskInput"}
 	if s.TaskId == nil {
 		invalidParams.Add(request.NewErrParamRequired("TaskId"))
+	}
+	if s.TaskId != nil && len(*s.TaskId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TaskId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/iot1clickdevicesservice/api.go
+++ b/service/iot1clickdevicesservice/api.go
@@ -894,6 +894,9 @@ func (s *ClaimDevicesByClaimCodeInput) Validate() error {
 	if s.ClaimCode == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClaimCode"))
 	}
+	if s.ClaimCode != nil && len(*s.ClaimCode) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClaimCode", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -962,6 +965,9 @@ func (s *DescribeDeviceInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeDeviceInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1188,6 +1194,9 @@ func (s *FinalizeDeviceClaimInput) Validate() error {
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
 	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1245,6 +1254,9 @@ func (s *GetDeviceMethodsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDeviceMethodsInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1304,6 +1316,9 @@ func (s *InitiateDeviceClaimInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "InitiateDeviceClaimInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1368,6 +1383,9 @@ func (s *InvokeDeviceMethodInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "InvokeDeviceMethodInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1449,6 +1467,9 @@ func (s *ListDeviceEventsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListDeviceEventsInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 	if s.FromTimeStamp == nil {
 		invalidParams.Add(request.NewErrParamRequired("FromTimeStamp"))
@@ -1632,6 +1653,9 @@ func (s *UnclaimDeviceInput) Validate() error {
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
 	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1692,6 +1716,9 @@ func (s *UpdateDeviceStateInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateDeviceStateInput"}
 	if s.DeviceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DeviceId"))
+	}
+	if s.DeviceId != nil && len(*s.DeviceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DeviceId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/iotanalytics/api.go
+++ b/service/iotanalytics/api.go
@@ -3677,6 +3677,9 @@ func (s *CancelPipelineReprocessingInput) Validate() error {
 	if s.ReprocessingId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReprocessingId"))
 	}
+	if s.ReprocessingId != nil && len(*s.ReprocessingId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ReprocessingId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams

--- a/service/iotdataplane/api.go
+++ b/service/iotdataplane/api.go
@@ -569,6 +569,9 @@ func (s *PublishInput) Validate() error {
 	if s.Topic == nil {
 		invalidParams.Add(request.NewErrParamRequired("Topic"))
 	}
+	if s.Topic != nil && len(*s.Topic) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Topic", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams

--- a/service/iotjobsdataplane/api.go
+++ b/service/iotjobsdataplane/api.go
@@ -428,6 +428,9 @@ func (s *DescribeJobExecutionInput) Validate() error {
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
 	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
 	if s.ThingName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ThingName"))
 	}

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -1055,6 +1055,9 @@ func (s *DeleteClusterInput) Validate() error {
 	if s.ClusterArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClusterArn"))
 	}
+	if s.ClusterArn != nil && len(*s.ClusterArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterArn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1129,6 +1132,9 @@ func (s *DescribeClusterInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeClusterInput"}
 	if s.ClusterArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClusterArn"))
+	}
+	if s.ClusterArn != nil && len(*s.ClusterArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1307,6 +1313,9 @@ func (s *GetBootstrapBrokersInput) Validate() error {
 	if s.ClusterArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClusterArn"))
 	}
+	if s.ClusterArn != nil && len(*s.ClusterArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterArn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1457,6 +1466,9 @@ func (s *ListNodesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListNodesInput"}
 	if s.ClusterArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClusterArn"))
+	}
+	if s.ClusterArn != nil && len(*s.ClusterArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClusterArn", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -5049,6 +5049,9 @@ func (s *DeleteEventSourceMappingInput) Validate() error {
 	if s.UUID == nil {
 		invalidParams.Add(request.NewErrParamRequired("UUID"))
 	}
+	if s.UUID != nil && len(*s.UUID) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UUID", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5900,6 +5903,9 @@ func (s *GetEventSourceMappingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetEventSourceMappingInput"}
 	if s.UUID == nil {
 		invalidParams.Add(request.NewErrParamRequired("UUID"))
+	}
+	if s.UUID != nil && len(*s.UUID) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UUID", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7537,6 +7543,9 @@ func (s *ListTagsInput) Validate() error {
 	if s.Resource == nil {
 		invalidParams.Add(request.NewErrParamRequired("Resource"))
 	}
+	if s.Resource != nil && len(*s.Resource) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Resource", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8281,6 +8290,9 @@ func (s *TagResourceInput) Validate() error {
 	if s.Resource == nil {
 		invalidParams.Add(request.NewErrParamRequired("Resource"))
 	}
+	if s.Resource != nil && len(*s.Resource) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Resource", 1))
+	}
 	if s.Tags == nil {
 		invalidParams.Add(request.NewErrParamRequired("Tags"))
 	}
@@ -8398,6 +8410,9 @@ func (s *UntagResourceInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UntagResourceInput"}
 	if s.Resource == nil {
 		invalidParams.Add(request.NewErrParamRequired("Resource"))
+	}
+	if s.Resource != nil && len(*s.Resource) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Resource", 1))
 	}
 	if s.TagKeys == nil {
 		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
@@ -8608,6 +8623,9 @@ func (s *UpdateEventSourceMappingInput) Validate() error {
 	}
 	if s.UUID == nil {
 		invalidParams.Add(request.NewErrParamRequired("UUID"))
+	}
+	if s.UUID != nil && len(*s.UUID) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UUID", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -6661,6 +6661,9 @@ func (s *GetBotInput) Validate() error {
 	if s.VersionOrAlias == nil {
 		invalidParams.Add(request.NewErrParamRequired("VersionOrAlias"))
 	}
+	if s.VersionOrAlias != nil && len(*s.VersionOrAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VersionOrAlias", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7084,6 +7087,9 @@ func (s *GetBuiltinIntentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBuiltinIntentInput"}
 	if s.Signature == nil {
 		invalidParams.Add(request.NewErrParamRequired("Signature"))
+	}
+	if s.Signature != nil && len(*s.Signature) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Signature", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7544,6 +7550,9 @@ func (s *GetImportInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetImportInput"}
 	if s.ImportId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ImportId"))
+	}
+	if s.ImportId != nil && len(*s.ImportId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ImportId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -591,8 +591,14 @@ func (s *PostContentInput) Validate() error {
 	if s.BotAlias == nil {
 		invalidParams.Add(request.NewErrParamRequired("BotAlias"))
 	}
+	if s.BotAlias != nil && len(*s.BotAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BotAlias", 1))
+	}
 	if s.BotName == nil {
 		invalidParams.Add(request.NewErrParamRequired("BotName"))
+	}
+	if s.BotName != nil && len(*s.BotName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BotName", 1))
 	}
 	if s.ContentType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ContentType"))
@@ -929,8 +935,14 @@ func (s *PostTextInput) Validate() error {
 	if s.BotAlias == nil {
 		invalidParams.Add(request.NewErrParamRequired("BotAlias"))
 	}
+	if s.BotAlias != nil && len(*s.BotAlias) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BotAlias", 1))
+	}
 	if s.BotName == nil {
 		invalidParams.Add(request.NewErrParamRequired("BotName"))
+	}
+	if s.BotName != nil && len(*s.BotName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BotName", 1))
 	}
 	if s.InputText == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputText"))

--- a/service/mediaconnect/api.go
+++ b/service/mediaconnect/api.go
@@ -1581,6 +1581,9 @@ func (s *AddFlowOutputsInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 	if s.Outputs == nil {
 		invalidParams.Add(request.NewErrParamRequired("Outputs"))
 	}
@@ -1930,6 +1933,9 @@ func (s *DeleteFlowInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1998,6 +2004,9 @@ func (s *DescribeFlowInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeFlowInput"}
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
+	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2415,6 +2424,9 @@ func (s *GrantFlowEntitlementsInput) Validate() error {
 	}
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
+	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
 	}
 	if s.Entitlements != nil {
 		for i, v := range s.Entitlements {
@@ -2918,8 +2930,14 @@ func (s *RemoveFlowOutputInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 	if s.OutputArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("OutputArn"))
+	}
+	if s.OutputArn != nil && len(*s.OutputArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OutputArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3000,8 +3018,14 @@ func (s *RevokeFlowEntitlementInput) Validate() error {
 	if s.EntitlementArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("EntitlementArn"))
 	}
+	if s.EntitlementArn != nil && len(*s.EntitlementArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EntitlementArn", 1))
+	}
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
+	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3311,6 +3335,9 @@ func (s *StartFlowInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3379,6 +3406,9 @@ func (s *StopFlowInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "StopFlowInput"}
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
+	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3585,8 +3615,14 @@ func (s *UpdateFlowEntitlementInput) Validate() error {
 	if s.EntitlementArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("EntitlementArn"))
 	}
+	if s.EntitlementArn != nil && len(*s.EntitlementArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EntitlementArn", 1))
+	}
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
+	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3713,8 +3749,14 @@ func (s *UpdateFlowOutputInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 	if s.OutputArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("OutputArn"))
+	}
+	if s.OutputArn != nil && len(*s.OutputArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OutputArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3877,8 +3919,14 @@ func (s *UpdateFlowSourceInput) Validate() error {
 	if s.FlowArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("FlowArn"))
 	}
+	if s.FlowArn != nil && len(*s.FlowArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FlowArn", 1))
+	}
 	if s.SourceArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("SourceArn"))
+	}
+	if s.SourceArn != nil && len(*s.SourceArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SourceArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/mediaconvert/api.go
+++ b/service/mediaconvert/api.go
@@ -3767,6 +3767,9 @@ func (s *CancelJobInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5470,6 +5473,9 @@ func (s *DeleteJobTemplateInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5524,6 +5530,9 @@ func (s *DeletePresetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeletePresetInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5580,6 +5589,9 @@ func (s *DeleteQueueInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteQueueInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6744,6 +6756,9 @@ func (s *GetJobInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6807,6 +6822,9 @@ func (s *GetJobTemplateInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetJobTemplateInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6873,6 +6891,9 @@ func (s *GetPresetInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6936,6 +6957,9 @@ func (s *GetQueueInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetQueueInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10565,6 +10589,9 @@ func (s *ListTagsForResourceInput) Validate() error {
 	if s.Arn == nil {
 		invalidParams.Add(request.NewErrParamRequired("Arn"))
 	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14100,6 +14127,9 @@ func (s *UntagResourceInput) Validate() error {
 	if s.Arn == nil {
 		invalidParams.Add(request.NewErrParamRequired("Arn"))
 	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14174,6 +14204,9 @@ func (s *UpdateJobTemplateInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateJobTemplateInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 	if s.Settings != nil {
 		if err := s.Settings.Validate(); err != nil {
@@ -14280,6 +14313,9 @@ func (s *UpdatePresetInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 	if s.Settings != nil {
 		if err := s.Settings.Validate(); err != nil {
 			invalidParams.AddNested("Settings", err.(request.ErrInvalidParams))
@@ -14383,6 +14419,9 @@ func (s *UpdateQueueInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateQueueInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 	if s.ReservationPlanSettings != nil {
 		if err := s.ReservationPlanSettings.Validate(); err != nil {

--- a/service/medialive/api.go
+++ b/service/medialive/api.go
@@ -3893,6 +3893,9 @@ func (s *BatchUpdateScheduleInput) Validate() error {
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
 	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
+	}
 	if s.Creates != nil {
 		if err := s.Creates.Validate(); err != nil {
 			invalidParams.AddNested("Creates", err.(request.ErrInvalidParams))
@@ -5279,6 +5282,9 @@ func (s *DeleteChannelInput) Validate() error {
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
 	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5426,6 +5432,9 @@ func (s *DeleteInputInput) Validate() error {
 	if s.InputId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputId"))
 	}
+	if s.InputId != nil && len(*s.InputId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5476,6 +5485,9 @@ func (s *DeleteInputSecurityGroupInput) Validate() error {
 	if s.InputSecurityGroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputSecurityGroupId"))
 	}
+	if s.InputSecurityGroupId != nil && len(*s.InputSecurityGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputSecurityGroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5525,6 +5537,9 @@ func (s *DeleteReservationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteReservationInput"}
 	if s.ReservationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReservationId"))
+	}
+	if s.ReservationId != nil && len(*s.ReservationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ReservationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5716,6 +5731,9 @@ func (s *DescribeChannelInput) Validate() error {
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
 	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5863,6 +5881,9 @@ func (s *DescribeInputInput) Validate() error {
 	if s.InputId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputId"))
 	}
+	if s.InputId != nil && len(*s.InputId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5985,6 +6006,9 @@ func (s *DescribeInputSecurityGroupInput) Validate() error {
 	if s.InputSecurityGroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputSecurityGroupId"))
 	}
+	if s.InputSecurityGroupId != nil && len(*s.InputSecurityGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputSecurityGroupId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6074,6 +6098,9 @@ func (s *DescribeOfferingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeOfferingInput"}
 	if s.OfferingId == nil {
 		invalidParams.Add(request.NewErrParamRequired("OfferingId"))
+	}
+	if s.OfferingId != nil && len(*s.OfferingId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OfferingId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6215,6 +6242,9 @@ func (s *DescribeReservationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeReservationInput"}
 	if s.ReservationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReservationId"))
+	}
+	if s.ReservationId != nil && len(*s.ReservationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ReservationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6409,6 +6439,9 @@ func (s *DescribeScheduleInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeScheduleInput"}
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
+	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -11990,6 +12023,9 @@ func (s *PurchaseOfferingInput) Validate() error {
 	if s.OfferingId == nil {
 		invalidParams.Add(request.NewErrParamRequired("OfferingId"))
 	}
+	if s.OfferingId != nil && len(*s.OfferingId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("OfferingId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13577,6 +13613,9 @@ func (s *StartChannelInput) Validate() error {
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
 	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13963,6 +14002,9 @@ func (s *StopChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "StopChannelInput"}
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
+	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14414,6 +14456,9 @@ func (s *UpdateChannelInput) Validate() error {
 	if s.ChannelId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ChannelId"))
 	}
+	if s.ChannelId != nil && len(*s.ChannelId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ChannelId", 1))
+	}
 	if s.EncoderSettings != nil {
 		if err := s.EncoderSettings.Validate(); err != nil {
 			invalidParams.AddNested("EncoderSettings", err.(request.ErrInvalidParams))
@@ -14537,6 +14582,9 @@ func (s *UpdateInputInput) Validate() error {
 	if s.InputId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputId"))
 	}
+	if s.InputId != nil && len(*s.InputId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14620,6 +14668,9 @@ func (s *UpdateInputSecurityGroupInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateInputSecurityGroupInput"}
 	if s.InputSecurityGroupId == nil {
 		invalidParams.Add(request.NewErrParamRequired("InputSecurityGroupId"))
+	}
+	if s.InputSecurityGroupId != nil && len(*s.InputSecurityGroupId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputSecurityGroupId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/mediapackage/api.go
+++ b/service/mediapackage/api.go
@@ -1996,6 +1996,9 @@ func (s *DeleteChannelInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2046,6 +2049,9 @@ func (s *DeleteOriginEndpointInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2095,6 +2101,9 @@ func (s *DescribeChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeChannelInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2178,6 +2187,9 @@ func (s *DescribeOriginEndpointInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeOriginEndpointInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3231,6 +3243,9 @@ func (s *RotateChannelCredentialsInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3318,8 +3333,14 @@ func (s *RotateIngestEndpointCredentialsInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 	if s.IngestEndpointId == nil {
 		invalidParams.Add(request.NewErrParamRequired("IngestEndpointId"))
+	}
+	if s.IngestEndpointId != nil && len(*s.IngestEndpointId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("IngestEndpointId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3548,6 +3569,9 @@ func (s *UpdateChannelInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3658,6 +3682,9 @@ func (s *UpdateOriginEndpointInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateOriginEndpointInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 	if s.CmafPackage != nil {
 		if err := s.CmafPackage.Validate(); err != nil {

--- a/service/mediatailor/api.go
+++ b/service/mediatailor/api.go
@@ -403,6 +403,9 @@ func (s *DeletePlaybackConfigurationInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -452,6 +455,9 @@ func (s *GetPlaybackConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetPlaybackConfigurationInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/mobile/api.go
+++ b/service/mobile/api.go
@@ -1185,6 +1185,9 @@ func (s *DeleteProjectInput) Validate() error {
 	if s.ProjectId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ProjectId"))
 	}
+	if s.ProjectId != nil && len(*s.ProjectId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1257,6 +1260,9 @@ func (s *DescribeBundleInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeBundleInput"}
 	if s.BundleId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BundleId"))
+	}
+	if s.BundleId != nil && len(*s.BundleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BundleId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1402,6 +1408,9 @@ func (s *ExportBundleInput) Validate() error {
 	if s.BundleId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BundleId"))
 	}
+	if s.BundleId != nil && len(*s.BundleId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BundleId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1480,6 +1489,9 @@ func (s *ExportProjectInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ExportProjectInput"}
 	if s.ProjectId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ProjectId"))
+	}
+	if s.ProjectId != nil && len(*s.ProjectId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProjectId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/mq/api.go
+++ b/service/mq/api.go
@@ -2148,8 +2148,14 @@ func (s *CreateUserRequest) Validate() error {
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
 	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
+	}
 	if s.Username == nil {
 		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2210,6 +2216,9 @@ func (s *DeleteBrokerInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteBrokerInput"}
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
+	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2272,8 +2281,14 @@ func (s *DeleteUserInput) Validate() error {
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
 	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
+	}
 	if s.Username == nil {
 		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2330,6 +2345,9 @@ func (s *DescribeBrokerInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DescribeBrokerInput"}
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
+	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2541,6 +2559,9 @@ func (s *DescribeConfigurationInput) Validate() error {
 	if s.ConfigurationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationId"))
 	}
+	if s.ConfigurationId != nil && len(*s.ConfigurationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2660,8 +2681,14 @@ func (s *DescribeConfigurationRevisionInput) Validate() error {
 	if s.ConfigurationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationId"))
 	}
+	if s.ConfigurationId != nil && len(*s.ConfigurationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationId", 1))
+	}
 	if s.ConfigurationRevision == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationRevision"))
+	}
+	if s.ConfigurationRevision != nil && len(*s.ConfigurationRevision) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationRevision", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2754,8 +2781,14 @@ func (s *DescribeUserInput) Validate() error {
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
 	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
+	}
 	if s.Username == nil {
 		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2931,6 +2964,9 @@ func (s *ListConfigurationRevisionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListConfigurationRevisionsInput"}
 	if s.ConfigurationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationId"))
+	}
+	if s.ConfigurationId != nil && len(*s.ConfigurationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -3113,6 +3149,9 @@ func (s *ListUsersInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListUsersInput"}
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
+	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
 	}
 	if s.MaxResults != nil && *s.MaxResults < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
@@ -3342,6 +3381,9 @@ func (s *RebootBrokerInput) Validate() error {
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
 	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3444,6 +3486,9 @@ func (s *UpdateBrokerRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateBrokerRequest"}
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
+	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3564,6 +3609,9 @@ func (s *UpdateConfigurationRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateConfigurationRequest"}
 	if s.ConfigurationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationId"))
+	}
+	if s.ConfigurationId != nil && len(*s.ConfigurationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3699,8 +3747,14 @@ func (s *UpdateUserRequest) Validate() error {
 	if s.BrokerId == nil {
 		invalidParams.Add(request.NewErrParamRequired("BrokerId"))
 	}
+	if s.BrokerId != nil && len(*s.BrokerId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("BrokerId", 1))
+	}
 	if s.Username == nil {
 		invalidParams.Add(request.NewErrParamRequired("Username"))
+	}
+	if s.Username != nil && len(*s.Username) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Username", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/pinpoint/api.go
+++ b/service/pinpoint/api.go
@@ -9839,6 +9839,9 @@ func (s *CreateCampaignInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.WriteCampaignRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteCampaignRequest"))
 	}
@@ -9913,6 +9916,9 @@ func (s *CreateExportJobInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateExportJobInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.ExportJobRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("ExportJobRequest"))
@@ -9989,6 +9995,9 @@ func (s *CreateImportJobInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.ImportJobRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("ImportJobRequest"))
 	}
@@ -10063,6 +10072,9 @@ func (s *CreateSegmentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateSegmentInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.WriteSegmentRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteSegmentRequest"))
@@ -10255,6 +10267,9 @@ func (s *DeleteAdmChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10315,6 +10330,9 @@ func (s *DeleteApnsChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteApnsChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10377,6 +10395,9 @@ func (s *DeleteApnsSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10437,6 +10458,9 @@ func (s *DeleteApnsVoipChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteApnsVoipChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10499,6 +10523,9 @@ func (s *DeleteApnsVoipSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10560,6 +10587,9 @@ func (s *DeleteAppInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10620,6 +10650,9 @@ func (s *DeleteBaiduChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteBaiduChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10685,8 +10718,14 @@ func (s *DeleteCampaignInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
+	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10755,6 +10794,9 @@ func (s *DeleteEmailChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10819,8 +10861,14 @@ func (s *DeleteEndpointInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.EndpointId == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointId"))
+	}
+	if s.EndpointId != nil && len(*s.EndpointId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EndpointId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10889,6 +10937,9 @@ func (s *DeleteEventStreamInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10949,6 +11000,9 @@ func (s *DeleteGcmChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteGcmChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11014,8 +11068,14 @@ func (s *DeleteSegmentInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11084,6 +11144,9 @@ func (s *DeleteSmsChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11148,8 +11211,14 @@ func (s *DeleteUserEndpointsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11217,6 +11286,9 @@ func (s *DeleteVoiceChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteVoiceChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13537,6 +13609,9 @@ func (s *GetAdmChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13597,6 +13672,9 @@ func (s *GetApnsChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetApnsChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13659,6 +13737,9 @@ func (s *GetApnsSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13719,6 +13800,9 @@ func (s *GetApnsVoipChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetApnsVoipChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13781,6 +13865,9 @@ func (s *GetApnsVoipSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13842,6 +13929,9 @@ func (s *GetAppInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -13902,6 +13992,9 @@ func (s *GetApplicationSettingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetApplicationSettingsInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14019,6 +14112,9 @@ func (s *GetBaiduChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14087,8 +14183,14 @@ func (s *GetCampaignActivitiesInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
+	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14172,8 +14274,14 @@ func (s *GetCampaignInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
+	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14248,11 +14356,20 @@ func (s *GetCampaignVersionInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
 	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
+	}
 	if s.Version == nil {
 		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14334,8 +14451,14 @@ func (s *GetCampaignVersionsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
+	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14420,6 +14543,9 @@ func (s *GetCampaignsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14493,6 +14619,9 @@ func (s *GetChannelsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14553,6 +14682,9 @@ func (s *GetEmailChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetEmailChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14618,8 +14750,14 @@ func (s *GetEndpointInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.EndpointId == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointId"))
+	}
+	if s.EndpointId != nil && len(*s.EndpointId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EndpointId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14688,6 +14826,9 @@ func (s *GetEventStreamInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14752,8 +14893,14 @@ func (s *GetExportJobInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14825,6 +14972,9 @@ func (s *GetExportJobsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetExportJobsInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14899,6 +15049,9 @@ func (s *GetGcmChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -14963,8 +15116,14 @@ func (s *GetImportJobInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
+	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15036,6 +15195,9 @@ func (s *GetImportJobsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetImportJobsInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15117,8 +15279,14 @@ func (s *GetSegmentExportJobsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15206,8 +15374,14 @@ func (s *GetSegmentImportJobsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15291,8 +15465,14 @@ func (s *GetSegmentInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15367,11 +15547,20 @@ func (s *GetSegmentVersionInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
 	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
+	}
 	if s.Version == nil {
 		invalidParams.Add(request.NewErrParamRequired("Version"))
+	}
+	if s.Version != nil && len(*s.Version) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Version", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15453,8 +15642,14 @@ func (s *GetSegmentVersionsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15539,6 +15734,9 @@ func (s *GetSegmentsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15612,6 +15810,9 @@ func (s *GetSmsChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15676,8 +15877,14 @@ func (s *GetUserEndpointsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.UserId == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserId"))
+	}
+	if s.UserId != nil && len(*s.UserId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("UserId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15745,6 +15952,9 @@ func (s *GetVoiceChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetVoiceChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -17061,6 +17271,9 @@ func (s *PutEventStreamInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.WriteEventStream == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteEventStream"))
 	}
@@ -17135,6 +17348,9 @@ func (s *PutEventsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutEventsInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.EventsRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventsRequest"))
@@ -17315,8 +17531,14 @@ func (s *RemoveAttributesInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.AttributeType == nil {
 		invalidParams.Add(request.NewErrParamRequired("AttributeType"))
+	}
+	if s.AttributeType != nil && len(*s.AttributeType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AttributeType", 1))
 	}
 	if s.UpdateAttributesRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("UpdateAttributesRequest"))
@@ -18294,6 +18516,9 @@ func (s *SendMessagesInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.MessageRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("MessageRequest"))
 	}
@@ -18470,6 +18695,9 @@ func (s *SendUsersMessagesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "SendUsersMessagesInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.SendUsersMessageRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("SendUsersMessageRequest"))
@@ -18794,6 +19022,9 @@ func (s *UpdateAdmChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -18868,6 +19099,9 @@ func (s *UpdateApnsChannelInput) Validate() error {
 	}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -18944,6 +19178,9 @@ func (s *UpdateApnsSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -19018,6 +19255,9 @@ func (s *UpdateApnsVoipChannelInput) Validate() error {
 	}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -19094,6 +19334,9 @@ func (s *UpdateApnsVoipSandboxChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -19165,6 +19408,9 @@ func (s *UpdateApplicationSettingsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateApplicationSettingsInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.WriteApplicationSettingsRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteApplicationSettingsRequest"))
@@ -19265,6 +19511,9 @@ func (s *UpdateBaiduChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.BaiduChannelRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("BaiduChannelRequest"))
 	}
@@ -19343,8 +19592,14 @@ func (s *UpdateCampaignInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.CampaignId == nil {
 		invalidParams.Add(request.NewErrParamRequired("CampaignId"))
+	}
+	if s.CampaignId != nil && len(*s.CampaignId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CampaignId", 1))
 	}
 	if s.WriteCampaignRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteCampaignRequest"))
@@ -19427,6 +19682,9 @@ func (s *UpdateEmailChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.EmailChannelRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailChannelRequest"))
 	}
@@ -19505,8 +19763,14 @@ func (s *UpdateEndpointInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.EndpointId == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointId"))
+	}
+	if s.EndpointId != nil && len(*s.EndpointId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EndpointId", 1))
 	}
 	if s.EndpointRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointRequest"))
@@ -19589,6 +19853,9 @@ func (s *UpdateEndpointsBatchInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.EndpointBatchRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointBatchRequest"))
 	}
@@ -19663,6 +19930,9 @@ func (s *UpdateGcmChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateGcmChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.GCMChannelRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("GCMChannelRequest"))
@@ -19742,8 +20012,14 @@ func (s *UpdateSegmentInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SegmentId == nil {
 		invalidParams.Add(request.NewErrParamRequired("SegmentId"))
+	}
+	if s.SegmentId != nil && len(*s.SegmentId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SegmentId", 1))
 	}
 	if s.WriteSegmentRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("WriteSegmentRequest"))
@@ -19826,6 +20102,9 @@ func (s *UpdateSmsChannelInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SMSChannelRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("SMSChannelRequest"))
 	}
@@ -19900,6 +20179,9 @@ func (s *UpdateVoiceChannelInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateVoiceChannelInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.VoiceChannelRequest == nil {
 		invalidParams.Add(request.NewErrParamRequired("VoiceChannelRequest"))

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -3201,6 +3201,9 @@ func (s *CreateConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 	if s.EventDestination == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestination"))
 	}
@@ -3592,8 +3595,14 @@ func (s *DeleteConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 	if s.EventDestinationName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestinationName"))
+	}
+	if s.EventDestinationName != nil && len(*s.EventDestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventDestinationName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3656,6 +3665,9 @@ func (s *DeleteConfigurationSetInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3710,6 +3722,9 @@ func (s *DeleteDedicatedIpPoolInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteDedicatedIpPoolInput"}
 	if s.PoolName == nil {
 		invalidParams.Add(request.NewErrParamRequired("PoolName"))
+	}
+	if s.PoolName != nil && len(*s.PoolName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PoolName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3769,6 +3784,9 @@ func (s *DeleteEmailIdentityInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteEmailIdentityInput"}
 	if s.EmailIdentity == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailIdentity"))
+	}
+	if s.EmailIdentity != nil && len(*s.EmailIdentity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailIdentity", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4352,6 +4370,9 @@ func (s *GetConfigurationSetEventDestinationsInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4416,6 +4437,9 @@ func (s *GetConfigurationSetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetConfigurationSetInput"}
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
+	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4521,6 +4545,9 @@ func (s *GetDedicatedIpInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetDedicatedIpInput"}
 	if s.Ip == nil {
 		invalidParams.Add(request.NewErrParamRequired("Ip"))
+	}
+	if s.Ip != nil && len(*s.Ip) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Ip", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -4667,6 +4694,9 @@ func (s *GetEmailIdentityInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetEmailIdentityInput"}
 	if s.EmailIdentity == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailIdentity"))
+	}
+	if s.EmailIdentity != nil && len(*s.EmailIdentity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailIdentity", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5441,6 +5471,9 @@ func (s *PutConfigurationSetDeliveryOptionsInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5509,6 +5542,9 @@ func (s *PutConfigurationSetReputationOptionsInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5576,6 +5612,9 @@ func (s *PutConfigurationSetSendingOptionsInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5641,6 +5680,9 @@ func (s *PutConfigurationSetTrackingOptionsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutConfigurationSetTrackingOptionsInput"}
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
+	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5714,6 +5756,9 @@ func (s *PutDedicatedIpInPoolInput) Validate() error {
 	if s.Ip == nil {
 		invalidParams.Add(request.NewErrParamRequired("Ip"))
 	}
+	if s.Ip != nil && len(*s.Ip) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Ip", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -5779,6 +5824,9 @@ func (s *PutDedicatedIpWarmupAttributesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutDedicatedIpWarmupAttributesInput"}
 	if s.Ip == nil {
 		invalidParams.Add(request.NewErrParamRequired("Ip"))
+	}
+	if s.Ip != nil && len(*s.Ip) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Ip", 1))
 	}
 	if s.WarmupPercentage == nil {
 		invalidParams.Add(request.NewErrParamRequired("WarmupPercentage"))
@@ -5851,6 +5899,9 @@ func (s *PutEmailIdentityDkimAttributesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutEmailIdentityDkimAttributesInput"}
 	if s.EmailIdentity == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailIdentity"))
+	}
+	if s.EmailIdentity != nil && len(*s.EmailIdentity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailIdentity", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5929,6 +5980,9 @@ func (s *PutEmailIdentityFeedbackAttributesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutEmailIdentityFeedbackAttributesInput"}
 	if s.EmailIdentity == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailIdentity"))
+	}
+	if s.EmailIdentity != nil && len(*s.EmailIdentity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailIdentity", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6012,6 +6066,9 @@ func (s *PutEmailIdentityMailFromAttributesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutEmailIdentityMailFromAttributesInput"}
 	if s.EmailIdentity == nil {
 		invalidParams.Add(request.NewErrParamRequired("EmailIdentity"))
+	}
+	if s.EmailIdentity != nil && len(*s.EmailIdentity) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EmailIdentity", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -6502,11 +6559,17 @@ func (s *UpdateConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 	if s.EventDestination == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestination"))
 	}
 	if s.EventDestinationName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestinationName"))
+	}
+	if s.EventDestinationName != nil && len(*s.EventDestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventDestinationName", 1))
 	}
 	if s.EventDestination != nil {
 		if err := s.EventDestination.Validate(); err != nil {

--- a/service/pinpointsmsvoice/api.go
+++ b/service/pinpointsmsvoice/api.go
@@ -712,6 +712,9 @@ func (s *CreateConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -818,8 +821,14 @@ func (s *DeleteConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 	if s.EventDestinationName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestinationName"))
+	}
+	if s.EventDestinationName != nil && len(*s.EventDestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventDestinationName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -877,6 +886,9 @@ func (s *DeleteConfigurationSetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteConfigurationSetInput"}
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
+	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1049,6 +1061,9 @@ func (s *GetConfigurationSetEventDestinationsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetConfigurationSetEventDestinationsInput"}
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
+	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1330,8 +1345,14 @@ func (s *UpdateConfigurationSetEventDestinationInput) Validate() error {
 	if s.ConfigurationSetName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ConfigurationSetName"))
 	}
+	if s.ConfigurationSetName != nil && len(*s.ConfigurationSetName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConfigurationSetName", 1))
+	}
 	if s.EventDestinationName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EventDestinationName"))
+	}
+	if s.EventDestinationName != nil && len(*s.EventDestinationName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventDestinationName", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/polly/api.go
+++ b/service/polly/api.go
@@ -979,6 +979,9 @@ func (s *DeleteLexiconInput) Validate() error {
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
 	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1111,6 +1114,9 @@ func (s *GetLexiconInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetLexiconInput"}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1545,6 +1551,9 @@ func (s *PutLexiconInput) Validate() error {
 	}
 	if s.Name == nil {
 		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/quicksight/api.go
+++ b/service/quicksight/api.go
@@ -1613,6 +1613,9 @@ func (s *CreateGroupInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1702,6 +1705,9 @@ func (s *CreateGroupMembershipInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -1865,6 +1871,9 @@ func (s *DeleteGroupInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1948,6 +1957,9 @@ func (s *DeleteGroupMembershipInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2086,6 +2098,9 @@ func (s *DeleteUserInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 	if s.UserName == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserName"))
 	}
@@ -2197,6 +2212,9 @@ func (s *DescribeGroupInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2304,6 +2322,9 @@ func (s *DescribeUserInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 	if s.UserName == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserName"))
@@ -2429,6 +2450,9 @@ func (s *GetDashboardEmbedUrlInput) Validate() error {
 	}
 	if s.DashboardId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DashboardId"))
+	}
+	if s.DashboardId != nil && len(*s.DashboardId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DashboardId", 1))
 	}
 	if s.IdentityType == nil {
 		invalidParams.Add(request.NewErrParamRequired("IdentityType"))
@@ -2658,6 +2682,9 @@ func (s *ListGroupMembershipsInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2791,6 +2818,9 @@ func (s *ListGroupsInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2922,6 +2952,9 @@ func (s *ListUserGroupsInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 	if s.UserName == nil {
 		invalidParams.Add(request.NewErrParamRequired("UserName"))
@@ -3061,6 +3094,9 @@ func (s *ListUsersInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -3229,6 +3265,9 @@ func (s *RegisterUserInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 	if s.UserName != nil && len(*s.UserName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("UserName", 1))
 	}
@@ -3385,6 +3424,9 @@ func (s *UpdateGroupInput) Validate() error {
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
 	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -3519,6 +3561,9 @@ func (s *UpdateUserInput) Validate() error {
 	}
 	if s.Namespace == nil {
 		invalidParams.Add(request.NewErrParamRequired("Namespace"))
+	}
+	if s.Namespace != nil && len(*s.Namespace) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Namespace", 1))
 	}
 	if s.Role == nil {
 		invalidParams.Add(request.NewErrParamRequired("Role"))

--- a/service/rds/examples_test.go
+++ b/service/rds/examples_test.go
@@ -1289,7 +1289,7 @@ func ExampleRDS_DescribeDBClusterParameters_shared00() {
 	svc := rds.New(session.New())
 	input := &rds.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String("mydbclusterparametergroup"),
-		Source: aws.String("system"),
+		Source:                      aws.String("system"),
 	}
 
 	result, err := svc.DescribeDBClusterParameters(input)

--- a/service/resourcegroups/api.go
+++ b/service/resourcegroups/api.go
@@ -1670,6 +1670,9 @@ func (s *GetTagsInput) Validate() error {
 	if s.Arn == nil {
 		invalidParams.Add(request.NewErrParamRequired("Arn"))
 	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2506,6 +2509,9 @@ func (s *TagInput) Validate() error {
 	if s.Arn == nil {
 		invalidParams.Add(request.NewErrParamRequired("Arn"))
 	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
+	}
 	if s.Tags == nil {
 		invalidParams.Add(request.NewErrParamRequired("Tags"))
 	}
@@ -2589,6 +2595,9 @@ func (s *UntagInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UntagInput"}
 	if s.Arn == nil {
 		invalidParams.Add(request.NewErrParamRequired("Arn"))
+	}
+	if s.Arn != nil && len(*s.Arn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Arn", 1))
 	}
 	if s.Keys == nil {
 		invalidParams.Add(request.NewErrParamRequired("Keys"))

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -6239,6 +6239,9 @@ func (s *AssociateVPCWithHostedZoneInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.VPC == nil {
 		invalidParams.Add(request.NewErrParamRequired("VPC"))
 	}
@@ -6534,6 +6537,9 @@ func (s *ChangeResourceRecordSetsInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.ChangeBatch != nil {
 		if err := s.ChangeBatch.Validate(); err != nil {
 			invalidParams.AddNested("ChangeBatch", err.(request.ErrInvalidParams))
@@ -6641,8 +6647,14 @@ func (s *ChangeTagsForResourceInput) Validate() error {
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.ResourceType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+	if s.ResourceType != nil && len(*s.ResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceType", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7685,6 +7697,9 @@ func (s *CreateVPCAssociationAuthorizationInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.VPC == nil {
 		invalidParams.Add(request.NewErrParamRequired("VPC"))
 	}
@@ -7823,6 +7838,9 @@ func (s *DeleteHealthCheckInput) Validate() error {
 	if s.HealthCheckId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
 	}
+	if s.HealthCheckId != nil && len(*s.HealthCheckId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7876,6 +7894,9 @@ func (s *DeleteHostedZoneInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteHostedZoneInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7997,6 +8018,9 @@ func (s *DeleteReusableDelegationSetInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteReusableDelegationSetInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8198,6 +8222,9 @@ func (s *DeleteVPCAssociationAuthorizationInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.VPC == nil {
 		invalidParams.Add(request.NewErrParamRequired("VPC"))
 	}
@@ -8315,6 +8342,9 @@ func (s *DisassociateVPCFromHostedZoneInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DisassociateVPCFromHostedZoneInput"}
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
 	}
 	if s.VPC == nil {
 		invalidParams.Add(request.NewErrParamRequired("VPC"))
@@ -8560,6 +8590,9 @@ func (s *GetAccountLimitInput) Validate() error {
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
 	}
+	if s.Type != nil && len(*s.Type) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Type", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8643,6 +8676,9 @@ func (s *GetChangeInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetChangeInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -8899,6 +8935,9 @@ func (s *GetHealthCheckInput) Validate() error {
 	if s.HealthCheckId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
 	}
+	if s.HealthCheckId != nil && len(*s.HealthCheckId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -8943,6 +8982,9 @@ func (s *GetHealthCheckLastFailureReasonInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetHealthCheckLastFailureReasonInput"}
 	if s.HealthCheckId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+	if s.HealthCheckId != nil && len(*s.HealthCheckId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9043,6 +9085,9 @@ func (s *GetHealthCheckStatusInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetHealthCheckStatusInput"}
 	if s.HealthCheckId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
+	}
+	if s.HealthCheckId != nil && len(*s.HealthCheckId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9153,6 +9198,9 @@ func (s *GetHostedZoneInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9204,8 +9252,14 @@ func (s *GetHostedZoneLimitInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.Type != nil && len(*s.Type) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Type", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9411,6 +9465,9 @@ func (s *GetReusableDelegationSetInput) Validate() error {
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9458,8 +9515,14 @@ func (s *GetReusableDelegationSetLimitInput) Validate() error {
 	if s.DelegationSetId == nil {
 		invalidParams.Add(request.NewErrParamRequired("DelegationSetId"))
 	}
+	if s.DelegationSetId != nil && len(*s.DelegationSetId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DelegationSetId", 1))
+	}
 	if s.Type == nil {
 		invalidParams.Add(request.NewErrParamRequired("Type"))
+	}
+	if s.Type != nil && len(*s.Type) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Type", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11283,6 +11346,9 @@ func (s *ListResourceRecordSetsInput) Validate() error {
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
 	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
+	}
 	if s.StartRecordIdentifier != nil && len(*s.StartRecordIdentifier) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("StartRecordIdentifier", 1))
 	}
@@ -11566,8 +11632,14 @@ func (s *ListTagsForResourceInput) Validate() error {
 	if s.ResourceId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceId"))
 	}
+	if s.ResourceId != nil && len(*s.ResourceId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceId", 1))
+	}
 	if s.ResourceType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+	if s.ResourceType != nil && len(*s.ResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceType", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11657,6 +11729,9 @@ func (s *ListTagsForResourcesInput) Validate() error {
 	}
 	if s.ResourceType == nil {
 		invalidParams.Add(request.NewErrParamRequired("ResourceType"))
+	}
+	if s.ResourceType != nil && len(*s.ResourceType) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ResourceType", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12557,6 +12632,9 @@ func (s *ListVPCAssociationAuthorizationsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListVPCAssociationAuthorizationsInput"}
 	if s.HostedZoneId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HostedZoneId"))
+	}
+	if s.HostedZoneId != nil && len(*s.HostedZoneId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HostedZoneId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -14274,6 +14352,9 @@ func (s *UpdateHealthCheckInput) Validate() error {
 	if s.HealthCheckId == nil {
 		invalidParams.Add(request.NewErrParamRequired("HealthCheckId"))
 	}
+	if s.HealthCheckId != nil && len(*s.HealthCheckId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheckId", 1))
+	}
 	if s.HealthCheckVersion != nil && *s.HealthCheckVersion < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("HealthCheckVersion", 1))
 	}
@@ -14451,6 +14532,9 @@ func (s *UpdateHostedZoneCommentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateHostedZoneCommentInput"}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Id != nil && len(*s.Id) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Id", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -7103,6 +7103,9 @@ func (s *AbortMultipartUploadInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -8105,6 +8108,9 @@ func (s *CompleteMultipartUploadInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -8540,6 +8546,9 @@ func (s *CopyObjectInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CopyObjectInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.CopySource == nil {
 		invalidParams.Add(request.NewErrParamRequired("CopySource"))
@@ -9027,6 +9036,9 @@ func (s *CreateBucketInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9231,6 +9243,9 @@ func (s *CreateMultipartUploadInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateMultipartUploadInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -9664,6 +9679,9 @@ func (s *DeleteBucketAnalyticsConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
@@ -9730,6 +9748,9 @@ func (s *DeleteBucketCorsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9790,6 +9811,9 @@ func (s *DeleteBucketEncryptionInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9847,6 +9871,9 @@ func (s *DeleteBucketInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9896,6 +9923,9 @@ func (s *DeleteBucketInventoryConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketInventoryConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
@@ -9963,6 +9993,9 @@ func (s *DeleteBucketLifecycleInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10026,6 +10059,9 @@ func (s *DeleteBucketMetricsConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketMetricsConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
@@ -10107,6 +10143,9 @@ func (s *DeleteBucketPolicyInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10169,6 +10208,9 @@ func (s *DeleteBucketReplicationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10226,6 +10268,9 @@ func (s *DeleteBucketTaggingInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -10282,6 +10327,9 @@ func (s *DeleteBucketWebsiteInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketWebsiteInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -10446,6 +10494,9 @@ func (s *DeleteObjectInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -10575,6 +10626,9 @@ func (s *DeleteObjectTaggingInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -10676,6 +10730,9 @@ func (s *DeleteObjectsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeleteObjectsInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Delete == nil {
 		invalidParams.Add(request.NewErrParamRequired("Delete"))
@@ -10793,6 +10850,9 @@ func (s *DeletePublicAccessBlockInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DeletePublicAccessBlockInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11241,6 +11301,9 @@ func (s *GetBucketAccelerateConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11306,6 +11369,9 @@ func (s *GetBucketAclInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketAclInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11388,6 +11454,9 @@ func (s *GetBucketAnalyticsConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
@@ -11463,6 +11532,9 @@ func (s *GetBucketCorsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11530,6 +11602,9 @@ func (s *GetBucketEncryptionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketEncryptionInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11604,6 +11679,9 @@ func (s *GetBucketInventoryConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketInventoryConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
@@ -11680,6 +11758,9 @@ func (s *GetBucketLifecycleConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11744,6 +11825,9 @@ func (s *GetBucketLifecycleInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketLifecycleInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11810,6 +11894,9 @@ func (s *GetBucketLocationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -11874,6 +11961,9 @@ func (s *GetBucketLoggingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketLoggingInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -11949,6 +12039,9 @@ func (s *GetBucketMetricsConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketMetricsConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
@@ -12027,6 +12120,9 @@ func (s *GetBucketNotificationConfigurationRequest) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12069,6 +12165,9 @@ func (s *GetBucketPolicyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketPolicyInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12138,6 +12237,9 @@ func (s *GetBucketPolicyStatusInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12203,6 +12305,9 @@ func (s *GetBucketReplicationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketReplicationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12271,6 +12376,9 @@ func (s *GetBucketRequestPaymentInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12337,6 +12445,9 @@ func (s *GetBucketTaggingInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12402,6 +12513,9 @@ func (s *GetBucketVersioningInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketVersioningInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12479,6 +12593,9 @@ func (s *GetBucketWebsiteInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetBucketWebsiteInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -12580,6 +12697,9 @@ func (s *GetObjectAclInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetObjectAclInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -12758,6 +12878,9 @@ func (s *GetObjectInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetObjectInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -12939,6 +13062,9 @@ func (s *GetObjectLegalHoldInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -13030,6 +13156,9 @@ func (s *GetObjectLockConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetObjectLockConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13424,6 +13553,9 @@ func (s *GetObjectRetentionInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -13518,6 +13650,9 @@ func (s *GetObjectTaggingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetObjectTaggingInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -13715,6 +13850,9 @@ func (s *GetPublicAccessBlockInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetPublicAccessBlockInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13940,6 +14078,9 @@ func (s *HeadBucketInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "HeadBucketInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15462,6 +15603,9 @@ func (s *ListBucketAnalyticsConfigurationsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15573,6 +15717,9 @@ func (s *ListBucketInventoryConfigurationsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -15683,6 +15830,9 @@ func (s *ListBucketMetricsConfigurationsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListBucketMetricsConfigurationsInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -15861,6 +16011,9 @@ func (s *ListMultipartUploadsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListMultipartUploadsInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16098,6 +16251,9 @@ func (s *ListObjectVersionsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -16330,6 +16486,9 @@ func (s *ListObjectsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -16546,6 +16705,9 @@ func (s *ListObjectsV2Input) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListObjectsV2Input"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -16791,6 +16953,9 @@ func (s *ListPartsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListPartsInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -18470,6 +18635,9 @@ func (s *PutBucketAclInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.AccessControlPolicy != nil {
 		if err := s.AccessControlPolicy.Validate(); err != nil {
 			invalidParams.AddNested("AccessControlPolicy", err.(request.ErrInvalidParams))
@@ -18589,6 +18757,9 @@ func (s *PutBucketAnalyticsConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
@@ -18669,6 +18840,9 @@ func (s *PutBucketCorsInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.CORSConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("CORSConfiguration"))
 	}
@@ -18748,6 +18922,9 @@ func (s *PutBucketEncryptionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketEncryptionInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.ServerSideEncryptionConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("ServerSideEncryptionConfiguration"))
@@ -18832,6 +19009,9 @@ func (s *PutBucketInventoryConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
 	}
@@ -18914,6 +19094,9 @@ func (s *PutBucketLifecycleConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.LifecycleConfiguration != nil {
 		if err := s.LifecycleConfiguration.Validate(); err != nil {
 			invalidParams.AddNested("LifecycleConfiguration", err.(request.ErrInvalidParams))
@@ -18983,6 +19166,9 @@ func (s *PutBucketLifecycleInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketLifecycleInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.LifecycleConfiguration != nil {
 		if err := s.LifecycleConfiguration.Validate(); err != nil {
@@ -19054,6 +19240,9 @@ func (s *PutBucketLoggingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketLoggingInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.BucketLoggingStatus == nil {
 		invalidParams.Add(request.NewErrParamRequired("BucketLoggingStatus"))
@@ -19137,6 +19326,9 @@ func (s *PutBucketMetricsConfigurationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketMetricsConfigurationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Id == nil {
 		invalidParams.Add(request.NewErrParamRequired("Id"))
@@ -19224,6 +19416,9 @@ func (s *PutBucketNotificationConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.NotificationConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("NotificationConfiguration"))
 	}
@@ -19297,6 +19492,9 @@ func (s *PutBucketNotificationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketNotificationInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.NotificationConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("NotificationConfiguration"))
@@ -19372,6 +19570,9 @@ func (s *PutBucketPolicyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketPolicyInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Policy == nil {
 		invalidParams.Add(request.NewErrParamRequired("Policy"))
@@ -19451,6 +19652,9 @@ func (s *PutBucketReplicationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.ReplicationConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReplicationConfiguration"))
 	}
@@ -19525,6 +19729,9 @@ func (s *PutBucketRequestPaymentInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.RequestPaymentConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("RequestPaymentConfiguration"))
 	}
@@ -19598,6 +19805,9 @@ func (s *PutBucketTaggingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketTaggingInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Tagging == nil {
 		invalidParams.Add(request.NewErrParamRequired("Tagging"))
@@ -19677,6 +19887,9 @@ func (s *PutBucketVersioningInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.VersioningConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("VersioningConfiguration"))
 	}
@@ -19751,6 +19964,9 @@ func (s *PutBucketWebsiteInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutBucketWebsiteInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.WebsiteConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("WebsiteConfiguration"))
@@ -19855,6 +20071,9 @@ func (s *PutObjectAclInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutObjectAclInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -20101,6 +20320,9 @@ func (s *PutObjectInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -20344,6 +20566,9 @@ func (s *PutObjectLegalHoldInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutObjectLegalHoldInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -20659,6 +20884,9 @@ func (s *PutObjectRetentionInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -20878,6 +21106,9 @@ func (s *PutPublicAccessBlockInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutPublicAccessBlockInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.PublicAccessBlockConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("PublicAccessBlockConfiguration"))
@@ -21637,6 +21868,9 @@ func (s *RestoreObjectInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -22344,6 +22578,9 @@ func (s *SelectObjectContentInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "SelectObjectContentInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Expression == nil {
 		invalidParams.Add(request.NewErrParamRequired("Expression"))
@@ -23385,6 +23622,9 @@ func (s *UploadPartCopyInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UploadPartCopyInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.CopySource == nil {
 		invalidParams.Add(request.NewErrParamRequired("CopySource"))

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -13755,6 +13755,9 @@ func (s *GetObjectTorrentInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
 	}
@@ -14191,6 +14194,9 @@ func (s *HeadObjectInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "HeadObjectInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -18551,6 +18557,9 @@ func (s *PutBucketAccelerateConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -20680,6 +20689,9 @@ func (s *PutObjectLockConfigurationInput) Validate() error {
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
 	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -20997,6 +21009,9 @@ func (s *PutObjectTaggingInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutObjectTaggingInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))
@@ -23927,6 +23942,9 @@ func (s *UploadPartInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UploadPartInput"}
 	if s.Bucket == nil {
 		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 1))
 	}
 	if s.Key == nil {
 		invalidParams.Add(request.NewErrParamRequired("Key"))

--- a/service/s3/bucket_location_test.go
+++ b/service/s3/bucket_location_test.go
@@ -114,7 +114,7 @@ func TestPopulateLocationConstraint(t *testing.T) {
 func TestNoPopulateLocationConstraintIfProvided(t *testing.T) {
 	s := s3.New(unit.Session)
 	req, _ := s.CreateBucketRequest(&s3.CreateBucketInput{
-		Bucket: aws.String("bucket"),
+		Bucket:                    aws.String("bucket"),
 		CreateBucketConfiguration: &s3.CreateBucketConfiguration{},
 	})
 	if err := req.Build(); err != nil {

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -58,7 +58,7 @@ func NewDecryptionClient(prov client.ConfigProvider, options ...func(*Decryption
 			}).decryptHandler,
 		},
 		CEKRegistry: map[string]CEKEntry{
-			AESGCMNoPadding:                                          newAESGCMContentCipher,
+			AESGCMNoPadding: newAESGCMContentCipher,
 			strings.Join([]string{AESCBC, AESCBCPadder.Name()}, "/"): newAESCBCContentCipher,
 		},
 		PadderRegistry: map[string]Padder{

--- a/service/s3/sse_test.go
+++ b/service/s3/sse_test.go
@@ -34,9 +34,9 @@ func TestSSECustomerKeyOverHTTPError(t *testing.T) {
 func TestCopySourceSSECustomerKeyOverHTTPError(t *testing.T) {
 	s := s3.New(unit.Session, &aws.Config{DisableSSL: aws.Bool(true)})
 	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
-		Bucket:     aws.String("bucket"),
-		CopySource: aws.String("bucket/source"),
-		Key:        aws.String("dest"),
+		Bucket:                   aws.String("bucket"),
+		CopySource:               aws.String("bucket/source"),
+		Key:                      aws.String("dest"),
 		CopySourceSSECustomerKey: aws.String("key"),
 	})
 	err := req.Build()

--- a/service/sagemakerruntime/api.go
+++ b/service/sagemakerruntime/api.go
@@ -159,6 +159,9 @@ func (s *InvokeEndpointInput) Validate() error {
 	if s.EndpointName == nil {
 		invalidParams.Add(request.NewErrParamRequired("EndpointName"))
 	}
+	if s.EndpointName != nil && len(*s.EndpointName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EndpointName", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams

--- a/service/securityhub/api.go
+++ b/service/securityhub/api.go
@@ -4813,6 +4813,9 @@ func (s *DeleteInsightInput) Validate() error {
 	if s.InsightArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("InsightArn"))
 	}
+	if s.InsightArn != nil && len(*s.InsightArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InsightArn", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -4971,6 +4974,9 @@ func (s *DisableImportFindingsForProductInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "DisableImportFindingsForProductInput"}
 	if s.ProductSubscriptionArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("ProductSubscriptionArn"))
+	}
+	if s.ProductSubscriptionArn != nil && len(*s.ProductSubscriptionArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ProductSubscriptionArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -5400,6 +5406,9 @@ func (s *GetInsightResultsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetInsightResultsInput"}
 	if s.InsightArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("InsightArn"))
+	}
+	if s.InsightArn != nil && len(*s.InsightArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InsightArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -7500,6 +7509,9 @@ func (s *UpdateInsightInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateInsightInput"}
 	if s.InsightArn == nil {
 		invalidParams.Add(request.NewErrParamRequired("InsightArn"))
+	}
+	if s.InsightArn != nil && len(*s.InsightArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InsightArn", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -1974,8 +1974,14 @@ func (s *CreateApplicationVersionRequest) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.SemanticVersion == nil {
 		invalidParams.Add(request.NewErrParamRequired("SemanticVersion"))
+	}
+	if s.SemanticVersion != nil && len(*s.SemanticVersion) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("SemanticVersion", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2110,6 +2116,9 @@ func (s *CreateCloudFormationChangeSetRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateCloudFormationChangeSetRequest"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.StackName == nil {
 		invalidParams.Add(request.NewErrParamRequired("StackName"))
@@ -2249,6 +2258,9 @@ func (s *CreateCloudFormationTemplateInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2361,6 +2373,9 @@ func (s *DeleteApplicationInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2412,6 +2427,9 @@ func (s *GetApplicationInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetApplicationInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2558,6 +2576,9 @@ func (s *GetApplicationPolicyInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -2619,8 +2640,14 @@ func (s *GetCloudFormationTemplateInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.TemplateId == nil {
 		invalidParams.Add(request.NewErrParamRequired("TemplateId"))
+	}
+	if s.TemplateId != nil && len(*s.TemplateId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TemplateId", 1))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2739,6 +2766,9 @@ func (s *ListApplicationDependenciesInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ListApplicationDependenciesInput"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 	if s.MaxItems != nil && *s.MaxItems < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
@@ -3226,6 +3256,9 @@ func (s *PutApplicationPolicyInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.Statements == nil {
 		invalidParams.Add(request.NewErrParamRequired("Statements"))
 	}
@@ -3592,6 +3625,9 @@ func (s *UpdateApplicationRequest) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "UpdateApplicationRequest"}
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
+	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
 	}
 
 	if invalidParams.Len() > 0 {

--- a/service/serverlessapplicationrepository/api.go
+++ b/service/serverlessapplicationrepository/api.go
@@ -2861,6 +2861,9 @@ func (s *ListApplicationVersionsInput) Validate() error {
 	if s.ApplicationId == nil {
 		invalidParams.Add(request.NewErrParamRequired("ApplicationId"))
 	}
+	if s.ApplicationId != nil && len(*s.ApplicationId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ApplicationId", 1))
+	}
 	if s.MaxItems != nil && *s.MaxItems < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("MaxItems", 1))
 	}

--- a/service/signer/api.go
+++ b/service/signer/api.go
@@ -1097,6 +1097,9 @@ func (s *DescribeSigningJobInput) Validate() error {
 	if s.JobId == nil {
 		invalidParams.Add(request.NewErrParamRequired("JobId"))
 	}
+	if s.JobId != nil && len(*s.JobId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("JobId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -1329,6 +1332,9 @@ func (s *GetSigningPlatformInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetSigningPlatformInput"}
 	if s.PlatformId == nil {
 		invalidParams.Add(request.NewErrParamRequired("PlatformId"))
+	}
+	if s.PlatformId != nil && len(*s.PlatformId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PlatformId", 1))
 	}
 
 	if invalidParams.Len() > 0 {


### PR DESCRIPTION
Updates the SDK's validation to require that members serialized to URI path must not have empty (zero length) values. Generally these fields are modeled as required, but not always. Fixing this will prevent bugs with REST URI paths requests made for unexpected resources.
