### PR TITLE
aws/request: Fix duplicate request attempt metric reporting

### DIFF
--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -227,9 +227,7 @@ func (rep *Reporter) InjectHandlers(handlers *request.Handlers) {
 	apiCallAttemptHandler := request.NamedHandler{Name: APICallAttemptMetricHandlerName, Fn: rep.sendAPICallAttemptMetric}
 
 	handlers.Complete.PushFrontNamed(apiCallHandler)
-	handlers.Complete.PushFrontNamed(apiCallAttemptHandler)
-
-	handlers.AfterRetry.PushFrontNamed(apiCallAttemptHandler)
+	handlers.CompleteAttempt.PushFrontNamed(apiCallAttemptHandler)
 }
 
 // boolIntValue return 1 for true and 0 for false.

--- a/aws/csm/reporter_test.go
+++ b/aws/csm/reporter_test.go
@@ -30,6 +30,7 @@ func TestReportingMetrics(t *testing.T) {
 	md := metadata.ClientInfo{}
 	op := &request.Operation{}
 	r := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 0}, op, nil, nil)
+	sess.Handlers.CompleteAttempt.Run(r)
 	sess.Handlers.Complete.Run(r)
 
 	foundAttempt := false

--- a/aws/csm/reporter_test.go
+++ b/aws/csm/reporter_test.go
@@ -1,65 +1,213 @@
+// +build go1.7
+
 package csm_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/csm"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
 
 func TestReportingMetrics(t *testing.T) {
+	sess := unit.Session.Copy(&aws.Config{
+		SleepDelay: func(time.Duration) {},
+	})
+	sess.Handlers.Validate.Clear()
+	sess.Handlers.Sign.Clear()
+	sess.Handlers.Send.Clear()
+
 	reporter := csm.Get()
 	if reporter == nil {
 		t.Errorf("expected non-nil reporter")
 	}
-
-	sess := session.New()
-	sess.Handlers.Clear()
 	reporter.InjectHandlers(&sess.Handlers)
 
-	md := metadata.ClientInfo{}
-	op := &request.Operation{}
-	r := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 0}, op, nil, nil)
-	sess.Handlers.CompleteAttempt.Run(r)
-	sess.Handlers.Complete.Run(r)
+	cases := map[string]struct {
+		Request       *request.Request
+		ExpectMetrics []map[string]interface{}
+	}{
+		"successful request": {
+			Request: func() *request.Request {
+				md := metadata.ClientInfo{}
+				op := &request.Operation{Name: "OperationName"}
+				req := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 3}, op, nil, nil)
+				req.Handlers.Send.PushBack(func(r *request.Request) {
+					req.HTTPResponse = &http.Response{
+						StatusCode: 200,
+						Header:     http.Header{},
+					}
+				})
+				return req
+			}(),
+			ExpectMetrics: []map[string]interface{}{
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(200),
+				},
+				{
+					"Type": "ApiCall",
+				},
+			},
+		},
+		"failed request, no retry": {
+			Request: func() *request.Request {
+				md := metadata.ClientInfo{}
+				op := &request.Operation{Name: "OperationName"}
+				req := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 3}, op, nil, nil)
+				req.Handlers.Send.PushBack(func(r *request.Request) {
+					req.HTTPResponse = &http.Response{
+						StatusCode: 400,
+						Header:     http.Header{},
+					}
+					req.Retryable = aws.Bool(false)
+				})
 
-	foundAttempt := false
-	foundCall := false
+				return req
+			}(),
+			ExpectMetrics: []map[string]interface{}{
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(400),
+				},
+				{
+					"Type":         "ApiCall",
+					"AttemptCount": float64(1),
+				},
+			},
+		},
+		"failed request, with retry": {
+			Request: func() *request.Request {
+				md := metadata.ClientInfo{}
+				op := &request.Operation{Name: "OperationName"}
+				req := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 1}, op, nil, nil)
+				resps := []*http.Response{
+					{
+						StatusCode: 500,
+						Header:     http.Header{},
+					},
+					{
+						StatusCode: 500,
+						Header:     http.Header{},
+					},
+				}
+				req.Handlers.Send.PushBack(func(r *request.Request) {
+					req.HTTPResponse = resps[0]
+					resps = resps[1:]
+				})
 
-	expectedMetrics := 2
+				return req
+			}(),
+			ExpectMetrics: []map[string]interface{}{
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(500),
+				},
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(500),
+				},
+				{
+					"Type":         "ApiCall",
+					"AttemptCount": float64(2),
+				},
+			},
+		},
+		"success request, with retry": {
+			Request: func() *request.Request {
+				md := metadata.ClientInfo{}
+				op := &request.Operation{Name: "OperationName"}
+				req := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 3}, op, nil, nil)
+				resps := []*http.Response{
+					{
+						StatusCode: 500,
+						Header:     http.Header{},
+					},
+					{
+						StatusCode: 500,
+						Header:     http.Header{},
+					},
+					{
+						StatusCode: 200,
+						Header:     http.Header{},
+					},
+				}
+				req.Handlers.Send.PushBack(func(r *request.Request) {
+					req.HTTPResponse = resps[0]
+					resps = resps[1:]
+				})
 
-	for i := 0; i < expectedMetrics; i++ {
-		m := <-csm.MetricsCh
-		for k, v := range m {
-			switch k {
-			case "Type":
-				a := v.(string)
-				foundCall = foundCall || a == "ApiCall"
-				foundAttempt = foundAttempt || a == "ApiCallAttempt"
+				return req
+			}(),
+			ExpectMetrics: []map[string]interface{}{
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(500),
+				},
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(500),
+				},
+				{
+					"Type":           "ApiCallAttempt",
+					"HttpStatusCode": float64(200),
+				},
+				{
+					"Type":         "ApiCall",
+					"AttemptCount": float64(3),
+				},
+			},
+		},
+	}
 
-				if prefix := "ApiCall"; !strings.HasPrefix(a, prefix) {
-					t.Errorf("expected 'APICall' prefix, but received %q", a)
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
+			defer cancelFn()
+
+			c.Request.Send()
+			for i := 0; i < len(c.ExpectMetrics); i++ {
+				select {
+				case m := <-csm.MetricsCh:
+					for ek, ev := range c.ExpectMetrics[i] {
+						if _, ok := m[ek]; !ok {
+							t.Errorf("expect %v metric member", ek)
+						}
+						if e, a := ev, m[ek]; e != a {
+							t.Errorf("expect %v:%v(%T), metric value, got %v(%T)", ek, e, e, a, a)
+						}
+					}
+				case <-ctx.Done():
+					t.Errorf("timeout waiting for metrics")
+					return
 				}
 			}
-		}
-	}
 
-	if !foundAttempt {
-		t.Errorf("expected attempt event to have occurred")
-	}
-
-	if !foundCall {
-		t.Errorf("expected call event to have occurred")
+			var extraMetrics []map[string]interface{}
+		Loop:
+			for {
+				select {
+				case m := <-csm.MetricsCh:
+					extraMetrics = append(extraMetrics, m)
+				default:
+					break Loop
+				}
+			}
+			if len(extraMetrics) != 0 {
+				t.Fatalf("unexpected metrics, %#v", extraMetrics)
+			}
+		})
 	}
 }
 
@@ -91,7 +239,7 @@ func BenchmarkWithCSM(b *testing.B) {
 		Endpoint: aws.String(server.URL),
 	}
 
-	sess := session.New(&cfg)
+	sess := unit.Session.Copy(&cfg)
 	r := csm.Get()
 
 	r.InjectHandlers(&sess.Handlers)
@@ -136,7 +284,7 @@ func BenchmarkWithCSMNoUDPConnection(b *testing.B) {
 		Endpoint: aws.String(server.URL),
 	}
 
-	sess := session.New(&cfg)
+	sess := unit.Session.Copy(&cfg)
 	r := csm.Get()
 	r.Pause()
 	r.InjectHandlers(&sess.Handlers)
@@ -181,7 +329,7 @@ func BenchmarkWithoutCSM(b *testing.B) {
 	cfg := aws.Config{
 		Endpoint: aws.String(server.URL),
 	}
-	sess := session.New(&cfg)
+	sess := unit.Session.Copy(&cfg)
 	c := sess.ClientConfig("id", &cfg)
 
 	svc := mockService{

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -19,6 +19,7 @@ type Handlers struct {
 	UnmarshalError   HandlerList
 	Retry            HandlerList
 	AfterRetry       HandlerList
+	CompleteAttempt  HandlerList
 	Complete         HandlerList
 }
 
@@ -36,6 +37,7 @@ func (h *Handlers) Copy() Handlers {
 		UnmarshalMeta:    h.UnmarshalMeta.copy(),
 		Retry:            h.Retry.copy(),
 		AfterRetry:       h.AfterRetry.copy(),
+		CompleteAttempt:  h.CompleteAttempt.copy(),
 		Complete:         h.Complete.copy(),
 	}
 }
@@ -53,6 +55,7 @@ func (h *Handlers) Clear() {
 	h.ValidateResponse.Clear()
 	h.Retry.Clear()
 	h.AfterRetry.Clear()
+	h.CompleteAttempt.Clear()
 	h.Complete.Clear()
 }
 

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -266,9 +266,9 @@ func (r *Request) SetReaderBody(reader io.ReadSeeker) {
 }
 
 // Presign returns the request's signed URL. Error will be returned
-// if the signing fails. The expire parameter is only used for presigned Amazon 
+// if the signing fails. The expire parameter is only used for presigned Amazon
 // S3 API requests. All other AWS services will use a fixed expriation
-// time of 15 minutes. 
+// time of 15 minutes.
 //
 // It is invalid to create a presigned URL with a expire duration 0 or less. An
 // error is returned if expire duration is 0 or less.
@@ -466,80 +466,78 @@ func (r *Request) Send() error {
 		r.Handlers.Complete.Run(r)
 	}()
 
+	if err := r.Error; err != nil {
+		return err
+	}
+
 	for {
+		r.Error = nil
 		r.AttemptTime = time.Now()
-		if aws.BoolValue(r.Retryable) {
-			if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {
-				r.Config.Logger.Log(fmt.Sprintf("DEBUG: Retrying Request %s/%s, attempt %d",
-					r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
-			}
 
-			// The previous http.Request will have a reference to the r.Body
-			// and the HTTP Client's Transport may still be reading from
-			// the request's body even though the Client's Do returned.
-			r.HTTPRequest = copyHTTPRequest(r.HTTPRequest, nil)
-			r.ResetBody()
-
-			// Closing response body to ensure that no response body is leaked
-			// between retry attempts.
-			if r.HTTPResponse != nil && r.HTTPResponse.Body != nil {
-				r.HTTPResponse.Body.Close()
-			}
+		if err := r.Sign(); err != nil {
+			debugLogReqError(r, "Sign Request", false, err)
+			return err
 		}
 
-		r.Sign()
-		if r.Error != nil {
-			return r.Error
-		}
-
-		r.Retryable = nil
-
-		r.Handlers.Send.Run(r)
-		if r.Error != nil {
-			if !shouldRetryCancel(r) {
-				return r.Error
-			}
-
-			err := r.Error
+		if err := r.sendRequest(); err == nil {
+			return nil
+		} else if !shouldRetryCancel(r) {
+			return err
+		} else {
 			r.Handlers.Retry.Run(r)
 			r.Handlers.AfterRetry.Run(r)
-			if r.Error != nil {
-				debugLogReqError(r, "Send Request", false, err)
+
+			if r.Error != nil || !aws.BoolValue(r.Retryable) {
 				return r.Error
 			}
-			debugLogReqError(r, "Send Request", true, err)
+
+			r.prepareRetry()
 			continue
 		}
-		r.Handlers.UnmarshalMeta.Run(r)
-		r.Handlers.ValidateResponse.Run(r)
-		if r.Error != nil {
-			r.Handlers.UnmarshalError.Run(r)
-			err := r.Error
+	}
+}
 
-			r.Handlers.Retry.Run(r)
-			r.Handlers.AfterRetry.Run(r)
-			if r.Error != nil {
-				debugLogReqError(r, "Validate Response", false, err)
-				return r.Error
-			}
-			debugLogReqError(r, "Validate Response", true, err)
-			continue
-		}
+func (r *Request) prepareRetry() {
+	if r.Config.LogLevel.Matches(aws.LogDebugWithRequestRetries) {
+		r.Config.Logger.Log(fmt.Sprintf("DEBUG: Retrying Request %s/%s, attempt %d",
+			r.ClientInfo.ServiceName, r.Operation.Name, r.RetryCount))
+	}
 
-		r.Handlers.Unmarshal.Run(r)
-		if r.Error != nil {
-			err := r.Error
-			r.Handlers.Retry.Run(r)
-			r.Handlers.AfterRetry.Run(r)
-			if r.Error != nil {
-				debugLogReqError(r, "Unmarshal Response", false, err)
-				return r.Error
-			}
-			debugLogReqError(r, "Unmarshal Response", true, err)
-			continue
-		}
+	// The previous http.Request will have a reference to the r.Body
+	// and the HTTP Client's Transport may still be reading from
+	// the request's body even though the Client's Do returned.
+	r.HTTPRequest = copyHTTPRequest(r.HTTPRequest, nil)
+	r.ResetBody()
 
-		break
+	// Closing response body to ensure that no response body is leaked
+	// between retry attempts.
+	if r.HTTPResponse != nil && r.HTTPResponse.Body != nil {
+		r.HTTPResponse.Body.Close()
+	}
+}
+
+func (r *Request) sendRequest() (sendErr error) {
+	defer r.Handlers.CompleteAttempt.Run(r)
+
+	r.Retryable = nil
+	r.Handlers.Send.Run(r)
+	if r.Error != nil {
+		debugLogReqError(r, "Send Request", r.WillRetry(), r.Error)
+		return r.Error
+	}
+
+	r.Handlers.UnmarshalMeta.Run(r)
+	r.Handlers.ValidateResponse.Run(r)
+	if r.Error != nil {
+		r.Handlers.UnmarshalError.Run(r)
+		debugLogReqError(r, "Validate Response", r.WillRetry(), r.Error)
+		return r.Error
+	}
+
+	r.Handlers.Unmarshal.Run(r)
+	if r.Error != nil {
+		debugLogReqError(r, "Unmarshal Response", r.WillRetry(), r.Error)
+		return r.Error
 	}
 
 	return nil

--- a/aws/request/timeout_read_closer_test.go
+++ b/aws/request/timeout_read_closer_test.go
@@ -61,6 +61,7 @@ func TestTimeoutReadCloserSameDuration(t *testing.T) {
 
 func TestWithResponseReadTimeout(t *testing.T) {
 	r := Request{
+		HTTPRequest: &http.Request{},
 		HTTPResponse: &http.Response{
 			Body: ioutil.NopCloser(bytes.NewReader(nil)),
 		},


### PR DESCRIPTION
Fixes duplicate request attempt metrics being reported when the request fails or retries.