### PR TITLE
Increase DefaultBufSize for `credential_process`

### DIFF
--- a/aws/credentials/processcreds/provider.go
+++ b/aws/credentials/processcreds/provider.go
@@ -142,7 +142,7 @@ const (
 
 	// DefaultBufSize limits buffer size from growing to an enormous
 	// amount due to a faulty process.
-	DefaultBufSize = 512
+	DefaultBufSize = 1024
 
 	// DefaultTimeout default limit on time a process can run.
 	DefaultTimeout = time.Duration(1) * time.Minute


### PR DESCRIPTION
The current buffer size is too small to account for the size of the session token along with the other values. The size I typically see is 587, however I increased the default size to 1024, which seems pretty
reasonable.

Addresses #2334