### PR TITLE
aws/signer: Always sign a request with the current time.

### DIFF
--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -72,9 +72,9 @@ var ValidateReqSigHandler = request.NamedHandler{
 			signedTime = r.LastSignedAt
 		}
 
-		// 10 minutes to allow for some clock skew/delays in transmission.
+		// 5 minutes to allow for some clock skew/delays in transmission.
 		// Would be improved with aws/aws-sdk-go#423
-		if signedTime.Add(10 * time.Minute).After(time.Now()) {
+		if signedTime.Add(5 * time.Minute).After(time.Now()) {
 			return
 		}
 

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -122,7 +122,6 @@ func New(cfg aws.Config, clientInfo metadata.ClientInfo, handlers Handlers,
 		Handlers:   handlers.Copy(),
 
 		Retryer:     retryer,
-		AttemptTime: time.Now(),
 		Time:        time.Now(),
 		ExpireTime:  0,
 		Operation:   operation,

--- a/aws/signer/v4/functional_test.go
+++ b/aws/signer/v4/functional_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -30,15 +31,24 @@ var standaloneSignCases = []struct {
 	},
 }
 
+func epochTime() time.Time { return time.Unix(0, 0) }
+
 func TestPresignHandler(t *testing.T) {
 	svc := s3.New(unit.Session)
+	svc.Handlers.Sign.SwapNamed(request.NamedHandler{
+		Name: v4.SignRequestHandler.Name,
+		Fn: func(r *request.Request) {
+			v4.SignSDKRequestWithCurrentTime(r, epochTime)
+		},
+	})
+
 	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
 		Bucket:             aws.String("bucket"),
 		Key:                aws.String("key"),
 		ContentDisposition: aws.String("a+b c$d"),
 		ACL:                aws.String("public-read"),
 	})
-	req.Time = time.Unix(0, 0)
+	req.Time = epochTime()
 	urlstr, err := req.Presign(5 * time.Minute)
 
 	if err != nil {
@@ -82,13 +92,20 @@ func TestPresignHandler(t *testing.T) {
 
 func TestPresignRequest(t *testing.T) {
 	svc := s3.New(unit.Session)
+	svc.Handlers.Sign.SwapNamed(request.NamedHandler{
+		Name: v4.SignRequestHandler.Name,
+		Fn: func(r *request.Request) {
+			v4.SignSDKRequestWithCurrentTime(r, epochTime)
+		},
+	})
+
 	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
 		Bucket:             aws.String("bucket"),
 		Key:                aws.String("key"),
 		ContentDisposition: aws.String("a+b c$d"),
 		ACL:                aws.String("public-read"),
 	})
-	req.Time = time.Unix(0, 0)
+	req.Time = epochTime()
 	urlstr, headers, err := req.PresignRequest(5 * time.Minute)
 
 	if err != nil {
@@ -154,7 +171,7 @@ func TestStandaloneSign_CustomURIEscape(t *testing.T) {
 	req.URL.Path = `/log-*/_search`
 	req.URL.Opaque = "//subdomain.us-east-1.es.amazonaws.com/log-%2A/_search"
 
-	_, err = signer.Sign(req, nil, "es", "us-east-1", time.Unix(0, 0))
+	_, err = signer.Sign(req, nil, "es", "us-east-1", epochTime())
 	if err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
@@ -197,7 +214,7 @@ func TestStandaloneSign_WithPort(t *testing.T) {
 	for _, c := range cases {
 		signer := v4.NewSigner(unit.Session.Config.Credentials)
 		req, _ := http.NewRequest("GET", c.url, nil)
-		_, err := signer.Sign(req, nil, "es", "us-east-1", time.Unix(0, 0))
+		_, err := signer.Sign(req, nil, "es", "us-east-1", epochTime())
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}
@@ -241,7 +258,7 @@ func TestStandalonePresign_WithPort(t *testing.T) {
 	for _, c := range cases {
 		signer := v4.NewSigner(unit.Session.Config.Credentials)
 		req, _ := http.NewRequest("GET", c.url, nil)
-		_, err := signer.Presign(req, nil, "es", "us-east-1", 5*time.Minute, time.Unix(0, 0))
+		_, err := signer.Presign(req, nil, "es", "us-east-1", 5*time.Minute, epochTime())
 		if err != nil {
 			t.Fatalf("expect no error, got %v", err)
 		}

--- a/aws/signer/v4/v4.go
+++ b/aws/signer/v4/v4.go
@@ -98,25 +98,25 @@ var ignoredHeaders = rules{
 var requiredSignedHeaders = rules{
 	whitelist{
 		mapRule{
-			"Cache-Control":                                               struct{}{},
-			"Content-Disposition":                                         struct{}{},
-			"Content-Encoding":                                            struct{}{},
-			"Content-Language":                                            struct{}{},
-			"Content-Md5":                                                 struct{}{},
-			"Content-Type":                                                struct{}{},
-			"Expires":                                                     struct{}{},
-			"If-Match":                                                    struct{}{},
-			"If-Modified-Since":                                           struct{}{},
-			"If-None-Match":                                               struct{}{},
-			"If-Unmodified-Since":                                         struct{}{},
-			"Range":                                                       struct{}{},
-			"X-Amz-Acl":                                                   struct{}{},
-			"X-Amz-Copy-Source":                                           struct{}{},
-			"X-Amz-Copy-Source-If-Match":                                  struct{}{},
-			"X-Amz-Copy-Source-If-Modified-Since":                         struct{}{},
-			"X-Amz-Copy-Source-If-None-Match":                             struct{}{},
-			"X-Amz-Copy-Source-If-Unmodified-Since":                       struct{}{},
-			"X-Amz-Copy-Source-Range":                                     struct{}{},
+			"Cache-Control":                         struct{}{},
+			"Content-Disposition":                   struct{}{},
+			"Content-Encoding":                      struct{}{},
+			"Content-Language":                      struct{}{},
+			"Content-Md5":                           struct{}{},
+			"Content-Type":                          struct{}{},
+			"Expires":                               struct{}{},
+			"If-Match":                              struct{}{},
+			"If-Modified-Since":                     struct{}{},
+			"If-None-Match":                         struct{}{},
+			"If-Unmodified-Since":                   struct{}{},
+			"Range":                                 struct{}{},
+			"X-Amz-Acl":                             struct{}{},
+			"X-Amz-Copy-Source":                     struct{}{},
+			"X-Amz-Copy-Source-If-Match":            struct{}{},
+			"X-Amz-Copy-Source-If-Modified-Since":   struct{}{},
+			"X-Amz-Copy-Source-If-None-Match":       struct{}{},
+			"X-Amz-Copy-Source-If-Unmodified-Since": struct{}{},
+			"X-Amz-Copy-Source-Range":               struct{}{},
 			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": struct{}{},
 			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key":       struct{}{},
 			"X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-Md5":   struct{}{},
@@ -134,7 +134,7 @@ var requiredSignedHeaders = rules{
 			"X-Amz-Server-Side-Encryption-Customer-Key":                   struct{}{},
 			"X-Amz-Server-Side-Encryption-Customer-Key-Md5":               struct{}{},
 			"X-Amz-Storage-Class":                                         struct{}{},
-			"X-Amz-Tagging":					       struct{}{},
+			"X-Amz-Tagging":                                               struct{}{},
 			"X-Amz-Website-Redirect-Location":                             struct{}{},
 			"X-Amz-Content-Sha256":                                        struct{}{},
 		},
@@ -422,7 +422,7 @@ var SignRequestHandler = request.NamedHandler{
 // If the credentials of the request's config are set to
 // credentials.AnonymousCredentials the request will not be signed.
 func SignSDKRequest(req *request.Request) {
-	signSDKRequestWithCurrTime(req, time.Now)
+	SignSDKRequestWithCurrentTime(req, time.Now)
 }
 
 // BuildNamedHandler will build a generic handler for signing.
@@ -430,12 +430,15 @@ func BuildNamedHandler(name string, opts ...func(*Signer)) request.NamedHandler 
 	return request.NamedHandler{
 		Name: name,
 		Fn: func(req *request.Request) {
-			signSDKRequestWithCurrTime(req, time.Now, opts...)
+			SignSDKRequestWithCurrentTime(req, time.Now, opts...)
 		},
 	}
 }
 
-func signSDKRequestWithCurrTime(req *request.Request, curTimeFn func() time.Time, opts ...func(*Signer)) {
+// SignSDKRequestWithCurrentTime will sign the SDK's request using the time
+// function passed in. Behaves the same as SignSDKRequest with the exception
+// the request is signed with the value returned by the current time function.
+func SignSDKRequestWithCurrentTime(req *request.Request, curTimeFn func() time.Time, opts ...func(*Signer)) {
 	// If the request does not need to be signed ignore the signing of the
 	// request if the AnonymousCredentials object is used.
 	if req.Config.Credentials == credentials.AnonymousCredentials {
@@ -471,13 +474,9 @@ func signSDKRequestWithCurrTime(req *request.Request, curTimeFn func() time.Time
 		opt(v4)
 	}
 
-	signingTime := req.Time
-	if !req.LastSignedAt.IsZero() {
-		signingTime = req.LastSignedAt
-	}
-
+	curTime := curTimeFn()
 	signedHeaders, err := v4.signWithBody(req.HTTPRequest, req.GetBody(),
-		name, region, req.ExpireTime, req.ExpireTime > 0, signingTime,
+		name, region, req.ExpireTime, req.ExpireTime > 0, curTime,
 	)
 	if err != nil {
 		req.Error = err
@@ -486,7 +485,7 @@ func signSDKRequestWithCurrTime(req *request.Request, curTimeFn func() time.Time
 	}
 
 	req.SignedHeaderVals = signedHeaders
-	req.LastSignedAt = curTimeFn()
+	req.LastSignedAt = curTime
 }
 
 const logSignInfoMsg = `DEBUG: Request Signature:


### PR DESCRIPTION
Updates the SDK's v4 request signer to always sign requests with the
current time. For the first request attempt, the request's creation time
was used in the request's signature. In edge cases this allowed the
signature to expire before the request was sent if there was significant
delay between creating the request and sending it, (e.g. rate limiting).
