### PR TITLE
aws/session: Use HTTP_PROXY environment variable when AWS_CA_BUNDLE is specified

### DIFF
--- a/aws/session/cabundle_transport.go
+++ b/aws/session/cabundle_transport.go
@@ -1,0 +1,26 @@
+// +build go1.7
+
+package session
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport that should be used when a custom CA bundle is specified with the
+// SDK.
+func getCABundleTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/aws/session/cabundle_transport_1_5.go
+++ b/aws/session/cabundle_transport_1_5.go
@@ -1,0 +1,22 @@
+// +build !go1.6,go1.5
+
+package session
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport that should be used when a custom CA bundle is specified with the
+// SDK.
+func getCABundleTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+}

--- a/aws/session/cabundle_transport_1_6.go
+++ b/aws/session/cabundle_transport_1_6.go
@@ -1,0 +1,23 @@
+// +build !go1.7,go1.6
+
+package session
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// Transport that should be used when a custom CA bundle is specified with the
+// SDK.
+func getCABundleTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}

--- a/aws/session/custom_ca_bundle_test.go
+++ b/aws/session/custom_ca_bundle_test.go
@@ -140,6 +140,36 @@ func TestNewSession_WithCustomCABundle_Option(t *testing.T) {
 	}
 }
 
+func TestNewSession_WithCustomCABundle_HTTPProxyAvailable(t *testing.T) {
+	skipTravisTest(t)
+
+	oldEnv := initSessionTestEnv()
+	defer awstesting.PopEnv(oldEnv)
+
+	s, err := NewSessionWithOptions(Options{
+		Config: aws.Config{
+			HTTPClient:  &http.Client{},
+			Region:      aws.String("mock-region"),
+			Credentials: credentials.AnonymousCredentials,
+		},
+		CustomCABundle: bytes.NewReader(awstesting.TLSBundleCA),
+	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+	if s == nil {
+		t.Fatalf("expect session to be created, got none")
+	}
+
+	tr := s.Config.HTTPClient.Transport.(*http.Transport)
+	if tr.Proxy == nil {
+		t.Fatalf("expect transport proxy, was nil")
+	}
+	if tr.TLSClientConfig.RootCAs == nil {
+		t.Fatalf("expect TLS config to have root CAs")
+	}
+}
+
 func TestNewSession_WithCustomCABundle_OptionPriority(t *testing.T) {
 	skipTravisTest(t)
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -407,8 +409,20 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 		}
 	}
 	if t == nil {
+		// Nil transport implies `http.DefaultTransport` should be used. Since
+		// the SDK cannot modify, nor copy the `DefaultTransport` specifying
+		// the values the next closest behavior.
 		t = &http.Transport{
-			Proxy:  http.ProxyFromEnvironment,
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 		}
 	}
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -412,18 +410,7 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 		// Nil transport implies `http.DefaultTransport` should be used. Since
 		// the SDK cannot modify, nor copy the `DefaultTransport` specifying
 		// the values the next closest behavior.
-		t = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-				DualStack: true,
-			}).DialContext,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
+		t = getCABundleTransport()
 	}
 
 	p, err := loadCertPool(bundle)

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -407,7 +407,9 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 		}
 	}
 	if t == nil {
-		t = &http.Transport{}
+		t = &http.Transport{
+			Proxy:  http.ProxyFromEnvironment,
+		}
 	}
 
 	p, err := loadCertPool(bundle)


### PR DESCRIPTION
Ensures HTTP_PROXY environment variable is read when specifying AWS_CA_BUNDLE environment variable.

Fix #2287 