### PR TITLE
deps: Update Go Deps lock file to correct tracking hash

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,13 +2,15 @@
 
 
 [[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "0b12d6b5"
+  pruneopts = ""
+  revision = "c2b33e84"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "51a86a867df617990082dec6b868e4efe2fdb2ed0e02a3daa93cd30f962b5085"
+  input-imports = ["github.com/jmespath/go-jmespath"]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Updates Go dep's lock file to contain the correct tracking hash. The Gopkg.toml file was updated in #2284 but the lock file was missed.