### PR TITLE
private/model/api: Remove unused shapes before processing model

### DIFF
--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -167,6 +167,11 @@ func (a *API) Setup() {
 	a.setMetadataEndpointsKey()
 	a.writeShapeNames()
 	a.resolveReferences()
+
+	if !a.NoRemoveUnusedShapes {
+		a.removeUnusedShapes()
+	}
+
 	a.fixStutterNames()
 	a.renameExportable()
 	a.applyShapeNameAliases()


### PR DESCRIPTION
Updates SDK code generation to remove unused shapes sooner in the process. This prevents unused shapes from colliding with the SDK's renamed type names.