### PR TITLE
aws/corehandlers: Fix execution environment user agent identifer

### DIFF
--- a/aws/corehandlers/user_agent.go
+++ b/aws/corehandlers/user_agent.go
@@ -17,7 +17,7 @@ var SDKVersionUserAgentHandler = request.NamedHandler{
 }
 
 const execEnvVar = `AWS_EXECUTION_ENV`
-const execEnvUAKey = `exec_env`
+const execEnvUAKey = `exec-env`
 
 // AddHostExecEnvUserAgentHander is a request handler appending the SDK's
 // execution environment to the user agent.

--- a/aws/corehandlers/user_agent_test.go
+++ b/aws/corehandlers/user_agent_test.go
@@ -13,9 +13,9 @@ func TestAddHostExecEnvUserAgentHander(t *testing.T) {
 		ExecEnv string
 		Expect  string
 	}{
-		{ExecEnv: "Lambda", Expect: "exec_env/Lambda"},
+		{ExecEnv: "Lambda", Expect: execEnvUAKey + "/Lambda"},
 		{ExecEnv: "", Expect: ""},
-		{ExecEnv: "someThingCool", Expect: "exec_env/someThingCool"},
+		{ExecEnv: "someThingCool", Expect: execEnvUAKey + "/someThingCool"},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Fixes the execution environment variable's identifier used in the SDK's user agent. Was using underscore(_) instead of dash(-).