### PR TITLE
Update unit tests to not use testing framework.

### DIFF
--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/stretchr/testify/assert"
 )
 
 type stubProvider struct {
@@ -34,17 +33,27 @@ func TestCredentialsGet(t *testing.T) {
 	})
 
 	creds, err := c.Get()
-	assert.Nil(t, err, "Expected no error")
-	assert.Equal(t, "AKID", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "SECRET", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Empty(t, creds.SessionToken, "Expect session token to be empty")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("Expect access key ID to match, %v got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("Expect secret access key to match, %v got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect session token to be empty, %v", v)
+	}
 }
 
 func TestCredentialsGetWithError(t *testing.T) {
 	c := NewCredentials(&stubProvider{err: awserr.New("provider error", "", nil), expired: true})
 
 	_, err := c.Get()
-	assert.Equal(t, "provider error", err.(awserr.Error).Code(), "Expected provider error")
+	if e, a := "provider error", err.(awserr.Error).Code(); e != a {
+		t.Errorf("Expected provider error, %v got %v", e, a)
+	}
 }
 
 func TestCredentialsExpire(t *testing.T) {
@@ -52,15 +61,23 @@ func TestCredentialsExpire(t *testing.T) {
 	c := NewCredentials(stub)
 
 	stub.expired = false
-	assert.True(t, c.IsExpired(), "Expected to start out expired")
+	if !c.IsExpired() {
+		t.Errorf("Expected to start out expired")
+	}
 	c.Expire()
-	assert.True(t, c.IsExpired(), "Expected to be expired")
+	if !c.IsExpired() {
+		t.Errorf("Expected to be expired")
+	}
 
 	c.forceRefresh = false
-	assert.False(t, c.IsExpired(), "Expected not to be expired")
+	if c.IsExpired() {
+		t.Errorf("Expected not to be expired")
+	}
 
 	stub.expired = true
-	assert.True(t, c.IsExpired(), "Expected to be expired")
+	if !c.IsExpired() {
+		t.Errorf("Expected to be expired")
+	}
 }
 
 type MockProvider struct {
@@ -77,8 +94,12 @@ func TestCredentialsGetWithProviderName(t *testing.T) {
 	c := NewCredentials(stub)
 
 	creds, err := c.Get()
-	assert.Nil(t, err, "Expected no error")
-	assert.Equal(t, creds.ProviderName, "stubProvider", "Expected provider name to match")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := creds.ProviderName, "stubProvider"; e != a {
+		t.Errorf("Expected provider name to match, %v got %v", e, a)
+	}
 }
 
 func TestCredentialsIsExpired_Race(t *testing.T) {

--- a/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
@@ -59,11 +57,19 @@ func TestEC2RoleProvider(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error, %v", err)
+	if err != nil {
+		t.Errorf("Expect no error, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("Expect access key ID to match, %v got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("Expect secret access key to match, %v got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("Expect session token to match, %v got %v", e, a)
+	}
 }
 
 func TestEC2RoleProviderFailAssume(t *testing.T) {
@@ -75,16 +81,30 @@ func TestEC2RoleProviderFailAssume(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Error(t, err, "Expect error")
+	if err == nil {
+		t.Errorf("Expect error")
+	}
 
 	e := err.(awserr.Error)
-	assert.Equal(t, "ErrorCode", e.Code())
-	assert.Equal(t, "ErrorMsg", e.Message())
-	assert.Nil(t, e.OrigErr())
+	if e, a := "ErrorCode", e.Code(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "ErrorMsg", e.Message(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := e.OrigErr(); v != nil {
+		t.Errorf("expect nil, got %v", v)
+	}
 
-	assert.Equal(t, "", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "", creds.SessionToken, "Expect session token to match")
+	if e, a := "", creds.AccessKeyID; e != a {
+		t.Errorf("Expect access key ID to match, %v got %v", e, a)
+	}
+	if e, a := "", creds.SecretAccessKey; e != a {
+		t.Errorf("Expect secret access key to match, %v got %v", e, a)
+	}
+	if e, a := "", creds.SessionToken; e != a {
+		t.Errorf("Expect session token to match, %v got %v", e, a)
+	}
 }
 
 func TestEC2RoleProviderIsExpired(t *testing.T) {
@@ -98,18 +118,26 @@ func TestEC2RoleProviderIsExpired(t *testing.T) {
 		return time.Date(2014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
-	assert.True(t, p.IsExpired(), "Expect creds to be expired before retrieve.")
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired before retrieve.")
+	}
 
 	_, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error, %v", err)
+	if v := err; v != nil {
+		t.Errorf("Expect no error, %v", err)
+	}
 
-	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
+	if p.IsExpired() {
+		t.Errorf("Expect creds to not be expired after retrieve.")
+	}
 
 	p.CurrentTime = func() time.Time {
 		return time.Date(3014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
-	assert.True(t, p.IsExpired(), "Expect creds to be expired.")
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired.")
+	}
 }
 
 func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
@@ -124,18 +152,26 @@ func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
 		return time.Date(2014, 12, 15, 0, 51, 37, 0, time.UTC)
 	}
 
-	assert.True(t, p.IsExpired(), "Expect creds to be expired before retrieve.")
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired before retrieve.")
+	}
 
 	_, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error, %v", err)
+	if v := err; v != nil {
+		t.Errorf("Expect no error, %v", err)
+	}
 
-	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
+	if p.IsExpired() {
+		t.Errorf("Expect creds to not be expired after retrieve.")
+	}
 
 	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 16, 0, 55, 37, 0, time.UTC)
 	}
 
-	assert.True(t, p.IsExpired(), "Expect creds to be expired.")
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired.")
+	}
 }
 
 func BenchmarkEC3RoleProvider(b *testing.B) {

--- a/aws/credentials/env_provider_test.go
+++ b/aws/credentials/env_provider_test.go
@@ -1,7 +1,6 @@
 package credentials
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 )
@@ -14,11 +13,19 @@ func TestEnvProviderRetrieve(t *testing.T) {
 
 	e := EnvProvider{}
 	creds, err := e.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "access", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+	if e, a := "access", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestEnvProviderIsExpired(t *testing.T) {
@@ -29,12 +36,18 @@ func TestEnvProviderIsExpired(t *testing.T) {
 
 	e := EnvProvider{}
 
-	assert.True(t, e.IsExpired(), "Expect creds to be expired before retrieve.")
+	if !e.IsExpired() {
+		t.Errorf("Expect creds to be expired before retrieve.")
+	}
 
 	_, err := e.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.False(t, e.IsExpired(), "Expect creds to not be expired after retrieve.")
+	if e.IsExpired() {
+		t.Errorf("Expect creds to not be expired after retrieve.")
+	}
 }
 
 func TestEnvProviderNoAccessKeyID(t *testing.T) {
@@ -42,8 +55,10 @@ func TestEnvProviderNoAccessKeyID(t *testing.T) {
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
 
 	e := EnvProvider{}
-	creds, err := e.Retrieve()
-	assert.Equal(t, ErrAccessKeyIDNotFound, err, "ErrAccessKeyIDNotFound expected, but was %#v error: %#v", creds, err)
+	_, err := e.Retrieve()
+	if e, a := ErrAccessKeyIDNotFound, err; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestEnvProviderNoSecretAccessKey(t *testing.T) {
@@ -51,8 +66,10 @@ func TestEnvProviderNoSecretAccessKey(t *testing.T) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "access")
 
 	e := EnvProvider{}
-	creds, err := e.Retrieve()
-	assert.Equal(t, ErrSecretAccessKeyNotFound, err, "ErrSecretAccessKeyNotFound expected, but was %#v error: %#v", creds, err)
+	_, err := e.Retrieve()
+	if e, a := ErrSecretAccessKeyNotFound, err; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestEnvProviderAlternateNames(t *testing.T) {
@@ -62,9 +79,17 @@ func TestEnvProviderAlternateNames(t *testing.T) {
 
 	e := EnvProvider{}
 	creds, err := e.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "access", creds.AccessKeyID, "Expected access key ID")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expected secret access key")
-	assert.Empty(t, creds.SessionToken, "Expected no token")
+	if e, a := "access", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expected no token, %v", v)
+	}
 }

--- a/aws/credentials/shared_credentials_provider_test.go
+++ b/aws/credentials/shared_credentials_provider_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/internal/shareddefaults"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSharedCredentialsProvider(t *testing.T) {
@@ -14,11 +13,19 @@ func TestSharedCredentialsProvider(t *testing.T) {
 
 	p := SharedCredentialsProvider{Filename: "example.ini", Profile: ""}
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestSharedCredentialsProviderIsExpired(t *testing.T) {
@@ -26,12 +33,18 @@ func TestSharedCredentialsProviderIsExpired(t *testing.T) {
 
 	p := SharedCredentialsProvider{Filename: "example.ini", Profile: ""}
 
-	assert.True(t, p.IsExpired(), "Expect creds to be expired before retrieve")
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired before retrieve")
+	}
 
 	_, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve")
+	if p.IsExpired() {
+		t.Errorf("Expect creds to not be expired after retrieve")
+	}
 }
 
 func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) {
@@ -40,25 +53,43 @@ func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) 
 	p := SharedCredentialsProvider{}
 	creds, err := p.Retrieve()
 
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILEAbsPath(t *testing.T) {
 	os.Clearenv()
 	wd, err := os.Getwd()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("expect no error, got %v", err)
+	}
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "example.ini"))
 	p := SharedCredentialsProvider{}
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestSharedCredentialsProviderWithAWS_PROFILE(t *testing.T) {
@@ -67,11 +98,19 @@ func TestSharedCredentialsProviderWithAWS_PROFILE(t *testing.T) {
 
 	p := SharedCredentialsProvider{Filename: "example.ini", Profile: ""}
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Empty(t, creds.SessionToken, "Expect no token")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect no token, %v", v)
+	}
 }
 
 func TestSharedCredentialsProviderWithoutTokenFromProfile(t *testing.T) {
@@ -79,11 +118,19 @@ func TestSharedCredentialsProviderWithoutTokenFromProfile(t *testing.T) {
 
 	p := SharedCredentialsProvider{Filename: "example.ini", Profile: "no_token"}
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Empty(t, creds.SessionToken, "Expect no token")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect no token, %v", v)
+	}
 }
 
 func TestSharedCredentialsProviderColonInCredFile(t *testing.T) {
@@ -91,11 +138,19 @@ func TestSharedCredentialsProviderColonInCredFile(t *testing.T) {
 
 	p := SharedCredentialsProvider{Filename: "example.ini", Profile: "with_colon"}
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Empty(t, creds.SessionToken, "Expect no token")
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect no token, %v", v)
+	}
 }
 
 func TestSharedCredentialsProvider_DefaultFilename(t *testing.T) {

--- a/aws/credentials/static_provider_test.go
+++ b/aws/credentials/static_provider_test.go
@@ -1,7 +1,6 @@
 package credentials
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -15,10 +14,18 @@ func TestStaticProviderGet(t *testing.T) {
 	}
 
 	creds, err := s.Retrieve()
-	assert.Nil(t, err, "Expect no error")
-	assert.Equal(t, "AKID", creds.AccessKeyID, "Expect access key ID to match")
-	assert.Equal(t, "SECRET", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Empty(t, creds.SessionToken, "Expect no session token")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("Expect no session token, %v", v)
+	}
 }
 
 func TestStaticProviderIsExpired(t *testing.T) {
@@ -30,5 +37,7 @@ func TestStaticProviderIsExpired(t *testing.T) {
 		},
 	}
 
-	assert.False(t, s.IsExpired(), "Expect static credentials to never expire")
+	if s.IsExpired() {
+		t.Errorf("Expect static credentials to never expire")
+	}
 }

--- a/aws/credentials/stscreds/assume_role_provider_test.go
+++ b/aws/credentials/stscreds/assume_role_provider_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/stretchr/testify/assert"
 )
 
 type stubSTS struct {
@@ -38,18 +37,30 @@ func TestAssumeRoleProvider(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "roleARN", creds.AccessKeyID, "Expect access key ID to be reflected role ARN")
-	assert.Equal(t, "assumedSecretAccessKey", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "assumedSessionToken", creds.SessionToken, "Expect session token to match")
+	if e, a := "roleARN", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSecretAccessKey", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestAssumeRoleProvider_WithTokenCode(t *testing.T) {
 	stub := &stubSTS{
 		TestInput: func(in *sts.AssumeRoleInput) {
-			assert.Equal(t, "0123456789", *in.SerialNumber)
-			assert.Equal(t, "code", *in.TokenCode)
+			if e, a := "0123456789", *in.SerialNumber; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+			if e, a := "code", *in.TokenCode; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
 		},
 	}
 	p := &AssumeRoleProvider{
@@ -60,18 +71,30 @@ func TestAssumeRoleProvider_WithTokenCode(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "roleARN", creds.AccessKeyID, "Expect access key ID to be reflected role ARN")
-	assert.Equal(t, "assumedSecretAccessKey", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "assumedSessionToken", creds.SessionToken, "Expect session token to match")
+	if e, a := "roleARN", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSecretAccessKey", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestAssumeRoleProvider_WithTokenProvider(t *testing.T) {
 	stub := &stubSTS{
 		TestInput: func(in *sts.AssumeRoleInput) {
-			assert.Equal(t, "0123456789", *in.SerialNumber)
-			assert.Equal(t, "code", *in.TokenCode)
+			if e, a := "0123456789", *in.SerialNumber; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+			if e, a := "code", *in.TokenCode; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
 		},
 	}
 	p := &AssumeRoleProvider{
@@ -84,17 +107,25 @@ func TestAssumeRoleProvider_WithTokenProvider(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Nil(t, err, "Expect no error")
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
 
-	assert.Equal(t, "roleARN", creds.AccessKeyID, "Expect access key ID to be reflected role ARN")
-	assert.Equal(t, "assumedSecretAccessKey", creds.SecretAccessKey, "Expect secret access key to match")
-	assert.Equal(t, "assumedSessionToken", creds.SessionToken, "Expect session token to match")
+	if e, a := "roleARN", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSecretAccessKey", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestAssumeRoleProvider_WithTokenProviderError(t *testing.T) {
 	stub := &stubSTS{
 		TestInput: func(in *sts.AssumeRoleInput) {
-			assert.Fail(t, "API request should not of been called")
+			t.Errorf("API request should not of been called")
 		},
 	}
 	p := &AssumeRoleProvider{
@@ -107,17 +138,25 @@ func TestAssumeRoleProvider_WithTokenProviderError(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error")
+	}
 
-	assert.Empty(t, creds.AccessKeyID)
-	assert.Empty(t, creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
+	if v := creds.AccessKeyID; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
+	if v := creds.SecretAccessKey; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
 }
 
 func TestAssumeRoleProvider_MFAWithNoToken(t *testing.T) {
 	stub := &stubSTS{
 		TestInput: func(in *sts.AssumeRoleInput) {
-			assert.Fail(t, "API request should not of been called")
+			t.Errorf("API request should not of been called")
 		},
 	}
 	p := &AssumeRoleProvider{
@@ -127,11 +166,19 @@ func TestAssumeRoleProvider_MFAWithNoToken(t *testing.T) {
 	}
 
 	creds, err := p.Retrieve()
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expect error")
+	}
 
-	assert.Empty(t, creds.AccessKeyID)
-	assert.Empty(t, creds.SecretAccessKey)
-	assert.Empty(t, creds.SessionToken)
+	if v := creds.AccessKeyID; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
+	if v := creds.SecretAccessKey; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
+	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
 }
 
 func BenchmarkAssumeRoleProvider(b *testing.B) {

--- a/aws/request/http_request_retry_test.go
+++ b/aws/request/http_request_retry_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/mock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRequestCancelRetry(t *testing.T) {
@@ -32,6 +31,10 @@ func TestRequestCancelRetry(t *testing.T) {
 	close(c)
 
 	err := r.Send()
-	assert.True(t, strings.Contains(err.Error(), "canceled"))
-	assert.Equal(t, 1, reqNum)
+	if !strings.Contains(err.Error(), "canceled") {
+		t.Errorf("expect canceled in error, %v", err)
+	}
+	if e, a := 1, reqNum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }

--- a/aws/request/offset_reader_test.go
+++ b/aws/request/offset_reader_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/internal/sdkio"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOffsetReaderRead(t *testing.T) {
@@ -20,9 +19,15 @@ func TestOffsetReaderRead(t *testing.T) {
 
 	n, err := reader.Read(tempBuf)
 
-	assert.Equal(t, n, len(buf))
-	assert.Nil(t, err)
-	assert.Equal(t, buf, tempBuf)
+	if e, a := n, len(buf); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := buf, tempBuf; !bytes.Equal(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestOffsetReaderSeek(t *testing.T) {
@@ -30,16 +35,28 @@ func TestOffsetReaderSeek(t *testing.T) {
 	reader := newOffsetReader(bytes.NewReader(buf), 0)
 
 	orig, err := reader.Seek(0, sdkio.SeekCurrent)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), orig)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := int64(0), orig; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	n, err := reader.Seek(0, sdkio.SeekEnd)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(len(buf)), n)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := int64(len(buf)), n; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	n, err = reader.Seek(orig, sdkio.SeekStart)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(0), n)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := int64(0), n; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestOffsetReaderClose(t *testing.T) {
@@ -47,12 +64,18 @@ func TestOffsetReaderClose(t *testing.T) {
 	reader := &offsetReader{buf: bytes.NewReader(buf)}
 
 	err := reader.Close()
-	assert.Nil(t, err)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 
 	tempBuf := make([]byte, len(buf))
 	n, err := reader.Read(tempBuf)
-	assert.Equal(t, n, 0)
-	assert.Equal(t, err, io.EOF)
+	if e, a := n, 0; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := err, io.EOF; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestOffsetReaderCloseAndCopy(t *testing.T) {
@@ -63,13 +86,23 @@ func TestOffsetReaderCloseAndCopy(t *testing.T) {
 	newReader := reader.CloseAndCopy(0)
 
 	n, err := reader.Read(tempBuf)
-	assert.Equal(t, n, 0)
-	assert.Equal(t, err, io.EOF)
+	if e, a := n, 0; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := err, io.EOF; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	n, err = newReader.Read(tempBuf)
-	assert.Equal(t, n, len(buf))
-	assert.Nil(t, err)
-	assert.Equal(t, buf, tempBuf)
+	if e, a := n, len(buf); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := buf, tempBuf; !bytes.Equal(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestOffsetReaderCloseAndCopyOffset(t *testing.T) {
@@ -79,11 +112,17 @@ func TestOffsetReaderCloseAndCopyOffset(t *testing.T) {
 
 	newReader := reader.CloseAndCopy(4)
 	n, err := newReader.Read(tempBuf)
-	assert.Equal(t, n, len(buf)-4)
-	assert.Nil(t, err)
+	if e, a := n, len(buf)-4; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 
 	expected := []byte{'D', 'a', 't', 'a', 0, 0, 0, 0}
-	assert.Equal(t, expected, tempBuf)
+	if e, a := expected, tempBuf; !bytes.Equal(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestOffsetReaderRace(t *testing.T) {

--- a/aws/request/request_1_6_test.go
+++ b/aws/request/request_1_6_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -31,7 +29,9 @@ func TestRequestInvalidEndpoint(t *testing.T) {
 		nil,
 	)
 
-	assert.Error(t, r.Error)
+	if r.Error == nil {
+		t.Errorf("expect error")
+	}
 }
 
 type timeoutErr struct {

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -1,9 +1,8 @@
 package request_test
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -78,28 +77,40 @@ func TestPaginationQueryPage(t *testing.T) {
 		}
 		if last {
 			if gotToEnd {
-				assert.Fail(t, "last=true happened twice")
+				t.Errorf("last=true happened twice")
 			}
 			gotToEnd = true
 		}
 		return true
 	})
-	assert.Nil(t, err)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 
-	assert.Equal(t,
+	if e, a :=
 		[]map[string]*dynamodb.AttributeValue{
 			{"key": {S: aws.String("key1")}},
 			{"key": {S: aws.String("key2")}},
-		}, tokens)
-	assert.Equal(t,
+		}, tokens; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a :=
 		[]map[string]*dynamodb.AttributeValue{
 			{"key": {S: aws.String("key1")}},
 			{"key": {S: aws.String("key2")}},
 			{"key": {S: aws.String("key3")}},
-		}, pages)
-	assert.Equal(t, 3, numPages)
-	assert.True(t, gotToEnd)
-	assert.Nil(t, params.ExclusiveStartKey)
+		}, pages; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, numPages; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect true")
+	}
+	if params.ExclusiveStartKey != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 // Use DynamoDB methods for simplicity
@@ -139,19 +150,31 @@ func TestPagination(t *testing.T) {
 		}
 		if last {
 			if gotToEnd {
-				assert.Fail(t, "last=true happened twice")
+				t.Errorf("last=true happened twice")
 			}
 			gotToEnd = true
 		}
 		return true
 	})
 
-	assert.Equal(t, []string{"Table2", "Table4"}, tokens)
-	assert.Equal(t, []string{"Table1", "Table2", "Table3", "Table4", "Table5"}, pages)
-	assert.Equal(t, 3, numPages)
-	assert.True(t, gotToEnd)
-	assert.Nil(t, err)
-	assert.Nil(t, params.ExclusiveStartTableName)
+	if e, a := []string{"Table2", "Table4"}, tokens; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := []string{"Table1", "Table2", "Table3", "Table4", "Table5"}, pages; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, numPages; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect true")
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if params.ExclusiveStartTableName != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 // Use DynamoDB methods for simplicity
@@ -192,7 +215,7 @@ func TestPaginationEachPage(t *testing.T) {
 		}
 		if last {
 			if gotToEnd {
-				assert.Fail(t, "last=true happened twice")
+				t.Errorf("last=true happened twice")
 			}
 			gotToEnd = true
 		}
@@ -200,11 +223,21 @@ func TestPaginationEachPage(t *testing.T) {
 		return true
 	})
 
-	assert.Equal(t, []string{"Table2", "Table4"}, tokens)
-	assert.Equal(t, []string{"Table1", "Table2", "Table3", "Table4", "Table5"}, pages)
-	assert.Equal(t, 3, numPages)
-	assert.True(t, gotToEnd)
-	assert.Nil(t, err)
+	if e, a := []string{"Table2", "Table4"}, tokens; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := []string{"Table1", "Table2", "Table3", "Table4", "Table5"}, pages; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, numPages; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect true")
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 // Use DynamoDB methods for simplicity
@@ -236,16 +269,22 @@ func TestPaginationEarlyExit(t *testing.T) {
 		}
 		if last {
 			if gotToEnd {
-				assert.Fail(t, "last=true happened twice")
+				t.Errorf("last=true happened twice")
 			}
 			gotToEnd = true
 		}
 		return true
 	})
 
-	assert.Equal(t, 2, numPages)
-	assert.False(t, gotToEnd)
-	assert.Nil(t, err)
+	if e, a := 2, numPages; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if gotToEnd {
+		t.Errorf("expect false")
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 func TestSkipPagination(t *testing.T) {
@@ -268,8 +307,12 @@ func TestSkipPagination(t *testing.T) {
 		}
 		return true
 	})
-	assert.Equal(t, 1, numPages)
-	assert.True(t, gotToEnd)
+	if e, a := 1, numPages; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !gotToEnd {
+		t.Errorf("expect true")
+	}
 }
 
 // Use S3 for simplicity
@@ -301,8 +344,12 @@ func TestPaginationTruncation(t *testing.T) {
 		return true
 	})
 
-	assert.Equal(t, []string{"Key1", "Key2", "Key3"}, results)
-	assert.Nil(t, err)
+	if e, a := []string{"Key1", "Key2", "Key3"}, results; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 
 	// Try again without truncation token at all
 	reqNum = 0
@@ -314,8 +361,12 @@ func TestPaginationTruncation(t *testing.T) {
 		return true
 	})
 
-	assert.Equal(t, []string{"Key1", "Key2"}, results)
-	assert.Nil(t, err)
+	if e, a := []string{"Key1", "Key2"}, results; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 func TestPaginationNilToken(t *testing.T) {
@@ -376,9 +427,15 @@ func TestPaginationNilToken(t *testing.T) {
 		return true
 	})
 
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"", "second", ""}, idents)
-	assert.Equal(t, []string{"first.example.com.", "second.example.com.", "third.example.com."}, results)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := []string{"", "second", ""}, idents; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := []string{"first.example.com.", "second.example.com.", "third.example.com."}, results; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestPaginationNilInput(t *testing.T) {

--- a/aws/request/waiter_test.go
+++ b/aws/request/waiter_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -92,7 +90,7 @@ func TestWaiterPathAll(t *testing.T) {
 	})
 	svc.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		if reqNum >= len(resps) {
-			assert.Fail(t, "too many polling requests made")
+			t.Errorf("too many polling requests made")
 			return
 		}
 		r.Data = resps[reqNum]
@@ -115,9 +113,15 @@ func TestWaiterPathAll(t *testing.T) {
 	}
 
 	err := w.WaitWithContext(aws.BackgroundContext())
-	assert.NoError(t, err)
-	assert.Equal(t, 3, numBuiltReq)
-	assert.Equal(t, 3, reqNum)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := 3, numBuiltReq; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, reqNum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestWaiterPath(t *testing.T) {
@@ -157,7 +161,7 @@ func TestWaiterPath(t *testing.T) {
 	})
 	svc.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		if reqNum >= len(resps) {
-			assert.Fail(t, "too many polling requests made")
+			t.Errorf("too many polling requests made")
 			return
 		}
 		r.Data = resps[reqNum]
@@ -180,9 +184,15 @@ func TestWaiterPath(t *testing.T) {
 	}
 
 	err := w.WaitWithContext(aws.BackgroundContext())
-	assert.NoError(t, err)
-	assert.Equal(t, 3, numBuiltReq)
-	assert.Equal(t, 3, reqNum)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := 3, numBuiltReq; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, reqNum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestWaiterFailure(t *testing.T) {
@@ -222,7 +232,7 @@ func TestWaiterFailure(t *testing.T) {
 	})
 	svc.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		if reqNum >= len(resps) {
-			assert.Fail(t, "too many polling requests made")
+			t.Errorf("too many polling requests made")
 			return
 		}
 		r.Data = resps[reqNum]
@@ -251,11 +261,21 @@ func TestWaiterFailure(t *testing.T) {
 	}
 
 	err := w.WaitWithContext(aws.BackgroundContext()).(awserr.Error)
-	assert.Error(t, err)
-	assert.Equal(t, request.WaiterResourceNotReadyErrorCode, err.Code())
-	assert.Equal(t, "failed waiting for successful resource state", err.Message())
-	assert.Equal(t, 3, numBuiltReq)
-	assert.Equal(t, 3, reqNum)
+	if err == nil {
+		t.Errorf("expect error")
+	}
+	if e, a := request.WaiterResourceNotReadyErrorCode, err.Code(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "failed waiting for successful resource state", err.Message(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, numBuiltReq; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := 3, reqNum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestWaiterError(t *testing.T) {
@@ -308,7 +328,7 @@ func TestWaiterError(t *testing.T) {
 	})
 	svc.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		if reqNum >= len(resps) {
-			assert.Fail(t, "too many polling requests made")
+			t.Errorf("too many polling requests made")
 			return
 		}
 		r.Data = resps[reqNum]
@@ -408,8 +428,12 @@ func TestWaiterStatus(t *testing.T) {
 	}
 
 	err := w.WaitWithContext(aws.BackgroundContext())
-	assert.NoError(t, err)
-	assert.Equal(t, 3, reqNum)
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := 3, reqNum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestWaiter_ApplyOptions(t *testing.T) {

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -3,11 +3,12 @@ package session
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/internal/ini"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -129,12 +130,18 @@ func TestLoadSharedConfig(t *testing.T) {
 	for i, c := range cases {
 		cfg, err := loadSharedConfig(c.Profile, c.Filenames)
 		if c.Err != nil {
-			assert.Contains(t, err.Error(), c.Err.Error(), "expected error, %d", i)
+			if e, a := c.Err.Error(), err.Error(); !strings.Contains(a, e) {
+				t.Errorf("%d, expect %v, to contain %v", i, e, a)
+			}
 			continue
 		}
 
-		assert.NoError(t, err, "unexpected error, %d", i)
-		assert.Equal(t, c.Expected, cfg, "not equal, %d", i)
+		if err != nil {
+			t.Errorf("%d, expect nil, %v", i, err)
+		}
+		if e, a := c.Expected, cfg; !reflect.DeepEqual(e,a) {
+			t.Errorf("%d, expect %v, got %v", i, e, a)
+		}
 	}
 }
 
@@ -233,12 +240,18 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 
 		err := cfg.setFromIniFile(c.Profile, iniFile)
 		if c.Err != nil {
-			assert.Contains(t, err.Error(), c.Err.Error(), "expected error, %d", i)
+			if e, a := c.Err.Error(), err.Error(); !strings.Contains(a, e) {
+				t.Errorf("%d, expect %v, to contain %v", i, e, a)
+			}
 			continue
 		}
 
-		assert.NoError(t, err, "unexpected error, %d", i)
-		assert.Equal(t, c.Expected, cfg, "not equal, %d", i)
+		if err != nil {
+			t.Errorf("%d, expect nil, %v", i, err)
+		}
+		if e, a := c.Expected, cfg; e != a {
+			t.Errorf("%d, expect %v, got %v", i, e, a)
+		}
 	}
 }
 
@@ -264,11 +277,17 @@ func TestLoadSharedConfigIniFiles(t *testing.T) {
 
 	for i, c := range cases {
 		files, err := loadSharedConfigIniFiles(c.Filenames)
-		assert.NoError(t, err, "unexpected error, %d", i)
-		assert.Equal(t, len(c.Expected), len(files), "expected num files, %d", i)
+		if err != nil {
+			t.Errorf("%d, expect nil, %v", i, err)
+		}
+		if e, a := len(c.Expected), len(files); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
 
 		for i, expectedFile := range c.Expected {
-			assert.Equal(t, expectedFile.Filename, files[i].Filename)
+			if e, a := expectedFile.Filename, files[i].Filename; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
 		}
 	}
 }

--- a/private/protocol/idempotency_test.go
+++ b/private/protocol/idempotency_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/private/protocol"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCanSetIdempotencyToken(t *testing.T) {
@@ -55,7 +54,9 @@ func TestCanSetIdempotencyToken(t *testing.T) {
 		v := reflect.Indirect(reflect.ValueOf(c.Case))
 		ty := v.Type()
 		canSet := protocol.CanSetIdempotencyToken(v.Field(0), ty.Field(0))
-		assert.Equal(t, c.CanSet, canSet, "Expect case %d can set to match", i)
+		if e, a := c.CanSet, canSet; e != a {
+			t.Errorf("%d, expect %v, got %v", i, e, a)
+		}
 	}
 }
 
@@ -89,18 +90,24 @@ func TestSetIdempotencyToken(t *testing.T) {
 		v := reflect.Indirect(reflect.ValueOf(c.Case))
 
 		protocol.SetIdempotencyToken(v.Field(0))
-		assert.NotEmpty(t, v.Field(0).Interface(), "Expect case %d to be set", i)
+		if v.Field(0).Interface() == nil {
+			t.Errorf("%d, expect not nil", i)
+		}
 	}
 }
 
 func TestUUIDVersion4(t *testing.T) {
 	uuid := protocol.UUIDVersion4(make([]byte, 16))
-	assert.Equal(t, `00000000-0000-4000-8000-000000000000`, uuid)
+	if e, a := `00000000-0000-4000-8000-000000000000`, uuid; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 	b := make([]byte, 16)
 	for i := 0; i < len(b); i++ {
 		b[i] = 1
 	}
 	uuid = protocol.UUIDVersion4(b)
-	assert.Equal(t, `01010101-0101-4101-8101-010101010101`, uuid)
+	if e, a := `01010101-0101-4101-8101-010101010101`, uuid; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }

--- a/private/protocol/json/jsonutil/build_test.go
+++ b/private/protocol/json/jsonutil/build_test.go
@@ -2,11 +2,11 @@ package jsonutil_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func S(s string) *string {
@@ -83,11 +83,19 @@ func TestBuildJSON(t *testing.T) {
 	for _, test := range jsonTests {
 		out, err := jsonutil.BuildJSON(test.in)
 		if test.err != "" {
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), test.err)
+			if err == nil {
+				t.Errorf("expect error")
+			}
+			if e, a := test.err, err.Error(); !strings.Contains(a, e) {
+				t.Errorf("expect %v, to contain %v", e, a)
+			}
 		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, string(out), test.out)
+			if err != nil {
+				t.Errorf("expect nil, %v", err)
+			}
+			if e, a := string(out), test.out; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
 		}
 	}
 }

--- a/private/protocol/protocol_test.go
+++ b/private/protocol/protocol_test.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting"
@@ -117,13 +115,21 @@ func checkForLeak(data interface{}, build, fn func(*request.Request), t *testing
 	fn(req)
 
 	if result.errExists {
-		assert.NotNil(t, req.Error)
+		if err := req.Error; err == nil {
+			t.Errorf("expect error")
+		}
 	} else {
-		assert.Nil(t, req.Error)
+		if err := req.Error; err != nil {
+			t.Errorf("expect nil, %v", err)
+		}
 	}
 
-	assert.Equal(t, reader.Closed, result.closed)
-	assert.Equal(t, reader.Size, result.size)
+	if e, a := reader.Closed, result.closed; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := reader.Size, result.size; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestJSONRpc(t *testing.T) {

--- a/private/protocol/unmarshal_test.go
+++ b/private/protocol/unmarshal_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/query"
 	"github.com/aws/aws-sdk-go/private/protocol/restjson"
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockCloser struct {
@@ -34,16 +33,24 @@ func TestUnmarshalDrainBody(t *testing.T) {
 	}}
 
 	protocol.UnmarshalDiscardBody(r)
-	assert.NoError(t, r.Error)
-	assert.Equal(t, 0, b.Len())
-	assert.True(t, b.Closed)
+	if err := r.Error; err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := 0, b.Len(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if !b.Closed {
+		t.Errorf("expect true")
+	}
 }
 
 func TestUnmarshalDrainBodyNoBody(t *testing.T) {
 	r := &request.Request{HTTPResponse: &http.Response{}}
 
 	protocol.UnmarshalDiscardBody(r)
-	assert.NoError(t, r.Error)
+	if err := r.Error; err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
 }
 
 func TestUnmarshalSeriaizationError(t *testing.T) {


### PR DESCRIPTION
Updates the SDK's unit tests to not use a testing framework and instead
use the Go standard library's provided testing calls directly.