### PR TITLE
Documentation link fix

### DIFF
--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -183,7 +183,7 @@ be returned when creating the session.
     // from assumed role.
     svc := s3.New(sess)
 
-To setup assume role outside of a session see the stscrds.AssumeRoleProvider
+To setup assume role outside of a session see the stscreds.AssumeRoleProvider
 documentation.
 
 Environment Variables

--- a/doc-src/aws-godoc/templates/package_service.html
+++ b/doc-src/aws-godoc/templates/package_service.html
@@ -25,11 +25,11 @@
 			</dl>
 			<dl>
 			<dd><a href="#pkg-overview" class="overviewLink">Overview</a></dd>
-			{{if .Consts}}
-				<dd><a href="#pkg-constants" class="examplesLink">Constants</a></dd>
-			{{end}}
 			{{if $.Examples}}
 				<dd><a href="#pkg-examples" class="examplesLink">Examples</a></dd>
+			{{end}}
+			{{if .Consts}}
+				<dd><a href="#pkg-constants" class="examplesLink">Constants</a></dd>
 			{{end}}
 			</dl>
 		</div>
@@ -193,7 +193,7 @@
 		</div>
 		</div> <!-- #pkg-callgraph -->
 		{{ with .Consts -}}
-			<div id="pkg-consts" class="toggle">
+			<div id="pkg-constants" class="toggle">
 				<div class="collapsed">
 					<h2 class="toggleButton" title="Click to show Index section">Constants ▹</h2>
 				</div>


### PR DESCRIPTION
- Fix pkg-constants anchor in documentation.
- Reorder links in short-nav to match actual order in document.

Example page with broken Constants link: https://docs.aws.amazon.com/sdk-for-go/api/service/sts/

I also noticed that this link has the `examplesLink` class, which may also be a mistake? I didn't remove it since I'm not sure if it is a mistake or not.
