### PR TITLE
Support credential caching by sdk users.

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -49,6 +49,9 @@
 package credentials
 
 import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"reflect"
 	"sync"
 	"time"
 )
@@ -95,6 +98,14 @@ type Provider interface {
 	// IsExpired returns if the credentials are no longer valid, and need
 	// to be retrieved.
 	IsExpired() bool
+}
+
+// An Expirer is an interface that Providers can implement to expose the expiration
+// time, if known.  If the Provider cannot accurately provide this info,
+// it should not implement this interface.
+type Expirer interface {
+	// The time at which the credentials are no longer valid
+	ExpiresAt() time.Time
 }
 
 // An ErrorProvider is a stub credentials provider that always returns an error
@@ -161,6 +172,11 @@ func (e *Expiry) IsExpired() bool {
 		curTime = time.Now
 	}
 	return e.expiration.Before(curTime())
+}
+
+// ExpiresAt returns the expiration time of the credential
+func (e *Expiry) ExpiresAt() time.Time {
+	return e.expiration
 }
 
 // A Credentials provides concurrency safe retrieval of AWS credentials Value.
@@ -254,4 +270,17 @@ func (c *Credentials) IsExpired() bool {
 // isExpired helper method wrapping the definition of expired credentials.
 func (c *Credentials) isExpired() bool {
 	return c.forceRefresh || c.provider.IsExpired()
+}
+
+// ExpiresAt provides access to the functionality of the Expirer interface of
+// the underlying Provider, if it supports that interface.  Otherwise, it returns
+// an error.
+func (c *Credentials) ExpiresAt() (time.Time, error) {
+	expirer, ok := c.provider.(Expirer)
+	if !ok {
+		return time.Time{}, awserr.New("ProviderNotExpirer",
+			fmt.Sprintf("provider %s does not support ExpiresAt()", reflect.TypeOf(c.provider)),
+			nil)
+	}
+	return expirer.ExpiresAt(), nil
 }

--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -143,12 +143,27 @@ func TestCredentialsExpiresAt_HasExpirer(t *testing.T) {
 	stub := &stubProviderExpirer{}
 	c := NewCredentials(stub)
 
+	// fetch initial credentials so that forceRefresh is set false
+	_, err := c.Get()
+	if err != nil {
+		t.Errorf("Unexpecte error: %v", err)
+	}
+
 	stub.expiration = time.Unix(rand.Int63(), 0)
 	expiration, err := c.ExpiresAt()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
 	if stub.expiration != expiration {
-		t.Errorf("Expected matching expirotion, %v got %v", stub.expiration, expiration)
+		t.Errorf("Expected matching expiration, %v got %v", stub.expiration, expiration)
+	}
+
+	c.Expire()
+	expiration, err = c.ExpiresAt()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if !expiration.IsZero() {
+		t.Errorf("Expected distant past expiration, got %v", expiration)
 	}
 }

--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -117,4 +118,37 @@ func TestCredentialsIsExpired_Race(t *testing.T) {
 	close(starter)
 
 	time.Sleep(10 * time.Second)
+}
+
+func TestCredentialsExpiresAt_NoExpirer(t *testing.T) {
+	stub := &stubProvider{}
+	c := NewCredentials(stub)
+
+	_, err := c.ExpiresAt()
+	if e, a := "ProviderNotExpirer", err.(awserr.Error).Code(); e != a {
+		t.Errorf("Expected provider error, %v got %v", e, a)
+	}
+}
+
+type stubProviderExpirer struct {
+	stubProvider
+	expiration time.Time
+}
+
+func (s *stubProviderExpirer) ExpiresAt() time.Time {
+	return s.expiration
+}
+
+func TestCredentialsExpiresAt_HasExpirer(t *testing.T) {
+	stub := &stubProviderExpirer{}
+	c := NewCredentials(stub)
+
+	stub.expiration = time.Unix(rand.Int63(), 0)
+	expiration, err := c.ExpiresAt()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if stub.expiration != expiration {
+		t.Errorf("Expected matching expirotion, %v got %v", stub.expiration, expiration)
+	}
 }


### PR DESCRIPTION
Add an Expirer interface that Providers can implement, and add a suitable
implementation to Expiry class used by most Providers. Add a method on
Credentials to get the expiration time of the underlying Provider, if
Expirer is supported, without exposing Provider to callers.

If there is an existing bug or feature this PR is answers please reference it here.
Provides partial solution to issue #1329 discussion.