### PR TITLE
ec2metadata: bounds check region identifier before string split

### DIFF
--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -118,6 +118,10 @@ func (c *EC2Metadata) Region() (string, error) {
 		return "", err
 	}
 
+	if len(resp) == 0 {
+		return "", awserr.New("EC2MetadataError", "invalid Region response", nil)
+	}
+
 	// returns region without the suffix. Eg: us-west-2a becomes us-west-2
 	return resp[:len(resp)-1], nil
 }

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -167,6 +167,25 @@ func TestGetRegion(t *testing.T) {
 	}
 }
 
+
+
+func TestGetRegion_invalidResponse(t *testing.T) {
+	server := initTestServer(
+		"/latest/meta-data/placement/availability-zone",
+		"", // no data in response
+	)
+	defer server.Close()
+	c := ec2metadata.New(unit.Session, &aws.Config{Endpoint: aws.String(server.URL + "/latest")})
+
+	region, err := c.Region()
+	if err == nil {
+		t.Errorf("expected error, got %v", err)
+	}
+	if e, a := "", region; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
 func TestMetadataAvailable(t *testing.T) {
 	server := initTestServer(
 		"/latest/meta-data/instance-id",


### PR DESCRIPTION
We use the SDK to detect if our product is running in AWS via requesting EC2 metadata, however we've been made aware of instances of the SDK causing an [out-of-bounds panic](https://github.com/storageos/storageos.github.io/issues/251) during initialisation. After a bit of digging it is believed their environment includes an non-AWS API listening on the metadata IP (169.254.169.254) which is returning empty responses in response to Region metadata requests.

This crash has also been observed in the Amazon SSM agent (see [here](https://github.com/aws/amazon-ssm-agent/issues/81)). 

While the AWS SDK shouldn't really have to handle different customer environments, it probably should return an error when presented with invalid data rather than panicking. `Region()` could perform better validation on the response but I opted for the smallest effective change for this PR - happy to expand if desired.

Dom

