### PR TITLE
private/model/api: Assert smoke integration tests error are not empty

### DIFF
--- a/private/model/api/smoke.go
+++ b/private/model/api/smoke.go
@@ -106,6 +106,9 @@ var smokeTestTmpl = template.Must(template.New(`smokeTestTmpl`).Parse(`
 			if !ok {
 				t.Fatalf("expect awserr, was %T", err)
 			}
+			if len(aerr.Code()) == 0 {
+				t.Errorf("expect non-empty error code")
+			}
 			if v := aerr.Code(); v == request.ErrCodeSerialization {
 				t.Errorf("expect API error code got serialization failure")
 			}

--- a/service/acm/integ_test.go
+++ b/service/acm/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetCertificate(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/apigateway/integ_test.go
+++ b/service/apigateway/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_CreateUsagePlanKey(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/autoscaling/integ_test.go
+++ b/service/autoscaling/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_CreateLaunchConfiguration(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudfront/integ_test.go
+++ b/service/cloudfront/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_GetDistribution(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudhsmv2/integ_test.go
+++ b/service/cloudhsmv2/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ListTags(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudtrail/integ_test.go
+++ b/service/cloudtrail/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DeleteTrail(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudwatchevents/integ_test.go
+++ b/service/cloudwatchevents/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeRule(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudwatchlogs/integ_test.go
+++ b/service/cloudwatchlogs/integ_test.go
@@ -50,6 +50,9 @@ func TestInteg_01_GetLogEvents(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codecommit/integ_test.go
+++ b/service/codecommit/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ListBranches(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codedeploy/integ_test.go
+++ b/service/codedeploy/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetDeployment(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codepipeline/integ_test.go
+++ b/service/codepipeline/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetPipeline(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cognitoidentityprovider/integ_test.go
+++ b/service/cognitoidentityprovider/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_DescribeUserPool(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/configservice/integ_test.go
+++ b/service/configservice/integ_test.go
@@ -50,6 +50,9 @@ func TestInteg_01_GetResourceConfigHistory(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/databasemigrationservice/integ_test.go
+++ b/service/databasemigrationservice/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeTableStatistics(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/devicefarm/integ_test.go
+++ b/service/devicefarm/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetDevice(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/directconnect/integ_test.go
+++ b/service/directconnect/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeConnections(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/directoryservice/integ_test.go
+++ b/service/directoryservice/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_CreateDirectory(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/dynamodb/integ_test.go
+++ b/service/dynamodb/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_DescribeTable(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ec2/integ_test.go
+++ b/service/ec2/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_DescribeInstances(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ecr/integ_test.go
+++ b/service/ecr/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ListImages(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/efs/integ_test.go
+++ b/service/efs/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DeleteFileSystem(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticache/integ_test.go
+++ b/service/elasticache/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeCacheClusters(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticbeanstalk/integ_test.go
+++ b/service/elasticbeanstalk/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeEnvironmentResources(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticsearchservice/integ_test.go
+++ b/service/elasticsearchservice/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeElasticsearchDomain(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elastictranscoder/integ_test.go
+++ b/service/elastictranscoder/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ReadJob(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elb/integ_test.go
+++ b/service/elb/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elbv2/integ_test.go
+++ b/service/elbv2/integ_test.go
@@ -51,6 +51,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/emr/integ_test.go
+++ b/service/emr/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeCluster(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/firehose/integ_test.go
+++ b/service/firehose/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeDeliveryStream(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/glacier/integ_test.go
+++ b/service/glacier/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ListVaults(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/iam/integ_test.go
+++ b/service/iam/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetUser(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/inspector/integ_test.go
+++ b/service/inspector/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_ListTagsForResource(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/iot/integ_test.go
+++ b/service/iot/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeThing(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/kinesis/integ_test.go
+++ b/service/kinesis/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeStream(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/kms/integ_test.go
+++ b/service/kms/integ_test.go
@@ -50,6 +50,9 @@ func TestInteg_01_GetKeyPolicy(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/lambda/integ_test.go
+++ b/service/lambda/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_Invoke(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/opsworks/integ_test.go
+++ b/service/opsworks/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeLayers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/rds/integ_test.go
+++ b/service/rds/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/redshift/integ_test.go
+++ b/service/redshift/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeClusters(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/route53/integ_test.go
+++ b/service/route53/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetHostedZone(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/route53resolver/integ_test.go
+++ b/service/route53resolver/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetResolverRule(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/secretsmanager/integ_test.go
+++ b/service/secretsmanager/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeSecret(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ses/integ_test.go
+++ b/service/ses/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_VerifyEmailIdentity(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sms/integ_test.go
+++ b/service/sms/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DeleteReplicationJob(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sns/integ_test.go
+++ b/service/sns/integ_test.go
@@ -50,6 +50,9 @@ func TestInteg_01_Publish(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sqs/integ_test.go
+++ b/service/sqs/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetQueueUrl(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ssm/integ_test.go
+++ b/service/ssm/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_GetDocument(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sts/integ_test.go
+++ b/service/sts/integ_test.go
@@ -50,6 +50,9 @@ func TestInteg_01_GetFederationToken(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/waf/integ_test.go
+++ b/service/waf/integ_test.go
@@ -52,6 +52,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/wafregional/integ_test.go
+++ b/service/wafregional/integ_test.go
@@ -53,6 +53,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/workspaces/integ_test.go
+++ b/service/workspaces/integ_test.go
@@ -49,6 +49,9 @@ func TestInteg_01_DescribeWorkspaces(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect awserr, was %T", err)
 	}
+	if len(aerr.Code()) == 0 {
+		t.Errorf("expect non-empty error code")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}


### PR DESCRIPTION
Updates SDK integration smoke test code generation to assert that error codes are non-empty.

Related to #2377