### PR TITLE
service/s3control: Update codegen to use modeled endpoint

### DIFF
--- a/service/s3control/api.go
+++ b/service/s3control/api.go
@@ -50,8 +50,8 @@ func (c *S3Control) DeletePublicAccessBlockRequest(input *DeletePublicAccessBloc
 	output = &DeletePublicAccessBlockOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
-	req.Handlers.Build.PushBackNamed(buildPrefixHostHandler("AccountID", aws.StringValue(input.AccountId)))
-	req.Handlers.Build.PushBackNamed(buildRemoveHeaderHandler("X-Amz-Account-Id"))
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
 	return
 }
 
@@ -127,8 +127,8 @@ func (c *S3Control) GetPublicAccessBlockRequest(input *GetPublicAccessBlockInput
 
 	output = &GetPublicAccessBlockOutput{}
 	req = c.newRequest(op, input, output)
-	req.Handlers.Build.PushBackNamed(buildPrefixHostHandler("AccountID", aws.StringValue(input.AccountId)))
-	req.Handlers.Build.PushBackNamed(buildRemoveHeaderHandler("X-Amz-Account-Id"))
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
 	return
 }
 
@@ -211,8 +211,8 @@ func (c *S3Control) PutPublicAccessBlockRequest(input *PutPublicAccessBlockInput
 	output = &PutPublicAccessBlockOutput{}
 	req = c.newRequest(op, input, output)
 	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
-	req.Handlers.Build.PushBackNamed(buildPrefixHostHandler("AccountID", aws.StringValue(input.AccountId)))
-	req.Handlers.Build.PushBackNamed(buildRemoveHeaderHandler("X-Amz-Account-Id"))
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
 	return
 }
 
@@ -275,6 +275,9 @@ func (s *DeletePublicAccessBlockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -286,6 +289,12 @@ func (s *DeletePublicAccessBlockInput) Validate() error {
 func (s *DeletePublicAccessBlockInput) SetAccountId(v string) *DeletePublicAccessBlockInput {
 	s.AccountId = &v
 	return s
+}
+
+func (s *DeletePublicAccessBlockInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
 }
 
 type DeletePublicAccessBlockOutput struct {
@@ -328,6 +337,9 @@ func (s *GetPublicAccessBlockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -339,6 +351,12 @@ func (s *GetPublicAccessBlockInput) Validate() error {
 func (s *GetPublicAccessBlockInput) SetAccountId(v string) *GetPublicAccessBlockInput {
 	s.AccountId = &v
 	return s
+}
+
+func (s *GetPublicAccessBlockInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
 }
 
 type GetPublicAccessBlockOutput struct {
@@ -505,6 +523,9 @@ func (s *PutPublicAccessBlockInput) Validate() error {
 	if s.AccountId == nil {
 		invalidParams.Add(request.NewErrParamRequired("AccountId"))
 	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
 	if s.PublicAccessBlockConfiguration == nil {
 		invalidParams.Add(request.NewErrParamRequired("PublicAccessBlockConfiguration"))
 	}
@@ -525,6 +546,12 @@ func (s *PutPublicAccessBlockInput) SetAccountId(v string) *PutPublicAccessBlock
 func (s *PutPublicAccessBlockInput) SetPublicAccessBlockConfiguration(v *PublicAccessBlockConfiguration) *PutPublicAccessBlockInput {
 	s.PublicAccessBlockConfiguration = v
 	return s
+}
+
+func (s *PutPublicAccessBlockInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
 }
 
 type PutPublicAccessBlockOutput struct {

--- a/service/s3control/customizations.go
+++ b/service/s3control/customizations.go
@@ -2,14 +2,8 @@ package s3control
 
 import (
 	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/s3err"
-	"github.com/aws/aws-sdk-go/private/protocol"
 )
-
-type accountIDGetter interface {
-	getAccountId() string
-}
 
 func init() {
 	initClient = defaultInitClientFn
@@ -17,27 +11,4 @@ func init() {
 
 func defaultInitClientFn(c *client.Client) {
 	c.Handlers.UnmarshalError.PushBackNamed(s3err.RequestFailureWrapperHandler())
-}
-
-func buildPrefixHostHandler(fieldName, value string) request.NamedHandler {
-	return request.NamedHandler{
-		Name: "awssdk.s3control.prefixhost",
-		Fn: func(r *request.Request) {
-			paramErrs := request.ErrInvalidParams{Context: r.Operation.Name}
-			if !protocol.ValidHostLabel(value) {
-				paramErrs.Add(request.NewErrParamFormat(fieldName, "[a-zA-Z0-9-]{1,63}", value))
-				r.Error = paramErrs
-				return
-			}
-			r.HTTPRequest.URL.Host = value + "." + r.HTTPRequest.URL.Host
-		},
-	}
-}
-func buildRemoveHeaderHandler(key string) request.NamedHandler {
-	return request.NamedHandler{
-		Name: "awssdk.s3control.removeHeader",
-		Fn: func(r *request.Request) {
-			r.HTTPRequest.Header.Del(key)
-		},
-	}
 }


### PR DESCRIPTION
Updates the S3 Control services code generation to use the modeled endpoint trait if available. Will fallback to injecting the customization if no trait is set.
