### PR TITLE
aws: Update Context to be an alias of context.Context for Go 1.9

### DIFF
--- a/aws/context_1_5.go
+++ b/aws/context_1_5.go
@@ -1,8 +1,8 @@
+// +build !go1.9
+
 package aws
 
-import (
-	"time"
-)
+import "time"
 
 // Context is an copy of the Go v1.7 stdlib's context.Context interface.
 // It is represented as a SDK interface to enable you to use the "WithContext"
@@ -34,38 +34,4 @@ type Context interface {
 	// processes and API boundaries, not for passing optional parameters to
 	// functions.
 	Value(key interface{}) interface{}
-}
-
-// BackgroundContext returns a context that will never be canceled, has no
-// values, and no deadline. This context is used by the SDK to provide
-// backwards compatibility with non-context API operations and functionality.
-//
-// Go 1.6 and before:
-// This context function is equivalent to context.Background in the Go stdlib.
-//
-// Go 1.7 and later:
-// The context returned will be the value returned by context.Background()
-//
-// See https://golang.org/pkg/context for more information on Contexts.
-func BackgroundContext() Context {
-	return backgroundCtx
-}
-
-// SleepWithContext will wait for the timer duration to expire, or the context
-// is canceled. Which ever happens first. If the context is canceled the Context's
-// error will be returned.
-//
-// Expects Context to always return a non-nil error if the Done channel is closed.
-func SleepWithContext(ctx Context, dur time.Duration) error {
-	t := time.NewTimer(dur)
-	defer t.Stop()
-
-	select {
-	case <-t.C:
-		break
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	return nil
 }

--- a/aws/context_1_7.go
+++ b/aws/context_1_7.go
@@ -1,9 +1,0 @@
-// +build go1.7
-
-package aws
-
-import "context"
-
-var (
-	backgroundCtx = context.Background()
-)

--- a/aws/context_1_9.go
+++ b/aws/context_1_9.go
@@ -1,0 +1,11 @@
+// +build go1.9
+
+package aws
+
+import "context"
+
+// Context is an alias of the Go stdlib's context.Context interface.
+// It can be used within the SDK's API operation "WithContext" methods.
+//
+// See https://golang.org/pkg/context on how to use contexts.
+type Context = context.Context

--- a/aws/context_background_1_5.go
+++ b/aws/context_background_1_5.go
@@ -39,3 +39,18 @@ func (e *emptyCtx) String() string {
 var (
 	backgroundCtx = new(emptyCtx)
 )
+
+// BackgroundContext returns a context that will never be canceled, has no
+// values, and no deadline. This context is used by the SDK to provide
+// backwards compatibility with non-context API operations and functionality.
+//
+// Go 1.6 and before:
+// This context function is equivalent to context.Background in the Go stdlib.
+//
+// Go 1.7 and later:
+// The context returned will be the value returned by context.Background()
+//
+// See https://golang.org/pkg/context for more information on Contexts.
+func BackgroundContext() Context {
+	return backgroundCtx
+}

--- a/aws/context_background_1_7.go
+++ b/aws/context_background_1_7.go
@@ -1,0 +1,20 @@
+// +build go1.7
+
+package aws
+
+import "context"
+
+// BackgroundContext returns a context that will never be canceled, has no
+// values, and no deadline. This context is used by the SDK to provide
+// backwards compatibility with non-context API operations and functionality.
+//
+// Go 1.6 and before:
+// This context function is equivalent to context.Background in the Go stdlib.
+//
+// Go 1.7 and later:
+// The context returned will be the value returned by context.Background()
+//
+// See https://golang.org/pkg/context for more information on Contexts.
+func BackgroundContext() Context {
+	return context.Background()
+}

--- a/aws/context_sleep.go
+++ b/aws/context_sleep.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"time"
+)
+
+// SleepWithContext will wait for the timer duration to expire, or the context
+// is canceled. Which ever happens first. If the context is canceled the Context's
+// error will be returned.
+//
+// Expects Context to always return a non-nil error if the Done channel is closed.
+func SleepWithContext(ctx Context, dur time.Duration) error {
+	t := time.NewTimer(dur)
+	defer t.Stop()
+
+	select {
+	case <-t.C:
+		break
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Updates `aws.Context` interface to be an alias of the standard libraries `context.Context` type instead of redefining the interface. This will allow IDEs and utilities to interpret the `aws.Context` as the exactly same type as the standard libraries `context.Context`.