### PR TITLE
aws/request: Add retrying refused connections

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -571,6 +571,12 @@ func shouldRetryCancel(err error) bool {
 		if err.Code() == CanceledErrorCode {
 			return false
 		}
+		if strings.Contains(err.Error(), "connection refused") {
+			// Refused connections should be retried as the service may not yet
+			// be running on the port. net.OpError considers refused
+			// connections as not temporary.
+			return true
+		}
 		return shouldRetryCancel(err.OrigErr())
 	case temporary:
 		// If the error is temporary, we want to allow continuation of the

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -571,21 +571,21 @@ func shouldRetryCancel(err error) bool {
 		if err.Code() == CanceledErrorCode {
 			return false
 		}
+		return shouldRetryCancel(err.OrigErr())
+	case *url.Error:
 		if strings.Contains(err.Error(), "connection refused") {
 			// Refused connections should be retried as the service may not yet
-			// be running on the port. net.OpError considers refused
+			// be running on the port. Go TCP dial considers refused
 			// connections as not temporary.
 			return true
 		}
-		return shouldRetryCancel(err.OrigErr())
+		// *url.Error only implements Temporary after golang 1.6 but since
+		// url.Error only wraps the error:
+		return shouldRetryCancel(err.Err)
 	case temporary:
 		// If the error is temporary, we want to allow continuation of the
 		// retry process
 		return err.Temporary()
-	case *url.Error:
-		// *url.Error only implements Temporary after golang 1.6 but since
-		// url.Error only wraps the error:
-		return shouldRetryCancel(err.Err)
 	case nil:
 		// `awserr.Error.OrigErr()` can be nil, meaning there was an error but
 		// because we don't know the cause, it is marked as retriable. See

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1121,4 +1122,47 @@ func Test501NotRetrying(t *testing.T) {
 	if e, a := 1, int(r.RetryCount); e != a {
 		t.Errorf("expect %d retry count, got %d", e, a)
 	}
+}
+
+func TestRequestNoConnection(t *testing.T) {
+	port, err := getFreePort()
+	if err != nil {
+		t.Fatalf("failed to get free port for test")
+	}
+	s := awstesting.NewClient(aws.NewConfig().
+		WithMaxRetries(10).
+		WithEndpoint("https://localhost:" + strconv.Itoa(port)).
+		WithSleepDelay(func(time.Duration) {}),
+	)
+	s.Handlers.Validate.Clear()
+	s.Handlers.Unmarshal.PushBack(unmarshal)
+	s.Handlers.UnmarshalError.PushBack(unmarshalError)
+
+	out := &testData{}
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
+
+	if err = r.Send(); err == nil {
+		t.Fatal("expect error, but got none")
+	}
+
+	if e, a := 10, r.RetryCount; e != a {
+		t.Errorf("expect %v retry count, got %v", e, a)
+	}
+}
+
+func getFreePort() (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	strAddr := l.Addr().String()
+	parts := strings.Split(strAddr, ":")
+	strPort := parts[len(parts)-1]
+	port, err := strconv.ParseInt(strPort, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int(port), nil
 }


### PR DESCRIPTION
Updates the SDK to ensure refused connections are retried. url.Error
does not consider these errors to be temporary. This was preventing the
SDK from retrying refused connections.

Related to #2298
