### PR TITLE
aws/request: Fix unstable sleep and request tests.

### DIFF
--- a/aws/context_test.go
+++ b/aws/context_test.go
@@ -26,7 +26,7 @@ func TestSleepWithContext_Canceled(t *testing.T) {
 	ctx.Error = expectErr
 	close(ctx.DoneCh)
 
-	err := aws.SleepWithContext(ctx, 1*time.Millisecond)
+	err := aws.SleepWithContext(ctx, 10*time.Second)
 	if err == nil {
 		t.Fatalf("expect error, did not get one")
 	}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -593,7 +593,8 @@ func shouldRetryCancel(err error) bool {
 		return true
 	default:
 		switch err.Error() {
-		case "net/http: request canceled while waiting for connection":
+		case "net/http: request canceled",
+			"net/http: request canceled while waiting for connection":
 			// known 1.5 error case when an http request is cancelled
 			return false
 		}


### PR DESCRIPTION
Fixes unstable unit tests in the SDK's request package.

* TestSleepWithContext_Canceled - Adjusts the delay to be more reasonable, reducing the risk of timer triggering before the switch's ctx.Done is checked.
* TestShouldRetryCancel_cancelled - Ensure the request cancel doesn't occur until after the request has started to ensure the error returned from the request invoke is consistent.