### PR TITLE
service/dynamodb/dynamodbattribute: Add marshaling nil map as empty map

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -163,7 +163,7 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 		if u != nil {
 			return u.UnmarshalDynamoDBAttributeValue(av)
 		}
-		return d.decodeNull(v)
+		return d.decodeNull(fieldTag.NilAsEmpty, v)
 	}
 
 	u, v = indirect(v, false)
@@ -191,7 +191,7 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	case len(av.SS) != 0:
 		return d.decodeStringSet(av.SS, v)
 	}
-
+	d.decodeEmpty(fieldTag.NilAsEmpty, av, v)
 	return nil
 }
 
@@ -512,11 +512,18 @@ func (d *Decoder) decodeMap(avMap map[string]*dynamodb.AttributeValue, v reflect
 	return nil
 }
 
-func (d *Decoder) decodeNull(v reflect.Value) error {
+func (d *Decoder) decodeNull(nilAsEmpty bool, v reflect.Value) error {
 	if v.IsValid() && v.CanSet() {
 		v.Set(reflect.Zero(v.Type()))
 	}
-
+	if nilAsEmpty {
+		switch v.Kind() {
+		case reflect.Map:
+			v.Set(reflect.MakeMap(v.Type()))
+		case reflect.Slice:
+			v.Set(reflect.MakeSlice(v.Type(), 0, 0))
+		}
+	}
 	return nil
 }
 
@@ -598,6 +605,16 @@ func (d *Decoder) decodeStringSet(ss []*string, v reflect.Value) error {
 	}
 
 	return nil
+}
+
+func (d *Decoder) decodeEmpty(nilAsEmpty bool, av *dynamodb.AttributeValue, v reflect.Value) {
+	if !nilAsEmpty {
+		return
+	}
+	switch {
+	case len(av.B) == 0, len(av.BS) == 0, len(av.NS) == 0, len(av.SS) == 0, len(av.L) == 0, len(av.M) == 0:
+		d.decodeNull(nilAsEmpty, v)
+	}
 }
 
 func decodeUnixTime(n string) (time.Time, error) {

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -163,7 +163,7 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 		if u != nil {
 			return u.UnmarshalDynamoDBAttributeValue(av)
 		}
-		return d.decodeNull(fieldTag.NilAsEmpty || d.NilAsEmpty, v)
+		return d.decodeNull(fieldTag.KeepEmpty || d.KeepEmpty, v)
 	}
 
 	u, v = indirect(v, false)
@@ -191,7 +191,7 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	case len(av.SS) != 0:
 		return d.decodeStringSet(av.SS, v)
 	}
-	d.decodeEmpty(fieldTag.NilAsEmpty || d.NilAsEmpty, av, v)
+	d.decodeEmpty(fieldTag.KeepEmpty || d.KeepEmpty, av, v)
 	return nil
 }
 

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -1,3 +1,5 @@
+// +build go1.9
+
 package dynamodbattribute
 
 import (
@@ -626,7 +628,7 @@ type UnmarshalHelperStruct struct {
 	actual, expect interface{}
 }
 
-func TestUnmarshal_Structag_NilAsEmpty(t *testing.T) {
+func TestUnmarshal_Structag_KeepEmpty(t *testing.T) {
 	inputSliceNull := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
 			"BinarySet": {NULL: aws.Bool(true)},
@@ -656,68 +658,68 @@ func TestUnmarshal_Structag_NilAsEmpty(t *testing.T) {
 	}
 
 	cases := map[string]UnmarshalHelperStruct{
-		"unmarshal nil slice as nil when nilasempty tag is not set": {
+		"unmarshal nil slice as nil when keepempty tag is not set": {
 			input:  inputSliceNull,
-			actual: &testWithoutNilAsEmptyStruct{},
-			expect: &testWithoutNilAsEmptyStruct{
+			actual: &testWithoutKeepEmptyStruct{},
+			expect: &testWithoutKeepEmptyStruct{
 				BinarySet: nil,
 				StringSet: nil,
 				NumberSet: nil,
 				OtherList: nil,
 			},
 		},
-		"unmarshal nil slice as empty when nilasempty tag is set": {
+		"unmarshal nil slice as empty when keepempty tag is set": {
 			input:  inputSliceNull,
-			actual: &testNilAsEmptySliceStruct{},
-			expect: &testNilAsEmptySliceStruct{
+			actual: &testKeepEmptySliceStruct{},
+			expect: &testKeepEmptySliceStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
 				OtherList: []string{},
 			},
 		},
-		"unmarshal nil map as empty when nilasempty tag is not set": {
+		"unmarshal nil map as empty when keepempty tag is not set": {
 			input:  inputSliceEmpty,
 			actual: &testNilElemMapStruct{},
 			expect: &testNilElemMapStruct{
 				Values: nil,
 			},
 		},
-		"unmarshal nil map as empty when nilasempty tag is set": {
+		"unmarshal nil map as empty when keepempty tag is set": {
 			input:  inputSliceEmpty,
-			actual: &testNilAsEmptyElemMapStruct{},
-			expect: &testNilAsEmptyElemMapStruct{
+			actual: &testKeepEmptyElemMapStruct{},
+			expect: &testKeepEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
-		"unmarshal empty map as nil when nilasempty tag is not set": {
+		"unmarshal empty map as nil when keepempty tag is not set": {
 			input:  inputForMap,
 			actual: &testOmitEmptyElemMapStruct{},
 			expect: &testOmitEmptyElemMapStruct{
 				Values: nil,
 			},
 		},
-		"unmarshal empty map as empty when nilasempty tag is set": {
+		"unmarshal empty map as empty when keepempty tag is set": {
 			input:  inputForMap,
-			actual: &testNilAsEmptyElemMapStruct{},
-			expect: &testNilAsEmptyElemMapStruct{
+			actual: &testKeepEmptyElemMapStruct{},
+			expect: &testKeepEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
-		"unmarshal empty slices as nil when nilasempty tag is not set": {
+		"unmarshal empty slices as nil when keepempty tag is not set": {
 			input:  inputForSlice,
-			actual: &testWithoutNilAsEmptyStruct{},
-			expect: &testWithoutNilAsEmptyStruct{
+			actual: &testWithoutKeepEmptyStruct{},
+			expect: &testWithoutKeepEmptyStruct{
 				BinarySet: nil,
 				StringSet: nil,
 				NumberSet: nil,
 				OtherList: nil,
 			},
 		},
-		"unmarshal empty slices as empty when nilasempty tag is not set": {
+		"unmarshal empty slices as empty when keepempty tag is not set": {
 			input:  inputForSlice,
-			actual: &testNilAsEmptySliceStruct{},
-			expect: &testNilAsEmptySliceStruct{
+			actual: &testKeepEmptySliceStruct{},
+			expect: &testKeepEmptySliceStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
@@ -730,7 +732,7 @@ func TestUnmarshal_Structag_NilAsEmpty(t *testing.T) {
 	tableTestUnmarshalAssertion(t, cases, opts)
 }
 
-func TestUnmarshal_DecodeOption_NilAsEmpty_NullInput(t *testing.T) {
+func TestUnmarshal_DecodeOption_KeepEmpty(t *testing.T) {
 	inputSliceNull := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
 			"BinarySet": {NULL: aws.Bool(true)},
@@ -759,78 +761,78 @@ func TestUnmarshal_DecodeOption_NilAsEmpty_NullInput(t *testing.T) {
 	}
 
 	cases := map[string]UnmarshalHelperStruct{
-		"unmarshal nil slice as empty when nilasempty tag is not set": {
+		"unmarshal nil slice as empty when keepempty tag is not set": {
 			input:  inputSliceNull,
-			actual: &testWithoutNilAsEmptyStruct{},
-			expect: &testWithoutNilAsEmptyStruct{
+			actual: &testWithoutKeepEmptyStruct{},
+			expect: &testWithoutKeepEmptyStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
 				OtherList: []string{},
 			},
 		},
-		"unmarshal nil slice as empty when nilasempty tag is set": {
+		"unmarshal nil slice as empty when keepempty tag is set": {
 			input:  inputSliceNull,
-			actual: &testNilAsEmptySliceStruct{},
-			expect: &testNilAsEmptySliceStruct{
+			actual: &testKeepEmptySliceStruct{},
+			expect: &testKeepEmptySliceStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
 				OtherList: []string{},
 			},
 		},
-		"unmarshal nil map as empty when nilasempty tag is not set": {
+		"unmarshal nil map as empty when keepempty tag is not set": {
 			input:  inputSliceEmpty,
 			actual: &testNilElemMapStruct{},
 			expect: &testNilElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
-		"unmarshal nil map as empty when nilasempty tag is set": {
+		"unmarshal nil map as empty when keepempty tag is set": {
 			input:  inputSliceEmpty,
-			actual: &testNilAsEmptyElemMapStruct{},
-			expect: &testNilAsEmptyElemMapStruct{
+			actual: &testKeepEmptyElemMapStruct{},
+			expect: &testKeepEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
-		"unmarshal empty slices as empty when nilasempty tag is not set": {
+		"unmarshal empty slices as empty when keepempty tag is not set": {
 			input:  inputForSlice,
-			actual: &testWithoutNilAsEmptyStruct{},
-			expect: &testWithoutNilAsEmptyStruct{
+			actual: &testWithoutKeepEmptyStruct{},
+			expect: &testWithoutKeepEmptyStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
 				OtherList: []string{},
 			},
 		},
-		"unmarshal empty slices as empty when nilasempty tag is set": {
+		"unmarshal empty slices as empty when keepempty tag is set": {
 			input:  inputForSlice,
-			actual: &testNilAsEmptySliceStruct{},
-			expect: &testNilAsEmptySliceStruct{
+			actual: &testKeepEmptySliceStruct{},
+			expect: &testKeepEmptySliceStruct{
 				BinarySet: [][]byte{},
 				StringSet: []*string{},
 				NumberSet: []int{},
 				OtherList: []string{},
 			},
 		},
-		"unmarshal empty map as empty when nilasempty tag is not set": {
+		"unmarshal empty map as empty when keepempty tag is not set": {
 			input:  inputForMap,
 			actual: &testOmitEmptyElemMapStruct{},
 			expect: &testOmitEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
-		"unmarshal empty map as empty when nilasempty tag is set": {
+		"unmarshal empty map as empty when keepempty tag is set": {
 			input:  inputForMap,
-			actual: &testNilAsEmptyElemMapStruct{},
-			expect: &testNilAsEmptyElemMapStruct{
+			actual: &testKeepEmptyElemMapStruct{},
+			expect: &testKeepEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
 		},
 	}
 
 	opts := MarshalOptions{
-		NilAsEmpty: true,
+		KeepEmpty: true,
 	}
 	tableTestUnmarshalAssertion(t, cases, opts)
 }

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -622,12 +622,11 @@ func TestDecodeAliasedUnixTime(t *testing.T) {
 }
 
 type UnmarshalHelperStruct struct {
-	name           string
 	input          *dynamodb.AttributeValue
 	actual, expect interface{}
 }
 
-func TestUnmarshalNilAsEmptyForNullInput(t *testing.T) {
+func TestUnmarshal_Structag_NilAsEmpty(t *testing.T) {
 	inputSliceNull := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
 			"BinarySet": {NULL: aws.Bool(true)},
@@ -641,46 +640,7 @@ func TestUnmarshalNilAsEmptyForNullInput(t *testing.T) {
 			"Values": {NULL: aws.Bool(true)},
 		},
 	}
-	tests := []UnmarshalHelperStruct{{
-		name:   "unmarshal nil slice as nil when nilasempty tag is not set",
-		input:  inputSliceNull,
-		actual: &testWithoutNilAsEmptyStruct{},
-		expect: &testWithoutNilAsEmptyStruct{
-			BinarySet: nil,
-			StringSet: nil,
-			NumberSet: nil,
-			OtherList: nil,
-		},
-	}, {
-		name:   "unmarshal nil slice as empty when nilasempty tag is set",
-		input:  inputSliceNull,
-		actual: &testNilAsEmptySliceStruct{},
-		expect: &testNilAsEmptySliceStruct{
-			BinarySet: [][]byte{},
-			StringSet: []*string{},
-			NumberSet: []int{},
-			OtherList: []string{},
-		},
-	}, {
-		name:   "unmarshal nil map as empty when nilasempty tag is not set",
-		input:  inputSliceEmpty,
-		actual: &testNilElemMapStruct{},
-		expect: &testNilElemMapStruct{
-			Values: nil,
-		},
-	}, {
-		name:   "unmarshal nil map as empty when nilasempty tag is set",
-		input:  inputSliceEmpty,
-		actual: &testNilAsEmptyElemMapStruct{},
-		expect: &testNilAsEmptyElemMapStruct{
-			Values: map[string]interface{}{},
-		},
-	},
-	}
-	tableTestUnmarshalAssertion(t, tests)
-}
 
-func TestUnmarshalNilAsEmptyForEmptyInput(t *testing.T) {
 	inputForMap := &dynamodb.AttributeValue{
 		M: map[string]*dynamodb.AttributeValue{
 			"Values": {M: map[string]*dynamodb.AttributeValue{}},
@@ -694,24 +654,57 @@ func TestUnmarshalNilAsEmptyForEmptyInput(t *testing.T) {
 			"OtherList": {L: []*dynamodb.AttributeValue{}},
 		},
 	}
-	tests := []UnmarshalHelperStruct{
-		{
-			name:   "unmarshal empty map as nil when nilasempty tag is not set",
+
+	cases := map[string]UnmarshalHelperStruct{
+		"unmarshal nil slice as nil when nilasempty tag is not set": {
+			input:  inputSliceNull,
+			actual: &testWithoutNilAsEmptyStruct{},
+			expect: &testWithoutNilAsEmptyStruct{
+				BinarySet: nil,
+				StringSet: nil,
+				NumberSet: nil,
+				OtherList: nil,
+			},
+		},
+		"unmarshal nil slice as empty when nilasempty tag is set": {
+			input:  inputSliceNull,
+			actual: &testNilAsEmptySliceStruct{},
+			expect: &testNilAsEmptySliceStruct{
+				BinarySet: [][]byte{},
+				StringSet: []*string{},
+				NumberSet: []int{},
+				OtherList: []string{},
+			},
+		},
+		"unmarshal nil map as empty when nilasempty tag is not set": {
+			input:  inputSliceEmpty,
+			actual: &testNilElemMapStruct{},
+			expect: &testNilElemMapStruct{
+				Values: nil,
+			},
+		},
+		"unmarshal nil map as empty when nilasempty tag is set": {
+			input:  inputSliceEmpty,
+			actual: &testNilAsEmptyElemMapStruct{},
+			expect: &testNilAsEmptyElemMapStruct{
+				Values: map[string]interface{}{},
+			},
+		},
+		"unmarshal empty map as nil when nilasempty tag is not set": {
 			input:  inputForMap,
 			actual: &testOmitEmptyElemMapStruct{},
 			expect: &testOmitEmptyElemMapStruct{
 				Values: nil,
 			},
 		},
-		{
-			name:   "unmarshal empty map as empty when nilasempty tag is set",
+		"unmarshal empty map as empty when nilasempty tag is set": {
 			input:  inputForMap,
 			actual: &testNilAsEmptyElemMapStruct{},
 			expect: &testNilAsEmptyElemMapStruct{
 				Values: map[string]interface{}{},
 			},
-		}, {
-			name:   "unmarshal empty slices as nil when nilasempty tag is not set",
+		},
+		"unmarshal empty slices as nil when nilasempty tag is not set": {
 			input:  inputForSlice,
 			actual: &testWithoutNilAsEmptyStruct{},
 			expect: &testWithoutNilAsEmptyStruct{
@@ -720,8 +713,8 @@ func TestUnmarshalNilAsEmptyForEmptyInput(t *testing.T) {
 				NumberSet: nil,
 				OtherList: nil,
 			},
-		}, {
-			name:   "unmarshal empty slices as empty when nilasempty tag is not set",
+		},
+		"unmarshal empty slices as empty when nilasempty tag is not set": {
 			input:  inputForSlice,
 			actual: &testNilAsEmptySliceStruct{},
 			expect: &testNilAsEmptySliceStruct{
@@ -732,17 +725,132 @@ func TestUnmarshalNilAsEmptyForEmptyInput(t *testing.T) {
 			},
 		},
 	}
-	tableTestUnmarshalAssertion(t, tests)
+
+	var opts MarshalOptions
+	tableTestUnmarshalAssertion(t, cases, opts)
 }
 
-func tableTestUnmarshalAssertion(t *testing.T, tests []UnmarshalHelperStruct) {
-	for _, tt := range tests {
-		err := Unmarshal(tt.input, tt.actual)
-		if err != nil {
-			t.Errorf("expect nil, got %v", err)
-		}
-		if e, a := tt.expect, tt.actual; !reflect.DeepEqual(e, a) {
-			t.Errorf("%s: expect %v, got %v", tt.name, e, a)
-		}
+func TestUnmarshal_DecodeOption_NilAsEmpty_NullInput(t *testing.T) {
+	inputSliceNull := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {NULL: aws.Bool(true)},
+			"StringSet": {NULL: aws.Bool(true)},
+			"NumberSet": {NULL: aws.Bool(true)},
+			"OtherList": {NULL: aws.Bool(true)},
+		},
+	}
+	inputSliceEmpty := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {NULL: aws.Bool(true)},
+		},
+	}
+	inputForMap := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"Values": {M: map[string]*dynamodb.AttributeValue{}},
+		},
+	}
+	inputForSlice := &dynamodb.AttributeValue{
+		M: map[string]*dynamodb.AttributeValue{
+			"BinarySet": {BS: [][]byte{}},
+			"StringSet": {SS: []*string{}},
+			"NumberSet": {NS: []*string{}},
+			"OtherList": {L: []*dynamodb.AttributeValue{}},
+		},
+	}
+
+	cases := map[string]UnmarshalHelperStruct{
+		"unmarshal nil slice as empty when nilasempty tag is not set": {
+			input:  inputSliceNull,
+			actual: &testWithoutNilAsEmptyStruct{},
+			expect: &testWithoutNilAsEmptyStruct{
+				BinarySet: [][]byte{},
+				StringSet: []*string{},
+				NumberSet: []int{},
+				OtherList: []string{},
+			},
+		},
+		"unmarshal nil slice as empty when nilasempty tag is set": {
+			input:  inputSliceNull,
+			actual: &testNilAsEmptySliceStruct{},
+			expect: &testNilAsEmptySliceStruct{
+				BinarySet: [][]byte{},
+				StringSet: []*string{},
+				NumberSet: []int{},
+				OtherList: []string{},
+			},
+		},
+		"unmarshal nil map as empty when nilasempty tag is not set": {
+			input:  inputSliceEmpty,
+			actual: &testNilElemMapStruct{},
+			expect: &testNilElemMapStruct{
+				Values: map[string]interface{}{},
+			},
+		},
+		"unmarshal nil map as empty when nilasempty tag is set": {
+			input:  inputSliceEmpty,
+			actual: &testNilAsEmptyElemMapStruct{},
+			expect: &testNilAsEmptyElemMapStruct{
+				Values: map[string]interface{}{},
+			},
+		},
+		"unmarshal empty slices as empty when nilasempty tag is not set": {
+			input:  inputForSlice,
+			actual: &testWithoutNilAsEmptyStruct{},
+			expect: &testWithoutNilAsEmptyStruct{
+				BinarySet: [][]byte{},
+				StringSet: []*string{},
+				NumberSet: []int{},
+				OtherList: []string{},
+			},
+		},
+		"unmarshal empty slices as empty when nilasempty tag is set": {
+			input:  inputForSlice,
+			actual: &testNilAsEmptySliceStruct{},
+			expect: &testNilAsEmptySliceStruct{
+				BinarySet: [][]byte{},
+				StringSet: []*string{},
+				NumberSet: []int{},
+				OtherList: []string{},
+			},
+		},
+		"unmarshal empty map as empty when nilasempty tag is not set": {
+			input:  inputForMap,
+			actual: &testOmitEmptyElemMapStruct{},
+			expect: &testOmitEmptyElemMapStruct{
+				Values: map[string]interface{}{},
+			},
+		},
+		"unmarshal empty map as empty when nilasempty tag is set": {
+			input:  inputForMap,
+			actual: &testNilAsEmptyElemMapStruct{},
+			expect: &testNilAsEmptyElemMapStruct{
+				Values: map[string]interface{}{},
+			},
+		},
+	}
+
+	opts := MarshalOptions{
+		NilAsEmpty: true,
+	}
+	tableTestUnmarshalAssertion(t, cases, opts)
+}
+
+func tableTestUnmarshalAssertion(t *testing.T, cases map[string]UnmarshalHelperStruct, opts MarshalOptions) {
+	t.Helper()
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			decoder := NewDecoder(func(d *Decoder) {
+				d.MarshalOptions = opts
+			})
+
+			err := decoder.Decode(c.input, c.actual)
+			if err != nil {
+				t.Errorf("expect no error, got %v", err)
+			}
+			if e, a := c.expect, c.actual; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
 	}
 }

--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -8,12 +8,12 @@ import (
 type tag struct {
 	Name                         string
 	Ignore                       bool
+	KeepEmpty                    bool
 	OmitEmpty                    bool
 	OmitEmptyElem                bool
 	AsString                     bool
 	AsBinSet, AsNumSet, AsStrSet bool
 	AsUnixTime                   bool
-	NilAsEmpty                   bool
 }
 
 func (t *tag) parseAVTag(structTag reflect.StructTag) {
@@ -64,8 +64,8 @@ func (t *tag) parseTagStr(tagStr string) {
 			t.AsStrSet = true
 		case "unixtime":
 			t.AsUnixTime = true
-		case "nilasempty":
-			t.NilAsEmpty = true
+		case "keepempty":
+			t.KeepEmpty = true
 		}
 	}
 }

--- a/service/dynamodb/dynamodbattribute/tag.go
+++ b/service/dynamodb/dynamodbattribute/tag.go
@@ -13,6 +13,7 @@ type tag struct {
 	AsString                     bool
 	AsBinSet, AsNumSet, AsStrSet bool
 	AsUnixTime                   bool
+	NilAsEmpty                   bool
 }
 
 func (t *tag) parseAVTag(structTag reflect.StructTag) {
@@ -63,6 +64,8 @@ func (t *tag) parseTagStr(tagStr string) {
 			t.AsStrSet = true
 		case "unixtime":
 			t.AsUnixTime = true
+		case "nilasempty":
+			t.NilAsEmpty = true
 		}
 	}
 }


### PR DESCRIPTION
Adds support for optionally marshaling nil maps and slices as empty maps and lists instead of NULL DynamoDB AttributeValue.

* Adds `keepempty` struct tag for marshaling and unmarshaling structs. Maps and Slices decorated with this struct tag if nil or empty will be marshaled as empty lists, maps, sets, etc instead of default NULL value.

* Adds `MarshalOptions` `KeepEmpty` encoder and decoder marshaling options. Has same effect as the `keepempty` struct tag, but applying to all members marshaled.

Fix #682 #1890
Related: aws/aws-sdk-go-v2#195
Related PRs: #2105, #2032

TODO:
* [ ] Documentation
* [ ] Clarify interaction between `keepempty` tag, `KeepEmpty` option, and `omitempty` tag.