### PR TITLE
make strings.Contains args order less suspicious

### DIFF
--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -272,7 +272,7 @@ func TestUploadFailIfPartSizeTooSmall(t *testing.T) {
 		t.Errorf("Expected %q, but received %q", "ConfigError", aerr.Code())
 	}
 
-	if strings.Contains("part size must be at least", aerr.Message()) {
+	if strings.Contains(aerr.Message(), "part size must be at least") {
 		t.Errorf("Expected string to contain %q, but received %q", "part size must be at least", aerr.Message())
 	}
 }


### PR DESCRIPTION
The old code looked suspicious and was fragile.
It would fail if error messages were not totally the same.
Swapped the arguments order to fix that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
