### PR TITLE
service/s3: Update BucketRegionError message to include more information

### DIFF
--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -26,11 +26,16 @@ func unmarshalError(r *request.Request) {
 	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
+		msg := fmt.Sprintf(
+			"incorrect region, the bucket is not in '%s' region at endpoint '%s'",
+			aws.StringValue(r.Config.Region),
+			aws.StringValue(r.Config.Endpoint),
+		)
+		if v := r.HTTPResponse.Header.Get("x-amz-bucket-region"); len(v) != 0 {
+			msg += fmt.Sprintf(", bucket is in '%s' region", v)
+		}
 		r.Error = awserr.NewRequestFailure(
-			awserr.New("BucketRegionError",
-				fmt.Sprintf("incorrect region, the bucket is not in '%s' region",
-					aws.StringValue(r.Config.Region)),
-				nil),
+			awserr.New("BucketRegionError", msg, nil),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)

--- a/service/s3/unmarshal_error_test.go
+++ b/service/s3/unmarshal_error_test.go
@@ -162,7 +162,7 @@ func TestUnmarshalError(t *testing.T) {
 		if e, a := c.Code, err.(awserr.Error).Code(); e != a {
 			t.Errorf("%d, Code: expect %s, got %s", i, e, a)
 		}
-		if e, a := c.Msg, err.(awserr.Error).Message(); e != a {
+		if e, a := c.Msg, err.(awserr.Error).Message(); !strings.Contains(a, e) {
 			t.Errorf("%d, Message: expect %s, got %s", i, e, a)
 		}
 		if e, a := c.ReqID, err.(awserr.RequestFailure).RequestID(); e != a {


### PR DESCRIPTION
Updates the BucketRegionError error message to include information about
the endpoint and actual region the bucket is in if known. This error
message is created by the SDK, but could produce a confusing error
message if the user provided a region that doesn't match the endpoint.

Fix #2426