### PR TITLE
private/protocol/rest: Trim space in header key and value

### DIFF
--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -181,7 +181,7 @@ func Test{{ .OpName }}(t *testing.T) {
 	// assert headers
 	{{ range $k, $v := .TestCase.InputTest.Headers -}}
 		if e, a := "{{ $v }}", r.Header.Get("{{ $k }}"); e != a {
-			t.Errorf("expect %v to be %v", e, a)
+			t.Errorf("expect %v, got %v", e, a)
 		}
 	{{ end }}
 }

--- a/models/protocol_tests/input/rest-json.json
+++ b/models/protocol_tests/input/rest-json.json
@@ -1515,7 +1515,7 @@
           "FooEnum": "foo",
           "QueryFooEnum": "bar",
           "ListEnums": ["foo", "", "bar"],
-          "QueryListEnums": ["0", "", "1"]
+          "QueryListEnums": ["0", "1", ""]
         },
         "serialized": {
           "uri": "/path?Enum=bar&List=0&List=1&List=",
@@ -1603,7 +1603,7 @@
             "shape": "MemberRefInputShape"
           },
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/path"
           },
           "endpoint":{

--- a/models/protocol_tests/input/rest-json.json
+++ b/models/protocol_tests/input/rest-json.json
@@ -1620,5 +1620,76 @@
         }
       }
     ]
+  },
+  {
+    "description": "Header whitespace",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Header1": {
+            "shape": "StringType",
+            "location": "header"
+          },
+          "HeaderMap": {
+            "shape": "StringMap",
+            "location": "headers",
+            "locationName": "header-map-"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Header1": "   headerValue",
+          "HeaderMap": {
+              "leading-space": "   value",
+              "with-space": "   value   ",
+              "leading-tab": "    value",
+              "   key-leading-space": "value",
+              "   key-with-space   ": "value"
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/",
+          "headers": {
+              "header1": "headerValue",
+              "header-map-leading-space": "value",
+              "header-map-with-space": "value",
+              "header-map-leading-tab": "value",
+              "header-map-key-leading-space": "value",
+              "header-map-key-with-space": "value"
+          }
+        }
+      }
+    ]
   }
 ]

--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -1903,7 +1903,7 @@
             "locationName": "MemberRefOpRequest"
           },
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/path"
           },
           "endpoint":{

--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -1920,5 +1920,76 @@
         }
       }
     ]
+  },
+  {
+    "description": "Header whitespace",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Header1": {
+            "shape": "StringType",
+            "location": "header"
+          },
+          "HeaderMap": {
+            "shape": "StringMap",
+            "location": "headers",
+            "locationName": "header-map-"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Header1": "   headerValue",
+          "HeaderMap": {
+              "leading-space": "   value",
+              "with-space": "   value   ",
+              "leading-tab": "    value",
+              "   key-leading-space": "value",
+              "   key-with-space   ": "value"
+          }
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/",
+          "headers": {
+              "header1": "headerValue",
+              "header-map-leading-space": "value",
+              "header-map-with-space": "value",
+              "header-map-leading-tab": "value",
+              "header-map-key-leading-space": "value",
+              "header-map-key-with-space": "value"
+          }
+        }
+      }
+    ]
   }
 ]

--- a/models/protocol_tests/output/ec2.json
+++ b/models/protocol_tests/output/ec2.json
@@ -518,5 +518,54 @@
         }
       }
     ]
+  },
+  {
+    "description": "Enum output",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "FooEnum": {
+            "shape": "EC2EnumType"
+          },
+          "ListEnums": {
+            "shape": "EC2EnumList"
+          }
+        }
+      },
+      "EC2EnumType":{
+        "type":"string",
+        "enum":[
+          "foo",
+          "bar"
+        ]
+      },
+      "EC2EnumList":{
+        "type":"list",
+        "member": {"shape": "EC2EnumType"}
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "FooEnum": "foo",
+          "ListEnums": ["foo", "bar"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/models/protocol_tests/output/query.json
+++ b/models/protocol_tests/output/query.json
@@ -840,5 +840,54 @@
         }
       }
     ]
+  },
+  {
+    "description": "Enum output",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "FooEnum": {
+            "shape": "EC2EnumType"
+          },
+          "ListEnums": {
+            "shape": "EC2EnumList"
+          }
+        }
+      },
+      "EC2EnumType":{
+        "type":"string",
+        "enum":[
+          "foo",
+          "bar"
+        ]
+      },
+      "EC2EnumList":{
+        "type":"list",
+        "member": {"shape": "EC2EnumType"}
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "FooEnum": "foo",
+          "ListEnums": ["foo", "bar"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/models/protocol_tests/output/rest-json.json
+++ b/models/protocol_tests/output/rest-json.json
@@ -488,6 +488,26 @@
     ]
   },
   {
+    "description": "Ignores undefined output",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {},
+    "cases": [
+      {
+        "given": {
+          "name": "OperationName"
+        },
+        "result": {},
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "OK"
+        }
+      }
+    ]
+  },
+  {
     "description": "Supports header maps",
     "metadata": {
       "protocol": "rest-json"

--- a/models/protocol_tests/output/rest-xml.json
+++ b/models/protocol_tests/output/rest-xml.json
@@ -807,5 +807,166 @@
         }
       }
     ]
+  },
+  {
+    "description": "Enum",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "HeaderEnum": {
+            "shape": "RESTJSONEnumType",
+            "location": "header",
+            "locationName": "x-amz-enum"
+          },
+          "FooEnum": {
+            "shape": "RESTJSONEnumType"
+          },
+          "ListEnums": {
+            "shape": "EnumList"
+          }
+        }
+      },
+      "RESTJSONEnumType":{
+        "type":"string",
+        "enum":[
+          "foo",
+          "bar",
+          "0",
+          "1"
+        ]
+      },
+      "EnumList":{
+        "type":"list",
+        "member": {"shape": "RESTJSONEnumType"}
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "HeaderEnum": "baz",
+          "FooEnum": "foo",
+          "ListEnums": ["0", "1"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {"x-amz-enum": "baz"},
+          "body": "<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>0</member><member>1</member></ListEnums></OperationNameResponse>"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "OutputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "XML Attributes",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape":{
+        "type":"structure",
+        "members":{
+          "ListItems":{
+            "shape":"ListItemsShape",
+            "locationName":"ItemsList"
+          }
+        }
+      },
+      "ListItemsShape":{
+        "type":"list",
+        "member":{
+          "shape":"ItemShape",
+          "locationName":"Item"
+        }
+      },
+      "ItemShape":{
+        "type":"structure",
+        "members":{
+          "ItemDetail":{"shape":"ItemDetailShape"}
+        }
+      },
+      "ItemDetailShape":{
+        "type":"structure",
+        "required":["Type"],
+        "members":{
+          "ID":{"shape":"StringShape"},
+          "Type":{
+            "shape":"ItemType",
+            "locationName":"xsi:type",
+            "xmlAttribute":true
+          }
+        },
+        "xmlNamespace":{
+          "prefix":"xsi",
+          "uri":"http://www.w3.org/2001/XMLSchema-instance"
+        }
+      },
+      "StringShape":{
+        "type":"string"
+      },
+      "ItemType":{
+        "type":"string",
+        "enum":[
+          "Type1",
+          "Type2",
+          "Type3"
+        ]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListItems": [
+              {"ItemDetail": {"ID": "id1", "Type": "Type1"}},
+              {"ItemDetail": {"ID": "id2", "Type": "Type2"}},
+              {"ItemDetail": {"ID": "id3", "Type": "Type3"}}
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "body": "<SomeOutputDoc xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><ItemsList><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type1\"><ID>id1</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type2\"><ID>id2</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type3\"><ID>id3</ID></ItemDetail></Item></ItemsList></SomeOutputDoc>"
+        }
+      }
+    ]
   }
 ]

--- a/private/protocol/ec2query/unmarshal_test.go
+++ b/private/protocol/ec2query/unmarshal_test.go
@@ -1597,6 +1597,166 @@ func (s *OutputService10TestShapeTimeContainer) SetFoo(v time.Time) *OutputServi
 	return s
 }
 
+// OutputService11ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// OutputService11ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type OutputService11ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService11ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService11ProtocolTest client from just a session.
+//     svc := outputservice11protocoltest.New(mySession)
+//
+//     // Create a OutputService11ProtocolTest client with additional configuration
+//     svc := outputservice11protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService11ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService11ProtocolTest {
+	c := p.ClientConfig("outputservice11protocoltest", cfgs...)
+	return newOutputService11ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService11ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService11ProtocolTest {
+	svc := &OutputService11ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "OutputService11ProtocolTest",
+				ServiceID:     "OutputService11ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(ec2query.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(ec2query.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(ec2query.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(ec2query.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService11TestCaseOperation1 = "OperationName"
+
+// OutputService11TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService11TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService11TestCaseOperation1 for more information on using the OutputService11TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService11TestCaseOperation1Request method.
+//    req, resp := client.OutputService11TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *request.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:     opOutputService11TestCaseOperation1,
+		HTTPPath: "/",
+	}
+
+	if input == nil {
+		input = &OutputService11TestShapeOutputService11TestCaseOperation1Input{}
+	}
+
+	output = &OutputService11TestShapeOutputService11TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService11TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService11TestCaseOperation1 for usage and error information.
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (*OutputService11TestShapeOutputService11TestCaseOperation1Output, error) {
+	req, out := c.OutputService11TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// OutputService11TestCaseOperation1WithContext is the same as OutputService11TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService11TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1WithContext(ctx aws.Context, input *OutputService11TestShapeOutputService11TestCaseOperation1Input, opts ...request.Option) (*OutputService11TestShapeOutputService11TestCaseOperation1Output, error) {
+	req, out := c.OutputService11TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService11TestShapeEC2EnumType"`
+
+	ListEnums []*string `type:"list"`
+}
+
+// SetFooEnum sets the FooEnum field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetFooEnum(v string) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.FooEnum = &v
+	return s
+}
+
+// SetListEnums sets the ListEnums field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetListEnums(v []*string) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.ListEnums = v
+	return s
+}
+
+const (
+	// EC2EnumTypeFoo is a OutputService11TestShapeEC2EnumType enum value
+	EC2EnumTypeFoo = "foo"
+
+	// EC2EnumTypeBar is a OutputService11TestShapeEC2EnumType enum value
+	EC2EnumTypeBar = "bar"
+)
+
 //
 // Tests begin here
 //
@@ -1907,6 +2067,38 @@ func TestOutputService10ProtocolTestTimestampMembersCase1(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeFormat.UTC().String(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+
+}
+
+func TestOutputService11ProtocolTestEnumOutputCase1(t *testing.T) {
+	svc := NewOutputService11ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"))
+	req, out := svc.OutputService11TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+	if e, a := "foo", *out.FooEnum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "foo", *out.ListEnums[0]; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "bar", *out.ListEnums[1]; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 

--- a/private/protocol/jsonrpc/build_test.go
+++ b/private/protocol/jsonrpc/build_test.go
@@ -2288,10 +2288,10 @@ func TestInputService1ProtocolTestScalarMembersCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2324,10 +2324,10 @@ func TestInputService2ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2358,10 +2358,10 @@ func TestInputService3ProtocolTestBase64EncodedBlobsCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2395,10 +2395,10 @@ func TestInputService3ProtocolTestBase64EncodedBlobsCase2(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2432,10 +2432,10 @@ func TestInputService4ProtocolTestNestedBlobsCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2468,10 +2468,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2506,10 +2506,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase2(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2548,10 +2548,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase3(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2591,10 +2591,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase4(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2636,10 +2636,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase5(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2679,10 +2679,10 @@ func TestInputService5ProtocolTestRecursiveShapesCase6(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2713,10 +2713,10 @@ func TestInputService6ProtocolTestEmptyMapsCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.OperationName", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2853,10 +2853,10 @@ func TestInputService9ProtocolTestEndpointHostTraitStaticPrefixCase1(t *testing.
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.StaticOp", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -2887,10 +2887,10 @@ func TestInputService9ProtocolTestEndpointHostTraitStaticPrefixCase2(t *testing.
 
 	// assert headers
 	if e, a := "application/x-amz-json-1.1", r.Header.Get("Content-Type"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "com.amazonaws.foo.MemberRefOp", r.Header.Get("X-Amz-Target"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }

--- a/private/protocol/query/unmarshal_test.go
+++ b/private/protocol/query/unmarshal_test.go
@@ -2533,6 +2533,166 @@ func (s *OutputService16TestShapeTimeContainer) SetFoo(v time.Time) *OutputServi
 	return s
 }
 
+// OutputService17ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// OutputService17ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type OutputService17ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService17ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService17ProtocolTest client from just a session.
+//     svc := outputservice17protocoltest.New(mySession)
+//
+//     // Create a OutputService17ProtocolTest client with additional configuration
+//     svc := outputservice17protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService17ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService17ProtocolTest {
+	c := p.ClientConfig("outputservice17protocoltest", cfgs...)
+	return newOutputService17ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService17ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService17ProtocolTest {
+	svc := &OutputService17ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "OutputService17ProtocolTest",
+				ServiceID:     "OutputService17ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(query.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(query.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(query.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(query.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService17ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService17ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService17TestCaseOperation1 = "OperationName"
+
+// OutputService17TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService17TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService17TestCaseOperation1 for more information on using the OutputService17TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService17TestCaseOperation1Request method.
+//    req, resp := client.OutputService17TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService17ProtocolTest) OutputService17TestCaseOperation1Request(input *OutputService17TestShapeOutputService17TestCaseOperation1Input) (req *request.Request, output *OutputService17TestShapeOutputService17TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:     opOutputService17TestCaseOperation1,
+		HTTPPath: "/",
+	}
+
+	if input == nil {
+		input = &OutputService17TestShapeOutputService17TestCaseOperation1Input{}
+	}
+
+	output = &OutputService17TestShapeOutputService17TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService17TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService17TestCaseOperation1 for usage and error information.
+func (c *OutputService17ProtocolTest) OutputService17TestCaseOperation1(input *OutputService17TestShapeOutputService17TestCaseOperation1Input) (*OutputService17TestShapeOutputService17TestCaseOperation1Output, error) {
+	req, out := c.OutputService17TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// OutputService17TestCaseOperation1WithContext is the same as OutputService17TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService17TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService17ProtocolTest) OutputService17TestCaseOperation1WithContext(ctx aws.Context, input *OutputService17TestShapeOutputService17TestCaseOperation1Input, opts ...request.Option) (*OutputService17TestShapeOutputService17TestCaseOperation1Output, error) {
+	req, out := c.OutputService17TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type OutputService17TestShapeOutputService17TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService17TestShapeOutputService17TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService17TestShapeEC2EnumType"`
+
+	ListEnums []*string `type:"list"`
+}
+
+// SetFooEnum sets the FooEnum field's value.
+func (s *OutputService17TestShapeOutputService17TestCaseOperation1Output) SetFooEnum(v string) *OutputService17TestShapeOutputService17TestCaseOperation1Output {
+	s.FooEnum = &v
+	return s
+}
+
+// SetListEnums sets the ListEnums field's value.
+func (s *OutputService17TestShapeOutputService17TestCaseOperation1Output) SetListEnums(v []*string) *OutputService17TestShapeOutputService17TestCaseOperation1Output {
+	s.ListEnums = v
+	return s
+}
+
+const (
+	// EC2EnumTypeFoo is a OutputService17TestShapeEC2EnumType enum value
+	EC2EnumTypeFoo = "foo"
+
+	// EC2EnumTypeBar is a OutputService17TestShapeEC2EnumType enum value
+	EC2EnumTypeBar = "bar"
+)
+
 //
 // Tests begin here
 //
@@ -3035,6 +3195,38 @@ func TestOutputService16ProtocolTestTimestampMembersCase1(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeFormat.UTC().String(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+
+}
+
+func TestOutputService17ProtocolTestEnumOutputCase1(t *testing.T) {
+	svc := NewOutputService17ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member>bar</member></ListEnums></OperationNameResponse>"))
+	req, out := svc.OutputService17TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+	if e, a := "foo", *out.FooEnum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "foo", *out.ListEnums[0]; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "bar", *out.ListEnums[1]; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -155,6 +155,9 @@ func buildHeader(header *http.Header, v reflect.Value, name string, tag reflect.
 		return awserr.New("SerializationError", "failed to encode REST request", err)
 	}
 
+	name = strings.TrimSpace(name)
+	str = strings.TrimSpace(str)
+
 	header.Add(name, str)
 
 	return nil
@@ -170,8 +173,10 @@ func buildHeaderMap(header *http.Header, v reflect.Value, tag reflect.StructTag)
 			return awserr.New("SerializationError", "failed to encode REST request", err)
 
 		}
+		keyStr := strings.TrimSpace(key.String())
+		str = strings.TrimSpace(str)
 
-		header.Add(prefix+key.String(), str)
+		header.Add(prefix+keyStr, str)
 	}
 	return nil
 }

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -5189,6 +5189,160 @@ type InputService23TestShapeInputService23TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// InputService24ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// InputService24ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type InputService24ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService24ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService24ProtocolTest client from just a session.
+//     svc := inputservice24protocoltest.New(mySession)
+//
+//     // Create a InputService24ProtocolTest client with additional configuration
+//     svc := inputservice24protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService24ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService24ProtocolTest {
+	c := p.ClientConfig("inputservice24protocoltest", cfgs...)
+	return newInputService24ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService24ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService24ProtocolTest {
+	svc := &InputService24ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "InputService24ProtocolTest",
+				ServiceID:     "InputService24ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restjson.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restjson.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restjson.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restjson.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService24ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService24ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService24TestCaseOperation1 = "OperationName"
+
+// InputService24TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService24TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See InputService24TestCaseOperation1 for more information on using the InputService24TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the InputService24TestCaseOperation1Request method.
+//    req, resp := client.InputService24TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1Request(input *InputService24TestShapeInputService24TestCaseOperation1Input) (req *request.Request, output *InputService24TestShapeInputService24TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService24TestCaseOperation1,
+		HTTPMethod: "GET",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService24TestShapeInputService24TestCaseOperation1Input{}
+	}
+
+	output = &InputService24TestShapeInputService24TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restjson.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService24TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService24TestCaseOperation1 for usage and error information.
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1(input *InputService24TestShapeInputService24TestCaseOperation1Input) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
+	req, out := c.InputService24TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// InputService24TestCaseOperation1WithContext is the same as InputService24TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See InputService24TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *InputService24ProtocolTest) InputService24TestCaseOperation1WithContext(ctx aws.Context, input *InputService24TestShapeInputService24TestCaseOperation1Input, opts ...request.Option) (*InputService24TestShapeInputService24TestCaseOperation1Output, error) {
+	req, out := c.InputService24TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type InputService24TestShapeInputService24TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
+	Header1 *string `location:"header" type:"string"`
+
+	HeaderMap map[string]*string `location:"headers" locationName:"header-map-" type:"map"`
+}
+
+// SetHeader1 sets the Header1 field's value.
+func (s *InputService24TestShapeInputService24TestCaseOperation1Input) SetHeader1(v string) *InputService24TestShapeInputService24TestCaseOperation1Input {
+	s.Header1 = &v
+	return s
+}
+
+// SetHeaderMap sets the HeaderMap field's value.
+func (s *InputService24TestShapeInputService24TestCaseOperation1Input) SetHeaderMap(v map[string]*string) *InputService24TestShapeInputService24TestCaseOperation1Input {
+	s.HeaderMap = v
+	return s
+}
+
+type InputService24TestShapeInputService24TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
 //
 // Tests begin here
 //
@@ -6253,5 +6407,51 @@ func TestInputService23ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://foo-myname.service.region.amazonaws.com/path", r.URL.String())
 
 	// assert headers
+
+}
+
+func TestInputService24ProtocolTestHeaderWhitespaceCase1(t *testing.T) {
+	svc := NewInputService24ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService24TestShapeInputService24TestCaseOperation1Input{
+		Header1: aws.String("   headerValue"),
+		HeaderMap: map[string]*string{
+			"   key-leading-space": aws.String("value"),
+			"   key-with-space   ": aws.String("value"),
+			"leading-space":        aws.String("   value"),
+			"leading-tab":          aws.String("    value"),
+			"with-space":           aws.String("   value   "),
+		},
+	}
+	req, _ := svc.InputService24TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	req.Build()
+	if req.Error != nil {
+		t.Errorf("expect no error, got %v", req.Error)
+	}
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+	if e, a := "value", r.Header.Get("header-map-key-leading-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-key-with-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-leading-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-leading-tab"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-with-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "headerValue", r.Header.Get("header1"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -5089,7 +5089,7 @@ const opInputService23TestCaseOperation2 = "MemberRefOp"
 func (c *InputService23ProtocolTest) InputService23TestCaseOperation2Request(input *InputService23TestShapeInputService23TestCaseOperation2Input) (req *request.Request, output *InputService23TestShapeInputService23TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService23TestCaseOperation2,
-		HTTPMethod: "GET",
+		HTTPMethod: "POST",
 		HTTPPath:   "/path",
 	}
 
@@ -5465,7 +5465,7 @@ func TestInputService10ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBo
 
 	// assert headers
 	if e, a := "12345", r.Header.Get("x-amz-checksum"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -5500,7 +5500,7 @@ func TestInputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "foo", r.Header.Get("x-amz-sha256-tree-hash"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -5917,13 +5917,13 @@ func TestInputService17ProtocolTestTimestampValuesCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "Sun, 25 Jan 2015 08:00:00 GMT", r.Header.Get("x-amz-timearg"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "1422172800", r.Header.Get("x-amz-timecustom-header"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "1422172800", r.Header.Get("x-amz-timeformat-header"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -6076,7 +6076,7 @@ func TestInputService21ProtocolTestJSONValueTraitCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "eyJGb28iOiJCYXIifQ==", r.Header.Get("X-Amz-Foo"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -6151,8 +6151,8 @@ func TestInputService22ProtocolTestEnumCase1(t *testing.T) {
 		QueryFooEnum: aws.String("bar"),
 		QueryListEnums: []*string{
 			aws.String("0"),
-			aws.String(""),
 			aws.String("1"),
+			aws.String(""),
 		},
 	}
 	req, _ := svc.InputService22TestCaseOperation1Request(input)
@@ -6176,7 +6176,7 @@ func TestInputService22ProtocolTestEnumCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "baz", r.Header.Get("x-amz-enum"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }

--- a/private/protocol/restjson/unmarshal_test.go
+++ b/private/protocol/restjson/unmarshal_test.go
@@ -1474,6 +1474,7 @@ func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(inp
 
 	output = &OutputService9TestShapeOutputService9TestCaseOperation1Output{}
 	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restjson.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	return
 }
 
@@ -1512,22 +1513,6 @@ type OutputService9TestShapeOutputService9TestCaseOperation1Input struct {
 
 type OutputService9TestShapeOutputService9TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
-
-	AllHeaders map[string]*string `location:"headers" type:"map"`
-
-	PrefixedHeaders map[string]*string `location:"headers" locationName:"X-" type:"map"`
-}
-
-// SetAllHeaders sets the AllHeaders field's value.
-func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetAllHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
-	s.AllHeaders = v
-	return s
-}
-
-// SetPrefixedHeaders sets the PrefixedHeaders field's value.
-func (s *OutputService9TestShapeOutputService9TestCaseOperation1Output) SetPrefixedHeaders(v map[string]*string) *OutputService9TestShapeOutputService9TestCaseOperation1Output {
-	s.PrefixedHeaders = v
-	return s
 }
 
 // OutputService10ProtocolTest provides the API operation methods for making requests to
@@ -1658,39 +1643,27 @@ func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1WithConte
 	return out, req.Send()
 }
 
-type OutputService10TestShapeBodyStructure struct {
-	_ struct{} `type:"structure"`
-
-	Foo *string `type:"string"`
-}
-
-// SetFoo sets the Foo field's value.
-func (s *OutputService10TestShapeBodyStructure) SetFoo(v string) *OutputService10TestShapeBodyStructure {
-	s.Foo = &v
-	return s
-}
-
 type OutputService10TestShapeOutputService10TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
 type OutputService10TestShapeOutputService10TestCaseOperation1Output struct {
-	_ struct{} `type:"structure" payload:"Data"`
+	_ struct{} `type:"structure"`
 
-	Data *OutputService10TestShapeBodyStructure `type:"structure"`
+	AllHeaders map[string]*string `location:"headers" type:"map"`
 
-	Header *string `location:"header" locationName:"X-Foo" type:"string"`
+	PrefixedHeaders map[string]*string `location:"headers" locationName:"X-" type:"map"`
 }
 
-// SetData sets the Data field's value.
-func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetData(v *OutputService10TestShapeBodyStructure) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
-	s.Data = v
+// SetAllHeaders sets the AllHeaders field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetAllHeaders(v map[string]*string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.AllHeaders = v
 	return s
 }
 
-// SetHeader sets the Header field's value.
-func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetHeader(v string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
-	s.Header = &v
+// SetPrefixedHeaders sets the PrefixedHeaders field's value.
+func (s *OutputService10TestShapeOutputService10TestCaseOperation1Output) SetPrefixedHeaders(v map[string]*string) *OutputService10TestShapeOutputService10TestCaseOperation1Output {
+	s.PrefixedHeaders = v
 	return s
 }
 
@@ -1822,19 +1795,39 @@ func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1WithConte
 	return out, req.Send()
 }
 
+type OutputService11TestShapeBodyStructure struct {
+	_ struct{} `type:"structure"`
+
+	Foo *string `type:"string"`
+}
+
+// SetFoo sets the Foo field's value.
+func (s *OutputService11TestShapeBodyStructure) SetFoo(v string) *OutputService11TestShapeBodyStructure {
+	s.Foo = &v
+	return s
+}
+
 type OutputService11TestShapeOutputService11TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
 type OutputService11TestShapeOutputService11TestCaseOperation1Output struct {
-	_ struct{} `type:"structure" payload:"Stream"`
+	_ struct{} `type:"structure" payload:"Data"`
 
-	Stream []byte `type:"blob"`
+	Data *OutputService11TestShapeBodyStructure `type:"structure"`
+
+	Header *string `location:"header" locationName:"X-Foo" type:"string"`
 }
 
-// SetStream sets the Stream field's value.
-func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetStream(v []byte) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
-	s.Stream = v
+// SetData sets the Data field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetData(v *OutputService11TestShapeBodyStructure) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Data = v
+	return s
+}
+
+// SetHeader sets the Header field's value.
+func (s *OutputService11TestShapeOutputService11TestCaseOperation1Output) SetHeader(v string) *OutputService11TestShapeOutputService11TestCaseOperation1Output {
+	s.Header = &v
 	return s
 }
 
@@ -1966,135 +1959,19 @@ func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1WithConte
 	return out, req.Send()
 }
 
-const opOutputService12TestCaseOperation2 = "OperationName"
-
-// OutputService12TestCaseOperation2Request generates a "aws/request.Request" representing the
-// client's request for the OutputService12TestCaseOperation2 operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See OutputService12TestCaseOperation2 for more information on using the OutputService12TestCaseOperation2
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the OutputService12TestCaseOperation2Request method.
-//    req, resp := client.OutputService12TestCaseOperation2Request(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation2Request(input *OutputService12TestShapeOutputService12TestCaseOperation2Input) (req *request.Request, output *OutputService12TestShapeOutputService12TestCaseOperation2Output) {
-	op := &request.Operation{
-		Name:     opOutputService12TestCaseOperation2,
-		HTTPPath: "/",
-	}
-
-	if input == nil {
-		input = &OutputService12TestShapeOutputService12TestCaseOperation2Input{}
-	}
-
-	output = &OutputService12TestShapeOutputService12TestCaseOperation2Output{}
-	req = c.newRequest(op, input, output)
-	return
-}
-
-// OutputService12TestCaseOperation2 API operation for .
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the AWS API reference guide for 's
-// API operation OutputService12TestCaseOperation2 for usage and error information.
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation2(input *OutputService12TestShapeOutputService12TestCaseOperation2Input) (*OutputService12TestShapeOutputService12TestCaseOperation2Output, error) {
-	req, out := c.OutputService12TestCaseOperation2Request(input)
-	return out, req.Send()
-}
-
-// OutputService12TestCaseOperation2WithContext is the same as OutputService12TestCaseOperation2 with the addition of
-// the ability to pass a context and additional request options.
-//
-// See OutputService12TestCaseOperation2 for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation2WithContext(ctx aws.Context, input *OutputService12TestShapeOutputService12TestCaseOperation2Input, opts ...request.Option) (*OutputService12TestShapeOutputService12TestCaseOperation2Output, error) {
-	req, out := c.OutputService12TestCaseOperation2Request(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
 type OutputService12TestShapeOutputService12TestCaseOperation1Input struct {
 	_ struct{} `type:"structure"`
 }
 
 type OutputService12TestShapeOutputService12TestCaseOperation1Output struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `type:"structure" payload:"Stream"`
 
-	BodyField aws.JSONValue `type:"jsonvalue"`
-
-	BodyListField []aws.JSONValue `type:"list"`
-
-	HeaderField aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
+	Stream []byte `type:"blob"`
 }
 
-// SetBodyField sets the BodyField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetBodyField(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
-	s.BodyField = v
-	return s
-}
-
-// SetBodyListField sets the BodyListField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetBodyListField(v []aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
-	s.BodyListField = v
-	return s
-}
-
-// SetHeaderField sets the HeaderField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetHeaderField(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
-	s.HeaderField = v
-	return s
-}
-
-type OutputService12TestShapeOutputService12TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
-}
-
-type OutputService12TestShapeOutputService12TestCaseOperation2Output struct {
-	_ struct{} `type:"structure"`
-
-	BodyField aws.JSONValue `type:"jsonvalue"`
-
-	BodyListField []aws.JSONValue `type:"list"`
-
-	HeaderField aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
-}
-
-// SetBodyField sets the BodyField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation2Output) SetBodyField(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation2Output {
-	s.BodyField = v
-	return s
-}
-
-// SetBodyListField sets the BodyListField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation2Output) SetBodyListField(v []aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation2Output {
-	s.BodyListField = v
-	return s
-}
-
-// SetHeaderField sets the HeaderField field's value.
-func (s *OutputService12TestShapeOutputService12TestCaseOperation2Output) SetHeaderField(v aws.JSONValue) *OutputService12TestShapeOutputService12TestCaseOperation2Output {
-	s.HeaderField = v
+// SetStream sets the Stream field's value.
+func (s *OutputService12TestShapeOutputService12TestCaseOperation1Output) SetStream(v []byte) *OutputService12TestShapeOutputService12TestCaseOperation1Output {
+	s.Stream = v
 	return s
 }
 
@@ -2134,7 +2011,7 @@ func newOutputService13ProtocolTestClient(cfg aws.Config, handlers request.Handl
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
-				APIVersion:    "2014-01-01",
+				APIVersion:    "",
 			},
 			handlers,
 		),
@@ -2184,9 +2061,8 @@ const opOutputService13TestCaseOperation1 = "OperationName"
 //    }
 func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation1Request(input *OutputService13TestShapeOutputService13TestCaseOperation1Input) (req *request.Request, output *OutputService13TestShapeOutputService13TestCaseOperation1Output) {
 	op := &request.Operation{
-		Name:       opOutputService13TestCaseOperation1,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		Name:     opOutputService13TestCaseOperation1,
+		HTTPPath: "/",
 	}
 
 	if input == nil {
@@ -2253,9 +2129,8 @@ const opOutputService13TestCaseOperation2 = "OperationName"
 //    }
 func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation2Request(input *OutputService13TestShapeOutputService13TestCaseOperation2Input) (req *request.Request, output *OutputService13TestShapeOutputService13TestCaseOperation2Output) {
 	op := &request.Operation{
-		Name:       opOutputService13TestCaseOperation2,
-		HTTPMethod: "POST",
-		HTTPPath:   "/path",
+		Name:     opOutputService13TestCaseOperation2,
+		HTTPPath: "/",
 	}
 
 	if input == nil {
@@ -2264,7 +2139,6 @@ func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation2Request(i
 
 	output = &OutputService13TestShapeOutputService13TestCaseOperation2Output{}
 	req = c.newRequest(op, input, output)
-	req.Handlers.Unmarshal.Swap(restjson.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
 	return
 }
 
@@ -2304,74 +2178,337 @@ type OutputService13TestShapeOutputService13TestCaseOperation1Input struct {
 type OutputService13TestShapeOutputService13TestCaseOperation1Output struct {
 	_ struct{} `type:"structure"`
 
-	FooEnum *string `type:"string" enum:"OutputService13TestShapeRESTJSONEnumType"`
+	BodyField aws.JSONValue `type:"jsonvalue"`
 
-	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService13TestShapeRESTJSONEnumType"`
+	BodyListField []aws.JSONValue `type:"list"`
 
-	ListEnums []*string `type:"list"`
+	HeaderField aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
 }
 
-// SetFooEnum sets the FooEnum field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetFooEnum(v string) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
-	s.FooEnum = &v
+// SetBodyField sets the BodyField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetBodyField(v aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
+	s.BodyField = v
 	return s
 }
 
-// SetHeaderEnum sets the HeaderEnum field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetHeaderEnum(v string) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
-	s.HeaderEnum = &v
+// SetBodyListField sets the BodyListField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetBodyListField(v []aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
+	s.BodyListField = v
 	return s
 }
 
-// SetListEnums sets the ListEnums field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetListEnums(v []*string) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
-	s.ListEnums = v
+// SetHeaderField sets the HeaderField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation1Output) SetHeaderField(v aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation1Output {
+	s.HeaderField = v
 	return s
 }
 
 type OutputService13TestShapeOutputService13TestCaseOperation2Input struct {
 	_ struct{} `type:"structure"`
+}
 
-	FooEnum *string `type:"string" enum:"OutputService13TestShapeRESTJSONEnumType"`
+type OutputService13TestShapeOutputService13TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
 
-	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService13TestShapeRESTJSONEnumType"`
+	BodyField aws.JSONValue `type:"jsonvalue"`
+
+	BodyListField []aws.JSONValue `type:"list"`
+
+	HeaderField aws.JSONValue `location:"header" locationName:"X-Amz-Foo" type:"jsonvalue"`
+}
+
+// SetBodyField sets the BodyField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation2Output) SetBodyField(v aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation2Output {
+	s.BodyField = v
+	return s
+}
+
+// SetBodyListField sets the BodyListField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation2Output) SetBodyListField(v []aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation2Output {
+	s.BodyListField = v
+	return s
+}
+
+// SetHeaderField sets the HeaderField field's value.
+func (s *OutputService13TestShapeOutputService13TestCaseOperation2Output) SetHeaderField(v aws.JSONValue) *OutputService13TestShapeOutputService13TestCaseOperation2Output {
+	s.HeaderField = v
+	return s
+}
+
+// OutputService14ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// OutputService14ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type OutputService14ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService14ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService14ProtocolTest client from just a session.
+//     svc := outputservice14protocoltest.New(mySession)
+//
+//     // Create a OutputService14ProtocolTest client with additional configuration
+//     svc := outputservice14protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService14ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService14ProtocolTest {
+	c := p.ClientConfig("outputservice14protocoltest", cfgs...)
+	return newOutputService14ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService14ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService14ProtocolTest {
+	svc := &OutputService14ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "OutputService14ProtocolTest",
+				ServiceID:     "OutputService14ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restjson.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restjson.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restjson.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restjson.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService14ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService14TestCaseOperation1 = "OperationName"
+
+// OutputService14TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService14TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService14TestCaseOperation1 for more information on using the OutputService14TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService14TestCaseOperation1Request method.
+//    req, resp := client.OutputService14TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1Request(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (req *request.Request, output *OutputService14TestShapeOutputService14TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opOutputService14TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &OutputService14TestShapeOutputService14TestCaseOperation1Input{}
+	}
+
+	output = &OutputService14TestShapeOutputService14TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService14TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService14TestCaseOperation1 for usage and error information.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (*OutputService14TestShapeOutputService14TestCaseOperation1Output, error) {
+	req, out := c.OutputService14TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// OutputService14TestCaseOperation1WithContext is the same as OutputService14TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService14TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1WithContext(ctx aws.Context, input *OutputService14TestShapeOutputService14TestCaseOperation1Input, opts ...request.Option) (*OutputService14TestShapeOutputService14TestCaseOperation1Output, error) {
+	req, out := c.OutputService14TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opOutputService14TestCaseOperation2 = "OperationName"
+
+// OutputService14TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the OutputService14TestCaseOperation2 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService14TestCaseOperation2 for more information on using the OutputService14TestCaseOperation2
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService14TestCaseOperation2Request method.
+//    req, resp := client.OutputService14TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2Request(input *OutputService14TestShapeOutputService14TestCaseOperation2Input) (req *request.Request, output *OutputService14TestShapeOutputService14TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opOutputService14TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &OutputService14TestShapeOutputService14TestCaseOperation2Input{}
+	}
+
+	output = &OutputService14TestShapeOutputService14TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restjson.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// OutputService14TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService14TestCaseOperation2 for usage and error information.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2(input *OutputService14TestShapeOutputService14TestCaseOperation2Input) (*OutputService14TestShapeOutputService14TestCaseOperation2Output, error) {
+	req, out := c.OutputService14TestCaseOperation2Request(input)
+	return out, req.Send()
+}
+
+// OutputService14TestCaseOperation2WithContext is the same as OutputService14TestCaseOperation2 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService14TestCaseOperation2 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2WithContext(ctx aws.Context, input *OutputService14TestShapeOutputService14TestCaseOperation2Input, opts ...request.Option) (*OutputService14TestShapeOutputService14TestCaseOperation2Output, error) {
+	req, out := c.OutputService14TestCaseOperation2Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
 
 	ListEnums []*string `type:"list"`
 }
 
 // SetFooEnum sets the FooEnum field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation2Input) SetFooEnum(v string) *OutputService13TestShapeOutputService13TestCaseOperation2Input {
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetFooEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
 	s.FooEnum = &v
 	return s
 }
 
 // SetHeaderEnum sets the HeaderEnum field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation2Input) SetHeaderEnum(v string) *OutputService13TestShapeOutputService13TestCaseOperation2Input {
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetHeaderEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
 	s.HeaderEnum = &v
 	return s
 }
 
 // SetListEnums sets the ListEnums field's value.
-func (s *OutputService13TestShapeOutputService13TestCaseOperation2Input) SetListEnums(v []*string) *OutputService13TestShapeOutputService13TestCaseOperation2Input {
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetListEnums(v []*string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
 	s.ListEnums = v
 	return s
 }
 
-type OutputService13TestShapeOutputService13TestCaseOperation2Output struct {
+type OutputService14TestShapeOutputService14TestCaseOperation2Input struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	ListEnums []*string `type:"list"`
+}
+
+// SetFooEnum sets the FooEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetFooEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.FooEnum = &v
+	return s
+}
+
+// SetHeaderEnum sets the HeaderEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetHeaderEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.HeaderEnum = &v
+	return s
+}
+
+// SetListEnums sets the ListEnums field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetListEnums(v []*string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.ListEnums = v
+	return s
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
 const (
-	// RESTJSONEnumTypeFoo is a OutputService13TestShapeRESTJSONEnumType enum value
+	// RESTJSONEnumTypeFoo is a OutputService14TestShapeRESTJSONEnumType enum value
 	RESTJSONEnumTypeFoo = "foo"
 
-	// RESTJSONEnumTypeBar is a OutputService13TestShapeRESTJSONEnumType enum value
+	// RESTJSONEnumTypeBar is a OutputService14TestShapeRESTJSONEnumType enum value
 	RESTJSONEnumTypeBar = "bar"
 
-	// RESTJSONEnumType0 is a OutputService13TestShapeRESTJSONEnumType enum value
+	// RESTJSONEnumType0 is a OutputService14TestShapeRESTJSONEnumType enum value
 	RESTJSONEnumType0 = "0"
 
-	// RESTJSONEnumType1 is a OutputService13TestShapeRESTJSONEnumType enum value
+	// RESTJSONEnumType1 is a OutputService14TestShapeRESTJSONEnumType enum value
 	RESTJSONEnumType1 = "1"
 )
 
@@ -2661,11 +2798,34 @@ func TestOutputService8ProtocolTestIgnoresExtraDataCase1(t *testing.T) {
 
 }
 
-func TestOutputService9ProtocolTestSupportsHeaderMapsCase1(t *testing.T) {
+func TestOutputService9ProtocolTestIgnoresUndefinedOutputCase1(t *testing.T) {
 	svc := NewOutputService9ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
-	buf := bytes.NewReader([]byte("{}"))
+	buf := bytes.NewReader([]byte("OK"))
 	req, out := svc.OutputService9TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+
+}
+
+func TestOutputService10ProtocolTestSupportsHeaderMapsCase1(t *testing.T) {
+	svc := NewOutputService10ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte("{}"))
+	req, out := svc.OutputService10TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2702,11 +2862,11 @@ func TestOutputService9ProtocolTestSupportsHeaderMapsCase1(t *testing.T) {
 
 }
 
-func TestOutputService10ProtocolTestJSONPayloadCase1(t *testing.T) {
-	svc := NewOutputService10ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService11ProtocolTestJSONPayloadCase1(t *testing.T) {
+	svc := NewOutputService11ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte("{\"Foo\": \"abc\"}"))
-	req, out := svc.OutputService10TestCaseOperation1Request(nil)
+	req, out := svc.OutputService11TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2732,11 +2892,11 @@ func TestOutputService10ProtocolTestJSONPayloadCase1(t *testing.T) {
 
 }
 
-func TestOutputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
-	svc := NewOutputService11ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService12ProtocolTestStreamingPayloadCase1(t *testing.T) {
+	svc := NewOutputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte("abc"))
-	req, out := svc.OutputService11TestCaseOperation1Request(nil)
+	req, out := svc.OutputService12TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2758,11 +2918,11 @@ func TestOutputService11ProtocolTestStreamingPayloadCase1(t *testing.T) {
 
 }
 
-func TestOutputService12ProtocolTestJSONValueTraitCase1(t *testing.T) {
-	svc := NewOutputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService13ProtocolTestJSONValueTraitCase1(t *testing.T) {
+	svc := NewOutputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte("{\"BodyField\":\"{\\\"Foo\\\":\\\"Bar\\\"}\"}"))
-	req, out := svc.OutputService12TestCaseOperation1Request(nil)
+	req, out := svc.OutputService13TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2784,11 +2944,11 @@ func TestOutputService12ProtocolTestJSONValueTraitCase1(t *testing.T) {
 
 }
 
-func TestOutputService12ProtocolTestJSONValueTraitCase2(t *testing.T) {
-	svc := NewOutputService12ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService13ProtocolTestJSONValueTraitCase2(t *testing.T) {
+	svc := NewOutputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte("{\"BodyListField\":[\"{\\\"Foo\\\":\\\"Bar\\\"}\"]}"))
-	req, out := svc.OutputService12TestCaseOperation2Request(nil)
+	req, out := svc.OutputService13TestCaseOperation2Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2808,11 +2968,11 @@ func TestOutputService12ProtocolTestJSONValueTraitCase2(t *testing.T) {
 
 }
 
-func TestOutputService13ProtocolTestEnumCase1(t *testing.T) {
-	svc := NewOutputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService14ProtocolTestEnumCase1(t *testing.T) {
+	svc := NewOutputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte("{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"bar\"]}"))
-	req, out := svc.OutputService13TestCaseOperation1Request(nil)
+	req, out := svc.OutputService14TestCaseOperation1Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers
@@ -2844,11 +3004,11 @@ func TestOutputService13ProtocolTestEnumCase1(t *testing.T) {
 
 }
 
-func TestOutputService13ProtocolTestEnumCase2(t *testing.T) {
-	svc := NewOutputService13ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+func TestOutputService14ProtocolTestEnumCase2(t *testing.T) {
+	svc := NewOutputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
 
 	buf := bytes.NewReader([]byte(""))
-	req, out := svc.OutputService13TestCaseOperation2Request(nil)
+	req, out := svc.OutputService14TestCaseOperation2Request(nil)
 	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
 
 	// set headers

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -5788,6 +5788,160 @@ type InputService26TestShapeInputService26TestCaseOperation2Output struct {
 	_ struct{} `type:"structure"`
 }
 
+// InputService27ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// InputService27ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type InputService27ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the InputService27ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a InputService27ProtocolTest client from just a session.
+//     svc := inputservice27protocoltest.New(mySession)
+//
+//     // Create a InputService27ProtocolTest client with additional configuration
+//     svc := inputservice27protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewInputService27ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *InputService27ProtocolTest {
+	c := p.ClientConfig("inputservice27protocoltest", cfgs...)
+	return newInputService27ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newInputService27ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *InputService27ProtocolTest {
+	svc := &InputService27ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "InputService27ProtocolTest",
+				ServiceID:     "InputService27ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "2014-01-01",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a InputService27ProtocolTest operation and runs any
+// custom request initialization.
+func (c *InputService27ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opInputService27TestCaseOperation1 = "OperationName"
+
+// InputService27TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the InputService27TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See InputService27TestCaseOperation1 for more information on using the InputService27TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the InputService27TestCaseOperation1Request method.
+//    req, resp := client.InputService27TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *InputService27ProtocolTest) InputService27TestCaseOperation1Request(input *InputService27TestShapeInputService27TestCaseOperation1Input) (req *request.Request, output *InputService27TestShapeInputService27TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opInputService27TestCaseOperation1,
+		HTTPMethod: "GET",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &InputService27TestShapeInputService27TestCaseOperation1Input{}
+	}
+
+	output = &InputService27TestShapeInputService27TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// InputService27TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation InputService27TestCaseOperation1 for usage and error information.
+func (c *InputService27ProtocolTest) InputService27TestCaseOperation1(input *InputService27TestShapeInputService27TestCaseOperation1Input) (*InputService27TestShapeInputService27TestCaseOperation1Output, error) {
+	req, out := c.InputService27TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// InputService27TestCaseOperation1WithContext is the same as InputService27TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See InputService27TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *InputService27ProtocolTest) InputService27TestCaseOperation1WithContext(ctx aws.Context, input *InputService27TestShapeInputService27TestCaseOperation1Input, opts ...request.Option) (*InputService27TestShapeInputService27TestCaseOperation1Output, error) {
+	req, out := c.InputService27TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type InputService27TestShapeInputService27TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+
+	Header1 *string `location:"header" type:"string"`
+
+	HeaderMap map[string]*string `location:"headers" locationName:"header-map-" type:"map"`
+}
+
+// SetHeader1 sets the Header1 field's value.
+func (s *InputService27TestShapeInputService27TestCaseOperation1Input) SetHeader1(v string) *InputService27TestShapeInputService27TestCaseOperation1Input {
+	s.Header1 = &v
+	return s
+}
+
+// SetHeaderMap sets the HeaderMap field's value.
+func (s *InputService27TestShapeInputService27TestCaseOperation1Input) SetHeaderMap(v map[string]*string) *InputService27TestShapeInputService27TestCaseOperation1Input {
+	s.HeaderMap = v
+	return s
+}
+
+type InputService27TestShapeInputService27TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+}
+
 //
 // Tests begin here
 //
@@ -7037,5 +7191,51 @@ func TestInputService26ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://foo-myname.service.region.amazonaws.com/path", r.URL.String())
 
 	// assert headers
+
+}
+
+func TestInputService27ProtocolTestHeaderWhitespaceCase1(t *testing.T) {
+	svc := NewInputService27ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+	input := &InputService27TestShapeInputService27TestCaseOperation1Input{
+		Header1: aws.String("   headerValue"),
+		HeaderMap: map[string]*string{
+			"   key-leading-space": aws.String("value"),
+			"   key-with-space   ": aws.String("value"),
+			"leading-space":        aws.String("   value"),
+			"leading-tab":          aws.String("    value"),
+			"with-space":           aws.String("   value   "),
+		},
+	}
+	req, _ := svc.InputService27TestCaseOperation1Request(input)
+	r := req.HTTPRequest
+
+	// build request
+	req.Build()
+	if req.Error != nil {
+		t.Errorf("expect no error, got %v", req.Error)
+	}
+
+	// assert URL
+	awstesting.AssertURL(t, "https://test/", r.URL.String())
+
+	// assert headers
+	if e, a := "value", r.Header.Get("header-map-key-leading-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-key-with-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-leading-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-leading-tab"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "value", r.Header.Get("header-map-with-space"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "headerValue", r.Header.Get("header1"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -5688,7 +5688,7 @@ const opInputService26TestCaseOperation2 = "MemberRefOp"
 func (c *InputService26ProtocolTest) InputService26TestCaseOperation2Request(input *InputService26TestShapeInputService26TestCaseOperation2Input) (req *request.Request, output *InputService26TestShapeInputService26TestCaseOperation2Output) {
 	op := &request.Operation{
 		Name:       opInputService26TestCaseOperation2,
-		HTTPMethod: "GET",
+		HTTPMethod: "POST",
 		HTTPPath:   "/path",
 	}
 
@@ -6222,13 +6222,13 @@ func TestInputService11ProtocolTestTimestampShapesCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "Sun, 25 Jan 2015 08:00:00 GMT", r.Header.Get("x-amz-timearg"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "1422172800", r.Header.Get("x-amz-timecustom-header"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "1422172800", r.Header.Get("x-amz-timeformat-header"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -6255,10 +6255,10 @@ func TestInputService12ProtocolTestHeaderMapsCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "b", r.Header.Get("x-foo-a"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "d", r.Header.Get("x-foo-c"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }
@@ -6958,7 +6958,7 @@ func TestInputService25ProtocolTestEnumCase1(t *testing.T) {
 
 	// assert headers
 	if e, a := "baz", r.Header.Get("x-amz-enum"); e != a {
-		t.Errorf("expect %v to be %v", e, a)
+		t.Errorf("expect %v, got %v", e, a)
 	}
 
 }

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -2325,6 +2325,472 @@ func (s *OutputService13TestShapeTimeContainer) SetFoo(v time.Time) *OutputServi
 	return s
 }
 
+// OutputService14ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// OutputService14ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type OutputService14ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService14ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService14ProtocolTest client from just a session.
+//     svc := outputservice14protocoltest.New(mySession)
+//
+//     // Create a OutputService14ProtocolTest client with additional configuration
+//     svc := outputservice14protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService14ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService14ProtocolTest {
+	c := p.ClientConfig("outputservice14protocoltest", cfgs...)
+	return newOutputService14ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService14ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService14ProtocolTest {
+	svc := &OutputService14ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "OutputService14ProtocolTest",
+				ServiceID:     "OutputService14ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService14ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService14TestCaseOperation1 = "OperationName"
+
+// OutputService14TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService14TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService14TestCaseOperation1 for more information on using the OutputService14TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService14TestCaseOperation1Request method.
+//    req, resp := client.OutputService14TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1Request(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (req *request.Request, output *OutputService14TestShapeOutputService14TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opOutputService14TestCaseOperation1,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &OutputService14TestShapeOutputService14TestCaseOperation1Input{}
+	}
+
+	output = &OutputService14TestShapeOutputService14TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService14TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService14TestCaseOperation1 for usage and error information.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (*OutputService14TestShapeOutputService14TestCaseOperation1Output, error) {
+	req, out := c.OutputService14TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// OutputService14TestCaseOperation1WithContext is the same as OutputService14TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService14TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1WithContext(ctx aws.Context, input *OutputService14TestShapeOutputService14TestCaseOperation1Input, opts ...request.Option) (*OutputService14TestShapeOutputService14TestCaseOperation1Output, error) {
+	req, out := c.OutputService14TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opOutputService14TestCaseOperation2 = "OperationName"
+
+// OutputService14TestCaseOperation2Request generates a "aws/request.Request" representing the
+// client's request for the OutputService14TestCaseOperation2 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService14TestCaseOperation2 for more information on using the OutputService14TestCaseOperation2
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService14TestCaseOperation2Request method.
+//    req, resp := client.OutputService14TestCaseOperation2Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2Request(input *OutputService14TestShapeOutputService14TestCaseOperation2Input) (req *request.Request, output *OutputService14TestShapeOutputService14TestCaseOperation2Output) {
+	op := &request.Operation{
+		Name:       opOutputService14TestCaseOperation2,
+		HTTPMethod: "POST",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &OutputService14TestShapeOutputService14TestCaseOperation2Input{}
+	}
+
+	output = &OutputService14TestShapeOutputService14TestCaseOperation2Output{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// OutputService14TestCaseOperation2 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService14TestCaseOperation2 for usage and error information.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2(input *OutputService14TestShapeOutputService14TestCaseOperation2Input) (*OutputService14TestShapeOutputService14TestCaseOperation2Output, error) {
+	req, out := c.OutputService14TestCaseOperation2Request(input)
+	return out, req.Send()
+}
+
+// OutputService14TestCaseOperation2WithContext is the same as OutputService14TestCaseOperation2 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService14TestCaseOperation2 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation2WithContext(ctx aws.Context, input *OutputService14TestShapeOutputService14TestCaseOperation2Input, opts ...request.Option) (*OutputService14TestShapeOutputService14TestCaseOperation2Output, error) {
+	req, out := c.OutputService14TestCaseOperation2Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	ListEnums []*string `type:"list"`
+}
+
+// SetFooEnum sets the FooEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetFooEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
+	s.FooEnum = &v
+	return s
+}
+
+// SetHeaderEnum sets the HeaderEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetHeaderEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
+	s.HeaderEnum = &v
+	return s
+}
+
+// SetListEnums sets the ListEnums field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetListEnums(v []*string) *OutputService14TestShapeOutputService14TestCaseOperation1Output {
+	s.ListEnums = v
+	return s
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation2Input struct {
+	_ struct{} `type:"structure"`
+
+	FooEnum *string `type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	HeaderEnum *string `location:"header" locationName:"x-amz-enum" type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
+
+	ListEnums []*string `type:"list"`
+}
+
+// SetFooEnum sets the FooEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetFooEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.FooEnum = &v
+	return s
+}
+
+// SetHeaderEnum sets the HeaderEnum field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetHeaderEnum(v string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.HeaderEnum = &v
+	return s
+}
+
+// SetListEnums sets the ListEnums field's value.
+func (s *OutputService14TestShapeOutputService14TestCaseOperation2Input) SetListEnums(v []*string) *OutputService14TestShapeOutputService14TestCaseOperation2Input {
+	s.ListEnums = v
+	return s
+}
+
+type OutputService14TestShapeOutputService14TestCaseOperation2Output struct {
+	_ struct{} `type:"structure"`
+}
+
+const (
+	// RESTJSONEnumTypeFoo is a OutputService14TestShapeRESTJSONEnumType enum value
+	RESTJSONEnumTypeFoo = "foo"
+
+	// RESTJSONEnumTypeBar is a OutputService14TestShapeRESTJSONEnumType enum value
+	RESTJSONEnumTypeBar = "bar"
+
+	// RESTJSONEnumType0 is a OutputService14TestShapeRESTJSONEnumType enum value
+	RESTJSONEnumType0 = "0"
+
+	// RESTJSONEnumType1 is a OutputService14TestShapeRESTJSONEnumType enum value
+	RESTJSONEnumType1 = "1"
+)
+
+// OutputService15ProtocolTest provides the API operation methods for making requests to
+// . See this package's package overview docs
+// for details on the service.
+//
+// OutputService15ProtocolTest methods are safe to use concurrently. It is not safe to
+// modify mutate any of the struct's properties though.
+type OutputService15ProtocolTest struct {
+	*client.Client
+}
+
+// New creates a new instance of the OutputService15ProtocolTest client with a session.
+// If additional configuration is needed for the client instance use the optional
+// aws.Config parameter to add your extra config.
+//
+// Example:
+//     // Create a OutputService15ProtocolTest client from just a session.
+//     svc := outputservice15protocoltest.New(mySession)
+//
+//     // Create a OutputService15ProtocolTest client with additional configuration
+//     svc := outputservice15protocoltest.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
+func NewOutputService15ProtocolTest(p client.ConfigProvider, cfgs ...*aws.Config) *OutputService15ProtocolTest {
+	c := p.ClientConfig("outputservice15protocoltest", cfgs...)
+	return newOutputService15ProtocolTestClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+}
+
+// newClient creates, initializes and returns a new service client instance.
+func newOutputService15ProtocolTestClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *OutputService15ProtocolTest {
+	svc := &OutputService15ProtocolTest{
+		Client: client.New(
+			cfg,
+			metadata.ClientInfo{
+				ServiceName:   "OutputService15ProtocolTest",
+				ServiceID:     "OutputService15ProtocolTest",
+				SigningName:   signingName,
+				SigningRegion: signingRegion,
+				Endpoint:      endpoint,
+				APIVersion:    "",
+			},
+			handlers,
+		),
+	}
+
+	// Handlers
+	svc.Handlers.Sign.PushBackNamed(v4.SignRequestHandler)
+	svc.Handlers.Build.PushBackNamed(restxml.BuildHandler)
+	svc.Handlers.Unmarshal.PushBackNamed(restxml.UnmarshalHandler)
+	svc.Handlers.UnmarshalMeta.PushBackNamed(restxml.UnmarshalMetaHandler)
+	svc.Handlers.UnmarshalError.PushBackNamed(restxml.UnmarshalErrorHandler)
+
+	return svc
+}
+
+// newRequest creates a new request for a OutputService15ProtocolTest operation and runs any
+// custom request initialization.
+func (c *OutputService15ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
+
+	return req
+}
+
+const opOutputService15TestCaseOperation1 = "OperationName"
+
+// OutputService15TestCaseOperation1Request generates a "aws/request.Request" representing the
+// client's request for the OutputService15TestCaseOperation1 operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See OutputService15TestCaseOperation1 for more information on using the OutputService15TestCaseOperation1
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the OutputService15TestCaseOperation1Request method.
+//    req, resp := client.OutputService15TestCaseOperation1Request(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *OutputService15ProtocolTest) OutputService15TestCaseOperation1Request(input *OutputService15TestShapeOutputService15TestCaseOperation1Input) (req *request.Request, output *OutputService15TestShapeOutputService15TestCaseOperation1Output) {
+	op := &request.Operation{
+		Name:       opOutputService15TestCaseOperation1,
+		HTTPMethod: "GET",
+		HTTPPath:   "/path",
+	}
+
+	if input == nil {
+		input = &OutputService15TestShapeOutputService15TestCaseOperation1Input{}
+	}
+
+	output = &OutputService15TestShapeOutputService15TestCaseOperation1Output{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// OutputService15TestCaseOperation1 API operation for .
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for 's
+// API operation OutputService15TestCaseOperation1 for usage and error information.
+func (c *OutputService15ProtocolTest) OutputService15TestCaseOperation1(input *OutputService15TestShapeOutputService15TestCaseOperation1Input) (*OutputService15TestShapeOutputService15TestCaseOperation1Output, error) {
+	req, out := c.OutputService15TestCaseOperation1Request(input)
+	return out, req.Send()
+}
+
+// OutputService15TestCaseOperation1WithContext is the same as OutputService15TestCaseOperation1 with the addition of
+// the ability to pass a context and additional request options.
+//
+// See OutputService15TestCaseOperation1 for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *OutputService15ProtocolTest) OutputService15TestCaseOperation1WithContext(ctx aws.Context, input *OutputService15TestShapeOutputService15TestCaseOperation1Input, opts ...request.Option) (*OutputService15TestShapeOutputService15TestCaseOperation1Output, error) {
+	req, out := c.OutputService15TestCaseOperation1Request(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+type OutputService15TestShapeItemDetailShape struct {
+	_ struct{} `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+
+	ID *string `type:"string"`
+
+	// Type is a required field
+	Type *string `locationName:"xsi:type" type:"string" xmlAttribute:"true" required:"true" enum:"OutputService15TestShapeItemType"`
+}
+
+// SetID sets the ID field's value.
+func (s *OutputService15TestShapeItemDetailShape) SetID(v string) *OutputService15TestShapeItemDetailShape {
+	s.ID = &v
+	return s
+}
+
+// SetType sets the Type field's value.
+func (s *OutputService15TestShapeItemDetailShape) SetType(v string) *OutputService15TestShapeItemDetailShape {
+	s.Type = &v
+	return s
+}
+
+type OutputService15TestShapeItemShape struct {
+	_ struct{} `type:"structure"`
+
+	ItemDetail *OutputService15TestShapeItemDetailShape `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
+}
+
+// SetItemDetail sets the ItemDetail field's value.
+func (s *OutputService15TestShapeItemShape) SetItemDetail(v *OutputService15TestShapeItemDetailShape) *OutputService15TestShapeItemShape {
+	s.ItemDetail = v
+	return s
+}
+
+type OutputService15TestShapeOutputService15TestCaseOperation1Input struct {
+	_ struct{} `type:"structure"`
+}
+
+type OutputService15TestShapeOutputService15TestCaseOperation1Output struct {
+	_ struct{} `type:"structure"`
+
+	ListItems []*OutputService15TestShapeItemShape `locationName:"ItemsList" locationNameList:"Item" type:"list"`
+}
+
+// SetListItems sets the ListItems field's value.
+func (s *OutputService15TestShapeOutputService15TestCaseOperation1Output) SetListItems(v []*OutputService15TestShapeItemShape) *OutputService15TestShapeOutputService15TestCaseOperation1Output {
+	s.ListItems = v
+	return s
+}
+
+const (
+	// ItemTypeType1 is a OutputService15TestShapeItemType enum value
+	ItemTypeType1 = "Type1"
+
+	// ItemTypeType2 is a OutputService15TestShapeItemType enum value
+	ItemTypeType2 = "Type2"
+
+	// ItemTypeType3 is a OutputService15TestShapeItemType enum value
+	ItemTypeType3 = "Type3"
+)
+
 //
 // Tests begin here
 //
@@ -2831,6 +3297,106 @@ func TestOutputService13ProtocolTestTimestampMembersCase1(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := time.Unix(1.398796238e+09, 0).UTC().String(), out.TimeFormatInHeader.UTC().String(); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+
+}
+
+func TestOutputService14ProtocolTestEnumCase1(t *testing.T) {
+	svc := NewOutputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte("<OperationNameResponse><FooEnum>foo</FooEnum><ListEnums><member>0</member><member>1</member></ListEnums></OperationNameResponse>"))
+	req, out := svc.OutputService14TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+	req.HTTPResponse.Header.Set("x-amz-enum", "baz")
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+	if e, a := "foo", *out.FooEnum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "baz", *out.HeaderEnum; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "0", *out.ListEnums[0]; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "1", *out.ListEnums[1]; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+
+}
+
+func TestOutputService14ProtocolTestEnumCase2(t *testing.T) {
+	svc := NewOutputService14ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte(""))
+	req, out := svc.OutputService14TestCaseOperation2Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+
+}
+
+func TestOutputService15ProtocolTestXMLAttributesCase1(t *testing.T) {
+	svc := NewOutputService15ProtocolTest(unit.Session, &aws.Config{Endpoint: aws.String("https://test")})
+
+	buf := bytes.NewReader([]byte("<SomeOutputDoc xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><ItemsList><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type1\"><ID>id1</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type2\"><ID>id2</ID></ItemDetail></Item><Item><ItemDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Type3\"><ID>id3</ID></ItemDetail></Item></ItemsList></SomeOutputDoc>"))
+	req, out := svc.OutputService15TestCaseOperation1Request(nil)
+	req.HTTPResponse = &http.Response{StatusCode: 200, Body: ioutil.NopCloser(buf), Header: http.Header{}}
+
+	// set headers
+
+	// unmarshal response
+	req.Handlers.UnmarshalMeta.Run(req)
+	req.Handlers.Unmarshal.Run(req)
+	if req.Error != nil {
+		t.Errorf("expect not error, got %v", req.Error)
+	}
+
+	// assert response
+	if out == nil {
+		t.Errorf("expect not to be nil")
+	}
+	if e, a := "id1", *out.ListItems[0].ItemDetail.ID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "Type1", *out.ListItems[0].ItemDetail.Type; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "id2", *out.ListItems[1].ItemDetail.ID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "Type2", *out.ListItems[1].ItemDetail.Type; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "id3", *out.ListItems[2].ItemDetail.ID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "Type3", *out.ListItems[2].ItemDetail.Type; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 


### PR DESCRIPTION
Updates the REST protocol marshaler to trip leading and trailing space from header keys and values before setting the HTTP request  header.

Fixes a bug when using S3 metadata where metadata values with leading spaces would trigger request signature validation errors when the request is received by the service.

Fix #2448