### PR TITLE
aws/ec2metadata: Fix EC2 Metadata client panic with debug logging

### DIFF
--- a/aws/client/logger.go
+++ b/aws/client/logger.go
@@ -118,6 +118,12 @@ var LogHTTPResponseHandler = request.NamedHandler{
 func logResponse(r *request.Request) {
 	lw := &logWriter{r.Config.Logger, bytes.NewBuffer(nil)}
 
+	if r.HTTPResponse == nil {
+		lw.Logger.Log(fmt.Sprintf(logRespErrMsg,
+			r.ClientInfo.ServiceName, r.Operation.Name, "request's HTTPResponse is nil"))
+		return
+	}
+
 	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 	if logBody {
 		r.HTTPResponse.Body = &teeReaderCloser{

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -92,6 +92,9 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 		svc.Handlers.Send.SwapNamed(request.NamedHandler{
 			Name: corehandlers.SendHandler.Name,
 			Fn: func(r *request.Request) {
+				r.HTTPResponse = &http.Response{
+					Header: http.Header{},
+				}
 				r.Error = awserr.New(
 					request.CanceledErrorCode,
 					"EC2 IMDS access disabled via "+disableServiceEnvVar+" env var",

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -85,7 +85,9 @@ func TestClientDisableIMDS(t *testing.T) {
 
 	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 
-	svc := ec2metadata.New(unit.Session)
+	svc := ec2metadata.New(unit.Session, &aws.Config{
+		LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody),
+	})
 	resp, err := svc.Region()
 	if err == nil {
 		t.Fatalf("expect error, got none")


### PR DESCRIPTION
Fixes a panic that could occur witihin the EC2 Metadata client when both
`AWS_EC2_METADATA_DISABLED` env var is set and log level is
LogDebugWithHTTPBody. The SDK's client response body debug functionality
would panic because the Request.HTTPResponse value was not specified.

Updates the client debug loggers to check if the response is set before
attempting to log.