### PR TITLE
Update Travis CI tests for Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
     - 1.9.x
     - 1.10.x
     - 1.11.x
+    - 1.12.x
     - tip
 
 matrix:
@@ -29,9 +30,10 @@ matrix:
           env: GO15VENDOREXPERIMENT=1
 
 script:
-  - if [ $TRAVIS_GO_VERSION == "tip" ] ||
+  - if [ $TRAVIS_GO_VERSION == "1.10.x" ] ||
     [ $TRAVIS_GO_VERSION == "1.11.x" ] ||
-    [ $TRAVIS_GO_VERSION == "1.10.x" ]; then
+    [ $TRAVIS_GO_VERSION == "1.12.x" ] ||
+    [ $TRAVIS_GO_VERSION == "tip" ]; then
         make get-deps;
         make ci-test;
     else

--- a/Makefile
+++ b/Makefile
@@ -14,27 +14,12 @@ SDK_CLIENT_PKGS=./service/...
 SDK_COMPA_PKGS=${SDK_CORE_PKGS} ${SDK_CLIENT_PKGS}
 
 # SDK additional packages that are used for development of the SDK.
-SDK_EXAMPLES_PKGS=./examples/...
+SDK_EXAMPLES_PKGS=./example/...
 SDK_TESTING_PKGS=./awstesting/...
 SDK_MODELS_PKGS=./models/...
 SDK_ALL_PKGS=${SDK_COMPA_PKGS} ${SDK_TESTING_PKGS} ${SDK_EXAMPLES_PKGS} ${SDK_MODELS_PKGS}
 
 all: generate unit
-
-help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  api_info                to print a list of services and versions"
-	@echo "  docs                    to build SDK documentation"
-	@echo "  unit                    to run unit tests"
-	@echo "  integration             to run integration tests"
-	@echo "  performance             to run performance tests"
-	@echo "  verify                  to verify tests"
-	@echo "  lint                    to lint the SDK"
-	@echo "  vet                     to vet the SDK"
-	@echo "  generate                to go generate and make services"
-	@echo "  gen-test                to generate protocol tests"
-	@echo "  gen-services            to generate services"
-	@echo "  get-deps                to go get the SDK dependencies"
 
 ###################
 # Code Generation #
@@ -57,7 +42,7 @@ gen-protocol-test:
 
 gen-endpoints:
 	@echo "Generating SDK endpoints"
-	go generate ./models/endpoints/
+	go generate ./models/endpoints
 
 cleanup-models:
 	@echo "Cleaning up stale model versions"
@@ -94,7 +79,7 @@ integration: core-integ client-integ
 
 core-integ:
 	@echo "Integration Testing SDK core"
-	AWS_REGION="" go test -count=1 -tags "integration" -v -run '^TestInteg_' ./aws/... ./private/... ./internal/... ./awstesting/...
+	AWS_REGION="" go test -count=1 -tags "integration" -v -run '^TestInteg_' ${SDK_CORE_PKGS} ./awstesting/...
 
 client-integ:
 	@echo "Integration Testing SDK clients"
@@ -111,63 +96,70 @@ cleanup-integ-buckets:
 ###################
 # Sandbox Testing #
 ###################
-sandbox-tests: sandbox-test-go15 sandbox-test-go16 sandbox-test-go17 sandbox-test-go18 sandbox-test-go19 sandbox-test-go110 sandbox-test-go111 sandbox-test-gotip
+sandbox-tests: sandbox-test-go1.5 sandbox-test-go1.6 sandbox-test-go1.7 sandbox-test-go1.8 sandbox-test-go1.9 sandbox-test-go1.10 sandbox-test-go1.11 sandbox-test-go1.12 sandbox-test-gotip
 
-sandbox-build-go15:
+sandbox-build-go1.5:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.5 -t "aws-sdk-go-1.5" .
-sandbox-go15: sandbox-build-go15
+sandbox-go1.5: sandbox-build-go1.5
 	docker run -i -t aws-sdk-go-1.5 bash
-sandbox-test-go15: sandbox-build-go15
+sandbox-test-go1.5: sandbox-build-go1.5
 	docker run -t aws-sdk-go-1.5
 
-sandbox-build-go15-novendorexp:
+sandbox-build-go1.5-novendorexp:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.5-novendorexp -t "aws-sdk-go-1.5-novendorexp" .
-sandbox-go15-novendorexp: sandbox-build-go15-novendorexp
+sandbox-go1.5-novendorexp: sandbox-build-go1.5-novendorexp
 	docker run -i -t aws-sdk-go-1.5-novendorexp bash
-sandbox-test-go15-novendorexp: sandbox-build-go15-novendorexp
+sandbox-test-go1.5-novendorexp: sandbox-build-go1.5-novendorexp
 	docker run -t aws-sdk-go-1.5-novendorexp
 
-sandbox-build-go16:
+sandbox-build-go1.6:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.6 -t "aws-sdk-go-1.6" .
-sandbox-go16: sandbox-build-go16
+sandbox-go1.6: sandbox-build-go1.6
 	docker run -i -t aws-sdk-go-1.6 bash
-sandbox-test-go16: sandbox-build-go16
+sandbox-test-go1.6: sandbox-build-go1.6
 	docker run -t aws-sdk-go-1.6
 
-sandbox-build-go17:
+sandbox-build-go1.7:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.7 -t "aws-sdk-go-1.7" .
-sandbox-go17: sandbox-build-go17
+sandbox-go1.7: sandbox-build-go17
 	docker run -i -t aws-sdk-go-1.7 bash
-sandbox-test-go17: sandbox-build-go17
+sandbox-test-go1.7: sandbox-build-go17
 	docker run -t aws-sdk-go-1.7
 
-sandbox-build-go18:
+sandbox-build-go1.8:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.8 -t "aws-sdk-go-1.8" .
-sandbox-go18: sandbox-build-go18
+sandbox-go1.8: sandbox-build-go1.8
 	docker run -i -t aws-sdk-go-1.8 bash
-sandbox-test-go18: sandbox-build-go18
+sandbox-test-go1.8: sandbox-build-go1.8
 	docker run -t aws-sdk-go-1.8
 
-sandbox-build-go19:
+sandbox-build-go1.9:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.9 -t "aws-sdk-go-1.9" .
-sandbox-go19: sandbox-build-go19
+sandbox-go1.9: sandbox-build-go1.9
 	docker run -i -t aws-sdk-go-1.9 bash
-sandbox-test-go19: sandbox-build-go19
+sandbox-test-go1.9: sandbox-build-go1.9
 	docker run -t aws-sdk-go-1.9
 
-sandbox-build-go110:
+sandbox-build-go1.10:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.10 -t "aws-sdk-go-1.10" .
-sandbox-go110: sandbox-build-go110
+sandbox-go1.10: sandbox-build-go1.10
 	docker run -i -t aws-sdk-go-1.10 bash
-sandbox-test-go110: sandbox-build-go110
+sandbox-test-go1.10: sandbox-build-go1.10
 	docker run -t aws-sdk-go-1.10
 
-sandbox-build-go111:
+sandbox-build-go1.11:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.11 -t "aws-sdk-go-1.11" .
-sandbox-go111: sandbox-build-go111
+sandbox-go1.11: sandbox-build-go1.11
 	docker run -i -t aws-sdk-go-1.11 bash
-sandbox-test-go111: sandbox-build-go111
+sandbox-test-go1.11: sandbox-build-go1.11
 	docker run -t aws-sdk-go-1.11
+
+sandbox-build-go1.12:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.12 -t "aws-sdk-go-1.12" .
+sandbox-go1.12: sandbox-build-go1.12
+	docker run -i -t aws-sdk-go-1.12 bash
+sandbox-test-go1.12: sandbox-build-go1.12
+	docker run -t aws-sdk-go-1.12
 
 sandbox-build-gotip:
 	@echo "Run make update-aws-golang-tip, if this test fails because missing aws-golang:tip container"
@@ -216,6 +208,9 @@ get-deps-verify:
 	@echo "go get SDK verification utilities"
 	go get golang.org/x/lint/golint
 
+##############
+# Benchmarks #
+##############
 bench:
 	@echo "go bench SDK packages"
 	go test -run NONE -bench . -benchmem -tags 'bench' ${SDK_ALL_PKGS}

--- a/awstesting/sandbox/Dockerfile.test.go1.10
+++ b/awstesting/sandbox/Dockerfile.test.go1.10
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit"]
+CMD ["make", "get-deps", "unit"]

--- a/awstesting/sandbox/Dockerfile.test.go1.12
+++ b/awstesting/sandbox/Dockerfile.test.go1.12
@@ -1,5 +1,5 @@
 FROM ubuntu:12.04
-FROM golang:1.11
+FROM golang:1.12
 
 ADD . /go/src/github.com/aws/aws-sdk-go
 

--- a/awstesting/sandbox/Dockerfile.test.go1.5
+++ b/awstesting/sandbox/Dockerfile.test.go1.5
@@ -10,4 +10,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GO15VENDOREXPERIMENT="1"
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.go1.5-novendorexp
+++ b/awstesting/sandbox/Dockerfile.test.go1.5-novendorexp
@@ -4,4 +4,4 @@ FROM golang:1.5
 ADD . /go/src/github.com/aws/aws-sdk-go
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "get-deps", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.go1.6
+++ b/awstesting/sandbox/Dockerfile.test.go1.6
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.go1.7
+++ b/awstesting/sandbox/Dockerfile.test.go1.7
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.go1.8
+++ b/awstesting/sandbox/Dockerfile.test.go1.8
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.go1.9
+++ b/awstesting/sandbox/Dockerfile.test.go1.9
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit-old-go-race-cover"]
+CMD ["make", "get-deps-tests", "unit-old-go-race-cover"]

--- a/awstesting/sandbox/Dockerfile.test.gotip
+++ b/awstesting/sandbox/Dockerfile.test.gotip
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	&& rm -rf /var/list/apt/lists/*
 
 WORKDIR /go/src/github.com/aws/aws-sdk-go
-CMD ["make", "unit"]
+CMD ["make", "get-deps", "unit"]

--- a/example/service/s3/sync/sync.go
+++ b/example/service/s3/sync/sync.go
@@ -85,8 +85,7 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 	}
 
 	return s3manager.BatchUploadObject{
-		&input,
-		nil,
+		Object: &input,
 	}
 }
 


### PR DESCRIPTION
Updates the SDK's Travis CI tests to include Go 1.12.