### PR TITLE
aws/credentials/stscreds: Update StdinTokenProvider to prompt on stderr

### DIFF
--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -80,6 +80,7 @@ package stscreds
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -89,7 +90,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-// StdinTokenProvider will prompt on stdout and read from stdin for a string value.
+// StdinTokenProvider will prompt on stderr and read from stdin for a string value.
 // An error is returned if reading from stdin fails.
 //
 // Use this function go read MFA tokens from stdin. The function makes no attempt
@@ -102,7 +103,7 @@ import (
 // Will wait forever until something is provided on the stdin.
 func StdinTokenProvider() (string, error) {
 	var v string
-	fmt.Printf("Assume Role MFA token code: ")
+	fmt.Fprintf(os.Stderr, "Assume Role MFA token code: ")
 	_, err := fmt.Scanln(&v)
 
 	return v, err


### PR DESCRIPTION
This is to make it possible to redirect/pipe output when using StdinTokenProvider and still seeing the prompt text