### PR TITLE
skip credentials file if creds are present in envCfg, fixes: #2455

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -363,6 +364,18 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 			// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
 			cfgFiles = cfgFiles[1:]
 		}
+	}
+
+	// if both access key ID and secret access keys are in envCfg, remove credentials files
+	if envCfg.Creds.AccessKeyID != "" && envCfg.Creds.SecretAccessKey != "" {
+		i := 0
+		for _, file := range cfgFiles {
+			if !strings.HasSuffix(file, "credentials") {
+				cfgFiles[i] = file
+				i++
+			}
+		}
+		cfgFiles = cfgFiles[:i]
 	}
 
 	// Load additional config from file(s)


### PR DESCRIPTION
As mentioned in #2455 and at [aws cli userguide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), it should be safe to not load credentials file when creds are present in env vars.

Please let me know if it looks good, I shall change the status from Draft PR.