### PR TITLE
aws/request: Add RequestThrottledException to set of throttled exceptions

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -38,7 +38,7 @@ var throttleCodes = map[string]struct{}{
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
 	"RequestThrottled":                       {},
-	"RequestThrottledException":               {},
+	"RequestThrottledException":              {},
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 	"TransactionInProgressException":         {},

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -38,6 +38,7 @@ var throttleCodes = map[string]struct{}{
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
 	"RequestThrottled":                       {},
+	"RequestThrottledException":               {},
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 	"TransactionInProgressException":         {},


### PR DESCRIPTION
Adds RequestThrottledException to the set of the SDK's throttled exceptions to retry and rate limit.
