### PR TITLE
 private/protocol: Use correct Content-Type for rest json protocol

### DIFF
--- a/models/protocol_tests/input/rest-json.json
+++ b/models/protocol_tests/input/rest-json.json
@@ -475,7 +475,9 @@
         "serialized": {
           "body": "{\"Config\": {\"A\": \"one\", \"B\": \"two\"}}",
           "uri": "/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar",
-          "headers": {}
+          "headers": {
+            "Content-Type": "application/json"
+          }
         }
       }
     ]
@@ -556,7 +558,8 @@
           "body": "{\"Config\": {\"A\": \"one\", \"B\": \"two\"}}",
           "uri": "/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar",
           "headers": {
-            "x-amz-checksum": "12345"
+            "x-amz-checksum": "12345",
+            "Content-Type": "application/json"
           }
         }
       }
@@ -672,7 +675,10 @@
         },
         "serialized": {
           "body": "{\"Bar\": \"QmxvYiBwYXJhbQ==\"}",
-          "uri": "/2014-01-01/foo_name"
+          "uri": "/2014-01-01/foo_name",
+          "headers": {
+            "Content-Type": "application/json"
+          }
         }
       }
     ]
@@ -789,7 +795,10 @@
         "serialized": {
           "method": "POST",
           "body": "{\"baz\": \"bar\"}",
-          "uri": "/"
+          "uri": "/",
+          "headers": {
+            "Content-Type": "application/json"
+          }
         }
       },
       {
@@ -939,7 +948,9 @@
         },
         "serialized": {
           "uri": "/path" ,
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"NoRecurse\": \"foo\"}}"
         }
       },
@@ -963,7 +974,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"RecursiveStruct\": {\"NoRecurse\": \"foo\"}}}"
         }
       },
@@ -991,7 +1004,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"RecursiveStruct\": {\"RecursiveStruct\": {\"RecursiveStruct\": {\"NoRecurse\": \"foo\"}}}}}"
         }
       },
@@ -1020,7 +1035,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"RecursiveList\": [{\"NoRecurse\": \"foo\"}, {\"NoRecurse\": \"bar\"}]}}"
         }
       },
@@ -1051,7 +1068,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"RecursiveList\": [{\"NoRecurse\": \"foo\"}, {\"RecursiveStruct\": {\"NoRecurse\": \"bar\"}}]}}"
         }
       },
@@ -1080,7 +1099,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"RecursiveStruct\": {\"RecursiveMap\": {\"foo\": {\"NoRecurse\": \"foo\"}, \"bar\": {\"NoRecurse\": \"bar\"}}}}"
         }
       }
@@ -1180,7 +1201,8 @@
           "headers": {
             "x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT",
             "x-amz-timecustom-header": "1422172800",
-            "x-amz-timeformat-header": "1422172800"
+            "x-amz-timeformat-header": "1422172800",
+            "Content-Type": "application/json"
           },
           "body": "{\"TimeArg\": 1422172800, \"TimeCustom\": \"2015-01-25T08:00:00Z\", \"TimeFormat\": \"Sun, 25 Jan 2015 08:00:00 GMT\"}"
         }
@@ -1224,7 +1246,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"timestamp_location\": 1422172800}"
         }
       }
@@ -1310,7 +1334,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"Token\": \"abc123\"}"
         }
       },
@@ -1329,7 +1355,9 @@
         },
         "serialized": {
           "uri": "/path",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"Token\": \"00000000-0000-4000-8000-000000000000\"}"
         }
       }
@@ -1406,7 +1434,10 @@
         },
         "serialized": {
           "uri": "/?Bar=%7B%22Foo%22%3A%22Bar%22%7D",
-          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "headers": {
+            "X-Amz-Foo": "eyJGb28iOiJCYXIifQ==",
+            "Content-Type": "application/json"
+          },
           "body": "{\"BodyField\":\"{\\\"Foo\\\":\\\"Bar\\\"}\"}"
         }
       },
@@ -1427,7 +1458,9 @@
         },
         "serialized": {
           "uri": "/",
-          "headers": {},
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"BodyListField\":[\"{\\\"Foo\\\":\\\"Bar\\\"}\"]}"
         }
       },
@@ -1519,7 +1552,10 @@
         },
         "serialized": {
           "uri": "/path?Enum=bar&List=0&List=1&List=",
-          "headers": {"x-amz-enum": "baz"},
+          "headers": {
+            "x-amz-enum": "baz",
+            "Content-Type": "application/json"
+          },
           "body": "{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"\", \"bar\"]}"
         }
       },
@@ -1592,6 +1628,9 @@
         },
         "serialized": {
           "uri": "/path",
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"Name\": \"myname\"}",
           "host": "data-service.region.amazonaws.com"
         }
@@ -1615,6 +1654,9 @@
         },
         "serialized": {
           "uri": "/path",
+          "headers": {
+            "Content-Type": "application/json"
+          },
           "body": "{\"Name\": \"myname\"}",
           "host": "foo-myname.service.region.amazonaws.com"
         }

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -552,7 +552,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			SigningRegion: signingRegion,
 			Endpoint:     endpoint,
 			APIVersion:   "{{ .Metadata.APIVersion }}",
-			{{ if .Metadata.JSONVersion -}}
+			{{ if and (.Metadata.JSONVersion) (eq .Metadata.Protocol "json") -}}
 				JSONVersion:  "{{ .Metadata.JSONVersion }}",
 			{{- end }}
 			{{ if .Metadata.TargetPrefix -}}

--- a/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restjson/0000-00-00/api-2.json
@@ -3,7 +3,6 @@
   "metadata":{
     "apiVersion":"0000-00-00",
     "endpointPrefix":"restjsonservice",
-    "jsonVersion":"1.1",
     "protocol":"rest-json",
     "serviceAbbreviation":"RESTJSONService",
     "serviceFullName":"REST JSON Service",

--- a/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/restxml/0000-00-00/api-2.json
@@ -3,7 +3,6 @@
   "metadata":{
     "apiVersion":"0000-00-00",
     "endpointPrefix":"restxmlservice",
-    "jsonVersion":"1.1",
     "protocol":"rest-xml",
     "serviceAbbreviation":"RESTXMLService",
     "serviceFullName":"REST XML Service",

--- a/private/model/api/codegentest/service/restjsonservice/service.go
+++ b/private/model/api/codegentest/service/restjsonservice/service.go
@@ -61,8 +61,8 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "0000-00-00",
-				JSONVersion:   "1.1",
-				TargetPrefix:  "RESTJSONService_00000000",
+
+				TargetPrefix: "RESTJSONService_00000000",
 			},
 			handlers,
 		),

--- a/private/model/api/codegentest/service/restxmlservice/service.go
+++ b/private/model/api/codegentest/service/restxmlservice/service.go
@@ -61,8 +61,8 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "0000-00-00",
-				JSONVersion:   "1.1",
-				TargetPrefix:  "RESTXMLService_00000000",
+
+				TargetPrefix: "RESTXMLService_00000000",
 			},
 			handlers,
 		),

--- a/private/protocol/jsonrpc/jsonrpc.go
+++ b/private/protocol/jsonrpc/jsonrpc.go
@@ -52,9 +52,12 @@ func Build(req *request.Request) {
 		target := req.ClientInfo.TargetPrefix + "." + req.Operation.Name
 		req.HTTPRequest.Header.Add("X-Amz-Target", target)
 	}
-	if req.ClientInfo.JSONVersion != "" {
+
+	// Only set the content type if one is not already specified and an
+	// JSONVersion is specified.
+	if ct, v := req.HTTPRequest.Header.Get("Content-Type"), req.ClientInfo.JSONVersion; len(ct) == 0 && len(v) != 0 {
 		jsonVersion := req.ClientInfo.JSONVersion
-		req.HTTPRequest.Header.Add("Content-Type", "application/x-amz-json-"+jsonVersion)
+		req.HTTPRequest.Header.Set("Content-Type", "application/x-amz-json-"+jsonVersion)
 	}
 }
 

--- a/private/protocol/restjson/build_test.go
+++ b/private/protocol/restjson/build_test.go
@@ -5583,6 +5583,9 @@ func TestInputService9ProtocolTestURIParameterQuerystringParamsAndJSONBodyCase1(
 	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5618,6 +5621,9 @@ func TestInputService10ProtocolTestURIParameterQuerystringParamsHeadersAndJSONBo
 	awstesting.AssertURL(t, "https://test/2014-01-01/jobsByPipeline/foo?Ascending=true&PageToken=bar", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 	if e, a := "12345", r.Header.Get("x-amz-checksum"); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -5685,6 +5691,9 @@ func TestInputService12ProtocolTestSerializeBlobsInBodyCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/2014-01-01/foo_name", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5764,6 +5773,9 @@ func TestInputService14ProtocolTestStructurePayloadCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5853,6 +5865,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5885,6 +5900,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5921,6 +5939,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase3(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5958,6 +5979,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase4(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -5997,6 +6021,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase5(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6034,6 +6061,9 @@ func TestInputService16ProtocolTestRecursiveShapesCase6(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6070,6 +6100,9 @@ func TestInputService17ProtocolTestTimestampValuesCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path?TimeQuery=2015-01-25T08%3A00%3A00Z&TimeCustomQuery=1422172800&TimeFormatQuery=1422172800", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 	if e, a := "Sun, 25 Jan 2015 08:00:00 GMT", r.Header.Get("x-amz-timearg"); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6107,6 +6140,9 @@ func TestInputService18ProtocolTestNamedLocationsInJSONBodyCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6165,6 +6201,9 @@ func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6191,6 +6230,9 @@ func TestInputService20ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6229,6 +6271,9 @@ func TestInputService21ProtocolTestJSONValueTraitCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/?Bar=%7B%22Foo%22%3A%22Bar%22%7D", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 	if e, a := "eyJGb28iOiJCYXIifQ==", r.Header.Get("X-Amz-Foo"); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6270,6 +6315,9 @@ func TestInputService21ProtocolTestJSONValueTraitCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6329,6 +6377,9 @@ func TestInputService22ProtocolTestEnumCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://test/path?Enum=bar&List=0&List=1&List=", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 	if e, a := "baz", r.Header.Get("x-amz-enum"); e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
@@ -6379,6 +6430,9 @@ func TestInputService23ProtocolTestEndpointHostTraitCase1(t *testing.T) {
 	awstesting.AssertURL(t, "https://data-service.region.amazonaws.com/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 
@@ -6407,6 +6461,9 @@ func TestInputService23ProtocolTestEndpointHostTraitCase2(t *testing.T) {
 	awstesting.AssertURL(t, "https://foo-myname.service.region.amazonaws.com/path", r.URL.String())
 
 	// assert headers
+	if e, a := "application/json", r.Header.Get("Content-Type"); e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 
 }
 

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -33,6 +33,9 @@ func Build(r *request.Request) {
 	rest.Build(r)
 
 	if t := rest.PayloadType(r.Params); t == "structure" || t == "" {
+		if v := r.HTTPRequest.Header.Get("Content-Type"); len(v) == 0 {
+			r.HTTPRequest.Header.Set("Content-Type", "application/json")
+		}
 		jsonrpc.Build(r)
 	}
 }

--- a/service/amplify/service.go
+++ b/service/amplify/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-07-25",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/apigatewaymanagementapi/service.go
+++ b/service/apigatewaymanagementapi/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-11-29",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/apigatewayv2/service.go
+++ b/service/apigatewayv2/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-11-29",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/appmesh/service.go
+++ b/service/appmesh/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2019-01-25",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/appsync/service.go
+++ b/service/appsync/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-07-25",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/backup/service.go
+++ b/service/backup/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-11-15",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/batch/service.go
+++ b/service/batch/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-08-10",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -69,7 +69,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2013-01-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/cognitosync/service.go
+++ b/service/cognitosync/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2014-06-30",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/connect/service.go
+++ b/service/connect/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-08-08",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/dlm/service.go
+++ b/service/dlm/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-01-12",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/eks/service.go
+++ b/service/eks/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-11-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/greengrass/service.go
+++ b/service/greengrass/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-06-07",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/guardduty/service.go
+++ b/service/guardduty/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-11-28",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/iot1clickdevicesservice/service.go
+++ b/service/iot1clickdevicesservice/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-05-14",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/iot1clickprojects/service.go
+++ b/service/iot1clickprojects/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-05-14",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/kafka/service.go
+++ b/service/kafka/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-11-14",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/lexmodelbuildingservice/service.go
+++ b/service/lexmodelbuildingservice/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-04-19",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/lexruntimeservice/service.go
+++ b/service/lexruntimeservice/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-11-28",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mediaconnect/service.go
+++ b/service/mediaconnect/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-11-14",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mediaconvert/service.go
+++ b/service/mediaconvert/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-08-29",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/medialive/service.go
+++ b/service/medialive/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-10-14",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mediapackage/service.go
+++ b/service/mediapackage/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-10-12",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mediatailor/service.go
+++ b/service/mediatailor/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-04-23",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mobile/service.go
+++ b/service/mobile/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-07-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/mq/service.go
+++ b/service/mq/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-11-27",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/pinpoint/service.go
+++ b/service/pinpoint/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-12-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/pinpointemail/service.go
+++ b/service/pinpointemail/service.go
@@ -64,8 +64,8 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-07-26",
-				JSONVersion:   "1.1",
-				TargetPrefix:  "com.amazonaws.services.pinpoint.email",
+
+				TargetPrefix: "com.amazonaws.services.pinpoint.email",
 			},
 			handlers,
 		),

--- a/service/pinpointsmsvoice/service.go
+++ b/service/pinpointsmsvoice/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-09-05",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/quicksight/service.go
+++ b/service/quicksight/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-04-01",
-				JSONVersion:   "1.0",
 			},
 			handlers,
 		),

--- a/service/ram/service.go
+++ b/service/ram/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-01-04",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/rdsdataservice/service.go
+++ b/service/rdsdataservice/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-08-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/robomaker/service.go
+++ b/service/robomaker/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-06-29",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/sagemakerruntime/service.go
+++ b/service/sagemakerruntime/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-05-13",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/securityhub/service.go
+++ b/service/securityhub/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-10-26",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/serverlessapplicationrepository/service.go
+++ b/service/serverlessapplicationrepository/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-09-08",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/signer/service.go
+++ b/service/signer/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2017-08-25",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/workdocs/service.go
+++ b/service/workdocs/service.go
@@ -61,7 +61,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2016-05-01",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),

--- a/service/worklink/service.go
+++ b/service/worklink/service.go
@@ -64,7 +64,6 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
 				APIVersion:    "2018-09-25",
-				JSONVersion:   "1.1",
 			},
 			handlers,
 		),


### PR DESCRIPTION
Updates the SDK to use the correct `application/json` content type for
all rest json protocol based AWS services. This fixes the bug where the
jsonrpc protocol's `application/x-amz-json-X.Y` content type would be
used for services like Amazon Pinpoint SMS.

TODO:
* [x] Update rest-json/rest-xml protocol tests for header.