### PR TITLE
aws/ec2metadata: Improve readability of Send calls

### DIFF
--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -24,8 +24,9 @@ func (c *EC2Metadata) GetMetadata(p string) (string, error) {
 
 	output := &metadataOutput{}
 	req := c.NewRequest(op, nil, output)
+	err := req.Send()
 
-	return output.Content, req.Send()
+	return output.Content, err
 }
 
 // GetUserData returns the userdata that was configured for the service. If
@@ -45,8 +46,9 @@ func (c *EC2Metadata) GetUserData() (string, error) {
 			r.Error = awserr.New("NotFoundError", "user-data not found", r.Error)
 		}
 	})
+	err := req.Send()
 
-	return output.Content, req.Send()
+	return output.Content, err
 }
 
 // GetDynamicData uses the path provided to request information from the EC2
@@ -61,8 +63,9 @@ func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
 
 	output := &metadataOutput{}
 	req := c.NewRequest(op, nil, output)
+	err := req.Send()
 
-	return output.Content, req.Send()
+	return output.Content, err
 }
 
 // GetInstanceIdentityDocument retrieves an identity document describing an


### PR DESCRIPTION
output.Content in blank, and since its not a pointer the string is already copied for return, after which req.Send() is called.
This cause problem where req.Send() returns proper result but output.Content is not changed after calling req.Send() as its not a pointer but a string value.

#1861 