### PR TITLE
aws/request: Add LimitExceededException throttled exception for Kinesis

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -41,6 +41,7 @@ var throttleCodes = map[string]struct{}{
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 	"TransactionInProgressException":         {},
+	"LimitExceededException":                 {}, // Kinesis functions
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials


### PR DESCRIPTION
Kinesis returns LimitExceededException when the rate limit is hit. This PR adds this exception to the list of throttled exceptions. 