### PR TITLE
aws/defaults: Add default values to SDKs default http client

### DIFF
--- a/aws/defaults/client.go
+++ b/aws/defaults/client.go
@@ -1,0 +1,71 @@
+package defaults
+
+import (
+	"net/http"
+	"reflect"
+	"time"
+)
+
+// HTTP Client default configuration values
+var (
+	// net/http.DefaultTransport defaults to 0, i.e. wait for ever
+	defaultResponseHeaderTimeout = 60 * time.Second
+
+	// net/http.DefaultTransport defaults to DefaultMaxIdleConnsPerHost(2)
+	defaultMaxIdleConnsPerHost = 10
+)
+
+func getDefaultClient() *http.Client {
+	c := copyClient(http.DefaultClient)
+
+	// Apply SDK default overrides to transport.
+	if tr, ok := c.Transport.(*http.Transport); ok {
+		tr.ResponseHeaderTimeout = defaultResponseHeaderTimeout
+		tr.MaxIdleConnsPerHost = defaultMaxIdleConnsPerHost
+	}
+
+	return c
+}
+
+func copyClient(c *http.Client) *http.Client {
+	origClientVal := reflect.ValueOf(c).Elem()
+
+	c = &http.Client{}
+	copyStructFields(reflect.ValueOf(c).Elem(), origClientVal)
+
+	// Returned c.Transport will be nil if DefaultClient doesn't have a
+	// transport set and the http.DefaultTransport is not a http.Transport.
+	if c.Transport == nil {
+		if tr, ok := http.DefaultTransport.(*http.Transport); ok {
+			c.Transport = copyTransport(tr)
+		}
+	} else if tr, ok := c.Transport.(*http.Transport); ok {
+		c.Transport = copyTransport(tr)
+	}
+
+	return c
+}
+
+func copyTransport(tr *http.Transport) *http.Transport {
+	origTransportVal := reflect.ValueOf(tr).Elem()
+
+	tr = &http.Transport{}
+	copyStructFields(reflect.ValueOf(tr).Elem(), origTransportVal)
+
+	return tr
+}
+
+func copyStructFields(dst, src reflect.Value) {
+	srcType := src.Type()
+
+	for i := 0; i < srcType.NumField(); i++ {
+		ft := srcType.Field(i)
+		if len(ft.PkgPath) != 0 {
+			// Unexported fields include package path. Exported fields do not.
+			// https://godoc.org/reflect#StructField
+			continue
+		}
+
+		dst.Field(i).Set(src.Field(i))
+	}
+}

--- a/aws/defaults/client_test.go
+++ b/aws/defaults/client_test.go
@@ -1,0 +1,106 @@
+package defaults
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+	"time"
+)
+
+func TestGetDefaultClient(t *testing.T) {
+	c := getDefaultClient()
+
+	if e, a := http.DefaultClient, c; e == a {
+		t.Fatalf("expect not equal")
+	}
+	if e, a := http.DefaultClient.Transport, c.Transport; e == a {
+		t.Errorf("expect not equal")
+	}
+
+	tr := c.Transport.(*http.Transport)
+	if e, a := defaultResponseHeaderTimeout, tr.ResponseHeaderTimeout; e != a {
+		t.Errorf("expect %v response header timeout, got %v", e, a)
+	}
+	if e, a := defaultMaxIdleConnsPerHost, tr.MaxIdleConnsPerHost; e != a {
+		t.Errorf("expect %v idle conns per host, got %v", e, a)
+	}
+}
+
+func TestCopyClient(t *testing.T) {
+	orig := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns: 10,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return nil
+		},
+		Jar:     &cookiejar.Jar{},
+		Timeout: 10 * time.Second,
+	}
+
+	c := copyClient(orig)
+
+	if c == orig {
+		t.Fatalf("expect not equal")
+	}
+	if e, a := orig.Transport, c.Transport; e == a {
+		t.Errorf("expect transports not equal")
+	}
+	origTr := orig.Transport.(*http.Transport)
+	tr := orig.Transport.(*http.Transport)
+	if e, a := origTr.MaxIdleConns, tr.MaxIdleConns; e != a {
+		t.Errorf("expect %v max idle conns, got %v", e, a)
+	}
+	if c.CheckRedirect == nil {
+		t.Errorf("expect CheckRedirect set")
+	}
+	if e, a := orig.Jar, c.Jar; e != a {
+		t.Errorf("expect same jar, was not")
+	}
+	if e, a := orig.Timeout, c.Timeout; e != a {
+		t.Errorf("expect %v timeout, got %v", e, a)
+	}
+}
+
+type mockRoundTripper struct {
+	MaxIdleConns int
+}
+
+func (m *mockRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestCopyClient_NonTransportRoundtripper(t *testing.T) {
+	orig := &http.Client{
+		Transport: &mockRoundTripper{
+			MaxIdleConns: 10,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return nil
+		},
+		Jar:     &cookiejar.Jar{},
+		Timeout: 10 * time.Second,
+	}
+
+	c := copyClient(orig)
+
+	if c == orig {
+		t.Fatalf("expect not equal")
+	}
+	if e, a := orig.Transport, c.Transport; e != a {
+		t.Errorf("expect equal")
+	}
+	tr := orig.Transport.(*mockRoundTripper)
+	if e, a := 10, tr.MaxIdleConns; e != a {
+		t.Errorf("expect equal")
+	}
+	if c.CheckRedirect == nil {
+		t.Errorf("expect set")
+	}
+	if e, a := orig.Jar, c.Jar; e != a {
+		t.Errorf("expect equal")
+	}
+	if e, a := orig.Timeout, c.Timeout; e != a {
+		t.Errorf("expect equal")
+	}
+}

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -10,7 +10,6 @@ package defaults
 import (
 	"fmt"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"time"
@@ -56,7 +55,7 @@ func Config() *aws.Config {
 	return aws.NewConfig().
 		WithCredentials(credentials.AnonymousCredentials).
 		WithRegion(os.Getenv("AWS_REGION")).
-		WithHTTPClient(http.DefaultClient).
+		WithHTTPClient(getDefaultClient()).
 		WithMaxRetries(aws.UseServiceDefaultRetries).
 		WithLogger(aws.NewDefaultLogger()).
 		WithLogLevel(aws.LogOff).

--- a/aws/defaults/timeout_conn.go
+++ b/aws/defaults/timeout_conn.go
@@ -1,0 +1,132 @@
+package defaults
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+type Timeouts struct {
+	Connect              time.Duration
+	NetProtocolKeepalive time.Duration
+	Read                 time.Duration
+	Write                time.Duration
+
+	TLSHandshake   time.Duration
+	ExpectContinue time.Duration
+	IdleConn       time.Duration
+	ResponseHeader time.Duration
+}
+
+func DefaultTimeouts() Timeouts {
+	return Timeouts{
+		Connect:              30 * time.Second,
+		NetProtocolKeepalive: 30 * time.Second,
+		Read:                 30 * time.Second,
+		Write:                30 * time.Second,
+
+		TLSHandshake:   10 * time.Second,
+		ExpectContinue: 1 * time.Second,
+
+		IdleConn: 90 * time.Second,
+	}
+}
+
+func NewClient(timeouts Timeouts) *http.Client {
+	dialer := dialTimeoutConnWrapper{
+		Dialer: &net.Dialer{
+			// Connect timeout.
+			Timeout: timeouts.Connect,
+			// protocol keep alive, e.g. TCP keep-alive
+			KeepAlive: timeouts.NetProtocolKeepalive,
+		},
+		ReadTimeout:  timeouts.Read,
+		WriteTimeout: timeouts.Write,
+	}
+
+	tr := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       timeouts.IdleConn,
+		TLSHandshakeTimeout:   timeouts.TLSHandshake,
+		ExpectContinueTimeout: timeouts.ExpectContinue,
+		ResponseHeaderTimeout: timeouts.ResponseHeader,
+	}
+
+	return &http.Client{
+		Transport: tr,
+	}
+}
+
+type dialTimeoutConnWrapper struct {
+	*net.Dialer
+
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+}
+
+func (d *dialTimeoutConnWrapper) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *dialTimeoutConnWrapper) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := d.Dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &timeoutConn{
+		Conn:         conn,
+		ReadTimeout:  d.ReadTimeout,
+		WriteTimeout: d.WriteTimeout,
+	}, nil
+}
+
+type timeoutConn struct {
+	net.Conn
+
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+
+	readDeadlineSet  int32
+	writeDeadlineSet int32
+}
+
+func (c *timeoutConn) Read(b []byte) (int, error) {
+	if !atomic.CompareAndSwapInt32(&c.readDeadlineSet, 1, 0) {
+		c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout))
+	}
+
+	n, err := c.Conn.Read(b)
+
+	atomic.StoreInt32(&c.readDeadlineSet, 0)
+	return n, err
+}
+
+func (c *timeoutConn) Write(b []byte) (int, error) {
+	if !atomic.CompareAndSwapInt32(&c.writeDeadlineSet, 1, 0) {
+		c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout))
+	}
+
+	atomic.StoreInt32(&c.writeDeadlineSet, 0)
+	return c.Conn.Write(b)
+}
+
+func (c *timeoutConn) SetDeadline(v time.Time) error {
+	atomic.StoreInt32(&c.writeDeadlineSet, 1)
+	atomic.StoreInt32(&c.readDeadlineSet, 1)
+	return c.Conn.SetDeadline(v)
+}
+
+func (c *timeoutConn) SetReadDeadline(v time.Time) error {
+	atomic.StoreInt32(&c.readDeadlineSet, 1)
+	return c.Conn.SetReadDeadline(v)
+}
+
+func (c *timeoutConn) SetWriteDeadline(v time.Time) error {
+	atomic.StoreInt32(&c.writeDeadlineSet, 1)
+	return c.Conn.SetWriteDeadline(v)
+}

--- a/aws/defaults/timeout_conn_test.go
+++ b/aws/defaults/timeout_conn_test.go
@@ -1,0 +1,93 @@
+package defaults
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTimeoutConn(t *testing.T) {
+	mc := &mockConn{}
+	conn := &timeoutConn{
+		Conn:         mc,
+		ReadTimeout:  time.Millisecond,
+		WriteTimeout: time.Millisecond,
+	}
+	buf := make([]byte, 10)
+
+	cases := map[string]struct {
+		ReadWait  time.Duration
+		WriteWait time.Duration
+		ReadErr   bool
+		WriteErr  bool
+	}{
+		"Successful": {},
+		"Read timeout": {
+			ReadWait: 10 * time.Second,
+			ReadErr:  true,
+		},
+		"Write timeout": {
+			WriteWait: 10 * time.Second,
+			WriteErr:  true,
+		},
+	}
+
+	for nc, c := range cases {
+		t.Run(nc, func(t *testing.T) {
+			mc.readWait = c.ReadWait
+			mc.writeWait = c.WriteWait
+
+			_, err := conn.Read(buf)
+			if e, a := c.ReadErr, (err != nil); e != a {
+				t.Errorf("expect read error %t, got %t", e, a)
+			}
+
+			_, err = conn.Write(buf)
+			if e, a := c.WriteErr, (err != nil); e != a {
+				t.Errorf("expect write error %t, got %t", e, a)
+			}
+		})
+	}
+
+}
+
+type mockConn struct {
+	net.Conn
+
+	readWait  time.Duration
+	writeWait time.Duration
+
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+func (c *mockConn) Read(b []byte) (int, error) {
+	if time.Now().Add(c.readWait).After(c.readDeadline) {
+		return 0, fmt.Errorf("read deadline exceeded")
+	}
+	return len(b), nil
+}
+
+func (c *mockConn) Write(b []byte) (int, error) {
+	if time.Now().Add(c.writeWait).After(c.writeDeadline) {
+		return 0, fmt.Errorf("write deadline exceeded")
+	}
+	return len(b), nil
+}
+
+func (c *mockConn) SetDeadline(v time.Time) error {
+	c.readDeadline = v
+	c.writeDeadline = v
+	return nil
+}
+
+func (c *mockConn) SetReadDeadline(v time.Time) error {
+	c.readDeadline = v
+	return nil
+}
+
+func (c *mockConn) SetWriteDeadline(v time.Time) error {
+	c.writeDeadline = v
+	return nil
+}


### PR DESCRIPTION
Updates the SDK's usage of http.DefaultClient to make a copy, and add
ResponseHeaderTimeout, and MaxIdleConnsPerHost to the copied client's
transport.

The SDK will only use the copied HTTP client if the user does not
provide a custom HTTP client. The SDK will also only attempt to copy the
client's transport if the transport is a *http.Transport value.