### PR TITLE
Add json unmarshal for AWSEpochTime

### DIFF
--- a/service/cloudfront/sign/policy.go
+++ b/service/cloudfront/sign/policy.go
@@ -45,7 +45,6 @@ func (t *AWSEpochTime) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-
 // An IPAddress wraps an IPAddress source IP providing JSON serialization information
 type IPAddress struct {
 	SourceIP string `json:"AWS:SourceIp"`

--- a/service/cloudfront/sign/policy.go
+++ b/service/cloudfront/sign/policy.go
@@ -32,7 +32,7 @@ func (t AWSEpochTime) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`{"AWS:EpochTime":%d}`, t.UTC().Unix())), nil
 }
 
-// MarshalJSON serializes the epoch time as AWS Profile epoch time.
+// UnmarshalJSON unserializes AWS Profile epoch time.
 func (t *AWSEpochTime) UnmarshalJSON(data []byte) error {
 	var epochTime struct {
 		Sec int64 `json:"AWS:EpochTime"`

--- a/service/cloudfront/sign/policy.go
+++ b/service/cloudfront/sign/policy.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -30,6 +31,20 @@ func NewAWSEpochTime(t time.Time) *AWSEpochTime {
 func (t AWSEpochTime) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`{"AWS:EpochTime":%d}`, t.UTC().Unix())), nil
 }
+
+// MarshalJSON serializes the epoch time as AWS Profile epoch time.
+func (t *AWSEpochTime) UnmarshalJSON(data []byte) error {
+	var epochTime struct {
+		Sec int64 `json:"AWS:EpochTime"`
+	}
+	err := json.Unmarshal(data, &epochTime)
+	if err != nil {
+		return err
+	}
+	t.Time = time.Unix(epochTime.Sec, 0).UTC()
+	return nil
+}
+
 
 // An IPAddress wraps an IPAddress source IP providing JSON serialization information
 type IPAddress struct {

--- a/service/cloudfront/sign/policy_test.go
+++ b/service/cloudfront/sign/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -24,6 +25,22 @@ func TestEpochTimeMarshal(t *testing.T) {
 	if string(b) != expected {
 		t.Errorf("Expected marshaled time to match, expect: %s, actual: %s",
 			expected, string(b))
+	}
+}
+
+func TestEpochTimeUnmarshal(t *testing.T) {
+	now := time.Now().Round(time.Second)
+	data := fmt.Sprintf(`{"AWS:EpochTime":%d}`, now.Unix())
+	var v AWSEpochTime
+	err := json.Unmarshal([]byte(data), &v)
+	if err != nil {
+		t.Fatalf("Unexpected error, %#v", err)
+	}
+
+	expected := now.UTC()
+	if v.Time != expected {
+		t.Errorf("Expected unmarshaled time to match, expect: %s, actual: %s",
+			expected, v.Time)
 	}
 }
 


### PR DESCRIPTION
Added `UnmarshalJSON` for `AWSEpochTime`.
I wanted to use `sign.Policy` for testing purposes, to validate generated policy. But AWSEpochTime is not unmarshaled correctly.