### PR TITLE
aws/session: Handle AssumeRole on ECS the same way as EC2

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -507,9 +507,15 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config, envCfg envConfig, sharedCfg share
 
 				cfgCp := *cfg
 				p := defaults.RemoteCredProvider(cfgCp, handlers)
-				creds := credentials.NewCredentials(p)
+				cfgCp.Credentials = credentials.NewCredentials(p)
 
-				cfg.Credentials = creds
+				if len(sharedCfg.AssumeRole.MFASerial) > 0 && sessOpts.AssumeRoleTokenProvider == nil {
+					// AssumeRole Token provider is required if doing Assume Role
+					// with MFA.
+					return AssumeRoleTokenProviderNotSetError{}
+				}
+
+				cfg.Credentials = assumeRoleCredentials(cfgCp, handlers, sharedCfg, sessOpts)
 			default:
 				return ErrSharedConfigInvalidCredSource
 			}

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -714,8 +714,8 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 		{
 			name:              "ecs container credential source",
 			profile:           "ecscontainer",
-			expectedAccessKey: "access-key",
-			expectedSecretKey: "secret-key",
+			expectedAccessKey: "AKID",
+			expectedSecretKey: "SECRET",
 			init: func(cfg *aws.Config, profile string) func() error {
 				os.Setenv("AWS_REGION", "us-east-1")
 				os.Setenv("AWS_SDK_LOAD_CONFIG", "1")


### PR DESCRIPTION
I spent quite a bit of time debugging why an AssumeRole via NamedProfiles was not working via ECS task role.

After quite a bit of effort, I discovered that ECS & EC2 are being handled differently.  In the case of ECS, it never calls out to `assumeRoleCredentials`.  After bringing the two in-line, ECS works the same as EC2 given a NamedProfile with `role_arn` and `credential_source` specified.

### EC2 & ECS Disparity
https://github.com/aws/aws-sdk-go/blob/7798c2e0edc02ba058f7672d32f4ebf6603b5fc6/aws/session/session.go#L487-L512
