### PR TITLE
aws/credentials: Add missing Expiration field to the credentials.Value

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -79,6 +79,9 @@ type Value struct {
 	// AWS Session Token
 	SessionToken string
 
+	// AWS Session Expiration
+	Expiration time.Time
+
 	// Provider used to get credentials
 	ProviderName string
 }

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -294,6 +294,7 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 		AccessKeyID:     *roleOutput.Credentials.AccessKeyId,
 		SecretAccessKey: *roleOutput.Credentials.SecretAccessKey,
 		SessionToken:    *roleOutput.Credentials.SessionToken,
+		Expiration:      *roleOutput.Credentials.Expiration,
 		ProviderName:    ProviderName,
 	}, nil
 }

--- a/aws/credentials/stscreds/assume_role_provider_test.go
+++ b/aws/credentials/stscreds/assume_role_provider_test.go
@@ -13,11 +13,12 @@ type stubSTS struct {
 	TestInput func(*sts.AssumeRoleInput)
 }
 
+var expiry = time.Now().Add(60 * time.Minute)
+
 func (s *stubSTS) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	if s.TestInput != nil {
 		s.TestInput(input)
 	}
-	expiry := time.Now().Add(60 * time.Minute)
 	return &sts.AssumeRoleOutput{
 		Credentials: &sts.Credentials{
 			// Just reflect the role arn to the provider.
@@ -48,6 +49,9 @@ func TestAssumeRoleProvider(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := expiry, creds.Expiration; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
@@ -82,6 +86,9 @@ func TestAssumeRoleProvider_WithTokenCode(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := expiry, creds.Expiration; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
@@ -120,6 +127,9 @@ func TestAssumeRoleProvider_WithTokenProvider(t *testing.T) {
 	if e, a := "assumedSessionToken", creds.SessionToken; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
+	if e, a := expiry, creds.Expiration; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
 }
 
 func TestAssumeRoleProvider_WithTokenProviderError(t *testing.T) {
@@ -151,6 +161,9 @@ func TestAssumeRoleProvider_WithTokenProviderError(t *testing.T) {
 	if v := creds.SessionToken; len(v) != 0 {
 		t.Errorf("expect empty, got %v", v)
 	}
+	if v := creds.Expiration; !v.IsZero() {
+		t.Errorf("expect empty, got %v", v)
+	}
 }
 
 func TestAssumeRoleProvider_MFAWithNoToken(t *testing.T) {
@@ -177,6 +190,9 @@ func TestAssumeRoleProvider_MFAWithNoToken(t *testing.T) {
 		t.Errorf("expect empty, got %v", v)
 	}
 	if v := creds.SessionToken; len(v) != 0 {
+		t.Errorf("expect empty, got %v", v)
+	}
+	if v := creds.Expiration; !v.IsZero() {
 		t.Errorf("expect empty, got %v", v)
 	}
 }


### PR DESCRIPTION
According to the official docs, for the all request temporary credentials the response includes the expiration time of the credentials:
[Credentials Temp Request](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)

Expiration field even was in the [aws/credentials/stscreds/assume_role_provider_test.go](https://github.com/aws/aws-sdk-go/blob/v1.19.9/aws/credentials/stscreds/assume_role_provider_test.go#L27), but without real usage.

The STS API expects Expiration field in the [service/sts/api.go](https://github.com/aws/aws-sdk-go/blob/v1.19.9/service/sts/api.go#1914).

So as for me, it looks like a missing field. Please correct me if I'm wrong, I'm not an aws-sdk-go expert for sure.

Our use case is simple, we want an SDK which fully implements APIs, and we are using the Expiration fields in our environment.

And I've checked the docs, but as main info regarding AssumeRole is described in [service/sts/#STS.AssumeRole](https://docs.aws.amazon.com/sdk-for-go/api/service/sts/#STS.AssumeRole), looks like no changed needed.

P.S. I haven't found any issues or open PR regarding my finding above.
However, PR #2193 might be updated with tests, to include Expiration.