### PR TITLE
add jitter to AssumeRoleProvider

### DIFF
--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -271,7 +271,10 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 		// Expire as often as AWS permits.
 		p.Duration = DefaultDuration
 	}
-	jitter := time.Duration(sdkrand.SeededRand.Int63n(int64(p.MaxJitter)))
+	var jitter time.Duration
+	if p.MaxJitter > 0 {
+		jitter = time.Duration(sdkrand.SeededRand.Int63n(int64(p.MaxJitter)))
+	}
 	input := &sts.AssumeRoleInput{
 		DurationSeconds: aws.Int64(int64((p.Duration - jitter) / time.Second)),
 		RoleArn:         aws.String(p.RoleARN),

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -196,18 +196,14 @@ type AssumeRoleProvider struct {
 	// If ExpiryWindow is 0 or less it will be ignored.
 	ExpiryWindow time.Duration
 
-	// MaxJitterFrac makes the effective Duration different each time the STS
-	// credentials are requested. An arbitrary value between 0s and
-	// MaxJitterFrac*Duration is subtracted from Duration before the AssumeRole
-	// call is made.
-	//
+	// MaxJitterFrac reduces the effective Duration of each credential requested
+	// by a random percentage between 0 and MaxJitterFraction. MaxJitterFrac must
+	// have a value between 0 and 1. Any other value may lead to expected behavior.
+	// With a MaxJitterFrac value of 0, default) will no jitter will be used.
+	// 
 	// For example, with a Duration of 30m and a MaxJitterFrac of 0.1, the
 	// AssumeRole call will be made with an arbitrary Duration between 27m and
 	// 30m.
-	//
-	// MaxJitterFrac must not be so large as to potentially make the effective
-	// Duration less than the DefaultDuration.
-	// ie. (Duration - MaxJitterFrac*Duration >= DefaultDuration) must be true.
 	//
 	// MaxJitterFrac should not be negative.
 	MaxJitterFrac float64


### PR DESCRIPTION
This adds jitter to the `AssumeRoleProvider` which backs `stscreds.NewCredentials`. This helps to support large deployments.