### PR TITLE
Provide an option to set credential duration with NewSessionWithOptions

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -209,6 +210,12 @@ type Options struct {
 	// This field is only used if the shared configuration is enabled, and
 	// the config enables assume role wit MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
+
+	// When the SDK's shared config is configured to assume a role with MFA
+	// this option may be provided to set the expiry duration of the STS
+	// credentials. Defaults to 15 minutes if not set as documented in the
+	// stscreds.AssumeRoleProvider.
+	AssumeRoleTokenDuration time.Duration
 
 	// Reader for a custom Credentials Authority (CA) bundle in PEM format that
 	// the SDK will use instead of the default system's root CA bundle. Use this
@@ -579,6 +586,7 @@ func assumeRoleCredentials(cfg aws.Config, handlers request.Handlers, sharedCfg 
 			if len(sharedCfg.AssumeRole.MFASerial) > 0 {
 				opt.SerialNumber = aws.String(sharedCfg.AssumeRole.MFASerial)
 				opt.TokenProvider = sessOpts.AssumeRoleTokenProvider
+				opt.Duration = sessOpts.AssumeRoleTokenDuration
 			}
 		},
 	)

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -211,11 +211,11 @@ type Options struct {
 	// the config enables assume role wit MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
 
-	// When the SDK's shared config is configured to assume a role with MFA
-	// this option may be provided to set the expiry duration of the STS
-	// credentials. Defaults to 15 minutes if not set as documented in the
+	// When the SDK's shared config is configured to assume a role this option
+	// may be provided to set the expiry duration of the STS credentials.
+	// Defaults to 15 minutes if not set as documented in the
 	// stscreds.AssumeRoleProvider.
-	AssumeRoleTokenDuration time.Duration
+	AssumeRoleDuration time.Duration
 
 	// Reader for a custom Credentials Authority (CA) bundle in PEM format that
 	// the SDK will use instead of the default system's root CA bundle. Use this
@@ -576,6 +576,7 @@ func assumeRoleCredentials(cfg aws.Config, handlers request.Handlers, sharedCfg 
 		sharedCfg.AssumeRole.RoleARN,
 		func(opt *stscreds.AssumeRoleProvider) {
 			opt.RoleSessionName = sharedCfg.AssumeRole.RoleSessionName
+			opt.Duration = sessOpts.AssumeRoleDuration
 
 			// Assume role with external ID
 			if len(sharedCfg.AssumeRole.ExternalID) > 0 {
@@ -586,7 +587,6 @@ func assumeRoleCredentials(cfg aws.Config, handlers request.Handlers, sharedCfg 
 			if len(sharedCfg.AssumeRole.MFASerial) > 0 {
 				opt.SerialNumber = aws.String(sharedCfg.AssumeRole.MFASerial)
 				opt.TokenProvider = sessOpts.AssumeRoleTokenProvider
-				opt.Duration = sessOpts.AssumeRoleTokenDuration
 			}
 		},
 	)

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -514,7 +514,72 @@ func TestSessionAssumeRole_WithMFA(t *testing.T) {
 	if e, a := "SESSION_TOKEN", creds.SessionToken; e != a {
 		t.Errorf("expect %v, got %v", e, a)
 	}
-	if e, a := "AssumeRoleProvider", creds.ProviderName;  !strings.Contains(a, e) {
+	if e, a := "AssumeRoleProvider", creds.ProviderName; !strings.Contains(a, e) {
+		t.Errorf("expect %v, to contain %v", e, a)
+	}
+}
+
+func TestSessionAssumeRole_WithMFA_ExtendedDuration(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer awstesting.PopEnv(oldEnv)
+
+	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if e, a := "0123456789", r.FormValue("SerialNumber"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "tokencode", r.FormValue("TokenCode"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "1800", r.FormValue("DurationSeconds"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+
+		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(30*time.Minute).Format("2006-01-02T15:04:05Z"))))
+	}))
+
+	customProviderCalled := false
+	sess, err := NewSessionWithOptions(Options{
+		Profile: "assume_role_w_mfa",
+		Config: aws.Config{
+			Region:     aws.String("us-east-1"),
+			Endpoint:   aws.String(server.URL),
+			DisableSSL: aws.Bool(true),
+		},
+		SharedConfigState:       SharedConfigEnable,
+		AssumeRoleTokenDuration: 30 * time.Minute,
+		AssumeRoleTokenProvider: func() (string, error) {
+			customProviderCalled = true
+
+			return "tokencode", nil
+		},
+	})
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+
+	creds, err := sess.Config.Credentials.Get()
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if !customProviderCalled {
+		t.Errorf("expect true")
+	}
+
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SESSION_TOKEN", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "AssumeRoleProvider", creds.ProviderName; !strings.Contains(a, e) {
 		t.Errorf("expect %v, to contain %v", e, a)
 	}
 }


### PR DESCRIPTION
Provides an option to set role token duration in the AssumeRoleProvider
when using MFA. Without this it's difficult to change the token duration
from its default of 15 minutes while also using shared config.

Resolves #2532.