### PR TITLE
private/model/api: Fix minor SDK code gen import path logic

### DIFF
--- a/private/model/api/examples_builder.go
+++ b/private/model/api/examples_builder.go
@@ -22,6 +22,6 @@ func (builder defaultExamplesBuilder) Imports(a *API) string {
 	"` + SDKImportRoot + `/aws"
 	"` + SDKImportRoot + `/aws/awserr"
 	"` + SDKImportRoot + `/aws/session"
-	"` + SDKImportRoot + `/service/` + a.PackageName() + `"
+	"` + a.ImportPath() + `"
 	`
 }

--- a/private/model/api/s3manger_input.go
+++ b/private/model/api/s3manger_input.go
@@ -21,8 +21,8 @@ func S3ManagerUploadInputGoCode(a *API) string {
 	}
 
 	a.resetImports()
-	a.imports["io"] = true
-	a.imports["time"] = true
+	a.AddImport("io")
+	a.AddImport("time")
 
 	var w bytes.Buffer
 	if err := s3managerUploadInputTmpl.Execute(&w, s); err != nil {

--- a/private/model/cli/gen-api/main.go
+++ b/private/model/cli/gen-api/main.go
@@ -50,7 +50,7 @@ func main() {
 		"The `path` to generate service clients in to.",
 	)
 	flag.StringVar(&svcImportPath, "svc-import-path",
-		"github.com/aws/aws-sdk-go/service",
+		api.SDKImportRoot+"/service",
 		"The Go `import path` to generate client to be under.",
 	)
 	flag.Usage = usage


### PR DESCRIPTION
Fixes minor SDK code generation import path logic to use helpers instead of explicit modification of import map.