### PR TITLE
Update to reference correct variable

### DIFF
--- a/aws/endpoints/dep_service_ids.go
+++ b/aws/endpoints/dep_service_ids.go
@@ -2,7 +2,7 @@ package endpoints
 
 // Service identifiers
 //
-// Deprecated: Use client package's EndpointID value instead of these
+// Deprecated: Use client package's EndpointsID value instead of these
 // ServiceIDs. These IDs are not maintained, and are out of date.
 const (
 	A4bServiceID                          = "a4b"                          // A4b.


### PR DESCRIPTION
I hate to make a PR for a one character fix but I was searching for the variable `EndpointID` in the docs and couldn't find it in s3 nor dynamodb. I was able to find the `EndpointsID` however in both:
[DynamodDB](https://github.com/aws/aws-sdk-go/blob/master/service/dynamodb/service.go#L35)
[S3](https://github.com/aws/aws-sdk-go/blob/master/service/s3/service.go#L33)
[EC2](https://github.com/aws/aws-sdk-go/blob/master/service/ec2/service.go#L33)

(feel free to close this and change yourself)

For changes to files under the `/model/` folder, and manual edits to autogenerated code (e.g. `/service/s3/api.go`) please create an Issue instead of a PR for those type of changes.

