### PR TITLE
Add raw error message bytes to SerializationError errors

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -138,8 +138,27 @@ type RequestFailure interface {
 	RequestID() string
 }
 
-// NewRequestFailure returns a new request error wrapper for the given Error
-// provided.
+// NewRequestFailure returns a wrapped error with additional information for
+// request status code, and service requestID.
+//
+// Should be used to wrap all request which involve service requests. Even if
+// the request failed without a service response, but had an HTTP status code
+// that may be meaningful.
 func NewRequestFailure(err Error, statusCode int, reqID string) RequestFailure {
 	return newRequestError(err, statusCode, reqID)
+}
+
+// UnmarshalError provides the interface for the SDK failing to unmarshal data.
+type UnmarshalError interface {
+	awsError
+	Bytes() []byte
+}
+
+// NewUnmarshalError returns an initialized UnmarshalError error wrapper adding
+// the bytes that fail to unmarshal to the error.
+func NewUnmarshalError(err error, msg string, bytes []byte) UnmarshalError {
+	return &unmarshalError{
+		awsError: New("UnmarshalError", msg, err),
+		bytes:    bytes,
+	}
 }

--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -1,6 +1,9 @@
 package awserr
 
-import "fmt"
+import (
+	"encoding/hex"
+	"fmt"
+)
 
 // SprintError returns a string of the formatted error code.
 //
@@ -119,6 +122,7 @@ type requestError struct {
 	awsError
 	statusCode int
 	requestID  string
+	bytes      []byte
 }
 
 // newRequestError returns a wrapped error with additional information for
@@ -168,6 +172,29 @@ func (r requestError) OrigErrs() []error {
 		return b.OrigErrs()
 	}
 	return []error{r.OrigErr()}
+}
+
+type unmarshalError struct {
+	awsError
+	bytes []byte
+}
+
+// Error returns the string representation of the error.
+// Satisfies the error interface.
+func (e unmarshalError) Error() string {
+	extra := hex.Dump(e.bytes)
+	return SprintError(e.Code(), e.Message(), extra, e.OrigErr())
+}
+
+// String returns the string representation of the error.
+// Alias for Error to satisfy the stringer interface.
+func (e unmarshalError) String() string {
+	return e.Error()
+}
+
+// Bytes returns the bytes that failed to unmarshal.
+func (e unmarshalError) Bytes() []byte {
+	return e.bytes
 }
 
 // An error list that satisfies the golang interface

--- a/aws/credentials/ec2rolecreds/ec2_role_provider.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/sdkuri"
 )
 
@@ -142,7 +143,8 @@ func requestCredList(client *ec2metadata.EC2Metadata) ([]string, error) {
 	}
 
 	if err := s.Err(); err != nil {
-		return nil, awserr.New("SerializationError", "failed to read EC2 instance role from metadata service", err)
+		return nil, awserr.New(request.ErrCodeSerialization,
+			"failed to read EC2 instance role from metadata service", err)
 	}
 
 	return credsList, nil
@@ -164,7 +166,7 @@ func requestCred(client *ec2metadata.EC2Metadata, credsName string) (ec2RoleCred
 	respCreds := ec2RoleCredRespBody{}
 	if err := json.NewDecoder(strings.NewReader(resp)).Decode(&respCreds); err != nil {
 		return ec2RoleCredRespBody{},
-			awserr.New("SerializationError",
+			awserr.New(request.ErrCodeSerialization,
 				fmt.Sprintf("failed to decode %s EC2 instance role credentials", credsName),
 				err)
 	}

--- a/aws/credentials/endpointcreds/provider.go
+++ b/aws/credentials/endpointcreds/provider.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 )
 
 // ProviderName is the name of the credentials provider.
@@ -174,7 +175,7 @@ func unmarshalHandler(r *request.Request) {
 
 	out := r.Data.(*getCredentialsOutput)
 	if err := json.NewDecoder(r.HTTPResponse.Body).Decode(&out); err != nil {
-		r.Error = awserr.New("SerializationError",
+		r.Error = awserr.New(request.ErrCodeSerialization,
 			"failed to decode endpoint credentials",
 			err,
 		)
@@ -185,11 +186,15 @@ func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	var errOut errorOutput
-	if err := json.NewDecoder(r.HTTPResponse.Body).Decode(&errOut); err != nil {
-		r.Error = awserr.New("SerializationError",
-			"failed to decode endpoint credentials",
-			err,
+	err := jsonutil.UnmarshalJSONError(&errOut, r.HTTPResponse.Body)
+	if err != nil {
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(request.ErrCodeSerialization,
+				"failed to decode error message", err),
+			r.HTTPResponse.StatusCode,
+			r.RequestID,
 		)
+		return
 	}
 
 	// Response body format is not consistent between metadata endpoints.

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -96,7 +96,7 @@ func getMetricException(err awserr.Error) metricException {
 
 	switch code {
 	case "RequestError",
-		"SerializationError",
+		request.ErrCodeSerialization,
 		request.CanceledErrorCode:
 		return sdkException{
 			requestException{exception: code, message: msg},

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -82,7 +82,7 @@ func (c *EC2Metadata) GetInstanceIdentityDocument() (EC2InstanceIdentityDocument
 	doc := EC2InstanceIdentityDocument{}
 	if err := json.NewDecoder(strings.NewReader(resp)).Decode(&doc); err != nil {
 		return EC2InstanceIdentityDocument{},
-			awserr.New("SerializationError",
+			awserr.New(request.ErrCodeSerialization,
 				"failed to decode EC2 instance identity document", err)
 	}
 
@@ -101,7 +101,7 @@ func (c *EC2Metadata) IAMInfo() (EC2IAMInfo, error) {
 	info := EC2IAMInfo{}
 	if err := json.NewDecoder(strings.NewReader(resp)).Decode(&info); err != nil {
 		return EC2IAMInfo{},
-			awserr.New("SerializationError",
+			awserr.New(request.ErrCodeSerialization,
 				"failed to decode EC2 IAM info", err)
 	}
 

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -123,7 +123,7 @@ func unmarshalHandler(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	b := &bytes.Buffer{}
 	if _, err := io.Copy(b, r.HTTPResponse.Body); err != nil {
-		r.Error = awserr.New("SerializationError", "unable to unmarshal EC2 metadata respose", err)
+		r.Error = awserr.New(request.ErrCodeSerialization, "unable to unmarshal EC2 metadata respose", err)
 		return
 	}
 
@@ -136,7 +136,7 @@ func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	b := &bytes.Buffer{}
 	if _, err := io.Copy(b, r.HTTPResponse.Body); err != nil {
-		r.Error = awserr.New("SerializationError", "unable to unmarshal EC2 metadata error respose", err)
+		r.Error = awserr.New(request.ErrCodeSerialization, "unable to unmarshal EC2 metadata error respose", err)
 		return
 	}
 

--- a/aws/request/request_1_11_test.go
+++ b/aws/request/request_1_11_test.go
@@ -71,9 +71,9 @@ func TestSerializationErrConnectionReset_read(t *testing.T) {
 	req.ApplyOptions(request.WithResponseReadTimeout(time.Second))
 	err := req.Send()
 	if err == nil {
-		t.Error("Expected rror 'SerializationError', but received nil")
+		t.Error("Expected error 'SerializationError', but received nil")
 	}
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() != "SerializationError" {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() != request.ErrCodeSerialization {
 		t.Errorf("Expected 'SerializationError', but received %q", aerr.Code())
 	} else if !ok {
 		t.Errorf("Expected 'awserr.Error', but received %v", reflect.TypeOf(err))

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -675,9 +675,9 @@ func TestSerializationErrConnectionReset_accept(t *testing.T) {
 	req.ApplyOptions(request.WithResponseReadTimeout(time.Second))
 	err := req.Send()
 	if err == nil {
-		t.Error("Expected rror 'SerializationError', but received nil")
+		t.Error("Expected error 'SerializationError', but received nil")
 	}
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() != "SerializationError" {
+	if aerr, ok := err.(awserr.Error); ok && aerr.Code() != request.ErrCodeSerialization {
 		t.Errorf("Expected 'SerializationError', but received %q", aerr.Code())
 	} else if !ok {
 		t.Errorf("Expected 'awserr.Error', but received %v", reflect.TypeOf(err))

--- a/example/service/dynamodb/transactWriteItems/error_handler.go
+++ b/example/service/dynamodb/transactWriteItems/error_handler.go
@@ -45,14 +45,15 @@ func TxAwareUnmarshalError(req *request.Request) {
 	err := json.NewDecoder(req.HTTPResponse.Body).Decode(&jsonErr)
 	if err == io.EOF {
 		req.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", req.HTTPResponse.Status, nil),
+			awserr.New(request.ErrCodeSerialization, req.HTTPResponse.Status, nil),
 			req.HTTPResponse.StatusCode,
 			req.RequestID,
 		)
 		return
 	} else if err != nil {
 		req.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", "failed decoding JSON RPC error response", err),
+			awserr.New(request.ErrCodeSerialization,
+				"failed decoding JSON RPC error response", err),
 			req.HTTPResponse.StatusCode,
 			req.RequestID,
 		)

--- a/private/protocol/ec2query/build.go
+++ b/private/protocol/ec2query/build.go
@@ -21,7 +21,8 @@ func Build(r *request.Request) {
 		"Version": {r.ClientInfo.APIVersion},
 	}
 	if err := queryutil.Parse(body, r.Params, true); err != nil {
-		r.Error = awserr.New("SerializationError", "failed encoding EC2 Query request", err)
+		r.Error = awserr.New(request.ErrCodeSerialization,
+			"failed encoding EC2 Query request", err)
 	}
 
 	if !r.IsPresigned() {

--- a/private/protocol/ec2query/unmarshal_error_test.go
+++ b/private/protocol/ec2query/unmarshal_error_test.go
@@ -1,0 +1,82 @@
+// +build go1.8
+
+package ec2query
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestUnmarshalError(t *testing.T) {
+	cases := map[string]struct {
+		Request   *request.Request
+		Code, Msg string
+		ReqID     string
+		Status    int
+	}{
+		"ErrorResponse": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<Response>
+							<Errors>
+								<Error>
+									<Code>codeAbc</Code>
+									<Message>msg123</Message>
+								</Error>
+							</Errors>
+							<RequestID>reqID123</RequestID>
+						</Response>`)),
+				},
+			},
+			Code: "codeAbc", Msg: "msg123",
+			Status: 400, ReqID: "reqID123",
+		},
+		"unknown tag": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<Hello>
+							<World>.</World>
+						</Hello>`)),
+				},
+			},
+			Code:   request.ErrCodeSerialization,
+			Msg:    "failed to unmarshal error message",
+			Status: 400,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := c.Request
+			UnmarshalError(r)
+			if r.Error == nil {
+				t.Fatalf("expect error, got none")
+			}
+
+			aerr := r.Error.(awserr.RequestFailure)
+			if e, a := c.Code, aerr.Code(); e != a {
+				t.Errorf("expect %v code, got %v", e, a)
+			}
+			if e, a := c.Msg, aerr.Message(); e != a {
+				t.Errorf("expect %q message, got %q", e, a)
+			}
+			if e, a := c.ReqID, aerr.RequestID(); e != a {
+				t.Errorf("expect %v request ID, got %v", e, a)
+			}
+			if e, a := c.Status, aerr.StatusCode(); e != a {
+				t.Errorf("expect %v status code, got %v", e, a)
+			}
+		})
+	}
+}

--- a/private/protocol/jsonrpc/unmarshal_err_test.go
+++ b/private/protocol/jsonrpc/unmarshal_err_test.go
@@ -1,0 +1,79 @@
+// +build go1.8
+
+package jsonrpc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestUnmarshalError_SerializationError(t *testing.T) {
+	cases := map[string]struct {
+		Request     *request.Request
+		ExpectMsg   string
+		ExpectBytes []byte
+	}{
+		"empty body": {
+			Request: &request.Request{
+				Data: &struct{}{},
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header: http.Header{
+						"X-Amzn-Requestid": []string{"abc123"},
+					},
+					Body: ioutil.NopCloser(
+						bytes.NewReader([]byte{}),
+					),
+				},
+			},
+			ExpectMsg: "error message missing",
+		},
+		"HTML body": {
+			Request: &request.Request{
+				Data: &struct{}{},
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header: http.Header{
+						"X-Amzn-Requestid": []string{"abc123"},
+					},
+					Body: ioutil.NopCloser(
+						bytes.NewReader([]byte(`<html></html>`)),
+					),
+				},
+			},
+			ExpectBytes: []byte(`<html></html>`),
+			ExpectMsg:   "failed decoding",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := c.Request
+
+			UnmarshalError(req)
+			if req.Error == nil {
+				t.Fatal("expect error, got none")
+			}
+
+			aerr := req.Error.(awserr.RequestFailure)
+			if e, a := request.ErrCodeSerialization, aerr.Code(); e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+
+			uerr := aerr.OrigErr().(awserr.UnmarshalError)
+			if e, a := c.ExpectMsg, uerr.Message(); !strings.Contains(a, e) {
+				t.Errorf("Expect %q, in %q", e, a)
+			}
+			if e, a := c.ExpectBytes, uerr.Bytes(); !bytes.Equal(e, a) {
+				t.Errorf("expect:\n%v\nactual:\n%v", hex.Dump(e), hex.Dump(a))
+			}
+		})
+	}
+}

--- a/private/protocol/query/build.go
+++ b/private/protocol/query/build.go
@@ -21,7 +21,7 @@ func Build(r *request.Request) {
 		"Version": {r.ClientInfo.APIVersion},
 	}
 	if err := queryutil.Parse(body, r.Params, false); err != nil {
-		r.Error = awserr.New("SerializationError", "failed encoding Query request", err)
+		r.Error = awserr.New(request.ErrCodeSerialization, "failed encoding Query request", err)
 		return
 	}
 

--- a/private/protocol/query/unmarshal.go
+++ b/private/protocol/query/unmarshal.go
@@ -24,7 +24,7 @@ func Unmarshal(r *request.Request) {
 		err := xmlutil.UnmarshalXML(r.Data, decoder, r.Operation.Name+"Result")
 		if err != nil {
 			r.Error = awserr.NewRequestFailure(
-				awserr.New("SerializationError", "failed decoding Query response", err),
+				awserr.New(request.ErrCodeSerialization, "failed decoding Query response", err),
 				r.HTTPResponse.StatusCode,
 				r.RequestID,
 			)

--- a/private/protocol/query/unmarshal_error.go
+++ b/private/protocol/query/unmarshal_error.go
@@ -2,73 +2,68 @@ package query
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil"
 )
-
-type xmlErrorResponse struct {
-	XMLName   xml.Name `xml:"ErrorResponse"`
-	Code      string   `xml:"Error>Code"`
-	Message   string   `xml:"Error>Message"`
-	RequestID string   `xml:"RequestId"`
-}
-
-type xmlServiceUnavailableResponse struct {
-	XMLName xml.Name `xml:"ServiceUnavailableException"`
-}
 
 // UnmarshalErrorHandler is a name request handler to unmarshal request errors
 var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.query.UnmarshalError", Fn: UnmarshalError}
+
+type xmlErrorResponse struct {
+	Code      string `xml:"Error>Code"`
+	Message   string `xml:"Error>Message"`
+	RequestID string `xml:"RequestId"`
+}
+
+type xmlResponseError struct {
+	xmlErrorResponse
+}
+
+func (e *xmlResponseError) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	const svcUnavailableTagName = "ServiceUnavailableException"
+	const errorResponseTagName = "ErrorResponse"
+
+	switch start.Name.Local {
+	case svcUnavailableTagName:
+		e.Code = svcUnavailableTagName
+		e.Message = "service is unavailable"
+		return d.Skip()
+
+	case errorResponseTagName:
+		return d.DecodeElement(&e.xmlErrorResponse, &start)
+
+	default:
+		return fmt.Errorf("unknown error response tag, %v", start)
+	}
+}
 
 // UnmarshalError unmarshals an error response for an AWS Query service.
 func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	var respErr xmlResponseError
+	err := xmlutil.UnmarshalXMLError(&respErr, r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", "failed to read from query HTTP response body", err),
+			awserr.New(request.ErrCodeSerialization,
+				"failed to unmarshal error message", err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)
 		return
 	}
 
-	// First check for specific error
-	resp := xmlErrorResponse{}
-	decodeErr := xml.Unmarshal(bodyBytes, &resp)
-	if decodeErr == nil {
-		reqID := resp.RequestID
-		if reqID == "" {
-			reqID = r.RequestID
-		}
-		r.Error = awserr.NewRequestFailure(
-			awserr.New(resp.Code, resp.Message, nil),
-			r.HTTPResponse.StatusCode,
-			reqID,
-		)
-		return
+	reqID := respErr.RequestID
+	if len(reqID) == 0 {
+		reqID = r.RequestID
 	}
 
-	// Check for unhandled error
-	servUnavailResp := xmlServiceUnavailableResponse{}
-	unavailErr := xml.Unmarshal(bodyBytes, &servUnavailResp)
-	if unavailErr == nil {
-		r.Error = awserr.NewRequestFailure(
-			awserr.New("ServiceUnavailableException", "service is unavailable", nil),
-			r.HTTPResponse.StatusCode,
-			r.RequestID,
-		)
-		return
-	}
-
-	// Failed to retrieve any error message from the response body
 	r.Error = awserr.NewRequestFailure(
-		awserr.New("SerializationError",
-			"failed to decode query XML error response", decodeErr),
+		awserr.New(respErr.Code, respErr.Message, nil),
 		r.HTTPResponse.StatusCode,
-		r.RequestID,
+		reqID,
 	)
 }

--- a/private/protocol/query/unmarshal_error_test.go
+++ b/private/protocol/query/unmarshal_error_test.go
@@ -1,0 +1,94 @@
+// +build go1.8
+
+package query
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestUnmarshalError(t *testing.T) {
+	cases := map[string]struct {
+		Request   *request.Request
+		Code, Msg string
+		ReqID     string
+		Status    int
+	}{
+		"ErrorResponse": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<ErrorResponse>
+							<Error>
+								<Code>codeAbc</Code><Message>msg123</Message>
+							</Error>
+							<RequestId>reqID123</RequestId>
+						</ErrorResponse>`)),
+				},
+			},
+			Code: "codeAbc", Msg: "msg123",
+			Status: 400, ReqID: "reqID123",
+		},
+		"ServiceUnavailableException": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 502,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<ServiceUnavailableException>
+							<Something>else</Something>
+						</ServiceUnavailableException>`)),
+				},
+			},
+			Code:   "ServiceUnavailableException",
+			Msg:    "service is unavailable",
+			Status: 502,
+		},
+		"unknown tag": {
+			Request: &request.Request{
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{},
+					Body: ioutil.NopCloser(strings.NewReader(
+						`<Hello>
+							<World>.</World>
+						</Hello>`)),
+				},
+			},
+			Code:   request.ErrCodeSerialization,
+			Msg:    "failed to unmarshal error message",
+			Status: 400,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := c.Request
+			UnmarshalError(r)
+			if r.Error == nil {
+				t.Fatalf("expect error, got none")
+			}
+
+			aerr := r.Error.(awserr.RequestFailure)
+			if e, a := c.Code, aerr.Code(); e != a {
+				t.Errorf("expect %v code, got %v", e, a)
+			}
+			if e, a := c.Msg, aerr.Message(); e != a {
+				t.Errorf("expect %q message, got %q", e, a)
+			}
+			if e, a := c.ReqID, aerr.RequestID(); e != a {
+				t.Errorf("expect %v request ID, got %v", e, a)
+			}
+			if e, a := c.Status, aerr.StatusCode(); e != a {
+				t.Errorf("expect %v status code, got %v", e, a)
+			}
+		})
+	}
+}

--- a/private/protocol/rest/build.go
+++ b/private/protocol/rest/build.go
@@ -137,7 +137,7 @@ func buildBody(r *request.Request, v reflect.Value) {
 					case string:
 						r.SetStringBody(reader)
 					default:
-						r.Error = awserr.New("SerializationError",
+						r.Error = awserr.New(request.ErrCodeSerialization,
 							"failed to encode REST request",
 							fmt.Errorf("unknown payload type %s", payload.Type()))
 					}
@@ -152,7 +152,7 @@ func buildHeader(header *http.Header, v reflect.Value, name string, tag reflect.
 	if err == errValueNotSet {
 		return nil
 	} else if err != nil {
-		return awserr.New("SerializationError", "failed to encode REST request", err)
+		return awserr.New(request.ErrCodeSerialization, "failed to encode REST request", err)
 	}
 
 	name = strings.TrimSpace(name)
@@ -170,7 +170,7 @@ func buildHeaderMap(header *http.Header, v reflect.Value, tag reflect.StructTag)
 		if err == errValueNotSet {
 			continue
 		} else if err != nil {
-			return awserr.New("SerializationError", "failed to encode REST request", err)
+			return awserr.New(request.ErrCodeSerialization, "failed to encode REST request", err)
 
 		}
 		keyStr := strings.TrimSpace(key.String())
@@ -186,7 +186,7 @@ func buildURI(u *url.URL, v reflect.Value, name string, tag reflect.StructTag) e
 	if err == errValueNotSet {
 		return nil
 	} else if err != nil {
-		return awserr.New("SerializationError", "failed to encode REST request", err)
+		return awserr.New(request.ErrCodeSerialization, "failed to encode REST request", err)
 	}
 
 	u.Path = strings.Replace(u.Path, "{"+name+"}", value, -1)
@@ -219,7 +219,7 @@ func buildQueryString(query url.Values, v reflect.Value, name string, tag reflec
 		if err == errValueNotSet {
 			return nil
 		} else if err != nil {
-			return awserr.New("SerializationError", "failed to encode REST request", err)
+			return awserr.New(request.ErrCodeSerialization, "failed to encode REST request", err)
 		}
 		query.Set(name, str)
 	}

--- a/private/protocol/rest/unmarshal.go
+++ b/private/protocol/rest/unmarshal.go
@@ -57,7 +57,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
+							r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						} else {
 							payload.Set(reflect.ValueOf(b))
 						}
@@ -65,7 +65,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						defer r.HTTPResponse.Body.Close()
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
+							r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 						} else {
 							str := string(b)
 							payload.Set(reflect.ValueOf(&str))
@@ -77,7 +77,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						case "io.ReadSeeker":
 							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
-								r.Error = awserr.New("SerializationError",
+								r.Error = awserr.New(request.ErrCodeSerialization,
 									"failed to read response body", err)
 								return
 							}
@@ -85,7 +85,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						default:
 							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
 							defer r.HTTPResponse.Body.Close()
-							r.Error = awserr.New("SerializationError",
+							r.Error = awserr.New(request.ErrCodeSerialization,
 								"failed to decode REST response",
 								fmt.Errorf("unknown payload type %s", payload.Type()))
 						}
@@ -115,14 +115,14 @@ func unmarshalLocationElements(r *request.Request, v reflect.Value) {
 			case "header":
 				err := unmarshalHeader(m, r.HTTPResponse.Header.Get(name), field.Tag)
 				if err != nil {
-					r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
+					r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 					break
 				}
 			case "headers":
 				prefix := field.Tag.Get("locationName")
 				err := unmarshalHeaderMap(m, r.HTTPResponse.Header, prefix)
 				if err != nil {
-					r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
+					r.Error = awserr.New(request.ErrCodeSerialization, "failed to decode REST response", err)
 					break
 				}
 			}

--- a/private/protocol/restjson/restjson.go
+++ b/private/protocol/restjson/restjson.go
@@ -6,12 +6,11 @@ package restjson
 //go:generate go run -tags codegen ../../../models/protocol_tests/generate.go ../../../models/protocol_tests/output/rest-json.json unmarshal_test.go
 
 import (
-	"encoding/json"
-	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 )
@@ -59,17 +58,11 @@ func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	var jsonErr jsonErrorResponse
-	err := json.NewDecoder(r.HTTPResponse.Body).Decode(&jsonErr)
-	if err == io.EOF {
+	err := jsonutil.UnmarshalJSONError(&jsonErr, r.HTTPResponse.Body)
+	if err != nil {
 		r.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", r.HTTPResponse.Status, nil),
-			r.HTTPResponse.StatusCode,
-			r.RequestID,
-		)
-		return
-	} else if err != nil {
-		r.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", "failed decoding REST JSON error response", err),
+			awserr.New(request.ErrCodeSerialization,
+				"failed to unmarshal response error", err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)

--- a/private/protocol/restjson/unmarshal_error_test.go
+++ b/private/protocol/restjson/unmarshal_error_test.go
@@ -1,0 +1,79 @@
+// +build go1.8
+
+package restjson
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestUnmarshalError_SerializationError(t *testing.T) {
+	cases := map[string]struct {
+		Request     *request.Request
+		ExpectMsg   string
+		ExpectBytes []byte
+	}{
+		"empty body": {
+			Request: &request.Request{
+				Data: &struct{}{},
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header: http.Header{
+						"X-Amzn-Requestid": []string{"abc123"},
+					},
+					Body: ioutil.NopCloser(
+						bytes.NewReader([]byte{}),
+					),
+				},
+			},
+			ExpectMsg: "error message missing",
+		},
+		"HTML body": {
+			Request: &request.Request{
+				Data: &struct{}{},
+				HTTPResponse: &http.Response{
+					StatusCode: 400,
+					Header: http.Header{
+						"X-Amzn-Requestid": []string{"abc123"},
+					},
+					Body: ioutil.NopCloser(
+						bytes.NewReader([]byte(`<html></html>`)),
+					),
+				},
+			},
+			ExpectBytes: []byte(`<html></html>`),
+			ExpectMsg:   "failed decoding",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := c.Request
+
+			UnmarshalError(req)
+			if req.Error == nil {
+				t.Fatal("expect error, got none")
+			}
+
+			aerr := req.Error.(awserr.RequestFailure)
+			if e, a := request.ErrCodeSerialization, aerr.Code(); e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+
+			uerr := aerr.OrigErr().(awserr.UnmarshalError)
+			if e, a := c.ExpectMsg, uerr.Message(); !strings.Contains(a, e) {
+				t.Errorf("Expect %q, in %q", e, a)
+			}
+			if e, a := c.ExpectBytes, uerr.Bytes(); !bytes.Equal(e, a) {
+				t.Errorf("expect:\n%v\nactual:\n%v", hex.Dump(e), hex.Dump(a))
+			}
+		})
+	}
+}

--- a/private/protocol/restxml/restxml.go
+++ b/private/protocol/restxml/restxml.go
@@ -37,7 +37,8 @@ func Build(r *request.Request) {
 		err := xmlutil.BuildXML(r.Params, xml.NewEncoder(&buf))
 		if err != nil {
 			r.Error = awserr.NewRequestFailure(
-				awserr.New("SerializationError", "failed to encode rest XML request", err),
+				awserr.New(request.ErrCodeSerialization,
+					"failed to encode rest XML request", err),
 				r.HTTPResponse.StatusCode,
 				r.RequestID,
 			)
@@ -55,7 +56,8 @@ func Unmarshal(r *request.Request) {
 		err := xmlutil.UnmarshalXML(r.Data, decoder, "")
 		if err != nil {
 			r.Error = awserr.NewRequestFailure(
-				awserr.New("SerializationError", "failed to decode REST XML response", err),
+				awserr.New(request.ErrCodeSerialization,
+					"failed to decode REST XML response", err),
 				r.HTTPResponse.StatusCode,
 				r.RequestID,
 			)

--- a/private/protocol/unmarshal_test.go
+++ b/private/protocol/unmarshal_test.go
@@ -76,7 +76,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 			},
 			unmarshalFn: jsonrpc.Unmarshal,
 			expectedError: awserr.NewRequestFailure(
-				awserr.New("SerializationError", "", nil),
+				awserr.New(request.ErrCodeSerialization, "", nil),
 				502,
 				"",
 			),
@@ -92,7 +92,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 			},
 			unmarshalFn: ec2query.Unmarshal,
 			expectedError: awserr.NewRequestFailure(
-				awserr.New("SerializationError", "", nil),
+				awserr.New(request.ErrCodeSerialization, "", nil),
 				111,
 				"",
 			),
@@ -111,7 +111,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 			},
 			unmarshalFn: query.Unmarshal,
 			expectedError: awserr.NewRequestFailure(
-				awserr.New("SerializationError", "", nil),
+				awserr.New(request.ErrCodeSerialization, "", nil),
 				1,
 				"",
 			),
@@ -127,7 +127,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 			},
 			unmarshalFn: restjson.Unmarshal,
 			expectedError: awserr.NewRequestFailure(
-				awserr.New("SerializationError", "", nil),
+				awserr.New(request.ErrCodeSerialization, "", nil),
 				123,
 				"",
 			),
@@ -143,7 +143,7 @@ func TestUnmarshalSeriaizationError(t *testing.T) {
 			},
 			unmarshalFn: restxml.Unmarshal,
 			expectedError: awserr.NewRequestFailure(
-				awserr.New("SerializationError", "", nil),
+				awserr.New(request.ErrCodeSerialization, "", nil),
 				456,
 				"",
 			),

--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -1,6 +1,7 @@
 package xmlutil
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -10,8 +11,26 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/private/protocol"
 )
+
+// UnmarshalXMLError unmarshals the XML error from the stream into the value
+// type specified. The value must be a pointer. If the message fails to
+// unmarshal, the message content will be included in the returned error as a
+// awserr.UnmarshalError.
+func UnmarshalXMLError(v interface{}, stream io.Reader) error {
+	var errBuf bytes.Buffer
+	body := io.TeeReader(stream, &errBuf)
+
+	err := xml.NewDecoder(body).Decode(v)
+	if err != nil && err != io.EOF {
+		return awserr.NewUnmarshalError(err,
+			"failed to unmarshal error message", errBuf.Bytes())
+	}
+
+	return nil
+}
 
 // UnmarshalXML deserializes an xml.Decoder into the container v. V
 // needs to match the shape of the XML expected to be decoded.

--- a/service/route53/customizations.go
+++ b/service/route53/customizations.go
@@ -33,7 +33,7 @@ func sanitizeURL(r *request.Request) {
 	// Update Path so that it reflects the cleaned RawPath
 	updated, err := url.Parse(r.HTTPRequest.URL.RawPath)
 	if err != nil {
-		r.Error = awserr.New("SerializationError", "failed to clean Route53 URL", err)
+		r.Error = awserr.New(request.ErrCodeSerialization, "failed to clean Route53 URL", err)
 		return
 	}
 

--- a/service/s3/bucket_location.go
+++ b/service/s3/bucket_location.go
@@ -80,7 +80,8 @@ func buildGetBucketLocation(r *request.Request) {
 		out := r.Data.(*GetBucketLocationOutput)
 		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
-			r.Error = awserr.New("SerializationError", "failed reading response body", err)
+			r.Error = awserr.New(request.ErrCodeSerialization,
+				"failed reading response body", err)
 			return
 		}
 

--- a/service/s3/statusok_error.go
+++ b/service/s3/statusok_error.go
@@ -14,7 +14,7 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
-			awserr.New("SerializationError", "unable to read response body", err),
+			awserr.New(request.ErrCodeSerialization, "unable to read response body", err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)
@@ -31,7 +31,7 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 
 	unmarshalError(r)
 	if err, ok := r.Error.(awserr.Error); ok && err != nil {
-		if err.Code() == "SerializationError" {
+		if err.Code() == request.ErrCodeSerialization {
 			r.Error = nil
 			return
 		}

--- a/service/simpledb/unmarshall_error.go
+++ b/service/simpledb/unmarshall_error.go
@@ -8,17 +8,43 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil"
 )
 
 type xmlErrorDetail struct {
 	Code    string `xml:"Code"`
 	Message string `xml:"Message"`
 }
-
-type xmlErrorResponse struct {
+type xmlErrorMessage struct {
 	XMLName   xml.Name         `xml:"Response"`
 	Errors    []xmlErrorDetail `xml:"Errors>Error"`
 	RequestID string           `xml:"RequestID"`
+}
+
+type xmlErrorResponse struct {
+	Code        string
+	Message     string
+	RequestID   string
+	OtherErrors []xmlErrorDetail
+}
+
+func (r *xmlErrorResponse) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var errResp xmlErrorMessage
+	if err := d.DecodeElement(&errResp, &start); err != nil {
+		return err
+	}
+
+	r.RequestID = errResp.RequestID
+	if len(errResp.Errors) == 0 {
+		r.Code = "MissingError"
+		r.Message = "missing error code in SimpleDB XML error response"
+	} else {
+		r.Code = errResp.Errors[0].Code
+		r.Message = errResp.Errors[0].Message
+		r.OtherErrors = errResp.Errors[1:]
+	}
+
+	return nil
 }
 
 func unmarshalError(r *request.Request) {
@@ -30,24 +56,32 @@ func unmarshalError(r *request.Request) {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(strings.Replace(r.HTTPResponse.Status, " ", "", -1), r.HTTPResponse.Status, nil),
 			r.HTTPResponse.StatusCode,
-			"",
+			r.RequestID,
 		)
 		return
 	}
 
-	resp := &xmlErrorResponse{}
-	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
-	if err != nil && err != io.EOF {
-		r.Error = awserr.New("SerializationError", "failed to decode SimpleDB XML error response", nil)
-	} else if len(resp.Errors) == 0 {
-		r.Error = awserr.New("MissingError", "missing error code in SimpleDB XML error response", nil)
-	} else {
-		// If there are multiple error codes, return only the first as the aws.Error interface only supports
-		// one error code.
+	var errResp xmlErrorResponse
+	err := xmlutil.UnmarshalXMLError(&errResp, r.HTTPResponse.Body)
+	if err != nil {
 		r.Error = awserr.NewRequestFailure(
-			awserr.New(resp.Errors[0].Code, resp.Errors[0].Message, nil),
+			awserr.New(request.ErrCodeSerialization, "failed to unmarshal error message", err),
 			r.HTTPResponse.StatusCode,
-			resp.RequestID,
+			r.RequestID,
 		)
+		return
 	}
+
+	var otherErrs []error
+	for _, e := range errResp.OtherErrors {
+		otherErrs = append(otherErrs, awserr.New(e.Code, e.Message, nil))
+	}
+
+	// If there are multiple error codes, return only the first as the
+	// aws.Error interface only supports one error code.
+	r.Error = awserr.NewRequestFailure(
+		awserr.NewBatchError(errResp.Code, errResp.Message, otherErrs),
+		r.HTTPResponse.StatusCode,
+		errResp.RequestID,
+	)
 }


### PR DESCRIPTION
Updates the SDK's API error message SerializationError handling to
capture the original error message byte, and include it in the
SerializationError error value.

Also replaces the `"SerializationError"` literal string in the SDK with the constant, `ErrCodeSerialization`.

Fix #2562, #2411, #2315