### PR TITLE
aws/endpoints: Add option to only used regional endpoints

### DIFF
--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -85,7 +85,7 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
 	}
 
-	e, hasEndpoint := s.endpointForRegion(region)
+	e, hasEndpoint := s.endpointForRegion(region, opt)
 	if !hasEndpoint && opt.StrictMatching {
 		return resolved, NewUnknownEndpointError(p.ID, service, region, endpointList(s.Endpoints))
 	}
@@ -142,8 +142,8 @@ type service struct {
 	Endpoints         endpoints `json:"endpoints"`
 }
 
-func (s *service) endpointForRegion(region string) (endpoint, bool) {
-	if s.IsRegionalized == boxedFalse {
+func (s *service) endpointForRegion(region string, opt Options) (endpoint, bool) {
+	if s.IsRegionalized == boxedFalse && !opt.UseRegionalEndpoints {
 		return s.Endpoints[s.PartitionEndpoint], region == s.PartitionEndpoint
 	}
 


### PR DESCRIPTION
Updates the SDK's endpoints Resolver Options allowing endpoints to be
resolved for the service's regional endpoints instead of rewriting the
requested endpoint to be the service's global endpoint.
