### PR TITLE
service/s3: Fix SSE Customer Key value whitespace trimming

### DIFF
--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -110,6 +110,22 @@ func s3Customizations(a *API) {
 			}
 		}
 
+		// Decorate member references that are modeled with the wrong type.
+		// Specifically the case where a member was modeled as a string, but is
+		// expected to sent across the wire as a base64 value.
+		//
+		// e.g. S3's SSECustomerKey and CopySourceSSECustomerKey
+		for _, refName := range []string{
+			"SSECustomerKey",
+			"CopySourceSSECustomerKey",
+		} {
+			if ref, ok := s.MemberRefs[refName]; ok {
+				ref.CustomTags = append(ref.CustomTags, ShapeTag{
+					"marshal-as", "blob",
+				})
+			}
+		}
+
 		// Expires should be a string not time.Time since the format is not
 		// enforced by S3, and any value can be set to this field outside of the SDK.
 		if strings.HasSuffix(name, "Output") {

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -57,6 +57,9 @@ type ShapeRef struct {
 
 	IsEventPayload bool `json:"eventpayload"`
 	IsEventHeader  bool `json:"eventheader"`
+
+	// Collection of custom tags the shape reference includes.
+	CustomTags ShapeTags
 }
 
 // A Shape defines the definition of a shape type
@@ -434,7 +437,7 @@ func (s ShapeTags) String() string {
 
 // GoTags returns the rendered tags string for the ShapeRef
 func (ref *ShapeRef) GoTags(toplevel bool, isRequired bool) string {
-	tags := ShapeTags{}
+	tags := append(ShapeTags{}, ref.CustomTags...)
 
 	if ref.Location != "" {
 		tags = append(tags, ShapeTag{"location", ref.Location})

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -8409,7 +8409,7 @@ type CopyObjectInput struct {
 	// Specifies the customer-provided encryption key for Amazon S3 to use to decrypt
 	// the source object. The encryption key provided in this header must be one
 	// that was used when the source object was created.
-	CopySourceSSECustomerKey *string `location:"header" locationName:"x-amz-copy-source-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	CopySourceSSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-copy-source-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -8464,7 +8464,7 @@ type CopyObjectInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -9167,7 +9167,7 @@ type CreateMultipartUploadInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -12820,7 +12820,7 @@ type GetObjectInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -14136,7 +14136,7 @@ type HeadObjectInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -20253,7 +20253,7 @@ type PutObjectInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -22543,7 +22543,7 @@ type SelectObjectContentInput struct {
 
 	// The SSE Customer Key. For more information, see  Server-Side Encryption (Using
 	// Customer-Provided Encryption Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html).
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// The SSE Customer Key MD5. For more information, see  Server-Side Encryption
 	// (Using Customer-Provided Encryption Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html).
@@ -23550,7 +23550,7 @@ type UploadPartCopyInput struct {
 	// Specifies the customer-provided encryption key for Amazon S3 to use to decrypt
 	// the source object. The encryption key provided in this header must be one
 	// that was used when the source object was created.
-	CopySourceSSECustomerKey *string `location:"header" locationName:"x-amz-copy-source-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	CopySourceSSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-copy-source-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -23581,7 +23581,7 @@ type UploadPartCopyInput struct {
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header. This must be the same encryption key specified in the initiate multipart
 	// upload request.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption
@@ -23886,7 +23886,7 @@ type UploadPartInput struct {
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header. This must be the same encryption key specified in the initiate multipart
 	// upload request.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -17,7 +17,8 @@ func defaultInitClientFn(c *client.Client) {
 
 	// Require SSL when using SSE keys
 	c.Handlers.Validate.PushBack(validateSSERequiresSSL)
-	c.Handlers.Build.PushBack(computeSSEKeys)
+	c.Handlers.Build.PushBack(computeSSEKeyMD5)
+	c.Handlers.Build.PushBack(computeCopySourceSSEKeyMD5)
 
 	// S3 uses custom error unmarshaling logic
 	c.Handlers.UnmarshalError.Clear()

--- a/service/s3/s3manager/upload_input.go
+++ b/service/s3/s3manager/upload_input.go
@@ -92,7 +92,7 @@ type UploadInput struct {
 	// does not store the encryption key. The key must be appropriate for use with
 	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
 	// header.
-	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
+	SSECustomerKey *string `marshal-as:"blob" location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string" sensitive:"true"`
 
 	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
 	// Amazon S3 uses this header for a message integrity check to ensure the encryption

--- a/service/s3/sse.go
+++ b/service/s3/sse.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"crypto/md5"
 	"encoding/base64"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -30,25 +31,54 @@ func validateSSERequiresSSL(r *request.Request) {
 	}
 }
 
-func computeSSEKeys(r *request.Request) {
-	headers := []string{
-		"x-amz-server-side-encryption-customer-key",
-		"x-amz-copy-source-server-side-encryption-customer-key",
+const (
+	sseKeyHeader    = "x-amz-server-side-encryption-customer-key"
+	sseKeyMD5Header = sseKeyHeader + "-md5"
+)
+
+func computeSSEKeyMD5(r *request.Request) {
+	var key string
+	if g, ok := r.Params.(sseCustomerKeyGetter); ok {
+		key = g.getSSECustomerKey()
 	}
 
-	for _, h := range headers {
-		md5h := h + "-md5"
-		if key := r.HTTPRequest.Header.Get(h); key != "" {
-			// Base64-encode the value
-			b64v := base64.StdEncoding.EncodeToString([]byte(key))
-			r.HTTPRequest.Header.Set(h, b64v)
+	computeKeyMD5(sseKeyHeader, sseKeyMD5Header, key, r.HTTPRequest)
+}
 
-			// Add MD5 if it wasn't computed
-			if r.HTTPRequest.Header.Get(md5h) == "" {
-				sum := md5.Sum([]byte(key))
-				b64sum := base64.StdEncoding.EncodeToString(sum[:])
-				r.HTTPRequest.Header.Set(md5h, b64sum)
-			}
+const (
+	copySrcSSEKeyHeader    = "x-amz-copy-source-server-side-encryption-customer-key"
+	copySrcSSEKeyMD5Header = copySrcSSEKeyHeader + "-md5"
+)
+
+func computeCopySourceSSEKeyMD5(r *request.Request) {
+	var key string
+	if g, ok := r.Params.(copySourceSSECustomerKeyGetter); ok {
+		key = g.getCopySourceSSECustomerKey()
+	}
+
+	computeKeyMD5(copySrcSSEKeyHeader, copySrcSSEKeyMD5Header, key, r.HTTPRequest)
+}
+
+func computeKeyMD5(keyHeader, keyMD5Header, key string, r *http.Request) {
+	if len(key) == 0 {
+		// Backwards compatiablity where user just set the header value instead
+		// of using the API parameter, or setting the header value for an
+		// operation without the parameters modeled.
+		key = r.Header.Get(keyHeader)
+		if len(key) == 0 {
+			return
 		}
+
+		// In backwards compatiable, the header's value is not base64 encoded,
+		// and needs to be encoded and updated by the SDK's customizations.
+		b64Key := base64.StdEncoding.EncodeToString([]byte(key))
+		r.Header.Set(keyHeader, b64Key)
+	}
+
+	// Only update Key's MD5 if not already set.
+	if len(r.Header.Get(keyMD5Header)) == 0 {
+		sum := md5.Sum([]byte(key))
+		keyMD5 := base64.StdEncoding.EncodeToString(sum[:])
+		r.Header.Set(keyMD5Header, keyMD5)
 	}
 }

--- a/service/s3/sse_test.go
+++ b/service/s3/sse_test.go
@@ -109,3 +109,30 @@ func TestComputeSSEKeysShortcircuit(t *testing.T) {
 		t.Errorf("expected %s, but received %s", e, a)
 	}
 }
+
+func TestSSECustomerKeysWithSpaces(t *testing.T) {
+	s := s3.New(unit.Session)
+	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
+		Bucket:                   aws.String("bucket"),
+		CopySource:               aws.String("bucket/source"),
+		Key:                      aws.String("dest"),
+		SSECustomerKey:           aws.String("   key   "),
+		CopySourceSSECustomerKey: aws.String("   copykey   "),
+	})
+	err := req.Build()
+	if err != nil {
+		t.Errorf("expected no error, but received %v", err)
+	}
+	if e, a := "ICAga2V5ICAg", req.HTTPRequest.Header.Get("x-amz-server-side-encryption-customer-key"); e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+	if e, a := "ICAgY29weWtleSAgIA==", req.HTTPRequest.Header.Get("x-amz-copy-source-server-side-encryption-customer-key"); e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+	if e, a := "13XiUSCa6ReZ3CHtCLiJLg==", req.HTTPRequest.Header.Get("x-amz-server-side-encryption-customer-key-md5"); e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+	if e, a := "MHVtfmuml539o1871Vsc6w==", req.HTTPRequest.Header.Get("x-amz-copy-source-server-side-encryption-customer-key-md5"); e != a {
+		t.Errorf("expected %s, but received %s", e, a)
+	}
+}


### PR DESCRIPTION
Fixes the S3 client's SSSECustomerKey and CopySourceSSECustomerKey API
input parameter's with leading or trailing whitespace being trimmed from
the parameter's value before sent. The parameters are modeled as strings
when they should be base64 encoded.

Fix #2604 