### PR TITLE
Update s3manager's iface with missing methods

### DIFF
--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -19,14 +19,17 @@ type DownloaderAPI interface {
 
 var _ DownloaderAPI = (*s3manager.Downloader)(nil)
 
+// interface for DownloadWithIterator (separated from DownloaderAPI for user to compose)
 type DownloadWithIterator interface {
 	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
 
+// interface for NewDownloader (separated from DownloaderAPI for user to compose)
 type NewDownloader interface {
 	NewDownloader(client.ConfigProvider, ...func(*s3manager.Downloader)) *s3manager.Downloader
 }
 
+// interface for NewDownloaderWithClient (separated from DownloaderAPI for user to compose)
 type NewDownloaderWithClient interface {
 	NewDownloaderWithClient(s3iface.S3API, ...func(*s3manager.Downloader)) *s3manager.Downloader
 }
@@ -40,19 +43,23 @@ type UploaderAPI interface {
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
 
+// interface for NewDownloaderWithClient (separated from UploaderAPI for user to compose)
 type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
 
+// interface for NewUploader (separated from UploaderAPI for user to compose)
 type NewUploader interface {
 	NewUploader(client.ConfigProvider, ...func(*s3manager.Uploader)) *s3manager.Uploader
 }
 
+// interface for NewUploaderWithClient (separated from UploaderAPI for user to compose)
 type NewUploaderWithClient interface {
 	NewUploaderWithClient(s3iface.S3API, ...func(*s3manager.Uploader)) *s3manager.Uploader
 }
 
 
+// BatchDeleteAPI is the interface type for BatchDelete (separated for user to compose)
 type BatchDeleteAPI interface {
 	Delete(aws.Context, s3manager.BatchDeleteIterator) error
 }

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -43,7 +43,7 @@ type UploaderAPI interface {
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
 
-// NewDownloaderWithClient is the interface type for the contained method of the same name.
+// UploadWithIterator is the interface type for the contained method of the same name.
 type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -5,9 +5,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -17,6 +17,11 @@ type DownloaderAPI interface {
 
 var _ DownloaderAPI = (*s3manager.Downloader)(nil)
 
+type DownloadWithIterator interface {
+	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
+}
+
+
 // UploaderAPI is the interface type for s3manager.Uploader.
 type UploaderAPI interface {
 	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
@@ -24,3 +29,12 @@ type UploaderAPI interface {
 }
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
+
+type UploadWithIterator interface {
+	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
+}
+
+
+type Deleter interface {
+	Delete(aws.Context, s3manager.BatchDeleteIterator) error
+}

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -5,7 +5,9 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
@@ -21,6 +23,14 @@ type DownloadWithIterator interface {
 	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
 
+type NewDownloader interface {
+	NewDownloader(client.ConfigProvider, ...func(*s3manager.Downloader)) *s3manager.Downloader
+}
+
+type NewDownloaderWithClient interface {
+	NewDownloaderWithClient(s3iface.S3API, ...func(*s3manager.Downloader)) *s3manager.Downloader
+}
+
 
 // UploaderAPI is the interface type for s3manager.Uploader.
 type UploaderAPI interface {
@@ -34,7 +44,15 @@ type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
 
+type NewUploader interface {
+	NewUploader(client.ConfigProvider, ...func(*s3manager.Uploader)) *s3manager.Uploader
+}
 
-type Deleter interface {
+type NewUploaderWithClient interface {
+	NewUploaderWithClient(s3iface.S3API, ...func(*s3manager.Uploader)) *s3manager.Uploader
+}
+
+
+type BatchDeleteAPI interface {
 	Delete(aws.Context, s3manager.BatchDeleteIterator) error
 }

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -9,18 +9,21 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+var _ DownloaderAPI = (*s3manager.Downloader)(nil)
+
 // DownloaderAPI is the interface type for s3manager.Downloader.
 type DownloaderAPI interface {
 	Download(io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
 	DownloadWithContext(aws.Context, io.WriterAt, *s3.GetObjectInput, ...func(*s3manager.Downloader)) (int64, error)
 }
 
-var _ DownloaderAPI = (*s3manager.Downloader)(nil)
-
 // DownloadWithIterator is the interface type for the contained method of the same name.
 type DownloadWithIterator interface {
 	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
+
+var _ UploaderAPI = (*s3manager.Uploader)(nil)
+var _ UploadWithIterator = (*s3manager.Uploader)(nil)
 
 // UploaderAPI is the interface type for s3manager.Uploader.
 type UploaderAPI interface {
@@ -28,14 +31,16 @@ type UploaderAPI interface {
 	UploadWithContext(aws.Context, *s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 }
 
-var _ UploaderAPI = (*s3manager.Uploader)(nil)
-
-// UploadWithIterator is the interface type for the contained method of the same name.
+// UploadWithIterator is the interface for uploading objects to S3 using the S3
+// upload manager.
 type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
 
-// BatchDeleteAPI is the interface type for BatchDelete (separated for user to compose).
-type BatchDeleteAPI interface {
+var _ BatchDelete = (*s3manager.BatchDelete)(nil)
+
+// BatchDelete is the interface type for batch deleting objects from S3 using
+// the S3 manager. (separated for user to compose).
+type BatchDelete interface {
 	Delete(aws.Context, s3manager.BatchDeleteIterator) error
 }

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -19,17 +19,17 @@ type DownloaderAPI interface {
 
 var _ DownloaderAPI = (*s3manager.Downloader)(nil)
 
-// interface for DownloadWithIterator (separated from DownloaderAPI for user to compose)
+// DownloadWithIterator is the interface type for the contained method of the same name.
 type DownloadWithIterator interface {
 	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
 
-// interface for NewDownloader (separated from DownloaderAPI for user to compose)
+// NewDownloader is the interface type for the contained method of the same name.
 type NewDownloader interface {
 	NewDownloader(client.ConfigProvider, ...func(*s3manager.Downloader)) *s3manager.Downloader
 }
 
-// interface for NewDownloaderWithClient (separated from DownloaderAPI for user to compose)
+// NewDownloaderWithClient is the interface type for the contained method of the same name.
 type NewDownloaderWithClient interface {
 	NewDownloaderWithClient(s3iface.S3API, ...func(*s3manager.Downloader)) *s3manager.Downloader
 }
@@ -43,23 +43,23 @@ type UploaderAPI interface {
 
 var _ UploaderAPI = (*s3manager.Uploader)(nil)
 
-// interface for NewDownloaderWithClient (separated from UploaderAPI for user to compose)
+// NewDownloaderWithClient is the interface type for the contained method of the same name.
 type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
 
-// interface for NewUploader (separated from UploaderAPI for user to compose)
+// NewUploader is the interface type for the contained method of the same name.
 type NewUploader interface {
 	NewUploader(client.ConfigProvider, ...func(*s3manager.Uploader)) *s3manager.Uploader
 }
 
-// interface for NewUploaderWithClient (separated from UploaderAPI for user to compose)
+// NewUploaderWithClient is the interface type for the contained method of the same name.
 type NewUploaderWithClient interface {
 	NewUploaderWithClient(s3iface.S3API, ...func(*s3manager.Uploader)) *s3manager.Uploader
 }
 
 
-// BatchDeleteAPI is the interface type for BatchDelete (separated for user to compose)
+// BatchDeleteAPI is the interface type for BatchDelete (separated for user to compose).
 type BatchDeleteAPI interface {
 	Delete(aws.Context, s3manager.BatchDeleteIterator) error
 }

--- a/service/s3/s3manager/s3manageriface/interface.go
+++ b/service/s3/s3manager/s3manageriface/interface.go
@@ -24,17 +24,6 @@ type DownloadWithIterator interface {
 	DownloadWithIterator(aws.Context, s3manager.BatchDownloadIterator, ...func(*s3manager.Downloader)) error
 }
 
-// NewDownloader is the interface type for the contained method of the same name.
-type NewDownloader interface {
-	NewDownloader(client.ConfigProvider, ...func(*s3manager.Downloader)) *s3manager.Downloader
-}
-
-// NewDownloaderWithClient is the interface type for the contained method of the same name.
-type NewDownloaderWithClient interface {
-	NewDownloaderWithClient(s3iface.S3API, ...func(*s3manager.Downloader)) *s3manager.Downloader
-}
-
-
 // UploaderAPI is the interface type for s3manager.Uploader.
 type UploaderAPI interface {
 	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
@@ -47,17 +36,6 @@ var _ UploaderAPI = (*s3manager.Uploader)(nil)
 type UploadWithIterator interface {
 	UploadWithIterator(aws.Context, s3manager.BatchUploadIterator, ...func(*s3manager.Uploader)) error
 }
-
-// NewUploader is the interface type for the contained method of the same name.
-type NewUploader interface {
-	NewUploader(client.ConfigProvider, ...func(*s3manager.Uploader)) *s3manager.Uploader
-}
-
-// NewUploaderWithClient is the interface type for the contained method of the same name.
-type NewUploaderWithClient interface {
-	NewUploaderWithClient(s3iface.S3API, ...func(*s3manager.Uploader)) *s3manager.Uploader
-}
-
 
 // BatchDeleteAPI is the interface type for BatchDelete (separated for user to compose).
 type BatchDeleteAPI interface {


### PR DESCRIPTION
This addresses #2273 and adds some new methods on top of it:

- `NewDownloader`
- `NewDownloaderWithClient`
- `NewUploader`
- `NewUploaderWithClient`

that were missing in the interface before.

It was suggested in #2273 that since this interface was not autogenerated and had no warning, the methods should be added as separate interfaces that can be composed together by the user to avoid breaking when the API changes.
