### PR TITLE
service/dynamodb/expression: Fix Builder with KeyCondition example

### DIFF
--- a/service/dynamodb/expression/examples_test.go
+++ b/service/dynamodb/expression/examples_test.go
@@ -94,6 +94,7 @@ func ExampleBuilder_WithKeyCondition() {
 	// Use the built expression to populate the DynamoDB Query's API input
 	// parameters.
 	input := &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),
 		KeyConditionExpression:    expr.KeyCondition(),
 		ProjectionExpression:      expr.Projection(),


### PR DESCRIPTION
Fixes the ExampleBuilder_WithKeyCondition example to include the
ExpressionAttributeNames member being set.

Related to aws/aws-sdk-go-v2#285