### PR TITLE
service/mediastoredata: Add support for nonseekable io.Reader

### DIFF
--- a/example/service/mediastoredata/streamingNonSeekableReader/README.md
+++ b/example/service/mediastoredata/streamingNonSeekableReader/README.md
@@ -1,0 +1,17 @@
+# Example
+
+This is an example demonstrates how you can use the AWS Elemental MediaStore
+API PutObject operation with a non-seekable io.Reader.
+
+# Usage
+
+The example will create an Elemental MediaStore container, and upload a
+contrived non-seekable io.Reader to that container. Using the SDK's
+[aws.ReadSeekCloser](https://docs.aws.amazon.com/sdk-for-go/api/aws/#ReadSeekCloser)
+utility for wrapping the `io.Reader` in a value the
+[mediastore#PutObjectInput](https://docs.aws.amazon.com/sdk-for-go/api/service/mediastoredata/#PutObjectInput).Body will accept.
+
+The example will attempt to create the container if it does not already exist.
+
+```sh
+AWS_REGION=<region> go run -tags example main.go <containerName> <object-path>

--- a/example/service/mediastoredata/streamingNonSeekableReader/main.go
+++ b/example/service/mediastoredata/streamingNonSeekableReader/main.go
@@ -1,0 +1,92 @@
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/mediastore"
+	"github.com/aws/aws-sdk-go/service/mediastoredata"
+)
+
+func main() {
+	containerName := os.Args[1]
+	objectPath := os.Args[2]
+
+	// Create the SDK's session, and a AWS Elemental MediaStore Data client.
+	sess := session.Must(session.NewSession())
+	dataSvc, err := getMediaStoreDataClient(containerName, sess)
+	if err != nil {
+		log.Fatalf("failed to create client, %v", err)
+	}
+
+	// Create a random reader to simulate a unseekable reader, wrap the reader
+	// in an io.LimitReader to prevent uploading forever.
+	randReader := rand.New(rand.NewSource(0))
+	reader := io.LimitReader(randReader, 1024*1024 /* 1MB */)
+
+	// Wrap the unseekable reader with the SDK's RandSeekCloser. This type will
+	// allow the SDK's to use the nonseekable reader.
+	body := aws.ReadSeekCloser(reader)
+
+	// make the PutObject API call with the nonseekable reader, causing the SDK
+	// to send the request body payload as chunked transfer encoding.
+	_, err = dataSvc.PutObject(&mediastoredata.PutObjectInput{
+		Path: &objectPath,
+		Body: body,
+	})
+	if err != nil {
+		log.Fatalf("failed to upload object, %v", err)
+	}
+
+	fmt.Println("object uploaded")
+}
+
+// getMediaStoreDataClient uses the AWS Elemental MediaStore API to get the
+// endpoint for a container. If the container endpoint can be retrieved a AWS
+// Elemental MediaStore Data client will be created and returned. Otherwise
+// error is returned.
+func getMediaStoreDataClient(containerName string, sess *session.Session) (*mediastoredata.MediaStoreData, error) {
+	endpoint, err := containerEndpoint(containerName, sess)
+	if err != nil {
+		return nil, err
+	}
+
+	dataSvc := mediastoredata.New(sess, &aws.Config{
+		Endpoint: endpoint,
+	})
+
+	return dataSvc, nil
+}
+
+// ContainerEndpoint will attempt to get the endpoint for a container,
+// returning error if the container doesn't exist, or is not active within a
+// timeout.
+func containerEndpoint(name string, sess *session.Session) (*string, error) {
+	for i := 0; i < 3; i++ {
+		ctrlSvc := mediastore.New(sess)
+		descResp, err := ctrlSvc.DescribeContainer(&mediastore.DescribeContainerInput{
+			ContainerName: &name,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if status := aws.StringValue(descResp.Container.Status); status != "ACTIVE" {
+			log.Println("waiting for container to be active, ", status)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		return descResp.Container.Endpoint, nil
+	}
+
+	return nil, fmt.Errorf("container is not active")
+}

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -61,13 +61,13 @@ func (a *API) customizationPasses() {
 
 		// Backfill the authentication type for cognito identity and sts.
 		// Removes the need for the customizations in these services.
-		"cognitoidentity": backfillAuthType("none",
+		"cognitoidentity": backfillAuthType(NoneAuthType,
 			"GetId",
 			"GetOpenIdToken",
 			"UnlinkIdentity",
 			"GetCredentialsForIdentity",
 		),
-		"sts": backfillAuthType("none",
+		"sts": backfillAuthType(NoneAuthType,
 			"AssumeRoleWithSAML",
 			"AssumeRoleWithWebIdentity",
 		),
@@ -248,7 +248,7 @@ func disableEndpointResolving(a *API) {
 	a.Metadata.NoResolveEndpoint = true
 }
 
-func backfillAuthType(typ string, opNames ...string) func(*API) {
+func backfillAuthType(typ AuthType, opNames ...string) func(*API) {
 	return func(a *API) {
 		for _, opName := range opNames {
 			op, ok := a.Operations[opName]

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -181,6 +181,7 @@ func (a *API) Setup() {
 	a.updateTopLevelShapeReferences()
 	a.setupEventStreams()
 	a.findEndpointDiscoveryOp()
+	a.injectUnboundedOutputStreaming()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -23,9 +23,9 @@ type Operation struct {
 	OutputRef           ShapeRef   `json:"output"`
 	ErrorRefs           []ShapeRef `json:"errors"`
 	Paginator           *Paginator
-	Deprecated          bool   `json:"deprecated"`
-	DeprecatedMsg       string `json:"deprecatedMessage"`
-	AuthType            string `json:"authtype"`
+	Deprecated          bool     `json:"deprecated"`
+	DeprecatedMsg       string   `json:"deprecatedMessage"`
+	AuthType            AuthType `json:"authtype"`
 	imports             map[string]bool
 	CustomBuildHandlers []string
 
@@ -102,16 +102,25 @@ func (o *Operation) HasOutput() bool {
 	return o.OutputRef.ShapeName != ""
 }
 
+// AuthType provides the enumeration of AuthType trait.
+type AuthType string
+
+// Enumeration values for AuthType trait
+const (
+	NoneAuthType           AuthType = "none"
+	V4UnsignedBodyAuthType AuthType = "v4-unsigned-body"
+)
+
 // GetSigner returns the signer that should be used for a API request.
 func (o *Operation) GetSigner() string {
 	buf := bytes.NewBuffer(nil)
 
 	switch o.AuthType {
-	case "none":
+	case NoneAuthType:
 		o.API.AddSDKImport("aws/credentials")
 
 		buf.WriteString("req.Config.Credentials = credentials.AnonymousCredentials")
-	case "v4-unsigned-body":
+	case V4UnsignedBodyAuthType:
 		o.API.AddSDKImport("aws/signer/v4")
 
 		buf.WriteString("req.Handlers.Sign.Remove(v4.SignRequestHandler)\n")

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -386,3 +386,23 @@ func (a *API) findEndpointDiscoveryOp() {
 		}
 	}
 }
+func (a *API) injectUnboundedOutputStreaming() {
+	for _, op := range a.Operations {
+		if op.AuthType != V4UnsignedBodyAuthType {
+			continue
+		}
+		for _, ref := range op.InputRef.Shape.MemberRefs {
+			if ref.Streaming || ref.Shape.Streaming {
+				if len(ref.Documentation) != 0 {
+					ref.Documentation += `
+//`
+				}
+				ref.Documentation += `
+// To use an non-seekable io.Reader for this request wrap the io.Reader with
+// "aws.ReadSeekCloser". The SDK will not retry request errors for non-seekable
+// readers. This will allow the SDK to send the reader's payload as chunked
+// transfer encoding.`
+			}
+		}
+	}
+}

--- a/service/lexruntimeservice/api.go
+++ b/service/lexruntimeservice/api.go
@@ -488,6 +488,11 @@ type PostContentInput struct {
 	// that captures all of the audio data before sending. In general, you get better
 	// performance if you stream audio data rather than buffering the data locally.
 	//
+	// To use an non-seekable io.Reader for this request wrap the io.Reader with
+	// "aws.ReadSeekCloser". The SDK will not retry request errors for non-seekable
+	// readers. This will allow the SDK to send the reader's payload as chunked
+	// transfer encoding.
+	//
 	// InputStream is a required field
 	InputStream io.ReadSeeker `locationName:"inputStream" type:"blob" required:"true"`
 

--- a/service/mediastoredata/api.go
+++ b/service/mediastoredata/api.go
@@ -1010,6 +1010,11 @@ type PutObjectInput struct {
 
 	// The bytes to be stored.
 	//
+	// To use an non-seekable io.Reader for this request wrap the io.Reader with
+	// "aws.ReadSeekCloser". The SDK will not retry request errors for non-seekable
+	// readers. This will allow the SDK to send the reader's payload as chunked
+	// transfer encoding.
+	//
 	// Body is a required field
 	Body io.ReadSeeker `type:"blob" required:"true"`
 


### PR DESCRIPTION
Updates the SDK's documentation to clearify how you can use the SDK's
`aws.ReadSeekCloser` utility function to wrap an io.Reader to be used
with an API operation that allows streaming unsigned payload in the
operation's request.

Adds example using ReadSeekCloser with AWS Elemental MediaStore Data's
PutObject API operation.