### PR TITLE
Update CI validation testing for Go module files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,10 @@ ci-test: generate unit-with-race-cover ci-test-generate-validate
 
 ci-test-generate-validate:
 	@echo "CI test validate no generated code changes"
+	git update-index --assume-unchanged go.mod go.sum
 	git add . -A
 	gitstatus=`git diff --cached --ignore-space-change`; \
+	git update-index --no-assume-unchanged go.mod go.sum
 	echo "$$gitstatus"; \
 	if [ "$$gitstatus" != "" ] && [ "$$gitstatus" != "skipping validation" ]; then echo "$$gitstatus"; exit 1; fi
 


### PR DESCRIPTION
Suppress changes to the Go module definition files during CI
code generation validation testing. This change prevents validation
errors failing CI tests due to changes to the go.mod and go.sum files
being automatically updated during CI testing.

Fixup for [failing Travis CI tests](https://travis-ci.org/aws/aws-sdk-go/builds/538336526?utm_source=github_status&utm_medium=notification) with Go tip
