### PR TITLE
internal/ini: Update INI parser's error message.

### DIFF
--- a/internal/ini/ini_parser.go
+++ b/internal/ini/ini_parser.go
@@ -304,7 +304,9 @@ loop:
 			stmt := newCommentStatement(tok)
 			stack.Push(stmt)
 		default:
-			return nil, NewParseError(fmt.Sprintf("invalid state with ASTKind %v and TokenType %v", k, tok))
+			return nil, NewParseError(
+				fmt.Sprintf("invalid state with ASTKind %v and TokenType %v",
+					k, tok.Type()))
 		}
 
 		if len(tokens) > 0 {
@@ -314,7 +316,7 @@ loop:
 
 	// this occurs when a statement has not been completed
 	if stack.top > 1 {
-		return nil, NewParseError(fmt.Sprintf("incomplete expression: %v", stack.container))
+		return nil, NewParseError(fmt.Sprintf("incomplete ini expression"))
 	}
 
 	// returns a sublist which excludes the start symbol


### PR DESCRIPTION
Updates the INI parser's error message to not include unformatted string
struct values that are difficult to read, and do not provide meaningful
information.