### PR TITLE
service/s3/s3cyrpto: Fix NewKMSWrapEntry example documentation

### DIFF
--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -65,7 +65,7 @@ func NewKMSKeyGeneratorWithMatDesc(kmsClient kmsiface.KMSAPI, cmkID string, matd
 //	decryptHandler := s3crypto.NewKMSWrapEntry(customKMSClient)
 //
 //	svc := s3crypto.NewDecryptionClient(sess, func(svc *s3crypto.DecryptionClient) {
-//		svc.WrapRegistry[KMSWrap] = decryptHandler
+//		svc.WrapRegistry[s3crypto.KMSWrap] = decryptHandler
 //	}))
 func NewKMSWrapEntry(kmsClient kmsiface.KMSAPI) WrapEntry {
 	// These values are read only making them thread safe


### PR DESCRIPTION
The `KMSWrap` constant is part of the `s3crypto` package and therefore should be referenced as `s3crypto.KMSWrap` externally.
