### PR TITLE
service/s3/s3manager: Add unit test for S3 Upload manager part retries

### DIFF
--- a/aws/request/connection_reset_error.go
+++ b/aws/request/connection_reset_error.go
@@ -5,5 +5,14 @@ import (
 )
 
 func isErrConnectionReset(err error) bool {
-	return strings.Contains(err.Error(), "connection reset")
+	if strings.Contains(err.Error(), "read: connection reset") {
+		return false
+	}
+
+	if strings.Contains(err.Error(), "connection reset") ||
+		strings.Contains(err.Error(), "broken pipe") {
+		return true
+	}
+
+	return false
 }

--- a/aws/request/connection_reset_error_test.go
+++ b/aws/request/connection_reset_error_test.go
@@ -36,13 +36,21 @@ func TestSerializationErrConnectionReset_accept(t *testing.T) {
 		Err            error
 		ExpectAttempts int
 	}{
-		"with temporary": {
+		"accept with temporary": {
 			Err:            errAcceptConnectionResetStub,
 			ExpectAttempts: 6,
 		},
-		"not temporary": {
+		"read not temporary": {
 			Err:            errReadConnectionResetStub,
 			ExpectAttempts: 1,
+		},
+		"write with temporary": {
+			Err:            errWriteConnectionResetStub,
+			ExpectAttempts: 6,
+		},
+		"write broken pipe with temporary": {
+			Err:            errWriteBrokenPipeStub,
+			ExpectAttempts: 6,
 		},
 		"generic connection reset": {
 			Err:            errConnectionResetStub,
@@ -86,6 +94,7 @@ func TestSerializationErrConnectionReset_accept(t *testing.T) {
 			}
 			cfg := unit.Session.Config.Copy()
 			cfg.MaxRetries = aws.Int(5)
+			cfg.SleepDelay = func(time.Duration) {}
 
 			req := request.New(
 				*cfg,

--- a/aws/request/http_request_retry_test.go
+++ b/aws/request/http_request_retry_test.go
@@ -1,5 +1,3 @@
-// +build go1.5
-
 package request_test
 
 import (

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -231,6 +231,10 @@ func (r *Request) WillRetry() bool {
 	return r.Error != nil && aws.BoolValue(r.Retryable) && r.RetryCount < r.MaxRetries()
 }
 
+func fmtAttemptCount(retryCount, maxRetries int) string {
+	return fmt.Sprintf("attempt %v/%v", retryCount, maxRetries)
+}
+
 // ParamsFilled returns if the request's parameters have been populated
 // and the parameters are valid. False is returned if no parameters are
 // provided or invalid.
@@ -330,14 +334,15 @@ func getPresignedURL(r *Request, expire time.Duration) (string, http.Header, err
 	return r.HTTPRequest.URL.String(), r.SignedHeaderVals, nil
 }
 
-func debugLogReqError(r *Request, stage string, retrying bool, err error) {
+const (
+	willRetry   = "will retry"
+	notRetrying = "not retrying"
+	retryCount  = "retry %v/%v"
+)
+
+func debugLogReqError(r *Request, stage, retryStr string, err error) {
 	if !r.Config.LogLevel.Matches(aws.LogDebugWithRequestErrors) {
 		return
-	}
-
-	retryStr := "not retrying"
-	if retrying {
-		retryStr = "will retry"
 	}
 
 	r.Config.Logger.Log(fmt.Sprintf("DEBUG: %s %s/%s failed, %s, error %v",
@@ -358,12 +363,12 @@ func (r *Request) Build() error {
 	if !r.built {
 		r.Handlers.Validate.Run(r)
 		if r.Error != nil {
-			debugLogReqError(r, "Validate Request", false, r.Error)
+			debugLogReqError(r, "Validate Request", notRetrying, r.Error)
 			return r.Error
 		}
 		r.Handlers.Build.Run(r)
 		if r.Error != nil {
-			debugLogReqError(r, "Build Request", false, r.Error)
+			debugLogReqError(r, "Build Request", notRetrying, r.Error)
 			return r.Error
 		}
 		r.built = true
@@ -379,7 +384,7 @@ func (r *Request) Build() error {
 func (r *Request) Sign() error {
 	r.Build()
 	if r.Error != nil {
-		debugLogReqError(r, "Build Request", false, r.Error)
+		debugLogReqError(r, "Build Request", notRetrying, r.Error)
 		return r.Error
 	}
 
@@ -473,7 +478,7 @@ func (r *Request) Send() error {
 		r.AttemptTime = time.Now()
 
 		if err := r.Sign(); err != nil {
-			debugLogReqError(r, "Sign Request", false, err)
+			debugLogReqError(r, "Sign Request", notRetrying, err)
 			return err
 		}
 
@@ -520,7 +525,9 @@ func (r *Request) sendRequest() (sendErr error) {
 	r.Retryable = nil
 	r.Handlers.Send.Run(r)
 	if r.Error != nil {
-		debugLogReqError(r, "Send Request", r.WillRetry(), r.Error)
+		debugLogReqError(r, "Send Request",
+			fmtAttemptCount(r.RetryCount, r.MaxRetries()),
+			r.Error)
 		return r.Error
 	}
 
@@ -528,13 +535,17 @@ func (r *Request) sendRequest() (sendErr error) {
 	r.Handlers.ValidateResponse.Run(r)
 	if r.Error != nil {
 		r.Handlers.UnmarshalError.Run(r)
-		debugLogReqError(r, "Validate Response", r.WillRetry(), r.Error)
+		debugLogReqError(r, "Validate Response",
+			fmtAttemptCount(r.RetryCount, r.MaxRetries()),
+			r.Error)
 		return r.Error
 	}
 
 	r.Handlers.Unmarshal.Run(r)
 	if r.Error != nil {
-		debugLogReqError(r, "Unmarshal Response", r.WillRetry(), r.Error)
+		debugLogReqError(r, "Unmarshal Response",
+			fmtAttemptCount(r.RetryCount, r.MaxRetries()),
+			r.Error)
 		return r.Error
 	}
 
@@ -565,8 +576,8 @@ type temporary interface {
 	Temporary() bool
 }
 
-func shouldRetryCancel(err error) bool {
-	switch err := err.(type) {
+func shouldRetryCancel(origErr error) bool {
+	switch err := origErr.(type) {
 	case awserr.Error:
 		if err.Code() == CanceledErrorCode {
 			return false
@@ -585,7 +596,7 @@ func shouldRetryCancel(err error) bool {
 	case temporary:
 		// If the error is temporary, we want to allow continuation of the
 		// retry process
-		return err.Temporary()
+		return err.Temporary() || isErrConnectionReset(origErr)
 	case nil:
 		// `awserr.Error.OrigErr()` can be nil, meaning there was an error but
 		// because we don't know the cause, it is marked as retryable. See

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -43,10 +43,26 @@ func (e *tempNetworkError) Error() string {
 
 var (
 	// net.OpError accept, are always temporary
-	errAcceptConnectionResetStub = &tempNetworkError{isTemp: true, op: "accept", msg: "connection reset"}
+	errAcceptConnectionResetStub = &tempNetworkError{
+		isTemp: true, op: "accept", msg: "connection reset",
+	}
 
 	// net.OpError read for ECONNRESET is not temporary.
-	errReadConnectionResetStub = &tempNetworkError{isTemp: false, op: "read", msg: "connection reset"}
+	errReadConnectionResetStub = &tempNetworkError{
+		isTemp: false, op: "read", msg: "connection reset",
+	}
+
+	// net.OpError write for ECONNRESET may not be temporary, but is treaded as
+	// temporary by the SDK.
+	errWriteConnectionResetStub = &tempNetworkError{
+		isTemp: false, op: "write", msg: "connection reset",
+	}
+
+	// net.OpError write for broken pipe may not be temporary, but is treaded as
+	// temporary by the SDK.
+	errWriteBrokenPipeStub = &tempNetworkError{
+		isTemp: false, op: "write", msg: "broken pipe",
+	}
 
 	// Generic connection reset error
 	errConnectionResetStub = errors.New("connection reset")

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -1265,16 +1265,7 @@ func (h *failPartHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	contLenStr := r.Header.Get("Content-Length")
-	expectLen, err := strconv.ParseInt(contLenStr, 10, 64)
-	if err != nil {
-		h.tb.Logf("expect content-length, got %q, %v", contLenStr, err)
-		failRequest(w, 400, "BadRequest",
-			fmt.Sprintf("unable to get content-length %v", err))
-		return
-	}
-
-	io.Copy(ioutil.Discard, io.LimitReader(r.Body, expectLen/2))
+	io.Copy(ioutil.Discard, r.Body)
 
 	failRequest(w, 500, "InternalException",
 		fmt.Sprintf("mock error, partNumber %v", r.URL.Query().Get("partNumber")))

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1073,9 +1072,6 @@ func buildFailHandlers(tb testing.TB, parts, retry int) []http.Handler {
 }
 
 func TestUploadRetry(t *testing.T) {
-	if runtime.GOOS == "darwin" && strings.Contains(runtime.Version(), "go1.7") {
-		t.Skip("TestUploadRetry unstable for Go 1.7 on darwin, see #2636")
-	}
 	const numParts, retries = 3, 10
 
 	testFile, testFileCleanup, err := createTempFile(t, s3manager.DefaultUploadPartSize*numParts)

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -1,4 +1,4 @@
-// +build go1.7
+// +build go1.8
 
 package s3manager_test
 


### PR DESCRIPTION
Adds a new unit test to S3 Upload Manager to verify the SDK will
correctly retry concurrent multipart uploads.

Related to #2525