### PR TITLE
fixing some typos in the docs

### DIFF
--- a/service/s3/s3manager/batch.go
+++ b/service/s3/s3manager/batch.go
@@ -273,7 +273,7 @@ type DeleteObjectsIterator struct {
 	inc     bool
 }
 
-// Next will increment the default iterator's index and and ensure that there
+// Next will increment the default iterator's index and ensure that there
 // is another object to iterator to.
 func (iter *DeleteObjectsIterator) Next() bool {
 	if iter.inc {
@@ -458,7 +458,7 @@ type DownloadObjectsIterator struct {
 	inc     bool
 }
 
-// Next will increment the default iterator's index and and ensure that there
+// Next will increment the default iterator's index and ensure that there
 // is another object to iterator to.
 func (batcher *DownloadObjectsIterator) Next() bool {
 	if batcher.inc {
@@ -497,7 +497,7 @@ type UploadObjectsIterator struct {
 	inc     bool
 }
 
-// Next will increment the default iterator's index and and ensure that there
+// Next will increment the default iterator's index and ensure that there
 // is another object to iterator to.
 func (batcher *UploadObjectsIterator) Next() bool {
 	if batcher.inc {


### PR DESCRIPTION
Just some typos in the documentation comments