### PR TITLE
aws/session: Add option to set AssumeRole duration with NewSessionWithOptions

### DIFF
--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -148,6 +148,7 @@ func credsFromAssumeRole(cfg aws.Config,
 		sharedCfg.AssumeRole.RoleARN,
 		func(opt *stscreds.AssumeRoleProvider) {
 			opt.RoleSessionName = sharedCfg.AssumeRole.RoleSessionName
+			opt.Duration = sessOpts.AssumeRoleDuration
 
 			// Assume role with external ID
 			if len(sharedCfg.AssumeRole.ExternalID) > 0 {
@@ -158,7 +159,6 @@ func credsFromAssumeRole(cfg aws.Config,
 			if len(sharedCfg.AssumeRole.MFASerial) > 0 {
 				opt.SerialNumber = aws.String(sharedCfg.AssumeRole.MFASerial)
 				opt.TokenProvider = sessOpts.AssumeRoleTokenProvider
-				opt.Duration = sessOpts.AssumeRoleDuration
 			}
 		},
 	), nil

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -158,6 +158,7 @@ func credsFromAssumeRole(cfg aws.Config,
 			if len(sharedCfg.AssumeRole.MFASerial) > 0 {
 				opt.SerialNumber = aws.String(sharedCfg.AssumeRole.MFASerial)
 				opt.TokenProvider = sessOpts.AssumeRoleTokenProvider
+				opt.Duration = sessOpts.AssumeRoleDuration
 			}
 		},
 	), nil

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -177,8 +177,7 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 
 				sess, err := NewSessionWithOptions(Options{
 					Config: aws.Config{
-						Logger: t,
-						//						LogLevel:         aws.LogLevel(aws.LogDebugWithHTTPBody),
+						Logger:           t,
 						EndpointResolver: endpointResolver,
 					},
 					Handlers: handlers,
@@ -261,10 +260,15 @@ func TestSessionAssumeRole(t *testing.T) {
 	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+		w.Write([]byte(fmt.Sprintf(
+			assumeRoleRespMsg,
+			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
 
-	s, err := NewSession(&aws.Config{Endpoint: aws.String(server.URL), DisableSSL: aws.Bool(true)})
+	s, err := NewSession(&aws.Config{
+		Endpoint:   aws.String(server.URL),
+		DisableSSL: aws.Bool(true),
+	})
 
 	creds, err := s.Config.Credentials.Get()
 	if err != nil {
@@ -304,7 +308,9 @@ func TestSessionAssumeRole_WithMFA(t *testing.T) {
 			t.Errorf("expect %v, got %v", e, a)
 		}
 
-		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+		w.Write([]byte(fmt.Sprintf(
+			assumeRoleRespMsg,
+			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
 
 	customProviderCalled := false
@@ -432,7 +438,9 @@ func TestSessionAssumeRole_ExtendedDuration(t *testing.T) {
 			t.Errorf("expect %v, got %v", e, a)
 		}
 
-		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+		w.Write([]byte(fmt.Sprintf(
+			assumeRoleRespMsg,
+			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
 
 	s, err := NewSessionWithOptions(Options{
@@ -483,7 +491,9 @@ func TestSessionAssumeRole_WithMFA_ExtendedDuration(t *testing.T) {
 			t.Errorf("expect %v, got %v", e, a)
 		}
 
-		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(30*time.Minute).Format("2006-01-02T15:04:05Z"))))
+		w.Write([]byte(fmt.Sprintf(
+			assumeRoleRespMsg,
+			time.Now().Add(30*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
 
 	customProviderCalled := false

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -251,7 +251,7 @@ const assumeRoleRespMsg = `
 </AssumeRoleResponse>
 `
 
-func TestSesisonAssumeRole(t *testing.T) {
+func TestSessionAssumeRole(t *testing.T) {
 	oldEnv := initSessionTestEnv()
 	defer awstesting.PopEnv(oldEnv)
 
@@ -298,6 +298,9 @@ func TestSessionAssumeRole_WithMFA(t *testing.T) {
 			t.Errorf("expect %v, got %v", e, a)
 		}
 		if e, a := r.FormValue("TokenCode"), "tokencode"; e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "900", r.FormValue("DurationSeconds"); e != a {
 			t.Errorf("expect %v, got %v", e, a)
 		}
 
@@ -412,5 +415,115 @@ func TestSessionAssumeRole_InvalidSourceProfile(t *testing.T) {
 	}
 	if s != nil {
 		t.Errorf("expect nil, %v", err)
+	}
+}
+
+func TestSessionAssumeRole_ExtendedDuration(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer awstesting.PopEnv(oldEnv)
+
+	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if e, a := "1800", r.FormValue("DurationSeconds"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+
+		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+	}))
+
+	s, err := NewSessionWithOptions(Options{
+		Profile: "assume_role_w_creds",
+		Config: aws.Config{
+			Endpoint:   aws.String(server.URL),
+			DisableSSL: aws.Bool(true),
+		},
+		SharedConfigState:  SharedConfigEnable,
+		AssumeRoleDuration: 30 * time.Minute,
+	})
+
+	creds, err := s.Config.Credentials.Get()
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SESSION_TOKEN", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "AssumeRoleProvider", creds.ProviderName; !strings.Contains(a, e) {
+		t.Errorf("expect %v, to contain %v", e, a)
+	}
+}
+
+func TestSessionAssumeRole_WithMFA_ExtendedDuration(t *testing.T) {
+	oldEnv := initSessionTestEnv()
+	defer awstesting.PopEnv(oldEnv)
+
+	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", testConfigFilename)
+	os.Setenv("AWS_PROFILE", "assume_role_w_creds")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if e, a := "0123456789", r.FormValue("SerialNumber"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "tokencode", r.FormValue("TokenCode"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+		if e, a := "1800", r.FormValue("DurationSeconds"); e != a {
+			t.Errorf("expect %v, got %v", e, a)
+		}
+
+		w.Write([]byte(fmt.Sprintf(assumeRoleRespMsg, time.Now().Add(30*time.Minute).Format("2006-01-02T15:04:05Z"))))
+	}))
+
+	customProviderCalled := false
+	sess, err := NewSessionWithOptions(Options{
+		Profile: "assume_role_w_mfa",
+		Config: aws.Config{
+			Region:     aws.String("us-east-1"),
+			Endpoint:   aws.String(server.URL),
+			DisableSSL: aws.Bool(true),
+		},
+		SharedConfigState:  SharedConfigEnable,
+		AssumeRoleDuration: 30 * time.Minute,
+		AssumeRoleTokenProvider: func() (string, error) {
+			customProviderCalled = true
+
+			return "tokencode", nil
+		},
+	})
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+
+	creds, err := sess.Config.Credentials.Get()
+	if err != nil {
+		t.Errorf("expect nil, %v", err)
+	}
+	if !customProviderCalled {
+		t.Errorf("expect true")
+	}
+
+	if e, a := "AKID", creds.AccessKeyID; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SECRET", creds.SecretAccessKey; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "SESSION_TOKEN", creds.SessionToken; e != a {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+	if e, a := "AssumeRoleProvider", creds.ProviderName; !strings.Contains(a, e) {
+		t.Errorf("expect %v, to contain %v", e, a)
 	}
 }

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -207,9 +207,9 @@ type Options struct {
 	// the config enables assume role wit MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
 
-	// When the SDK's shared config is configured to assume a role with MFA
-	// this option may be provided to set the expiry duration of the STS
-	// credentials. Defaults to 15 minutes if not set as documented in the
+	// When the SDK's shared config is configured to assume a role this option
+	// may be provided to set the expiry duration of the STS credentials.
+	// Defaults to 15 minutes if not set as documented in the
 	// stscreds.AssumeRoleProvider.
 	AssumeRoleDuration time.Duration
 

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -205,6 +206,12 @@ type Options struct {
 	// This field is only used if the shared configuration is enabled, and
 	// the config enables assume role wit MFA via the mfa_serial field.
 	AssumeRoleTokenProvider func() (string, error)
+
+	// When the SDK's shared config is configured to assume a role with MFA
+	// this option may be provided to set the expiry duration of the STS
+	// credentials. Defaults to 15 minutes if not set as documented in the
+	// stscreds.AssumeRoleProvider.
+	AssumeRoleDuration time.Duration
 
 	// Reader for a custom Credentials Authority (CA) bundle in PEM format that
 	// the SDK will use instead of the default system's root CA bundle. Use this


### PR DESCRIPTION
 Provides an option to set role token duration in the AssumeRoleProvider
when using MFA. Without this it's difficult to change the token duration
from its default of 15 minutes while also using shared config.

Fix #2532.

Update merge conflict in #2554 