### PR TITLE
aws/csm: Add support for AWS_CSM_HOST env option

### DIFF
--- a/aws/csm/address_test.go
+++ b/aws/csm/address_test.go
@@ -1,0 +1,40 @@
+// +build go1.7
+
+package csm
+
+import "testing"
+
+func TestAddressWithDefaults(t *testing.T) {
+	cases := map[string]struct {
+		Host, Port string
+		Expect     string
+	}{
+		"ip": {
+			Host: "127.0.0.2", Port: "", Expect: "127.0.0.2:31000",
+		},
+		"localhost": {
+			Host: "localhost", Port: "", Expect: "127.0.0.1:31000",
+		},
+		"uppercase localhost": {
+			Host: "LOCALHOST", Port: "", Expect: "127.0.0.1:31000",
+		},
+		"port": {
+			Host: "localhost", Port: "32000", Expect: "127.0.0.1:32000",
+		},
+		"ip6": {
+			Host: "::1", Port: "", Expect: "[::1]:31000",
+		},
+		"unset": {
+			Host: "", Port: "", Expect: "127.0.0.1:31000",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := AddressWithDefaults(c.Host, c.Port)
+			if e, a := c.Expect, actual; e != a {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
+	}
+}

--- a/aws/csm/doc.go
+++ b/aws/csm/doc.go
@@ -1,30 +1,61 @@
-// Package csm provides Client Side Monitoring (CSM) which enables sending metrics
-// via UDP connection. Using the Start function will enable the reporting of
-// metrics on a given port. If Start is called, with different parameters, again,
-// a panic will occur.
+// Package csm provides the Client Side Monitoring (CSM) client which enables
+// sending metrics via UDP connection to the CSM agent. This package provides
+// control options, and configuration for the CSM client. The client can be
+// controlled manually, or automatically via the SDK's Session configuration.
 //
-// Pause can be called to pause any metrics publishing on a given port. Sessions
-// that have had their handlers modified via InjectHandlers may still be used.
-// However, the handlers will act as a no-op meaning no metrics will be published.
+// Enabling CSM client via SDK's Session configuration
 //
-//	Example:
+// The CSM client can be enabled automatically via SDK's Session configuration.
+// The SDK's session configuration enables the CSM client if the AWS_CSM_PORT
+// environment variable is set to a non-empty value.
+//
+// The configuration options for the CSM client via the SDK's session
+// configuration are:
+//
+//	* AWS_CSM_PORT=<port number>
+//	  The port number the CSM agent will receive metrics on.
+//
+//	* AWS_CSM_HOST=<hostname or ip>
+//	  The hostname, or IP address the CSM agent will receive metrics on.
+//	  Without port number.
+//
+// Manually enabling the CSM client
+//
+// The CSM client can be started, paused, and resumed manually. The Start
+// function will enable the CSM client to publish metrics to the CSM agent. It
+// is safe to call Start concurrently, but if Start is called additional times
+// with different ClientID or address it will panic.
+//
 //		r, err := csm.Start("clientID", ":31000")
 //		if err != nil {
 //			panic(fmt.Errorf("failed starting CSM:  %v", err))
 //		}
+//
+// When controlling the CSM client manually, you must also inject its request
+// handlers into the SDK's Session configuration for the SDK's API clients to
+// publish metrics.
 //
 //		sess, err := session.NewSession(&aws.Config{})
 //		if err != nil {
 //			panic(fmt.Errorf("failed loading session: %v", err))
 //		}
 //
+//		// Add CSM client's metric publishing request handlers to the SDK's
+//		// Session Configuration.
 //		r.InjectHandlers(&sess.Handlers)
 //
-//		client := s3.New(sess)
-//		resp, err := client.GetObject(&s3.GetObjectInput{
-//			Bucket: aws.String("bucket"),
-//			Key: aws.String("key"),
-//		})
+// Controlling CSM client
+//
+// Once the CSM client has been enabled the Get function will return a Reporter
+// value that you can use to pause and resume the metrics published to the CSM
+// agent. If Get function is called before the reporter is enabled with the
+// Start function or via SDK's Session configuration nil will be returned.
+//
+// The Pause method can be called to stop the CSM client publishing metrics to
+// the CSM agent. The Continue method will resume metric publishing.
+//
+//		// Get the CSM client Reporter.
+//		r := csm.Get()
 //
 //		// Will pause monitoring
 //		r.Pause()
@@ -34,13 +65,5 @@
 //		})
 //
 //		// Resume monitoring
-//		r.Continue()
-//
-// Start returns a Reporter that is used to enable or disable monitoring. If
-// access to the Reporter is required later, calling Get will return the Reporter
-// singleton.
-//
-//	Example:
-//		r := csm.Get()
 //		r.Continue()
 package csm

--- a/aws/csm/enable.go
+++ b/aws/csm/enable.go
@@ -2,6 +2,7 @@ package csm
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -15,13 +16,33 @@ const (
 	APICallAttemptMetricHandlerName = "awscsm.SendAPICallAttemptMetric"
 )
 
-// Start will start the a long running go routine to capture
+// AddressWithDefaults returns a CSM address built from the host and port
+// values. If the host or port is not set, default values will be used
+// instead. If host is "localhost" it will be replaced with "127.0.0.1".
+func AddressWithDefaults(host, port string) string {
+	if len(host) == 0 || strings.EqualFold(host, "localhost") {
+		host = DefaultHost
+	}
+
+	if len(port) == 0 {
+		port = DefaultPort
+	}
+
+	// Only IP6 host can contain a colon
+	if strings.Contains(host, ":") {
+		return "[" + host + "]:" + port
+	}
+
+	return host + ":" + port
+}
+
+// Start will start a long running go routine to capture
 // client side metrics. Calling start multiple time will only
 // start the metric listener once and will panic if a different
 // client ID or port is passed in.
 //
 //	Example:
-//		r, err := csm.Start("clientID", "127.0.0.1:8094")
+//		r, err := csm.Start("clientID", "127.0.0.1:31000")
 //		if err != nil {
 //			panic(fmt.Errorf("expected no error, but received %v", err))
 //		}

--- a/aws/csm/enable.go
+++ b/aws/csm/enable.go
@@ -10,10 +10,12 @@ var (
 	lock sync.Mutex
 )
 
-// Client side metric handler names
 const (
-	APICallMetricHandlerName        = "awscsm.SendAPICallMetric"
-	APICallAttemptMetricHandlerName = "awscsm.SendAPICallAttemptMetric"
+	// DefaultPort is used when no port is specified.
+	DefaultPort = "31000"
+
+	// DefaultHost is the host that will be used when none is specified.
+	DefaultHost = "127.0.0.1"
 )
 
 // AddressWithDefaults returns a CSM address built from the host and port

--- a/aws/csm/enable.go
+++ b/aws/csm/enable.go
@@ -41,7 +41,6 @@ func AddressWithDefaults(host, port string) string {
 // start the metric listener once and will panic if a different
 // client ID or port is passed in.
 //
-//	Example:
 //		r, err := csm.Start("clientID", "127.0.0.1:31000")
 //		if err != nil {
 //			panic(fmt.Errorf("expected no error, but received %v", err))

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -10,14 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
-const (
-	// DefaultPort is used when no port is specified.
-	DefaultPort = "31000"
-
-	// DefaultHost is the host that will be used when none is specified.
-	DefaultHost = "127.0.0.1"
-)
-
 // Reporter will gather metrics of API requests made and
 // send those metrics to the CSM endpoint.
 type Reporter struct {
@@ -223,6 +215,12 @@ func (rep *Reporter) Continue() {
 
 	rep.metricsCh.Continue()
 }
+
+// Client side metric handler names
+const (
+	APICallMetricHandlerName        = "awscsm.SendAPICallMetric"
+	APICallAttemptMetricHandlerName = "awscsm.SendAPICallAttemptMetric"
+)
 
 // InjectHandlers will will enable client side metrics and inject the proper
 // handlers to handle how metrics are sent.

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -11,8 +11,11 @@ import (
 )
 
 const (
-	// DefaultPort is used when no port is specified
+	// DefaultPort is used when no port is specified.
 	DefaultPort = "31000"
+
+	// DefaultHost is the host that will be used when none is specified.
+	DefaultHost = "127.0.0.1"
 )
 
 // Reporter will gather metrics of API requests made and

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -193,8 +193,9 @@ func (rep *Reporter) start() {
 	}
 }
 
-// Pause will pause the metric channel preventing any new metrics from
-// being added.
+// Pause will pause the metric channel preventing any new metrics from being
+// added. It is safe to call concurrently with other calls to Pause, but if
+// called concurently with Continue can lead to unexpected state.
 func (rep *Reporter) Pause() {
 	lock.Lock()
 	defer lock.Unlock()
@@ -206,8 +207,9 @@ func (rep *Reporter) Pause() {
 	rep.close()
 }
 
-// Continue will reopen the metric channel and allow for monitoring
-// to be resumed.
+// Continue will reopen the metric channel and allow for monitoring to be
+// resumed. It is safe to call concurrently with other calls to Continue, but
+// if called concurently with Pause can lead to unexpected state.
 func (rep *Reporter) Continue() {
 	lock.Lock()
 	defer lock.Unlock()
@@ -225,7 +227,9 @@ func (rep *Reporter) Continue() {
 // InjectHandlers will will enable client side metrics and inject the proper
 // handlers to handle how metrics are sent.
 //
-//	Example:
+// InjectHandlers is NOT safe to call concurrently. Calling InjectHandlers
+// multiple times may lead to unexpected behavior, (e.g. duplicate metrics).
+//
 //		// Start must be called in order to inject the correct handlers
 //		r, err := csm.Start("clientID", "127.0.0.1:8094")
 //		if err != nil {

--- a/aws/session/env_config.go
+++ b/aws/session/env_config.go
@@ -102,6 +102,7 @@ type envConfig struct {
 	CSMEnabled  bool
 	CSMPort     string
 	CSMClientID string
+	CSMHost     string
 
 	enableEndpointDiscovery string
 	// Enables endpoint discovery via environment variables.
@@ -113,6 +114,9 @@ type envConfig struct {
 var (
 	csmEnabledEnvKey = []string{
 		"AWS_CSM_ENABLED",
+	}
+	csmHostEnvKey = []string{
+		"AWS_CSM_HOST",
 	}
 	csmPortEnvKey = []string{
 		"AWS_CSM_PORT",
@@ -184,6 +188,7 @@ func envConfigLoad(enableSharedConfig bool) envConfig {
 
 	// CSM environment variables
 	setFromEnvVal(&cfg.csmEnabled, csmEnabledEnvKey)
+	setFromEnvVal(&cfg.CSMHost, csmHostEnvKey)
 	setFromEnvVal(&cfg.CSMPort, csmPortEnvKey)
 	setFromEnvVal(&cfg.CSMClientID, csmClientIDEnvKey)
 	cfg.CSMEnabled = len(cfg.csmEnabled) > 0


### PR DESCRIPTION
Adds support for a host to be configured for the SDK's metric reporting
Client Side Metrics (CSM) client via the `AWS_CSM_HOST` environment
variable.