### PR TITLE
Fix README example not compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ response.
   	}
   	// Ensure the context is canceled to prevent leaking.
   	// See context package for more information, https://golang.org/pkg/context/
-	if cancelFn {
+	if cancelFn != nil {
   		defer cancelFn()
 	}
 


### PR DESCRIPTION
Fixes the SDK's README example not compiling due to `cancelFn` not begin compared against nil.
