### PR TITLE
 aws/session: Fix SDK AWS_PROFILE and static environment credential behavior

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/session`: Fix SDK AWS_PROFILE and static environment credential behavior ()
+  * Fixes the SDK's behavior when determining the source of credentials to load. Previously the SDK would ignore the AWS_PROFILE environment, if static environment credentials were also specified.
+  * If both AWS_PROFILE and static environment credentials are defined, the SDK will load any credentials from the shared config/credentials file for the AWS_PROFILE first. Only if there are no credentials defined in the shared config/credentials file will the SDK use the static environment credentials instead.

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -19,12 +19,11 @@ func resolveCredentials(cfg *aws.Config,
 	handlers request.Handlers,
 	sessOpts Options,
 ) (*credentials.Credentials, error) {
-	// The resolveCredentials order of resolving credentials is wrong. It
-	// ignores the customer's provided profile if ENV credentials are also
-	// provided.
 
 	switch {
-	case len(sharedCfg.RoleARN) != 0 && len(sharedCfg.CredentialSource) != 0:
+	case len(envCfg.Profile) != 0:
+		// User explicitly provided an Profile, so load from shared config
+		// first.
 		return resolveCredsFromProfile(cfg, envCfg, sharedCfg, handlers, sessOpts)
 
 	case envCfg.Creds.HasKeys():

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -347,9 +347,9 @@ func TestNewSessionWithOptions_Overrides(t *testing.T) {
 			InProfile: "full_profile",
 			OutRegion: "env_region",
 			OutCreds: credentials.Value{
-				AccessKeyID:     "env_akid",
-				SecretAccessKey: "env_secret",
-				ProviderName:    "EnvConfigCredentials",
+				AccessKeyID:     "full_profile_akid",
+				SecretAccessKey: "full_profile_secret",
+				ProviderName:    "SharedConfigCredentials",
 			},
 		},
 		{


### PR DESCRIPTION
Fixes the SDK's behavior when determining the source of credentials to
load. Previously the SDK would ignore the AWS_PROFILE environment, if
static environment credentials were also specified.

If both AWS_PROFILE and static environment credentials are defined, the
SDK will load any credentials from the shared config/credentials file
for the AWS_PROFILE first. Only if there are no credentials defined in
the shared config/credentials file will the SDK use the static
environment credentials instead.