### PR TITLE
Simplify code

### DIFF
--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -208,7 +208,7 @@ func (e errorList) Error() string {
 	// How do we want to handle the array size being zero
 	if size := len(e); size > 0 {
 		for i := 0; i < size; i++ {
-			msg += fmt.Sprintf("%s", e[i].Error())
+			msg += e[i].Error()
 			// We check the next index to see if it is within the slice.
 			// If it is, then we append a newline. We do this, because unit tests
 			// could be broken with the additional '\n'

--- a/aws/awsutil/path_value.go
+++ b/aws/awsutil/path_value.go
@@ -185,13 +185,12 @@ func ValuesAtPath(i interface{}, path string) ([]interface{}, error) {
 // SetValueAtPath sets a value at the case insensitive lexical path inside
 // of a structure.
 func SetValueAtPath(i interface{}, path string, v interface{}) {
-	if rvals := rValuesAtPath(i, path, true, false, v == nil); rvals != nil {
-		for _, rval := range rvals {
-			if rval.Kind() == reflect.Ptr && rval.IsNil() {
-				continue
-			}
-			setValue(rval, v)
+	rvals := rValuesAtPath(i, path, true, false, v == nil)
+	for _, rval := range rvals {
+		if rval.Kind() == reflect.Ptr && rval.IsNil() {
+			continue
 		}
+		setValue(rval, v)
 	}
 }
 

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -120,7 +120,7 @@ func TestAfterRetryWithContextCanceled(t *testing.T) {
 
 	req := c.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 
-	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{}, 0)}
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
 	req.SetContext(ctx)
 
 	req.Error = fmt.Errorf("some error")
@@ -150,7 +150,7 @@ func TestAfterRetryWithContext(t *testing.T) {
 
 	req := c.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 
-	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{}, 0)}
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
 	req.SetContext(ctx)
 
 	req.Error = fmt.Errorf("some error")
@@ -178,7 +178,7 @@ func TestSendWithContextCanceled(t *testing.T) {
 
 	req := c.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 
-	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{}, 0)}
+	ctx := &awstesting.FakeContext{DoneCh: make(chan struct{})}
 	req.SetContext(ctx)
 
 	req.Error = fmt.Errorf("some error")

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -118,7 +118,7 @@ func (rep *Reporter) sendAPICallMetric(r *request.Request) {
 		Type:               aws.String("ApiCall"),
 		AttemptCount:       aws.Int(r.RetryCount + 1),
 		Region:             r.Config.Region,
-		Latency:            aws.Int(int(time.Now().Sub(r.Time) / time.Millisecond)),
+		Latency:            aws.Int(int(time.Since(r.Time) / time.Millisecond)),
 		XAmzRequestID:      aws.String(r.RequestID),
 		MaxRetriesExceeded: aws.Int(boolIntValue(r.RetryCount >= r.MaxRetries())),
 	}

--- a/aws/request/request_pagination.go
+++ b/aws/request/request_pagination.go
@@ -146,7 +146,7 @@ func (r *Request) nextPageTokens() []interface{} {
 				return nil
 			}
 		case bool:
-			if v == false {
+			if !v {
 				return nil
 			}
 		}

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -72,9 +72,7 @@ func TestPaginationQueryPage(t *testing.T) {
 	}
 	err := db.QueryPages(params, func(p *dynamodb.QueryOutput, last bool) bool {
 		numPages++
-		for _, item := range p.Items {
-			pages = append(pages, item)
-		}
+		pages = append(pages, p.Items...)
 		if last {
 			if gotToEnd {
 				t.Errorf("last=true happened twice")

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -81,7 +81,6 @@ func unmarshal(req *request.Request) {
 	if req.Data != nil {
 		json.NewDecoder(req.HTTPResponse.Body).Decode(req.Data)
 	}
-	return
 }
 
 func unmarshalError(req *request.Request) {


### PR DESCRIPTION
- Remove unnecessary returns
- Turn for range loop into a simple append call
- Don't specify capacity if it's the default value of 0
- Simpler bool conditionals