### PR TITLE
Fixed ineffectual assignments / missing error handling

### DIFF
--- a/aws/corehandlers/handlers_1_10_test.go
+++ b/aws/corehandlers/handlers_1_10_test.go
@@ -42,6 +42,9 @@ func TestSendHandler_HEADNoBody(t *testing.T) {
 			S3ForcePathStyle: aws.Bool(true),
 		},
 	})
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
 
 	svc := s3.New(sess)
 

--- a/aws/credentials/chain_provider_test.go
+++ b/aws/credentials/chain_provider_test.go
@@ -120,6 +120,9 @@ func TestChainProviderIsExpired(t *testing.T) {
 	}
 
 	_, err = p.Retrieve()
+	if err != nil {
+		t.Errorf("Expect no error, got %v", err)
+	}
 	if p.IsExpired() {
 		t.Errorf("Expect not expired after retrieve")
 	}

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -169,6 +169,9 @@ func TestResolveEndpointForPartition(t *testing.T) {
 	enum := testPartitions.Partitions()[0]
 
 	expected, err := testPartitions.EndpointFor("service1", "us-east-1")
+	if err != nil {
+		t.Fatalf("unexpected error, %v", err)
+	}
 
 	actual, err := enum.EndpointFor("service1", "us-east-1")
 	if err != nil {

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -566,6 +566,9 @@ func TestSignWithRequestBody(t *testing.T) {
 	}))
 
 	req, err := http.NewRequest("POST", server.URL, nil)
+	if err != nil {
+		t.Errorf("expect not no error, got %v", err)
+	}
 
 	_, err = signer.Sign(req, bytes.NewReader(expectBody), "service", "region", time.Now())
 	if err != nil {
@@ -600,6 +603,9 @@ func TestSignWithRequestBody_Overwrite(t *testing.T) {
 	}))
 
 	req, err := http.NewRequest("GET", server.URL, strings.NewReader("invalid body"))
+	if err != nil {
+		t.Errorf("expect not no error, got %v", err)
+	}
 
 	_, err = signer.Sign(req, nil, "service", "region", time.Now())
 	req.ContentLength = 0


### PR DESCRIPTION
Should it be intentional that those errors aren't checked, we should skip the
assignment altogether. No harm in those checks, though.