### PR TITLE
aws/endpoints: Expose DNSSuffix for partitions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/endpoints`: Expose DNSSuffix for partitions ([#2711](https://github.com/aws/aws-sdk-go/pull/2711))
+  * Exposes the underlying partition metadata's DNSSuffix value via the `DNSSuffix` method on the endpoint's `Partition` type. This allows access to the partition's DNS suffix, e.g. "amazon.com".
+  * Fix [#2710](https://github.com/aws/aws-sdk-go/issues/2710)
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,6 @@
 ### SDK Enhancements
 * `aws/endpoints`: Expose DNSSuffix for partitions ([#2711](https://github.com/aws/aws-sdk-go/pull/2711))
   * Exposes the underlying partition metadata's DNSSuffix value via the `DNSSuffix` method on the endpoint's `Partition` type. This allows access to the partition's DNS suffix, e.g. "amazon.com".
-  * Fix [#2710](https://github.com/aws/aws-sdk-go/issues/2710)
+  * Fixes [#2710](https://github.com/aws/aws-sdk-go/issues/2710)
 
 ### SDK Bugs

--- a/aws/endpoints/endpoints.go
+++ b/aws/endpoints/endpoints.go
@@ -170,9 +170,12 @@ func PartitionForRegion(ps []Partition, regionID string) (Partition, bool) {
 // A Partition provides the ability to enumerate the partition's regions
 // and services.
 type Partition struct {
-	id string
-	p  *partition
+	id, dnsSuffix string
+	p             *partition
 }
+
+// DNSSuffix returns the base domain name of the partition.
+func (p Partition) DNSSuffix() string { return p.dnsSuffix }
 
 // ID returns the identifier of the partition.
 func (p Partition) ID() string { return p.id }

--- a/aws/endpoints/endpoints_test.go
+++ b/aws/endpoints/endpoints_test.go
@@ -330,8 +330,11 @@ func TestPartitionForRegion(t *testing.T) {
 	if !ok {
 		t.Fatalf("expect partition to be found")
 	}
+	if e, a := expect.DNSSuffix(), actual.DNSSuffix(); e != a {
+		t.Errorf("expect %s partition DNSSuffix, got %s", e, a)
+	}
 	if e, a := expect.ID(), actual.ID(); e != a {
-		t.Errorf("expect %s partition, got %s", e, a)
+		t.Errorf("expect %s partition ID, got %s", e, a)
 	}
 }
 

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -54,8 +54,9 @@ type partition struct {
 
 func (p partition) Partition() Partition {
 	return Partition{
-		id: p.ID,
-		p:  &p,
+		dnsSuffix: p.DNSSuffix,
+		id:        p.ID,
+		p:         &p,
 	}
 }
 


### PR DESCRIPTION
Closes #2710
