### PR TITLE
Deprecated awstesting utilities: StashEnv and PopEnv

### DIFF
--- a/awstesting/util.go
+++ b/awstesting/util.go
@@ -97,6 +97,10 @@ func (c *FakeContext) Value(key interface{}) interface{} {
 
 // StashEnv stashes the current environment variables and returns an array of
 // all environment values as key=val strings.
+//
+// Deprecated: StashEnv exists for backward compatibility and may be removed from the future iterations
+// This is an internal utility and is subject to have breaking changes.
+// It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
 func StashEnv() []string {
 	env := os.Environ()
 	os.Clearenv()
@@ -106,6 +110,10 @@ func StashEnv() []string {
 // PopEnv takes the list of the environment values and injects them into the
 // process's environment variable data. Clears any existing environment values
 // that may already exist.
+//
+// Deprecated: PopEnv exists for backward compatibility and may be removed from the future iterations.
+// This is an internal utility and is subject to have breaking changes.
+// It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
 func PopEnv(env []string) {
 	os.Clearenv()
 

--- a/awstesting/util.go
+++ b/awstesting/util.go
@@ -98,8 +98,9 @@ func (c *FakeContext) Value(key interface{}) interface{} {
 // StashEnv stashes the current environment variables and returns an array of
 // all environment values as key=val strings.
 //
-// Deprecated: StashEnv exists for backward compatibility and may be removed from the future iterations
-// It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
+// Deprecated: StashEnv exists for backward compatibility and may be removed from the future iterations.
+// It is not `internal` so that if you really need to use its functionality, and understand breaking
+// changes will be made, you are able to.
 func StashEnv() []string {
 	env := os.Environ()
 	os.Clearenv()
@@ -111,7 +112,8 @@ func StashEnv() []string {
 // that may already exist.
 //
 // Deprecated: PopEnv exists for backward compatibility and may be removed from the future iterations.
-// It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
+// It is not `internal` so that if you really need to use its functionality, and understand breaking
+// changes will be made, you are able to.
 func PopEnv(env []string) {
 	os.Clearenv()
 

--- a/awstesting/util.go
+++ b/awstesting/util.go
@@ -99,7 +99,6 @@ func (c *FakeContext) Value(key interface{}) interface{} {
 // all environment values as key=val strings.
 //
 // Deprecated: StashEnv exists for backward compatibility and may be removed from the future iterations
-// This is an internal utility and is subject to have breaking changes.
 // It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
 func StashEnv() []string {
 	env := os.Environ()
@@ -112,7 +111,6 @@ func StashEnv() []string {
 // that may already exist.
 //
 // Deprecated: PopEnv exists for backward compatibility and may be removed from the future iterations.
-// This is an internal utility and is subject to have breaking changes.
 // It is not `internal` so that if you really need to use its functionality, and understand breaking changes will be made, you are able to.
 func PopEnv(env []string) {
 	os.Clearenv()


### PR DESCRIPTION
- The utilities StashEnv and PopEnv are moved to an internal package named sdktesting, and thus are deprecated from the awstesting package.