### PR TITLE
aws/session: Fix credential loading order for env and shared config

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,10 @@
 ### SDK Features
+* `aws/session`: Corrected order of SDK environment and shared config loading.
+  * Environment credentials have precedence over shared config credentials even if the AWS_PROFILE environment credentials are present. The session.Options.Profile value needs to be used to specify a profile for shared config to have precedence over environment credentials. #2694 incorrectly gave AWS_PROFILE for shared config precedence over environment credentials as well.
 
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/session`: Fix credential loading order for env and shared config ([#2729](https://github.com/aws/aws-sdk-go/pull/2729))
+  * Fixes the credential loading order for environment credentials, when the presence of an AWS_PROFILE value is also provided. The environment credentials have precedence over the AWS_PROFILE.
+  * Fixes [#2727](https://github.com/aws/aws-sdk-go/issues/2727)

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -21,9 +21,10 @@ func resolveCredentials(cfg *aws.Config,
 ) (*credentials.Credentials, error) {
 
 	switch {
-	case len(envCfg.Profile) != 0:
-		// User explicitly provided an Profile, so load from shared config
-		// first.
+	case len(sessOpts.Profile) != 0:
+		// User explicitly provided an Profile in the session's configuration
+		// so load that profile from shared config first.
+		// Github(aws/aws-sdk-go#2727)
 		return resolveCredsFromProfile(cfg, envCfg, sharedCfg, handlers, sessOpts)
 
 	case envCfg.Creds.HasKeys():

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -89,6 +89,7 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 	cases := []struct {
 		name              string
 		profile           string
+		sessOptProfile    string
 		expectedError     error
 		expectedAccessKey string
 		expectedSecretKey string
@@ -107,7 +108,7 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 		},
 		{
 			name:              "env var credential source",
-			profile:           "env_var_credential_source",
+			sessOptProfile:    "env_var_credential_source",
 			expectedAccessKey: "AKID",
 			expectedSecretKey: "SECRET",
 			expectedChain: []string{
@@ -191,7 +192,9 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 
 			os.Setenv("AWS_REGION", "us-east-1")
 			os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
-			os.Setenv("AWS_PROFILE", c.profile)
+			if len(c.profile) != 0 {
+				os.Setenv("AWS_PROFILE", c.profile)
+			}
 
 			endpointResolver, cleanupFn := setupCredentialsEndpoints(t)
 			defer cleanupFn()
@@ -211,6 +214,7 @@ func TestSharedConfigCredentialSource(t *testing.T) {
 			})
 
 			sess, err := NewSessionWithOptions(Options{
+				Profile: c.sessOptProfile,
 				Config: aws.Config{
 					Logger:           t,
 					EndpointResolver: endpointResolver,

--- a/aws/session/doc.go
+++ b/aws/session/doc.go
@@ -1,97 +1,93 @@
 /*
-Package session provides configuration for the SDK's service clients.
-
-Sessions can be shared across all service clients that share the same base
-configuration.  The Session is built from the SDK's default configuration and
-request handlers.
-
-Sessions should be cached when possible, because creating a new Session will
-load all configuration values from the environment, and config files each time
-the Session is created. Sharing the Session value across all of your service
-clients will ensure the configuration is loaded the fewest number of times possible.
-
-Concurrency
+Package session provides configuration for the SDK's service clients. Sessions
+can be shared across service clients that share the same base configuration.
 
 Sessions are safe to use concurrently as long as the Session is not being
-modified. The SDK will not modify the Session once the Session has been created.
-Creating service clients concurrently from a shared Session is safe.
+modified. Sessions should be cached when possible, because creating a new
+Session will load all configuration values from the environment, and config
+files each time the Session is created. Sharing the Session value across all of
+your service clients will ensure the configuration is loaded the fewest number
+of times possible.
 
-Sessions from Shared Config
-
-Sessions can be created using the method above that will only load the
-additional config if the AWS_SDK_LOAD_CONFIG environment variable is set.
-Alternatively you can explicitly create a Session with shared config enabled.
-To do this you can use NewSessionWithOptions to configure how the Session will
-be created. Using the NewSessionWithOptions with SharedConfigState set to
-SharedConfigEnable will create the session as if the AWS_SDK_LOAD_CONFIG
-environment variable was set.
-
-Creating Sessions
-
-When creating Sessions optional aws.Config values can be passed in that will
-override the default, or loaded config values the Session is being created
-with. This allows you to provide additional, or case based, configuration
-as needed.
+Sessions options from Shared Config
 
 By default NewSession will only load credentials from the shared credentials
 file (~/.aws/credentials). If the AWS_SDK_LOAD_CONFIG environment variable is
 set to a truthy value the Session will be created from the configuration
 values from the shared config (~/.aws/config) and shared credentials
-(~/.aws/credentials) files. See the section Sessions from Shared Config for
-more information.
+(~/.aws/credentials) files. Using the NewSessionWithOptions with
+SharedConfigState set to SharedConfigEnable will create the session as if the
+AWS_SDK_LOAD_CONFIG environment variable was set.
 
-Create a Session with the default config and request handlers. With credentials
-region, and profile loaded from the environment and shared config automatically.
-Requires the AWS_PROFILE to be set, or "default" is used.
+Credential and config loading order
+
+The Session will attempt to load configuration and credentials from the
+environment, configuration files, and other credential sources. The order
+configuration is loaded in is:
+
+  * Environment Variables
+  * Shared Credentials file
+  * Shared Configuration file (if SharedConfig is enabled)
+  * EC2 Instance Metadata (credentials only)
+
+The Environment variables for credentials will have precedence over shared
+config even if SharedConfig is enabled. To override this behavior, and use
+shared config credentials instead specify the session.Options.Profile, (e.g.
+when using credential_source=Environment to assume a role).
+
+  sess, err := session.NewSessionWithOptions(session.Options{
+	  Profile: "myProfile",
+  })
+
+Creating Sessions
+
+Creating a Session without additional options will load credentials region, and
+profile loaded from the environment and shared config automatically. See,
+"Environment Variables" section for information on environment variables used
+by Session.
 
 	// Create Session
-	sess := session.Must(session.NewSession())
+	sess, err := session.NewSession()
+
+
+When creating Sessions optional aws.Config values can be passed in that will
+override the default, or loaded, config values the Session is being created
+with. This allows you to provide additional, or case based, configuration
+as needed.
 
 	// Create a Session with a custom region
-	sess := session.Must(session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
-	}))
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-west-2"),
+	})
 
-	// Create a S3 client instance from a session
-	sess := session.Must(session.NewSession())
-
-	svc := s3.New(sess)
-
-Create Session With Option Overrides
-
-In addition to NewSession, Sessions can be created using NewSessionWithOptions.
-This func allows you to control and override how the Session will be created
-through code instead of being driven by environment variables only.
-
-Use NewSessionWithOptions when you want to provide the config profile, or
-override the shared config state (AWS_SDK_LOAD_CONFIG).
+Use NewSessionWithOptions to provide additional configuration driving how the
+Session's configuration will be loaded. Such as, specifying shared config
+profile, or override the shared config state,  (AWS_SDK_LOAD_CONFIG).
 
 	// Equivalent to session.NewSession()
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		// Options
-	}))
+	})
 
-	// Specify profile to load for the session's config
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		 Profile: "profile_name",
-	}))
+	sess, err := session.NewSessionWithOptions(session.Options{
+		// Specify profile to load for the session's config
+		Profile: "profile_name",
 
-	// Specify profile for config and region for requests
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		 Config: aws.Config{Region: aws.String("us-east-1")},
-		 Profile: "profile_name",
-	}))
+		// Provide SDK Config options, such as Region.
+		Config: aws.Config{
+			Region: aws.String("us-west-2"),
+		},
 
-	// Force enable Shared Config support
-	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		// Force enable Shared Config support
 		SharedConfigState: session.SharedConfigEnable,
-	}))
+	})
 
 Adding Handlers
 
-You can add handlers to a session for processing HTTP requests. All service
-clients that use the session inherit the handlers. For example, the following
-handler logs every request and its payload made by a service client:
+You can add handlers to a session to decorate API operation, (e.g. adding HTTP
+headers). All clients that use the Session receive a copy of the Session's
+handlers. For example, the following request handler added to the Session logs
+every requests made.
 
 	// Create a session, and add additional handlers for all service
 	// clients created with the Session to inherit. Adds logging handler.
@@ -99,22 +95,15 @@ handler logs every request and its payload made by a service client:
 
 	sess.Handlers.Send.PushFront(func(r *request.Request) {
 		// Log every request made and its payload
-		logger.Printf("Request: %s/%s, Payload: %s",
+		logger.Printf("Request: %s/%s, Params: %s",
 			r.ClientInfo.ServiceName, r.Operation, r.Params)
 	})
 
-Deprecated "New" function
-
-The New session function has been deprecated because it does not provide good
-way to return errors that occur when loading the configuration files and values.
-Because of this, NewSession was created so errors can be retrieved when
-creating a session fails.
-
 Shared Config Fields
 
-By default the SDK will only load the shared credentials file's (~/.aws/credentials)
-credentials values, and all other config is provided by the environment variables,
-SDK defaults, and user provided aws.Config values.
+By default the SDK will only load the shared credentials file's
+(~/.aws/credentials) credentials values, and all other config is provided by
+the environment variables, SDK defaults, and user provided aws.Config values.
 
 If the AWS_SDK_LOAD_CONFIG environment variable is set, or SharedConfigEnable
 option is used to create the Session the full shared config values will be
@@ -125,24 +114,31 @@ files have the same format.
 
 If both config files are present the configuration from both files will be
 read. The Session will be created from configuration values from the shared
-credentials file (~/.aws/credentials) over those in the shared config file (~/.aws/config).
+credentials file (~/.aws/credentials) over those in the shared config file
+(~/.aws/config).
 
-Credentials are the values the SDK should use for authenticating requests with
-AWS Services. They are from a configuration file will need to include both
-aws_access_key_id and aws_secret_access_key must be provided together in the
-same file to be considered valid. The values will be ignored if not a complete
-group. aws_session_token is an optional field that can be provided if both of
-the other two fields are also provided.
+Credentials are the values the SDK uses to authenticating requests with AWS
+Services. When specified in a file, both aws_access_key_id and
+aws_secret_access_key must be provided together in the same file to be
+considered valid. They will be ignored if both are not present.
+aws_session_token is an optional field that can be provided in addition to the
+other two fields.
 
 	aws_access_key_id = AKID
 	aws_secret_access_key = SECRET
 	aws_session_token = TOKEN
 
-Assume Role values allow you to configure the SDK to assume an IAM role using
-a set of credentials provided in a config file via the source_profile field.
-Both "role_arn" and "source_profile" are required. The SDK supports assuming
-a role with MFA token if the session option AssumeRoleTokenProvider
-is set.
+	; region only supported if SharedConfigEnabled.
+	region = us-east-1
+
+Assume Role configuration
+
+The role_arn field allows you to configure the SDK to assume an IAM role using
+a set of credentials from another source. Such as when paired with static
+credentials, "profile_source", "credential_process", or "credential_source"
+fields. If "role_arn" is provided, a source of credentials must also be
+specified, such as "source_profile", "credential_source", or
+"credential_process".
 
 	role_arn = arn:aws:iam::<account_number>:role/<role_name>
 	source_profile = profile_with_creds
@@ -150,40 +146,16 @@ is set.
 	mfa_serial = <serial or mfa arn>
 	role_session_name = session_name
 
-Region is the region the SDK should use for looking up AWS service endpoints
-and signing requests.
 
-	region = us-east-1
-
-Assume Role with MFA token
-
-To create a session with support for assuming an IAM role with MFA set the
-session option AssumeRoleTokenProvider to a function that will prompt for the
-MFA token code when the SDK assumes the role and refreshes the role's credentials.
-This allows you to configure the SDK via the shared config to assumea role
-with MFA tokens.
-
-In order for the SDK to assume a role with MFA the SharedConfigState
-session option must be set to SharedConfigEnable, or AWS_SDK_LOAD_CONFIG
-environment variable set.
-
-The shared configuration instructs the SDK to assume an IAM role with MFA
-when the mfa_serial configuration field is set in the shared config
-(~/.aws/config) or shared credentials (~/.aws/credentials) file.
-
-If mfa_serial is set in the configuration, the SDK will assume the role, and
-the AssumeRoleTokenProvider session option is not set an an error will
-be returned when creating the session.
+The SDK supports assuming a role with MFA token. If "mfa_serial" is set, you
+must also set the Session Option.AssumeRoleTokenProvider. The Session will fail
+to load if the AssumeRoleTokenProvider is not specified.
 
     sess := session.Must(session.NewSessionWithOptions(session.Options{
         AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
     }))
 
-    // Create service client value configured for credentials
-    // from assumed role.
-    svc := s3.New(sess)
-
-To setup assume role outside of a session see the stscreds.AssumeRoleProvider
+To setup Assume Role outside of a session see the stscreds.AssumeRoleProvider
 documentation.
 
 Environment Variables

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -281,7 +281,7 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 		envCfg = loadEnvConfig()
 	}
 
-	if len(opts.Profile) > 0 {
+	if len(opts.Profile) != 0 {
 		envCfg.Profile = opts.Profile
 	}
 


### PR DESCRIPTION
Fixes the credential loading order for environment credentials, when the
presence of an AWS_PROFILE value is also provided. The environment
credentials have precedence over the AWS_PROFILE.

If you want the profile to have precedence over the environment
credentials, (e.g when using credential_source=Environment) specify the
Profile option value when initializing the Session.

    sess, err := session.NewSessionWithOptions(session.Options{
        Profile: "myProfile",
    })

Specifying the Options.Profile value is equivalent to the AWS CLI's
--profile flag.

Fix #2727