### PR TITLE
aws: Add value/pointer conversion functions for all basic number types

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws`: Add value/pointer conversion functions for all basic number types ([#2740](https://github.com/aws/aws-sdk-go/pull/2740))
+  * Adds value and pointer conversion utilities for the remaining set of integer and float number types.
 
 ### SDK Bugs

--- a/aws/convert_types.go
+++ b/aws/convert_types.go
@@ -179,6 +179,242 @@ func IntValueMap(src map[string]*int) map[string]int {
 	return dst
 }
 
+// Uint returns a pointer to the uint value passed in.
+func Uint(v uint) *uint {
+	return &v
+}
+
+// UintValue returns the value of the uint pointer passed in or
+// 0 if the pointer is nil.
+func UintValue(v *uint) uint {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// UintSlice converts a slice of uint values uinto a slice of
+// uint pointers
+func UintSlice(src []uint) []*uint {
+	dst := make([]*uint, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// UintValueSlice converts a slice of uint pointers uinto a slice of
+// uint values
+func UintValueSlice(src []*uint) []uint {
+	dst := make([]uint, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// UintMap converts a string map of uint values uinto a string
+// map of uint pointers
+func UintMap(src map[string]uint) map[string]*uint {
+	dst := make(map[string]*uint)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// UintValueMap converts a string map of uint pointers uinto a string
+// map of uint values
+func UintValueMap(src map[string]*uint) map[string]uint {
+	dst := make(map[string]uint)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int8 returns a pointer to the int8 value passed in.
+func Int8(v int8) *int8 {
+	return &v
+}
+
+// Int8Value returns the value of the int8 pointer passed in or
+// 0 if the pointer is nil.
+func Int8Value(v *int8) int8 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int8Slice converts a slice of int8 values into a slice of
+// int8 pointers
+func Int8Slice(src []int8) []*int8 {
+	dst := make([]*int8, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int8ValueSlice converts a slice of int8 pointers into a slice of
+// int8 values
+func Int8ValueSlice(src []*int8) []int8 {
+	dst := make([]int8, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int8Map converts a string map of int8 values into a string
+// map of int8 pointers
+func Int8Map(src map[string]int8) map[string]*int8 {
+	dst := make(map[string]*int8)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int8ValueMap converts a string map of int8 pointers into a string
+// map of int8 values
+func Int8ValueMap(src map[string]*int8) map[string]int8 {
+	dst := make(map[string]int8)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int16 returns a pointer to the int16 value passed in.
+func Int16(v int16) *int16 {
+	return &v
+}
+
+// Int16Value returns the value of the int16 pointer passed in or
+// 0 if the pointer is nil.
+func Int16Value(v *int16) int16 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int16Slice converts a slice of int16 values into a slice of
+// int16 pointers
+func Int16Slice(src []int16) []*int16 {
+	dst := make([]*int16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int16ValueSlice converts a slice of int16 pointers into a slice of
+// int16 values
+func Int16ValueSlice(src []*int16) []int16 {
+	dst := make([]int16, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int16Map converts a string map of int16 values into a string
+// map of int16 pointers
+func Int16Map(src map[string]int16) map[string]*int16 {
+	dst := make(map[string]*int16)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int16ValueMap converts a string map of int16 pointers into a string
+// map of int16 values
+func Int16ValueMap(src map[string]*int16) map[string]int16 {
+	dst := make(map[string]int16)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Int32 returns a pointer to the int32 value passed in.
+func Int32(v int32) *int32 {
+	return &v
+}
+
+// Int32Value returns the value of the int32 pointer passed in or
+// 0 if the pointer is nil.
+func Int32Value(v *int32) int32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Int32Slice converts a slice of int32 values into a slice of
+// int32 pointers
+func Int32Slice(src []int32) []*int32 {
+	dst := make([]*int32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Int32ValueSlice converts a slice of int32 pointers into a slice of
+// int32 values
+func Int32ValueSlice(src []*int32) []int32 {
+	dst := make([]int32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Int32Map converts a string map of int32 values into a string
+// map of int32 pointers
+func Int32Map(src map[string]int32) map[string]*int32 {
+	dst := make(map[string]*int32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Int32ValueMap converts a string map of int32 pointers into a string
+// map of int32 values
+func Int32ValueMap(src map[string]*int32) map[string]int32 {
+	dst := make(map[string]int32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
 // Int64 returns a pointer to the int64 value passed in.
 func Int64(v int64) *int64 {
 	return &v
@@ -230,6 +466,301 @@ func Int64Map(src map[string]int64) map[string]*int64 {
 // map of int64 values
 func Int64ValueMap(src map[string]*int64) map[string]int64 {
 	dst := make(map[string]int64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint8 returns a pointer to the uint8 value passed in.
+func Uint8(v uint8) *uint8 {
+	return &v
+}
+
+// Uint8Value returns the value of the uint8 pointer passed in or
+// 0 if the pointer is nil.
+func Uint8Value(v *uint8) uint8 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint8Slice converts a slice of uint8 values into a slice of
+// uint8 pointers
+func Uint8Slice(src []uint8) []*uint8 {
+	dst := make([]*uint8, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint8ValueSlice converts a slice of uint8 pointers into a slice of
+// uint8 values
+func Uint8ValueSlice(src []*uint8) []uint8 {
+	dst := make([]uint8, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint8Map converts a string map of uint8 values into a string
+// map of uint8 pointers
+func Uint8Map(src map[string]uint8) map[string]*uint8 {
+	dst := make(map[string]*uint8)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint8ValueMap converts a string map of uint8 pointers into a string
+// map of uint8 values
+func Uint8ValueMap(src map[string]*uint8) map[string]uint8 {
+	dst := make(map[string]uint8)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint16 returns a pointer to the uint16 value passed in.
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+// Uint16Value returns the value of the uint16 pointer passed in or
+// 0 if the pointer is nil.
+func Uint16Value(v *uint16) uint16 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint16Slice converts a slice of uint16 values into a slice of
+// uint16 pointers
+func Uint16Slice(src []uint16) []*uint16 {
+	dst := make([]*uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint16ValueSlice converts a slice of uint16 pointers into a slice of
+// uint16 values
+func Uint16ValueSlice(src []*uint16) []uint16 {
+	dst := make([]uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint16Map converts a string map of uint16 values into a string
+// map of uint16 pointers
+func Uint16Map(src map[string]uint16) map[string]*uint16 {
+	dst := make(map[string]*uint16)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint16ValueMap converts a string map of uint16 pointers into a string
+// map of uint16 values
+func Uint16ValueMap(src map[string]*uint16) map[string]uint16 {
+	dst := make(map[string]uint16)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint32 returns a pointer to the uint32 value passed in.
+func Uint32(v uint32) *uint32 {
+	return &v
+}
+
+// Uint32Value returns the value of the uint32 pointer passed in or
+// 0 if the pointer is nil.
+func Uint32Value(v *uint32) uint32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint32Slice converts a slice of uint32 values into a slice of
+// uint32 pointers
+func Uint32Slice(src []uint32) []*uint32 {
+	dst := make([]*uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint32ValueSlice converts a slice of uint32 pointers into a slice of
+// uint32 values
+func Uint32ValueSlice(src []*uint32) []uint32 {
+	dst := make([]uint32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint32Map converts a string map of uint32 values into a string
+// map of uint32 pointers
+func Uint32Map(src map[string]uint32) map[string]*uint32 {
+	dst := make(map[string]*uint32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint32ValueMap converts a string map of uint32 pointers into a string
+// map of uint32 values
+func Uint32ValueMap(src map[string]*uint32) map[string]uint32 {
+	dst := make(map[string]uint32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Uint64 returns a pointer to the uint64 value passed in.
+func Uint64(v uint64) *uint64 {
+	return &v
+}
+
+// Uint64Value returns the value of the uint64 pointer passed in or
+// 0 if the pointer is nil.
+func Uint64Value(v *uint64) uint64 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Uint64Slice converts a slice of uint64 values into a slice of
+// uint64 pointers
+func Uint64Slice(src []uint64) []*uint64 {
+	dst := make([]*uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Uint64ValueSlice converts a slice of uint64 pointers into a slice of
+// uint64 values
+func Uint64ValueSlice(src []*uint64) []uint64 {
+	dst := make([]uint64, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Uint64Map converts a string map of uint64 values into a string
+// map of uint64 pointers
+func Uint64Map(src map[string]uint64) map[string]*uint64 {
+	dst := make(map[string]*uint64)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Uint64ValueMap converts a string map of uint64 pointers into a string
+// map of uint64 values
+func Uint64ValueMap(src map[string]*uint64) map[string]uint64 {
+	dst := make(map[string]uint64)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
+// Float32 returns a pointer to the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float32Slice converts a slice of float32 values into a slice of
+// float32 pointers
+func Float32Slice(src []float32) []*float32 {
+	dst := make([]*float32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Float32ValueSlice converts a slice of float32 pointers into a slice of
+// float32 values
+func Float32ValueSlice(src []*float32) []float32 {
+	dst := make([]float32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Float32Map converts a string map of float32 values into a string
+// map of float32 pointers
+func Float32Map(src map[string]float32) map[string]*float32 {
+	dst := make(map[string]*float32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Float32ValueMap converts a string map of float32 pointers into a string
+// map of float32 values
+func Float32ValueMap(src map[string]*float32) map[string]float32 {
+	dst := make(map[string]float32)
 	for k, val := range src {
 		if val != nil {
 			dst[k] = *val

--- a/aws/convert_types_test.go
+++ b/aws/convert_types_test.go
@@ -207,6 +207,105 @@ func TestBoolMap(t *testing.T) {
 	}
 }
 
+var testCasesUintSlice = [][]uint{
+	{1, 2, 3, 4},
+}
+
+func TestUintSlice(t *testing.T) {
+	for idx, in := range testCasesUintSlice {
+		if in == nil {
+			continue
+		}
+		out := UintSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := UintValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUintValueSlice = [][]*uint{}
+
+func TestUintValueSlice(t *testing.T) {
+	for idx, in := range testCasesUintValueSlice {
+		if in == nil {
+			continue
+		}
+		out := UintValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := UintSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesUintMap = []map[string]uint{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUintMap(t *testing.T) {
+	for idx, in := range testCasesUintMap {
+		if in == nil {
+			continue
+		}
+		out := UintMap(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := UintValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
 var testCasesIntSlice = [][]int{
 	{1, 2, 3, 4},
 }
@@ -306,6 +405,303 @@ func TestIntMap(t *testing.T) {
 	}
 }
 
+var testCasesInt8Slice = [][]int8{
+	{1, 2, 3, 4},
+}
+
+func TestInt8Slice(t *testing.T) {
+	for idx, in := range testCasesInt8Slice {
+		if in == nil {
+			continue
+		}
+		out := Int8Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int8ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesInt8ValueSlice = [][]*int8{}
+
+func TestInt8ValueSlice(t *testing.T) {
+	for idx, in := range testCasesInt8ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Int8ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Int8Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesInt8Map = []map[string]int8{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestInt8Map(t *testing.T) {
+	for idx, in := range testCasesInt8Map {
+		if in == nil {
+			continue
+		}
+		out := Int8Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int8ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesInt16Slice = [][]int16{
+	{1, 2, 3, 4},
+}
+
+func TestInt16Slice(t *testing.T) {
+	for idx, in := range testCasesInt16Slice {
+		if in == nil {
+			continue
+		}
+		out := Int16Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int16ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesInt16ValueSlice = [][]*int16{}
+
+func TestInt16ValueSlice(t *testing.T) {
+	for idx, in := range testCasesInt16ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Int16ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Int16Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesInt16Map = []map[string]int16{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestInt16Map(t *testing.T) {
+	for idx, in := range testCasesInt16Map {
+		if in == nil {
+			continue
+		}
+		out := Int16Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int16ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesInt32Slice = [][]int32{
+	{1, 2, 3, 4},
+}
+
+func TestInt32Slice(t *testing.T) {
+	for idx, in := range testCasesInt32Slice {
+		if in == nil {
+			continue
+		}
+		out := Int32Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int32ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesInt32ValueSlice = [][]*int32{}
+
+func TestInt32ValueSlice(t *testing.T) {
+	for idx, in := range testCasesInt32ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Int32ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Int32Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesInt32Map = []map[string]int32{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestInt32Map(t *testing.T) {
+	for idx, in := range testCasesInt32Map {
+		if in == nil {
+			continue
+		}
+		out := Int32Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Int32ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
 var testCasesInt64Slice = [][]int64{
 	{1, 2, 3, 4},
 }
@@ -396,6 +792,501 @@ func TestInt64Map(t *testing.T) {
 		}
 
 		out2 := Int64ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint8Slice = [][]uint8{
+	{1, 2, 3, 4},
+}
+
+func TestUint8Slice(t *testing.T) {
+	for idx, in := range testCasesUint8Slice {
+		if in == nil {
+			continue
+		}
+		out := Uint8Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint8ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint8ValueSlice = [][]*uint8{}
+
+func TestUint8ValueSlice(t *testing.T) {
+	for idx, in := range testCasesUint8ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Uint8ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Uint8Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesUint8Map = []map[string]uint8{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUint8Map(t *testing.T) {
+	for idx, in := range testCasesUint8Map {
+		if in == nil {
+			continue
+		}
+		out := Uint8Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint8ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint16Slice = [][]uint16{
+	{1, 2, 3, 4},
+}
+
+func TestUint16Slice(t *testing.T) {
+	for idx, in := range testCasesUint16Slice {
+		if in == nil {
+			continue
+		}
+		out := Uint16Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint16ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint16ValueSlice = [][]*uint16{}
+
+func TestUint16ValueSlice(t *testing.T) {
+	for idx, in := range testCasesUint16ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Uint16ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Uint16Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesUint16Map = []map[string]uint16{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUint16Map(t *testing.T) {
+	for idx, in := range testCasesUint16Map {
+		if in == nil {
+			continue
+		}
+		out := Uint16Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint16ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint32Slice = [][]uint32{
+	{1, 2, 3, 4},
+}
+
+func TestUint32Slice(t *testing.T) {
+	for idx, in := range testCasesUint32Slice {
+		if in == nil {
+			continue
+		}
+		out := Uint32Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint32ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint32ValueSlice = [][]*uint32{}
+
+func TestUint32ValueSlice(t *testing.T) {
+	for idx, in := range testCasesUint32ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Uint32ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Uint32Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesUint32Map = []map[string]uint32{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUint32Map(t *testing.T) {
+	for idx, in := range testCasesUint32Map {
+		if in == nil {
+			continue
+		}
+		out := Uint32Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint32ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint64Slice = [][]uint64{
+	{1, 2, 3, 4},
+}
+
+func TestUint64Slice(t *testing.T) {
+	for idx, in := range testCasesUint64Slice {
+		if in == nil {
+			continue
+		}
+		out := Uint64Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint64ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesUint64ValueSlice = [][]*uint64{}
+
+func TestUint64ValueSlice(t *testing.T) {
+	for idx, in := range testCasesUint64ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Uint64ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Uint64Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesUint64Map = []map[string]uint64{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUint64Map(t *testing.T) {
+	for idx, in := range testCasesUint64Map {
+		if in == nil {
+			continue
+		}
+		out := Uint64Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Uint64ValueMap(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesFloat32Slice = [][]float32{
+	{1, 2, 3, 4},
+}
+
+func TestFloat32Slice(t *testing.T) {
+	for idx, in := range testCasesFloat32Slice {
+		if in == nil {
+			continue
+		}
+		out := Float32Slice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Float32ValueSlice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		if e, a := in, out2; !reflect.DeepEqual(e, a) {
+			t.Errorf("Unexpected value at idx %d", idx)
+		}
+	}
+}
+
+var testCasesFloat32ValueSlice = [][]*float32{}
+
+func TestFloat32ValueSlice(t *testing.T) {
+	for idx, in := range testCasesFloat32ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Float32ValueSlice(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if in[i] == nil {
+				if out[i] != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := *(in[i]), out[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+
+		out2 := Float32Slice(out)
+		if e, a := len(out2), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out2 {
+			if in[i] == nil {
+				if *(out2[i]) != 0 {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			} else {
+				if e, a := in[i], out2[i]; e != a {
+					t.Errorf("Unexpected value at idx %d", idx)
+				}
+			}
+		}
+	}
+}
+
+var testCasesFloat32Map = []map[string]float32{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestFloat32Map(t *testing.T) {
+	for idx, in := range testCasesFloat32Map {
+		if in == nil {
+			continue
+		}
+		out := Float32Map(in)
+		if e, a := len(out), len(in); e != a {
+			t.Errorf("Unexpected len at idx %d", idx)
+		}
+		for i := range out {
+			if e, a := in[i], *(out[i]); e != a {
+				t.Errorf("Unexpected value at idx %d", idx)
+			}
+		}
+
+		out2 := Float32ValueMap(out)
 		if e, a := len(out2), len(in); e != a {
 			t.Errorf("Unexpected len at idx %d", idx)
 		}


### PR DESCRIPTION
This change adds value and pointer conversion utilities for the remaining set of basic types:
* uint, uint8, uint16, uint32 & uint64
* int8, int16, int32
* float32

It also adds tests for each of the new convert functions