### PR TITLE
private/model/api: Prevent overwriting existing shapes in fixStutterNames

### DIFF
--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -96,6 +96,11 @@ func s3Customizations(a *API) {
 	}
 
 	for name, s := range a.Shapes {
+		// Keep Location type for backwards compatibility
+		if name == "S3Location" {
+			s.Rename("Location")
+		}
+
 		// Remove ContentMD5 members unless specified otherwise.
 		if _, keep := keepContentMD5Ref[name]; !keep {
 			if _, have := s.MemberRefs["ContentMD5"]; have {

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -144,7 +144,7 @@ func (a *API) fixStutterNames() {
 
 	for k, s := range a.Shapes {
 		newName := re.ReplaceAllString(k, "")
-		if newName != s.ShapeName && len(newName) > 0 {
+		if newName != s.ShapeName && len(newName) > 0 && a.Shapes[newName] == nil {
 			s.Rename(newName)
 		}
 	}


### PR DESCRIPTION
Closes #2741

Previously, the service generator could overwrite existing shapes, when attempting to remove stutter names. According to the updated services generated by this change, this was occurring with two of them as of v1.22.2:

* service/glue: [`GlueTable`](https://github.com/aws/aws-sdk-go/blob/62608c7740021aaba4dd91670c798a8e8e5b4faf/models/apis/glue/2017-03-31/api-2.json#L4280-L4292) and [`Table`](https://github.com/aws/aws-sdk-go/blob/62608c7740021aaba4dd91670c798a8e8e5b4faf/models/apis/glue/2017-03-31/api-2.json#L5532-L5554) (broken since [v1.22.2](https://github.com/aws/aws-sdk-go/pull/2739/files#diff-a933a25e383e3d004d1445b743915556))
* service/iotevents: [`Action`](https://github.com/aws/aws-sdk-go/blob/62608c7740021aaba4dd91670c798a8e8e5b4faf/models/apis/iotevents/2018-07-27/api-2.json#L280-L294) and [`IoTEventsAction`](https://github.com/aws/aws-sdk-go/blob/62608c7740021aaba4dd91670c798a8e8e5b4faf/models/apis/iotevents/2018-07-27/api-2.json#L672-L678) (broken since [v1.21.1](https://github.com/aws/aws-sdk-go/commit/8ae9ae0c8959def54f4a180ed76812ccc5f888db#diff-e906b8b5cc947eb50556cb16446fd6cc))

<details><summary>Difference after the updates and running gen-services</summary>

```diff
diff --git a/service/glue/api.go b/service/glue/api.go
index 6a20831c4..67dcabbe6 100644
--- a/service/glue/api.go
+++ b/service/glue/api.go
@@ -16798,7 +16798,7 @@ type CreateMLTransformInput struct {
 	// A list of AWS Glue table definitions used by the transform.
 	//
 	// InputRecordTables is a required field
-	InputRecordTables []*Table `type:"list" required:"true"`
+	InputRecordTables []*GlueTable `type:"list" required:"true"`

 	// The number of AWS Glue data processing units (DPUs) that are allocated to
 	// task runs for this transform. You can allocate from 2 to 100 DPUs; the default
@@ -16916,7 +16916,7 @@ func (s *CreateMLTransformInput) SetDescription(v string) *CreateMLTransformInpu
 }

 // SetInputRecordTables sets the InputRecordTables field's value.
-func (s *CreateMLTransformInput) SetInputRecordTables(v []*Table) *CreateMLTransformInput {
+func (s *CreateMLTransformInput) SetInputRecordTables(v []*GlueTable) *CreateMLTransformInput {
 	s.InputRecordTables = v
 	return s
 }
@@ -21927,7 +21927,7 @@ type GetMLTransformOutput struct {
 	EvaluationMetrics *EvaluationMetrics `type:"structure"`

 	// A list of AWS Glue table definitions used by the transform.
-	InputRecordTables []*Table `type:"list"`
+	InputRecordTables []*GlueTable `type:"list"`

 	// The number of labels available for this transform.
 	LabelCount *int64 `type:"integer"`
@@ -22023,7 +22023,7 @@ func (s *GetMLTransformOutput) SetEvaluationMetrics(v *EvaluationMetrics) *GetML
 }

 // SetInputRecordTables sets the InputRecordTables field's value.
-func (s *GetMLTransformOutput) SetInputRecordTables(v []*Table) *GetMLTransformOutput {
+func (s *GetMLTransformOutput) SetInputRecordTables(v []*GlueTable) *GetMLTransformOutput {
 	s.InputRecordTables = v
 	return s
 }
@@ -24224,6 +24224,90 @@ func (s *GetWorkflowRunsOutput) SetRuns(v []*WorkflowRun) *GetWorkflowRunsOutput
 	return s
 }

+// The database and table in the AWS Glue Data Catalog that is used for input
+// or output data.
+type GlueTable struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for the AWS Glue Data Catalog.
+	CatalogId *string `min:"1" type:"string"`
+
+	// The name of the connection to the AWS Glue Data Catalog.
+	ConnectionName *string `min:"1" type:"string"`
+
+	// A database name in the AWS Glue Data Catalog.
+	//
+	// DatabaseName is a required field
+	DatabaseName *string `min:"1" type:"string" required:"true"`
+
+	// A table name in the AWS Glue Data Catalog.
+	//
+	// TableName is a required field
+	TableName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GlueTable) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GlueTable) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GlueTable) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GlueTable"}
+	if s.CatalogId != nil && len(*s.CatalogId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("CatalogId", 1))
+	}
+	if s.ConnectionName != nil && len(*s.ConnectionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ConnectionName", 1))
+	}
+	if s.DatabaseName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DatabaseName"))
+	}
+	if s.DatabaseName != nil && len(*s.DatabaseName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("DatabaseName", 1))
+	}
+	if s.TableName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TableName"))
+	}
+	if s.TableName != nil && len(*s.TableName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TableName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCatalogId sets the CatalogId field's value.
+func (s *GlueTable) SetCatalogId(v string) *GlueTable {
+	s.CatalogId = &v
+	return s
+}
+
+// SetConnectionName sets the ConnectionName field's value.
+func (s *GlueTable) SetConnectionName(v string) *GlueTable {
+	s.ConnectionName = &v
+	return s
+}
+
+// SetDatabaseName sets the DatabaseName field's value.
+func (s *GlueTable) SetDatabaseName(v string) *GlueTable {
+	s.DatabaseName = &v
+	return s
+}
+
+// SetTableName sets the TableName field's value.
+func (s *GlueTable) SetTableName(v string) *GlueTable {
+	s.TableName = &v
+	return s
+}
+
 // A classifier that uses grok patterns.
 type GrokClassifier struct {
 	_ struct{} `type:"structure"`
@@ -26090,7 +26174,7 @@ type MLTransform struct {
 	EvaluationMetrics *EvaluationMetrics `type:"structure"`

 	// A list of AWS Glue table definitions used by the transform.
-	InputRecordTables []*Table `type:"list"`
+	InputRecordTables []*GlueTable `type:"list"`

 	// A count identifier for the labeling files generated by AWS Glue for this
 	// transform. As you create a better transform, you can iteratively download,
@@ -26192,7 +26276,7 @@ func (s *MLTransform) SetEvaluationMetrics(v *EvaluationMetrics) *MLTransform {
 }

 // SetInputRecordTables sets the InputRecordTables field's value.
-func (s *MLTransform) SetInputRecordTables(v []*Table) *MLTransform {
+func (s *MLTransform) SetInputRecordTables(v []*GlueTable) *MLTransform {
 	s.InputRecordTables = v
 	return s
 }
@@ -28977,26 +29061,72 @@ func (s *StorageDescriptor) SetStoredAsSubDirectories(v bool) *StorageDescriptor
 	return s
 }

-// The database and table in the AWS Glue Data Catalog that is used for input
-// or output data.
+// Represents a collection of related data organized in columns and rows.
 type Table struct {
 	_ struct{} `type:"structure"`

-	// A unique identifier for the AWS Glue Data Catalog.
-	CatalogId *string `min:"1" type:"string"`
+	// The time when the table definition was created in the Data Catalog.
+	CreateTime *time.Time `type:"timestamp"`

-	// The name of the connection to the AWS Glue Data Catalog.
-	ConnectionName *string `min:"1" type:"string"`
+	// The person or entity who created the table.
+	CreatedBy *string `min:"1" type:"string"`

-	// A database name in the AWS Glue Data Catalog.
+	// The name of the database where the table metadata resides. For Hive compatibility,
+	// this must be all lowercase.
+	DatabaseName *string `min:"1" type:"string"`
+
+	// A description of the table.
+	Description *string `type:"string"`
+
+	// Indicates whether the table has been registered with AWS Lake Formation.
+	IsRegisteredWithLakeFormation *bool `type:"boolean"`
+
+	// The last time that the table was accessed. This is usually taken from HDFS,
+	// and might not be reliable.
+	LastAccessTime *time.Time `type:"timestamp"`
+
+	// The last time that column statistics were computed for this table.
+	LastAnalyzedTime *time.Time `type:"timestamp"`
+
+	// The table name. For Hive compatibility, this must be entirely lowercase.
 	//
-	// DatabaseName is a required field
-	DatabaseName *string `min:"1" type:"string" required:"true"`
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`

-	// A table name in the AWS Glue Data Catalog.
+	// The owner of the table.
+	Owner *string `min:"1" type:"string"`
+
+	// These key-value pairs define properties associated with the table.
+	Parameters map[string]*string `type:"map"`
+
+	// A list of columns by which the table is partitioned. Only primitive types
+	// are supported as partition keys.
 	//
-	// TableName is a required field
-	TableName *string `min:"1" type:"string" required:"true"`
+	// When you create a table used by Amazon Athena, and you do not specify any
+	// partitionKeys, you must at least set the value of partitionKeys to an empty
+	// list. For example:
+	//
+	// "PartitionKeys": []
+	PartitionKeys []*Column `type:"list"`
+
+	// The retention time for this table.
+	Retention *int64 `type:"integer"`
+
+	// A storage descriptor containing information about the physical storage of
+	// this table.
+	StorageDescriptor *StorageDescriptor `type:"structure"`
+
+	// The type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.).
+	TableType *string `type:"string"`
+
+	// The last time that the table was updated.
+	UpdateTime *time.Time `type:"timestamp"`
+
+	// If the table is a view, the expanded text of the view; otherwise null.
+	ViewExpandedText *string `type:"string"`
+
+	// If the table is a view, the original text of the view; otherwise null.
+	ViewOriginalText *string `type:"string"`
 }

 // String returns the string representation
@@ -29009,43 +29139,15 @@ func (s Table) GoString() string {
 	return s.String()
 }

-// Validate inspects the fields of the type to determine if they are valid.
-func (s *Table) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "Table"}
-	if s.CatalogId != nil && len(*s.CatalogId) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("CatalogId", 1))
-	}
-	if s.ConnectionName != nil && len(*s.ConnectionName) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("ConnectionName", 1))
-	}
-	if s.DatabaseName == nil {
-		invalidParams.Add(request.NewErrParamRequired("DatabaseName"))
-	}
-	if s.DatabaseName != nil && len(*s.DatabaseName) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("DatabaseName", 1))
-	}
-	if s.TableName == nil {
-		invalidParams.Add(request.NewErrParamRequired("TableName"))
-	}
-	if s.TableName != nil && len(*s.TableName) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("TableName", 1))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
-}
-
-// SetCatalogId sets the CatalogId field's value.
-func (s *Table) SetCatalogId(v string) *Table {
-	s.CatalogId = &v
+// SetCreateTime sets the CreateTime field's value.
+func (s *Table) SetCreateTime(v time.Time) *Table {
+	s.CreateTime = &v
 	return s
 }

-// SetConnectionName sets the ConnectionName field's value.
-func (s *Table) SetConnectionName(v string) *Table {
-	s.ConnectionName = &v
+// SetCreatedBy sets the CreatedBy field's value.
+func (s *Table) SetCreatedBy(v string) *Table {
+	s.CreatedBy = &v
 	return s
 }

@@ -29055,9 +29157,87 @@ func (s *Table) SetDatabaseName(v string) *Table {
 	return s
 }

-// SetTableName sets the TableName field's value.
-func (s *Table) SetTableName(v string) *Table {
-	s.TableName = &v
+// SetDescription sets the Description field's value.
+func (s *Table) SetDescription(v string) *Table {
+	s.Description = &v
+	return s
+}
+
+// SetIsRegisteredWithLakeFormation sets the IsRegisteredWithLakeFormation field's value.
+func (s *Table) SetIsRegisteredWithLakeFormation(v bool) *Table {
+	s.IsRegisteredWithLakeFormation = &v
+	return s
+}
+
+// SetLastAccessTime sets the LastAccessTime field's value.
+func (s *Table) SetLastAccessTime(v time.Time) *Table {
+	s.LastAccessTime = &v
+	return s
+}
+
+// SetLastAnalyzedTime sets the LastAnalyzedTime field's value.
+func (s *Table) SetLastAnalyzedTime(v time.Time) *Table {
+	s.LastAnalyzedTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Table) SetName(v string) *Table {
+	s.Name = &v
+	return s
+}
+
+// SetOwner sets the Owner field's value.
+func (s *Table) SetOwner(v string) *Table {
+	s.Owner = &v
+	return s
+}
+
+// SetParameters sets the Parameters field's value.
+func (s *Table) SetParameters(v map[string]*string) *Table {
+	s.Parameters = v
+	return s
+}
+
+// SetPartitionKeys sets the PartitionKeys field's value.
+func (s *Table) SetPartitionKeys(v []*Column) *Table {
+	s.PartitionKeys = v
+	return s
+}
+
+// SetRetention sets the Retention field's value.
+func (s *Table) SetRetention(v int64) *Table {
+	s.Retention = &v
+	return s
+}
+
+// SetStorageDescriptor sets the StorageDescriptor field's value.
+func (s *Table) SetStorageDescriptor(v *StorageDescriptor) *Table {
+	s.StorageDescriptor = v
+	return s
+}
+
+// SetTableType sets the TableType field's value.
+func (s *Table) SetTableType(v string) *Table {
+	s.TableType = &v
+	return s
+}
+
+// SetUpdateTime sets the UpdateTime field's value.
+func (s *Table) SetUpdateTime(v time.Time) *Table {
+	s.UpdateTime = &v
+	return s
+}
+
+// SetViewExpandedText sets the ViewExpandedText field's value.
+func (s *Table) SetViewExpandedText(v string) *Table {
+	s.ViewExpandedText = &v
+	return s
+}
+
+// SetViewOriginalText sets the ViewOriginalText field's value.
+func (s *Table) SetViewOriginalText(v string) *Table {
+	s.ViewOriginalText = &v
 	return s
 }

diff --git a/service/iotevents/api.go b/service/iotevents/api.go
index 3d4654316..3374e1a8d 100644
--- a/service/iotevents/api.go
+++ b/service/iotevents/api.go
@@ -1506,15 +1506,43 @@ func (c *IoTEvents) UpdateInputWithContext(ctx aws.Context, input *UpdateInputIn
 	return out, req.Send()
 }

-// Sends an IoT Events input, passing in information about the detector model
-// instance and the event which triggered the action.
+// An action to be performed when the "condition" is TRUE.
 type Action struct {
 	_ struct{} `type:"structure"`

-	// The name of the AWS IoT Events input where the data is sent.
-	//
-	// InputName is a required field
-	InputName *string `locationName:"inputName" min:"1" type:"string" required:"true"`
+	// Information needed to clear the timer.
+	ClearTimer *ClearTimerAction `locationName:"clearTimer" type:"structure"`
+
+	// Sends information about the detector model instance and the event which triggered
+	// the action to a Kinesis Data Firehose stream.
+	Firehose *FirehoseAction `locationName:"firehose" type:"structure"`
+
+	// Sends an IoT Events input, passing in information about the detector model
+	// instance and the event which triggered the action.
+	IotEvents *IotEventsAction `locationName:"iotEvents" type:"structure"`
+
+	// Publishes an MQTT message with the given topic to the AWS IoT message broker.
+	IotTopicPublish *IotTopicPublishAction `locationName:"iotTopicPublish" type:"structure"`
+
+	// Calls a Lambda function, passing in information about the detector model
+	// instance and the event which triggered the action.
+	Lambda *LambdaAction `locationName:"lambda" type:"structure"`
+
+	// Information needed to reset the timer.
+	ResetTimer *ResetTimerAction `locationName:"resetTimer" type:"structure"`
+
+	// Information needed to set the timer.
+	SetTimer *SetTimerAction `locationName:"setTimer" type:"structure"`
+
+	// Sets a variable to a specified value.
+	SetVariable *SetVariableAction `locationName:"setVariable" type:"structure"`
+
+	// Sends an Amazon SNS message.
+	Sns *SNSTopicPublishAction `locationName:"sns" type:"structure"`
+
+	// Sends information about the detector model instance and the event which triggered
+	// the action to an AWS SQS queue.
+	Sqs *SqsAction `locationName:"sqs" type:"structure"`
 }

 // String returns the string representation
@@ -1530,11 +1558,55 @@ func (s Action) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *Action) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "Action"}
-	if s.InputName == nil {
-		invalidParams.Add(request.NewErrParamRequired("InputName"))
+	if s.ClearTimer != nil {
+		if err := s.ClearTimer.Validate(); err != nil {
+			invalidParams.AddNested("ClearTimer", err.(request.ErrInvalidParams))
+		}
 	}
-	if s.InputName != nil && len(*s.InputName) < 1 {
-		invalidParams.Add(request.NewErrParamMinLen("InputName", 1))
+	if s.Firehose != nil {
+		if err := s.Firehose.Validate(); err != nil {
+			invalidParams.AddNested("Firehose", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.IotEvents != nil {
+		if err := s.IotEvents.Validate(); err != nil {
+			invalidParams.AddNested("IotEvents", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.IotTopicPublish != nil {
+		if err := s.IotTopicPublish.Validate(); err != nil {
+			invalidParams.AddNested("IotTopicPublish", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Lambda != nil {
+		if err := s.Lambda.Validate(); err != nil {
+			invalidParams.AddNested("Lambda", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.ResetTimer != nil {
+		if err := s.ResetTimer.Validate(); err != nil {
+			invalidParams.AddNested("ResetTimer", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SetTimer != nil {
+		if err := s.SetTimer.Validate(); err != nil {
+			invalidParams.AddNested("SetTimer", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.SetVariable != nil {
+		if err := s.SetVariable.Validate(); err != nil {
+			invalidParams.AddNested("SetVariable", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Sns != nil {
+		if err := s.Sns.Validate(); err != nil {
+			invalidParams.AddNested("Sns", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Sqs != nil {
+		if err := s.Sqs.Validate(); err != nil {
+			invalidParams.AddNested("Sqs", err.(request.ErrInvalidParams))
+		}
 	}

 	if invalidParams.Len() > 0 {
@@ -1543,9 +1615,63 @@ func (s *Action) Validate() error {
 	return nil
 }

-// SetInputName sets the InputName field's value.
-func (s *Action) SetInputName(v string) *Action {
-	s.InputName = &v
+// SetClearTimer sets the ClearTimer field's value.
+func (s *Action) SetClearTimer(v *ClearTimerAction) *Action {
+	s.ClearTimer = v
+	return s
+}
+
+// SetFirehose sets the Firehose field's value.
+func (s *Action) SetFirehose(v *FirehoseAction) *Action {
+	s.Firehose = v
+	return s
+}
+
+// SetIotEvents sets the IotEvents field's value.
+func (s *Action) SetIotEvents(v *IotEventsAction) *Action {
+	s.IotEvents = v
+	return s
+}
+
+// SetIotTopicPublish sets the IotTopicPublish field's value.
+func (s *Action) SetIotTopicPublish(v *IotTopicPublishAction) *Action {
+	s.IotTopicPublish = v
+	return s
+}
+
+// SetLambda sets the Lambda field's value.
+func (s *Action) SetLambda(v *LambdaAction) *Action {
+	s.Lambda = v
+	return s
+}
+
+// SetResetTimer sets the ResetTimer field's value.
+func (s *Action) SetResetTimer(v *ResetTimerAction) *Action {
+	s.ResetTimer = v
+	return s
+}
+
+// SetSetTimer sets the SetTimer field's value.
+func (s *Action) SetSetTimer(v *SetTimerAction) *Action {
+	s.SetTimer = v
+	return s
+}
+
+// SetSetVariable sets the SetVariable field's value.
+func (s *Action) SetSetVariable(v *SetVariableAction) *Action {
+	s.SetVariable = v
+	return s
+}
+
+// SetSns sets the Sns field's value.
+func (s *Action) SetSns(v *SNSTopicPublishAction) *Action {
+	s.Sns = v
+	return s
+}
+
+// SetSqs sets the Sqs field's value.
+func (s *Action) SetSqs(v *SqsAction) *Action {
+	s.Sqs = v
 	return s
 }

@@ -2925,6 +3051,49 @@ func (s *InputSummary) SetStatus(v string) *InputSummary {
 	return s
 }

+// Sends an IoT Events input, passing in information about the detector model
+// instance and the event which triggered the action.
+type IotEventsAction struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the AWS IoT Events input where the data is sent.
+	//
+	// InputName is a required field
+	InputName *string `locationName:"inputName" min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s IotEventsAction) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s IotEventsAction) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *IotEventsAction) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "IotEventsAction"}
+	if s.InputName == nil {
+		invalidParams.Add(request.NewErrParamRequired("InputName"))
+	}
+	if s.InputName != nil && len(*s.InputName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("InputName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInputName sets the InputName field's value.
+func (s *IotEventsAction) SetInputName(v string) *IotEventsAction {
+	s.InputName = &v
+	return s
+}
+
 // Information required to publish the MQTT message via the AWS IoT message
 // broker.
 type IotTopicPublishAction struct {
```

</details>