### PR TITLE
private/model/api: Fix API doc being generated with wrong value

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `private/model/api`: Fix API doc being generated with wrong value ([#2748](https://github.com/aws/aws-sdk-go/pull/2748))
+  * Fixes the SDK's generated API documentation for structure member being generated with the wrong documentation value when the member was included multiple times in the model doc-2.json file, but under different types.

--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -17,7 +17,6 @@ import (
 )
 
 type apiDocumentation struct {
-	*API
 	Operations map[string]string
 	Service    string
 	Shapes     map[string]shapeDocumentation
@@ -30,7 +29,7 @@ type shapeDocumentation struct {
 
 // AttachDocs attaches documentation from a JSON filename.
 func (a *API) AttachDocs(filename string) {
-	d := apiDocumentation{API: a}
+	var d apiDocumentation
 
 	f, err := os.Open(filename)
 	defer f.Close()
@@ -42,39 +41,41 @@ func (a *API) AttachDocs(filename string) {
 		panic(err)
 	}
 
-	d.setup()
-
+	d.setup(a)
 }
 
-func (d *apiDocumentation) setup() {
-	d.API.Documentation = docstring(d.Service)
+func (d *apiDocumentation) setup(a *API) {
+	a.Documentation = docstring(d.Service)
 
 	for opName, doc := range d.Operations {
-		if _, ok := d.API.Operations[opName]; !ok {
+		if _, ok := a.Operations[opName]; !ok {
 			panic(fmt.Sprintf("%s, doc op %q not found in API op set",
-				d.API.name, opName),
+				a.name, opName),
 			)
 		}
-		d.API.Operations[opName].Documentation = docstring(doc)
+		a.Operations[opName].Documentation = docstring(doc)
 	}
 
-	for shape, info := range d.Shapes {
-		if sh := d.API.Shapes[shape]; sh != nil {
-			sh.Documentation = docstring(info.Base)
+	for shapeName, docShape := range d.Shapes {
+		if s, ok := a.Shapes[shapeName]; ok {
+			s.Documentation = docstring(docShape.Base)
 		}
 
-		for ref, doc := range info.Refs {
+		for ref, doc := range docShape.Refs {
 			if doc == "" {
 				continue
 			}
 
 			parts := strings.Split(ref, "$")
 			if len(parts) != 2 {
-				fmt.Fprintf(os.Stderr, "Shape Doc %s has unexpected reference format, %q\n", shape, ref)
+				fmt.Fprintf(os.Stderr,
+					"Shape Doc %s has unexpected reference format, %q\n",
+					shapeName, ref)
 				continue
 			}
-			if sh := d.API.Shapes[parts[0]]; sh != nil {
-				if m := sh.MemberRefs[parts[1]]; m != nil {
+
+			if s, ok := a.Shapes[parts[0]]; ok && len(s.MemberRefs) != 0 {
+				if m, ok := s.MemberRefs[parts[1]]; ok && m.ShapeName == shapeName {
 					m.Documentation = docstring(doc)
 				}
 			}

--- a/service/kafka/api.go
+++ b/service/kafka/api.go
@@ -2683,7 +2683,7 @@ type CreateClusterInput struct {
 	// KafkaVersion is a required field
 	KafkaVersion *string `locationName:"kafkaVersion" min:"1" type:"string" required:"true"`
 
-	// The number of broker nodes in the cluster.
+	// The number of Kafka broker nodes in the Amazon MSK cluster.
 	//
 	// NumberOfBrokerNodes is a required field
 	NumberOfBrokerNodes *int64 `locationName:"numberOfBrokerNodes" min:"1" type:"integer" required:"true"`


### PR DESCRIPTION
Fixes the SDK's generated API documentation for structure member being
generated with the wrong documentation value when the member was
included multiple times in the model doc-2.json file, but under
different types.

The SDK was not considering the member's type when associating documetation
with the member. Only parent struct name and member names was being
used.