### PR TITLE
service/kinesis: Add support for retrying service specific API errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,9 @@
   * `AWS IoT Events`'s `IotEventsAction` with `Action`. The previously deleted `Action` is available as `ActionData`.
 
 ### SDK Enhancements
+* `service/kinesis`: Add support for retrying service specific API errors ([#2751](https://github.com/aws/aws-sdk-go/pull/2751)
+  * Adds support for retrying the Kinesis API error, LimitExceededException.
+  * Fixes [#1376](https://github.com/aws/aws-sdk-go/issues/1376)
 
 ### SDK Bugs
 * `private/model/api`: Fix broken shape stutter rename during generation ([#2747](https://github.com/aws/aws-sdk-go/pull/2747))

--- a/service/kinesis/customizations.go
+++ b/service/kinesis/customizations.go
@@ -9,14 +9,14 @@ import (
 var readDuration = 5 * time.Second
 
 func init() {
-	ops := []string{
-		opGetRecords,
+	initRequest = customizeRequest
+}
+
+func customizeRequest(r *request.Request) {
+	if r.Operation.Name == opGetRecords {
+		r.ApplyOptions(request.WithResponseReadTimeout(readDuration))
 	}
-	initRequest = func(r *request.Request) {
-		for _, operation := range ops {
-			if r.Operation.Name == operation {
-				r.ApplyOptions(request.WithResponseReadTimeout(readDuration))
-			}
-		}
-	}
+
+	// Service specific error codes. Github(aws/aws-sdk-go#1376)
+	r.RetryCodes = append(r.RetryCodes, ErrCodeLimitExceededException)
 }

--- a/service/kinesis/customizations.go
+++ b/service/kinesis/customizations.go
@@ -18,5 +18,5 @@ func customizeRequest(r *request.Request) {
 	}
 
 	// Service specific error codes. Github(aws/aws-sdk-go#1376)
-	r.RetryCodes = append(r.RetryCodes, ErrCodeLimitExceededException)
+	r.RetryErrorCodes = append(r.RetryErrorCodes, ErrCodeLimitExceededException)
 }


### PR DESCRIPTION
Adds support for retrying the Kinesis API error, `LimitExceededException`.

Fix #1376