### PR TITLE
aws/credentials/stscreds: Add STS and Assume Role specific retries

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,5 +4,7 @@
 * `service/kinesis`: Add support for retrying service specific API errors ([#2751](https://github.com/aws/aws-sdk-go/pull/2751)
   * Adds support for retrying the Kinesis API error, LimitExceededException.
   * Fixes [#1376](https://github.com/aws/aws-sdk-go/issues/1376)
+* `aws/credentials/stscreds`: Add STS and Assume Role specific retries ([#2752](https://github.com/aws/aws-sdk-go/pull/2752))
+  * Adds retries to specific STS API errors to the STS AssumeRoleWithWebIdentity credential provider, and STS API operations in general.
 
 ### SDK Bugs

--- a/aws/credentials/stscreds/web_identity_provider.go
+++ b/aws/credentials/stscreds/web_identity_provider.go
@@ -76,12 +76,15 @@ func (p *WebIdentityRoleProvider) Retrieve() (credentials.Value, error) {
 		// uses unix time in nanoseconds to uniquely identify sessions.
 		sessionName = strconv.FormatInt(now().UnixNano(), 10)
 	}
-	resp, err := p.client.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+	req, resp := p.client.AssumeRoleWithWebIdentityRequest(&sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          &p.roleARN,
 		RoleSessionName:  &sessionName,
 		WebIdentityToken: aws.String(string(b)),
 	})
-	if err != nil {
+	// InvalidIdentityToken error is a temporary error that can occur
+	// when assuming an Role with a JWT web identity token.
+	req.RetryCodes = append(req.RetryCodes, sts.ErrCodeInvalidIdentityTokenException)
+	if err := req.Send(); err != nil {
 		return credentials.Value{}, awserr.New(ErrCodeWebIdentity, "failed to retrieve credentials", err)
 	}
 

--- a/aws/credentials/stscreds/web_identity_provider.go
+++ b/aws/credentials/stscreds/web_identity_provider.go
@@ -83,7 +83,7 @@ func (p *WebIdentityRoleProvider) Retrieve() (credentials.Value, error) {
 	})
 	// InvalidIdentityToken error is a temporary error that can occur
 	// when assuming an Role with a JWT web identity token.
-	req.RetryCodes = append(req.RetryCodes, sts.ErrCodeInvalidIdentityTokenException)
+	req.RetryErrorCodes = append(req.RetryErrorCodes, sts.ErrCodeInvalidIdentityTokenException)
 	if err := req.Send(); err != nil {
 		return credentials.Value{}, awserr.New(ErrCodeWebIdentity, "failed to retrieve credentials", err)
 	}

--- a/service/sts/customizations.go
+++ b/service/sts/customizations.go
@@ -1,0 +1,11 @@
+package sts
+
+import "github.com/aws/aws-sdk-go/aws/request"
+
+func init() {
+	initRequest = customizeRequest
+}
+
+func customizeRequest(r *request.Request) {
+	r.RetryCodes = append(r.RetryCodes, ErrCodeIDPCommunicationErrorException)
+}

--- a/service/sts/customizations.go
+++ b/service/sts/customizations.go
@@ -7,5 +7,5 @@ func init() {
 }
 
 func customizeRequest(r *request.Request) {
-	r.RetryCodes = append(r.RetryCodes, ErrCodeIDPCommunicationErrorException)
+	r.RetryErrorCodes = append(r.RetryErrorCodes, ErrCodeIDPCommunicationErrorException)
 }

--- a/service/sts/customizations_test.go
+++ b/service/sts/customizations_test.go
@@ -1,9 +1,15 @@
 package sts_test
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
@@ -41,5 +47,46 @@ func TestUnsignedRequest_AssumeRoleWithWebIdentity(t *testing.T) {
 	}
 	if e, a := "", req.HTTPRequest.Header.Get("Authorization"); e != a {
 		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func TestSTSCustomRetryErrorCodes(t *testing.T) {
+	svc := sts.New(unit.Session, &aws.Config{
+		MaxRetries: aws.Int(1),
+	})
+	svc.Handlers.Validate.Clear()
+
+	const xmlErr = `<ErrorResponse><Error><Code>%s</Code><Message>some error message</Message></Error></ErrorResponse>`
+	var reqCount int
+	resps := []*http.Response{
+		{
+			StatusCode: 400,
+			Header:     http.Header{},
+			Body: ioutil.NopCloser(bytes.NewReader(
+				[]byte(fmt.Sprintf(xmlErr, sts.ErrCodeIDPCommunicationErrorException)),
+			)),
+		},
+		{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+		},
+	}
+
+	req, _ := svc.AssumeRoleWithWebIdentityRequest(&sts.AssumeRoleWithWebIdentityInput{})
+	req.Handlers.Send.Swap(corehandlers.SendHandler.Name, request.NamedHandler{
+		Name: "custom send handler",
+		Fn: func(r *request.Request) {
+			r.HTTPResponse = resps[reqCount]
+			reqCount++
+		},
+	})
+
+	if err := req.Send(); err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := 2, reqCount; e != a {
+		t.Errorf("expect %v requests, got %v", e, a)
 	}
 }


### PR DESCRIPTION
Adds retries to specific STS API errors to the STS AssumeRoleWithWebIdentity credential provider, and STS API operations in general.