### PR TITLE
service/s3/s3manager: Fix typo in downloader example

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -99,7 +99,7 @@ func NewDownloader(c client.ConfigProvider, options ...func(*Downloader)) *Downl
 //     sess := session.Must(session.NewSession())
 //
 //     // The S3 client the S3 Downloader will use
-//     s3Svc := s3.new(sess)
+//     s3Svc := s3.New(sess)
 //
 //     // Create a downloader with the s3 client and default options
 //     downloader := s3manager.NewDownloaderWithClient(s3Svc)


### PR DESCRIPTION
Fixes a typo in the S3 Download Manager's NewDownloaderWithClient usage example