### PR TITLE
aws/request: Fix IsErrorRetryable returning true for nil error

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/request`: Fix IsErrorRetryable returning true for nil error ([#2774](https://github.com/aws/aws-sdk-go/pull/2774))
+  * Fixes [#2773](https://github.com/aws/aws-sdk-go/pull/2773) where the IsErrorRetryable helper was incorrectly returning true for nil errors passed in. IsErrorRetryable will now correctly return false when the passed in error is nil like documented.
+

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -126,6 +126,9 @@ func isNestedErrorRetryable(parentErr awserr.Error) bool {
 // IsErrorRetryable returns whether the error is retryable, based on its Code.
 // Returns false if error is nil.
 func IsErrorRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
 	return shouldRetryError(err)
 }
 
@@ -216,9 +219,6 @@ func IsErrorExpiredCreds(err error) bool {
 //
 // Alias for the utility function IsErrorRetryable
 func (r *Request) IsErrorRetryable() bool {
-	if r.Error == nil {
-		return false
-	}
 	if isErrCode(r.Error, r.RetryErrorCodes) {
 		return true
 	}
@@ -246,7 +246,7 @@ func (r *Request) IsErrorThrottle() bool {
 }
 
 func isErrCode(err error, codes []string) bool {
-	if aerr, ok := err.(awserr.Error); ok {
+	if aerr, ok := err.(awserr.Error); ok && aerr != nil {
 		for _, code := range codes {
 			if code == aerr.Code() {
 				return true

--- a/aws/request/retryer_test.go
+++ b/aws/request/retryer_test.go
@@ -28,34 +28,38 @@ func (e mockTempError) Temporary() bool {
 
 func TestIsErrorRetryable(t *testing.T) {
 	cases := []struct {
-		Err    error
-		IsTemp bool
+		Err       error
+		Retryable bool
 	}{
 		{
-			Err:    awserr.New(ErrCodeSerialization, "temporary error", mockTempError(true)),
-			IsTemp: true,
+			Err:       awserr.New(ErrCodeSerialization, "temporary error", mockTempError(true)),
+			Retryable: true,
 		},
 		{
-			Err:    awserr.New(ErrCodeSerialization, "temporary error", mockTempError(false)),
-			IsTemp: false,
+			Err:       awserr.New(ErrCodeSerialization, "temporary error", mockTempError(false)),
+			Retryable: false,
 		},
 		{
-			Err:    awserr.New(ErrCodeSerialization, "some error", errors.New("blah")),
-			IsTemp: false,
+			Err:       awserr.New(ErrCodeSerialization, "some error", errors.New("blah")),
+			Retryable: false,
 		},
 		{
-			Err:    awserr.New("SomeError", "some error", nil),
-			IsTemp: false,
+			Err:       awserr.New("SomeError", "some error", nil),
+			Retryable: false,
 		},
 		{
-			Err:    awserr.New("RequestError", "some error", nil),
-			IsTemp: true,
+			Err:       awserr.New("RequestError", "some error", nil),
+			Retryable: true,
+		},
+		{
+			Err:       nil,
+			Retryable: false,
 		},
 	}
 
 	for i, c := range cases {
 		retryable := IsErrorRetryable(c.Err)
-		if e, a := c.IsTemp, retryable; e != a {
+		if e, a := c.Retryable, retryable; e != a {
 			t.Errorf("%d, expect %t temporary error, got %t", i, e, a)
 		}
 	}


### PR DESCRIPTION
Fixes #2773 where the IsErrorRetryable helper was incorrectly returning true for nil errors passed in. IsErrorRetryable will now correctly return false when the passed in error is nil like documented.