### PR TITLE
service/dynamodb/expression: Improved reporting of bad key conditions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+
+* `service/dynamodb/expression`: Improved reporting of bad key conditions ([#2775](https://github.com/aws/aws-sdk-go/pull/2775))
+  * Improved error reporting when invalid key conditions are constructed using KeyConditionBuilder

--- a/service/dynamodb/expression/key_condition.go
+++ b/service/dynamodb/expression/key_condition.go
@@ -11,6 +11,8 @@ type keyConditionMode int
 const (
 	// unsetKeyCond catches errors for unset KeyConditionBuilder structs
 	unsetKeyCond keyConditionMode = iota
+	// invalidKeyCond catches errors in the construction of KeyConditionBuilder structs
+	invalidKeyCond
 	// equalKeyCond represents the Equals KeyCondition
 	equalKeyCond
 	// lessThanKeyCond represents the Less Than KeyCondition
@@ -305,12 +307,12 @@ func (kb KeyBuilder) GreaterThanEqual(valueBuilder ValueBuilder) KeyConditionBui
 func KeyAnd(left, right KeyConditionBuilder) KeyConditionBuilder {
 	if left.mode != equalKeyCond {
 		return KeyConditionBuilder{
-			mode: andKeyCond,
+			mode: invalidKeyCond,
 		}
 	}
 	if right.mode == andKeyCond {
 		return KeyConditionBuilder{
-			mode: andKeyCond,
+			mode: invalidKeyCond,
 		}
 	}
 	return KeyConditionBuilder{
@@ -468,6 +470,8 @@ func (kcb KeyConditionBuilder) buildTree() (exprNode, error) {
 		return beginsWithBuildKeyCondition(ret)
 	case unsetKeyCond:
 		return exprNode{}, newUnsetParameterError("buildTree", "KeyConditionBuilder")
+	case invalidKeyCond:
+		return exprNode{}, fmt.Errorf("buildKeyCondition error: invalid key condition constructed")
 	default:
 		return exprNode{}, fmt.Errorf("buildKeyCondition error: unsupported mode: %v", kcb.mode)
 	}

--- a/service/dynamodb/expression/key_condition_test.go
+++ b/service/dynamodb/expression/key_condition_test.go
@@ -22,9 +22,9 @@ const (
 	// invalidKeyConditionOperand error will occur when an invalid OperandBuilder is used as
 	// an argument
 	invalidKeyConditionOperand = "BuildOperand error"
-	// invalidAndFormat error will occur when the first key condition is not an equal
-	// clause or if the second key condition is an and condition.
-	invalidAndFormat = "invalid parameter: KeyConditionBuilder"
+	// invalidKeyConditionFormat error will occur when the first key condition is not an equal
+	// clause or if more then one And condition is provided
+	invalidKeyConditionFormat = "buildKeyCondition error: invalid key condition constructed"
 )
 
 func TestKeyCompare(t *testing.T) {
@@ -336,12 +336,12 @@ func TestKeyAnd(t *testing.T) {
 		{
 			name:  "first condition is not equal",
 			input: Key("foo").LessThan(Value(5)).And(Key("bar").BeginsWith("baz")),
-			err:   invalidAndFormat,
+			err:   invalidKeyConditionFormat,
 		},
 		{
-			name:  "second condition is and",
+			name:  "more then one condition on key",
 			input: Key("foo").Equal(Value(5)).And(Key("bar").Equal(Value(1)).And(Key("baz").BeginsWith("yar"))),
-			err:   invalidAndFormat,
+			err:   invalidKeyConditionFormat,
 		},
 		{
 			name:  "operand error",


### PR DESCRIPTION
Improves the reporting of errors when an invalid key condition is constructed using the DynamoDB expression package.
