### PR TITLE
Added X-Ray support to s3crypto

### DIFF
--- a/service/s3/s3crypto/aes_cbc_content_cipher.go
+++ b/service/s3/s3crypto/aes_cbc_content_cipher.go
@@ -3,6 +3,8 @@ package s3crypto
 import (
 	"io"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 const (
@@ -21,8 +23,8 @@ func AESCBCContentCipherBuilder(generator CipherDataGenerator, padder Padder) Co
 	return cbcContentCipherBuilder{generator: generator, padder: padder}
 }
 
-func (builder cbcContentCipherBuilder) ContentCipher() (ContentCipher, error) {
-	cd, err := builder.generator.GenerateCipherData(cbcKeySize, cbcNonceSize)
+func (builder cbcContentCipherBuilder) ContentCipher(ctx aws.Context) (ContentCipher, error) {
+	cd, err := builder.generator.GenerateCipherData(ctx, cbcKeySize, cbcNonceSize)
 	if err != nil {
 		return nil, err
 	}

--- a/service/s3/s3crypto/aes_cbc_content_cipher_test.go
+++ b/service/s3/s3crypto/aes_cbc_content_cipher_test.go
@@ -1,6 +1,7 @@
 package s3crypto_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
@@ -13,7 +14,7 @@ func TestAESCBCBuilder(t *testing.T) {
 		t.Fatal(builder)
 	}
 
-	_, err := builder.ContentCipher()
+	_, err := builder.ContentCipher(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/s3/s3crypto/aes_cbc_content_cipher_test.go
+++ b/service/s3/s3crypto/aes_cbc_content_cipher_test.go
@@ -1,9 +1,9 @@
 package s3crypto_test
 
 import (
-	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
 )
 
@@ -14,7 +14,7 @@ func TestAESCBCBuilder(t *testing.T) {
 		t.Fatal(builder)
 	}
 
-	_, err := builder.ContentCipher(context.Background())
+	_, err := builder.ContentCipher(&awstesting.FakeContext{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/s3/s3crypto/aes_gcm_content_cipher.go
+++ b/service/s3/s3crypto/aes_gcm_content_cipher.go
@@ -2,6 +2,8 @@ package s3crypto
 
 import (
 	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 const (
@@ -19,8 +21,8 @@ func AESGCMContentCipherBuilder(generator CipherDataGenerator) ContentCipherBuil
 	return gcmContentCipherBuilder{generator}
 }
 
-func (builder gcmContentCipherBuilder) ContentCipher() (ContentCipher, error) {
-	cd, err := builder.generator.GenerateCipherData(gcmKeySize, gcmNonceSize)
+func (builder gcmContentCipherBuilder) ContentCipher(ctx aws.Context) (ContentCipher, error) {
+	cd, err := builder.generator.GenerateCipherData(ctx, gcmKeySize, gcmNonceSize)
 	if err != nil {
 		return nil, err
 	}

--- a/service/s3/s3crypto/aes_gcm_content_cipher_test.go
+++ b/service/s3/s3crypto/aes_gcm_content_cipher_test.go
@@ -1,9 +1,9 @@
 package s3crypto_test
 
 import (
-	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
 )
 
@@ -17,7 +17,7 @@ func TestAESGCMContentCipherBuilder(t *testing.T) {
 func TestAESGCMContentCipherNewEncryptor(t *testing.T) {
 	generator := mockGenerator{}
 	builder := s3crypto.AESGCMContentCipherBuilder(generator)
-	cipher, err := builder.ContentCipher(context.Background())
+	cipher, err := builder.ContentCipher(&awstesting.FakeContext{})
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)

--- a/service/s3/s3crypto/aes_gcm_content_cipher_test.go
+++ b/service/s3/s3crypto/aes_gcm_content_cipher_test.go
@@ -1,6 +1,7 @@
 package s3crypto_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
@@ -16,7 +17,7 @@ func TestAESGCMContentCipherBuilder(t *testing.T) {
 func TestAESGCMContentCipherNewEncryptor(t *testing.T) {
 	generator := mockGenerator{}
 	builder := s3crypto.AESGCMContentCipherBuilder(generator)
-	cipher, err := builder.ContentCipher()
+	cipher, err := builder.ContentCipher(context.Background())
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)

--- a/service/s3/s3crypto/cipher_builder.go
+++ b/service/s3/s3crypto/cipher_builder.go
@@ -1,11 +1,15 @@
 package s3crypto
 
-import "io"
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
 
 // ContentCipherBuilder is a builder interface that builds
 // ciphers for each request.
 type ContentCipherBuilder interface {
-	ContentCipher() (ContentCipher, error)
+	ContentCipher(aws.Context) (ContentCipher, error)
 }
 
 // ContentCipher deals with encrypting and decrypting content

--- a/service/s3/s3crypto/cipher_util.go
+++ b/service/s3/s3crypto/cipher_util.go
@@ -1,15 +1,15 @@
 package s3crypto
 
 import (
-	"context"
 	"encoding/base64"
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func (client *DecryptionClient) contentCipherFromEnvelope(ctx context.Context, env Envelope) (ContentCipher, error) {
+func (client *DecryptionClient) contentCipherFromEnvelope(ctx aws.Context, env Envelope) (ContentCipher, error) {
 	wrap, err := client.wrapFromEnvelope(env)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ const AESGCMNoPadding = "AES/GCM/NoPadding"
 // AESCBC is the string constant that signifies the AES CBC algorithm cipher.
 const AESCBC = "AES/CBC"
 
-func (client *DecryptionClient) cekFromEnvelope(ctx context.Context, env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
+func (client *DecryptionClient) cekFromEnvelope(ctx aws.Context, env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
 	f, ok := client.CEKRegistry[env.CEKAlg]
 	if !ok || f == nil {
 		return nil, awserr.New(

--- a/service/s3/s3crypto/cipher_util.go
+++ b/service/s3/s3crypto/cipher_util.go
@@ -1,6 +1,7 @@
 package s3crypto
 
 import (
+	"context"
 	"encoding/base64"
 	"strconv"
 	"strings"
@@ -8,13 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func (client *DecryptionClient) contentCipherFromEnvelope(env Envelope) (ContentCipher, error) {
+func (client *DecryptionClient) contentCipherFromEnvelope(ctx context.Context, env Envelope) (ContentCipher, error) {
 	wrap, err := client.wrapFromEnvelope(env)
 	if err != nil {
 		return nil, err
 	}
 
-	return client.cekFromEnvelope(env, wrap)
+	return client.cekFromEnvelope(ctx, env, wrap)
 }
 
 func (client *DecryptionClient) wrapFromEnvelope(env Envelope) (CipherDataDecrypter, error) {
@@ -36,7 +37,7 @@ const AESGCMNoPadding = "AES/GCM/NoPadding"
 // AESCBC is the string constant that signifies the AES CBC algorithm cipher.
 const AESCBC = "AES/CBC"
 
-func (client *DecryptionClient) cekFromEnvelope(env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
+func (client *DecryptionClient) cekFromEnvelope(ctx context.Context, env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
 	f, ok := client.CEKRegistry[env.CEKAlg]
 	if !ok || f == nil {
 		return nil, awserr.New(
@@ -55,7 +56,7 @@ func (client *DecryptionClient) cekFromEnvelope(env Envelope, decrypter CipherDa
 	if err != nil {
 		return nil, err
 	}
-	key, err = decrypter.DecryptKey(key)
+	key, err = decrypter.DecryptKey(ctx, key)
 	if err != nil {
 		return nil, err
 	}

--- a/service/s3/s3crypto/cipher_util_test.go
+++ b/service/s3/s3crypto/cipher_util_test.go
@@ -1,7 +1,6 @@
 package s3crypto
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/kms"
 )
@@ -141,7 +141,7 @@ func TestCEKFactory(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
+	cek, err := c.cekFromEnvelope(&awstesting.FakeContext{}, env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -200,7 +200,7 @@ func TestCEKFactoryNoCEK(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
+	cek, err := c.cekFromEnvelope(&awstesting.FakeContext{}, env, wrap)
 
 	if err == nil {
 		t.Error("expected error, but received none")
@@ -257,7 +257,7 @@ func TestCEKFactoryCustomEntry(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
+	cek, err := c.cekFromEnvelope(&awstesting.FakeContext{}, env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)

--- a/service/s3/s3crypto/cipher_util_test.go
+++ b/service/s3/s3crypto/cipher_util_test.go
@@ -1,6 +1,7 @@
 package s3crypto
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -140,7 +141,7 @@ func TestCEKFactory(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -199,7 +200,7 @@ func TestCEKFactoryNoCEK(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
 
 	if err == nil {
 		t.Error("expected error, but received none")
@@ -256,7 +257,7 @@ func TestCEKFactoryCustomEntry(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(context.Background(), env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"golang.org/x/net/context"
 )
 
 // WrapEntry is builder that return a proper key decrypter and error
@@ -117,7 +116,7 @@ func (c *DecryptionClient) GetObjectRequest(ctx aws.Context, input *s3.GetObject
 
 // GetObject is a wrapper for GetObjectRequest
 func (c *DecryptionClient) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-	req, out := c.GetObjectRequest(context.Background(), input)
+	req, out := c.GetObjectRequest(aws.BackgroundContext(), input)
 	return out, req.Send()
 }
 

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -1,7 +1,6 @@
 package s3crypto
 
 import (
-	"context"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"golang.org/x/net/context"
 )
 
 // WrapEntry is builder that return a proper key decrypter and error

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -85,7 +85,7 @@ func NewDecryptionClient(prov client.ConfigProvider, options ...func(*Decryption
 //	  Bucket: aws.String("testBucket"),
 //	})
 //	err := req.Send()
-func (c *DecryptionClient) GetObjectRequest(ctx context.Context, input *s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
+func (c *DecryptionClient) GetObjectRequest(ctx aws.Context, input *s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
 	req, out := c.S3Client.GetObjectRequest(input)
 	req.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		env, err := c.LoadStrategy.Load(r)

--- a/service/s3/s3crypto/decryption_client_test.go
+++ b/service/s3/s3crypto/decryption_client_test.go
@@ -2,7 +2,6 @@ package s3crypto_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -46,7 +45,7 @@ func TestGetObjectGCM(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(context.Background(), input)
+	req, out := c.GetObjectRequest(&awstesting.FakeContext{}, input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		iv, err := hex.DecodeString("0d18e06c7c725ac9e362e1ce")
@@ -117,7 +116,7 @@ func TestGetObjectCBC(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(context.Background(), input)
+	req, out := c.GetObjectRequest(&awstesting.FakeContext{}, input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		iv, err := hex.DecodeString("9dea7621945988f96491083849b068df")
@@ -186,7 +185,7 @@ func TestGetObjectCBC2(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(context.Background(), input)
+	req, out := c.GetObjectRequest(&awstesting.FakeContext{}, input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		b, err := hex.DecodeString("fd0c71ecb7ed16a9bf42ea5f75501d416df608f190890c3b4d8897f24744cd7f9ea4a0b212e60634302450e1c5378f047ff753ccefe365d411c36339bf22e301fae4c3a6226719a4b93dc74c1af79d0296659b5d56c0892315f2c7cc30190220db1eaafae3920d6d9c65d0aa366499afc17af493454e141c6e0fbdeb6a990cb4")

--- a/service/s3/s3crypto/decryption_client_test.go
+++ b/service/s3/s3crypto/decryption_client_test.go
@@ -2,6 +2,7 @@ package s3crypto_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -45,7 +46,7 @@ func TestGetObjectGCM(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(input)
+	req, out := c.GetObjectRequest(context.Background(), input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		iv, err := hex.DecodeString("0d18e06c7c725ac9e362e1ce")
@@ -116,7 +117,7 @@ func TestGetObjectCBC(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(input)
+	req, out := c.GetObjectRequest(context.Background(), input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		iv, err := hex.DecodeString("9dea7621945988f96491083849b068df")
@@ -185,7 +186,7 @@ func TestGetObjectCBC2(t *testing.T) {
 		Key:    aws.String("test"),
 		Bucket: aws.String("test"),
 	}
-	req, out := c.GetObjectRequest(input)
+	req, out := c.GetObjectRequest(context.Background(), input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		b, err := hex.DecodeString("fd0c71ecb7ed16a9bf42ea5f75501d416df608f190890c3b4d8897f24744cd7f9ea4a0b212e60634302450e1c5378f047ff753ccefe365d411c36339bf22e301fae4c3a6226719a4b93dc74c1af79d0296659b5d56c0892315f2c7cc30190220db1eaafae3920d6d9c65d0aa366499afc17af493454e141c6e0fbdeb6a990cb4")

--- a/service/s3/s3crypto/encryption_client.go
+++ b/service/s3/s3crypto/encryption_client.go
@@ -1,10 +1,10 @@
 package s3crypto
 
 import (
-	"context"
 	"encoding/hex"
 	"io"
 
+	"golang.org/x/net/context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"

--- a/service/s3/s3crypto/encryption_client_test.go
+++ b/service/s3/s3crypto/encryption_client_test.go
@@ -2,6 +2,7 @@ package s3crypto_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -61,7 +62,7 @@ func TestPutObject(t *testing.T) {
 		Bucket: aws.String("test"),
 		Body:   bytes.NewReader(data),
 	}
-	req, _ := c.PutObjectRequest(input)
+	req, _ := c.PutObjectRequest(context.Background(), input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		r.Error = errors.New("stop")

--- a/service/s3/s3crypto/encryption_client_test.go
+++ b/service/s3/s3crypto/encryption_client_test.go
@@ -2,7 +2,6 @@ package s3crypto_test
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -62,7 +61,7 @@ func TestPutObject(t *testing.T) {
 		Bucket: aws.String("test"),
 		Body:   bytes.NewReader(data),
 	}
-	req, _ := c.PutObjectRequest(context.Background(), input)
+	req, _ := c.PutObjectRequest(&awstesting.FakeContext{}, input)
 	req.Handlers.Send.Clear()
 	req.Handlers.Send.PushBack(func(r *request.Request) {
 		r.Error = errors.New("stop")

--- a/service/s3/s3crypto/key_handler.go
+++ b/service/s3/s3crypto/key_handler.go
@@ -1,6 +1,9 @@
 package s3crypto
 
-import "crypto/rand"
+import (
+	"context"
+	"crypto/rand"
+)
 
 // CipherDataGenerator handles generating proper key and IVs of proper size for the
 // content cipher. CipherDataGenerator will also encrypt the key and store it in
@@ -11,7 +14,7 @@ type CipherDataGenerator interface {
 
 // CipherDataDecrypter is a handler to decrypt keys from the envelope.
 type CipherDataDecrypter interface {
-	DecryptKey([]byte) ([]byte, error)
+	DecryptKey(context.Context, []byte) ([]byte, error)
 }
 
 func generateBytes(n int) []byte {

--- a/service/s3/s3crypto/key_handler.go
+++ b/service/s3/s3crypto/key_handler.go
@@ -1,8 +1,9 @@
 package s3crypto
 
 import (
-	"context"
 	"crypto/rand"
+
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 // CipherDataGenerator handles generating proper key and IVs of proper size for the
@@ -14,7 +15,7 @@ type CipherDataGenerator interface {
 
 // CipherDataDecrypter is a handler to decrypt keys from the envelope.
 type CipherDataDecrypter interface {
-	DecryptKey(context.Context, []byte) ([]byte, error)
+	DecryptKey(aws.Context, []byte) ([]byte, error)
 }
 
 func generateBytes(n int) []byte {

--- a/service/s3/s3crypto/key_handler.go
+++ b/service/s3/s3crypto/key_handler.go
@@ -10,7 +10,7 @@ import (
 // content cipher. CipherDataGenerator will also encrypt the key and store it in
 // the CipherData.
 type CipherDataGenerator interface {
-	GenerateCipherData(int, int) (CipherData, error)
+	GenerateCipherData(aws.Context, int, int) (CipherData, error)
 }
 
 // CipherDataDecrypter is a handler to decrypt keys from the envelope.

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -111,8 +111,8 @@ func (kp *kmsKeyHandler) DecryptKey(ctx aws.Context, key []byte) ([]byte, error)
 
 // GenerateCipherData makes a call to KMS to generate a data key, Upon making
 // the call, it also sets the encrypted key.
-func (kp *kmsKeyHandler) GenerateCipherData(keySize, ivSize int) (CipherData, error) {
-	out, err := kp.kms.GenerateDataKey(&kms.GenerateDataKeyInput{
+func (kp *kmsKeyHandler) GenerateCipherData(ctx aws.Context, keySize, ivSize int) (CipherData, error) {
+	out, err := kp.kms.GenerateDataKeyWithContext(ctx, &kms.GenerateDataKeyInput{
 		EncryptionContext: kp.CipherData.MaterialDescription,
 		KeyId:             kp.cmkID,
 		KeySpec:           aws.String("AES_256"),

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -1,6 +1,8 @@
 package s3crypto
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -97,8 +99,8 @@ func (kp kmsKeyHandler) decryptHandler(env Envelope) (CipherDataDecrypter, error
 }
 
 // DecryptKey makes a call to KMS to decrypt the key.
-func (kp *kmsKeyHandler) DecryptKey(key []byte) ([]byte, error) {
-	out, err := kp.kms.Decrypt(&kms.DecryptInput{
+func (kp *kmsKeyHandler) DecryptKey(ctx context.Context, key []byte) ([]byte, error) {
+	out, err := kp.kms.DecryptWithContext(ctx, &kms.DecryptInput{
 		EncryptionContext: map[string]*string(kp.CipherData.MaterialDescription),
 		CiphertextBlob:    key,
 		GrantTokens:       []*string{},

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -1,8 +1,6 @@
 package s3crypto
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -99,7 +97,7 @@ func (kp kmsKeyHandler) decryptHandler(env Envelope) (CipherDataDecrypter, error
 }
 
 // DecryptKey makes a call to KMS to decrypt the key.
-func (kp *kmsKeyHandler) DecryptKey(ctx context.Context, key []byte) ([]byte, error) {
+func (kp *kmsKeyHandler) DecryptKey(ctx aws.Context, key []byte) ([]byte, error) {
 	out, err := kp.kms.DecryptWithContext(ctx, &kms.DecryptInput{
 		EncryptionContext: map[string]*string(kp.CipherData.MaterialDescription),
 		CiphertextBlob:    key,

--- a/service/s3/s3crypto/kms_key_handler_test.go
+++ b/service/s3/s3crypto/kms_key_handler_test.go
@@ -2,6 +2,7 @@ package s3crypto
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -93,7 +94,7 @@ func TestKMSDecrypt(t *testing.T) {
 		t.Errorf("expected no error, but received %v", err)
 	}
 
-	plaintextKey, err := handler.DecryptKey([]byte{1, 2, 3, 4})
+	plaintextKey, err := handler.DecryptKey(context.Background(), []byte{1, 2, 3, 4})
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/service/s3/s3crypto/kms_key_handler_test.go
+++ b/service/s3/s3crypto/kms_key_handler_test.go
@@ -63,7 +63,7 @@ func TestKMSGenerateCipherData(t *testing.T) {
 	keySize := 32
 	ivSize := 16
 
-	cd, err := handler.GenerateCipherData(keySize, ivSize)
+	cd, err := handler.GenerateCipherData(context.Background(), keySize, ivSize)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/service/s3/s3crypto/kms_key_handler_test.go
+++ b/service/s3/s3crypto/kms_key_handler_test.go
@@ -2,7 +2,6 @@ package s3crypto
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/kms"
 )
@@ -63,7 +63,7 @@ func TestKMSGenerateCipherData(t *testing.T) {
 	keySize := 32
 	ivSize := 16
 
-	cd, err := handler.GenerateCipherData(context.Background(), keySize, ivSize)
+	cd, err := handler.GenerateCipherData(&awstesting.FakeContext{}, keySize, ivSize)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}
@@ -94,7 +94,7 @@ func TestKMSDecrypt(t *testing.T) {
 		t.Errorf("expected no error, but received %v", err)
 	}
 
-	plaintextKey, err := handler.DecryptKey(context.Background(), []byte{1, 2, 3, 4})
+	plaintextKey, err := handler.DecryptKey(&awstesting.FakeContext{}, []byte{1, 2, 3, 4})
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
 	}

--- a/service/s3/s3crypto/mock_test.go
+++ b/service/s3/s3crypto/mock_test.go
@@ -2,6 +2,7 @@ package s3crypto_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 
@@ -25,7 +26,7 @@ func (m mockGenerator) EncryptKey(key []byte) ([]byte, error) {
 	return b, nil
 }
 
-func (m mockGenerator) DecryptKey(key []byte) ([]byte, error) {
+func (m mockGenerator) DecryptKey(_ context.Context, key []byte) ([]byte, error) {
 	return make([]byte, 16), nil
 
 }

--- a/service/s3/s3crypto/mock_test.go
+++ b/service/s3/s3crypto/mock_test.go
@@ -2,17 +2,17 @@ package s3crypto_test
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
 )
 
 type mockGenerator struct {
 }
 
-func (m mockGenerator) GenerateCipherData(keySize, ivSize int) (s3crypto.CipherData, error) {
+func (m mockGenerator) GenerateCipherData(_ aws.Context, keySize, ivSize int) (s3crypto.CipherData, error) {
 	cd := s3crypto.CipherData{
 		Key: make([]byte, keySize),
 		IV:  make([]byte, ivSize),
@@ -26,7 +26,7 @@ func (m mockGenerator) EncryptKey(key []byte) ([]byte, error) {
 	return b, nil
 }
 
-func (m mockGenerator) DecryptKey(_ context.Context, key []byte) ([]byte, error) {
+func (m mockGenerator) DecryptKey(_ aws.Context, key []byte) ([]byte, error) {
 	return make([]byte, 16), nil
 
 }
@@ -35,8 +35,8 @@ type mockCipherBuilder struct {
 	generator s3crypto.CipherDataGenerator
 }
 
-func (builder mockCipherBuilder) ContentCipher() (s3crypto.ContentCipher, error) {
-	cd, err := builder.generator.GenerateCipherData(32, 16)
+func (builder mockCipherBuilder) ContentCipher(ctx aws.Context) (s3crypto.ContentCipher, error) {
+	cd, err := builder.generator.GenerateCipherData(ctx, 32, 16)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The s3crypto package was not passing a context object down to the KMS client calls so panics were being emitted by the X-Ray SDK.

The KMS client now calls `DecryptWithContext` and `GenerateDataKeyWithContext`.

This PR fixes with the absolute minimum number of changes I could make.

To support Go 1.5 and 1.6 which doesn't have a native `context` package I imported `golang.org/x/net/context` into `decryption_client.go` and `encryption_client.go` - if there is a preferred solution please let me know.