### PR TITLE
 service/s3/s3manager: Add Upload Buffer Provider

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,5 +5,6 @@
   * Non-Windows platforms will continue to employ a non-buffering behavior.
 
 ### SDK Enhancements
+* `awstesting/integration/performance/s3UploadManager`: Extended to support benchmarking and usage of new `BufferProvider` ([#2792](https://github.com/aws/aws-sdk-go/pull/2792))
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,8 @@
 ### SDK Features
+* `service/s3/s3manager`: Add Upload Buffer Provider ([#2792](https://github.com/aws/aws-sdk-go/pull/2792))
+  * Adds a new `BufferProvider` member for specifying how part data can be buffered in memory.
+  * Windows platforms will now default to buffering 1MB per part to reduce contention when uploading files.
+  * Non-Windows platforms will continue to employ a non-buffering behavior.
 
 ### SDK Enhancements
 

--- a/awstesting/integration/integration.go
+++ b/awstesting/integration/integration.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,6 +38,39 @@ func UniqueID() string {
 	uuid := make([]byte, 16)
 	io.ReadFull(rand.Reader, uuid)
 	return fmt.Sprintf("%x", uuid)
+}
+
+// CreateFileOfSize will return an *os.File that is of size bytes
+func CreateFileOfSize(dir string, size int64) (*os.File, error) {
+	file, err := ioutil.TempFile(dir, "s3Bench")
+	if err != nil {
+		return nil, err
+	}
+
+	err = file.Truncate(size)
+	if err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// SizeToName returns a human-readable string for the given size bytes
+func SizeToName(size int) string {
+	units := []string{"B", "KB", "MB", "GB"}
+	i := 0
+	for size >= 1024 {
+		size /= 1024
+		i++
+	}
+
+	if i > len(units)-1 {
+		i = len(units) - 1
+	}
+
+	return fmt.Sprintf("%d%s", size, units[i])
 }
 
 // SessionWithDefaultRegion returns a copy of the integration session with the

--- a/awstesting/integration/performance/s3UploadManager/README.md
+++ b/awstesting/integration/performance/s3UploadManager/README.md
@@ -3,8 +3,18 @@
 Uploads a file to a S3 bucket using the SDK's S3 upload manager. Allows passing
 in custom configuration for the HTTP client and SDK's Upload Manager behavior.
 
-## Usage Example:
+## Build
+### Standalone
+```sh
+go build -tags "integration perftest" -o s3UploadPerfGo ./awstesting/integration/performance/s3UploadManager
+```
+### Benchmarking
+```sh
+go test -tags "integration perftest" -c -o s3UploadPerfGo ./awstesting/integration/performance/s3UploadManager
+```
 
+## Usage Example:
+### Standalone
 ```sh
 AWS_REGION=us-west-2 AWS_PROFILE=aws-go-sdk-team-test ./s3UploadPerfGo \
 -bucket aws-sdk-go-data \
@@ -15,6 +25,19 @@ AWS_REGION=us-west-2 AWS_PROFILE=aws-go-sdk-team-test ./s3UploadPerfGo \
 -sdk.concurrency 100 \
 -sdk.unsigned \
 -sdk.100-continue=false \
+-client.timeout.connect=1s \
+-client.timeout.response-header=1s
+```
+
+### Benchmarking
+```sh
+AWS_REGION=us-west-2 AWS_PROFILE=aws-go-sdk-team-test ./s3UploadPerfGo \
+-test.bench=. \
+-test.benchmem \
+-test.benchtime 1x \
+-bucket aws-sdk-go-data \
+-client.idle-conns 1000 \
+-client.idle-conns-host 300 \
 -client.timeout.connect=1s \
 -client.timeout.response-header=1s
 ```

--- a/awstesting/integration/performance/s3UploadManager/main.go
+++ b/awstesting/integration/performance/s3UploadManager/main.go
@@ -4,86 +4,50 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/awstesting/integration"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 var config Config
 
-func init() {
-	config.SetupFlags("", flag.CommandLine)
-}
-
 func main() {
-	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
-		flag.CommandLine.PrintDefaults()
-		log.Fatalf("failed to parse CLI commands")
-	}
-	if err := config.Validate(); err != nil {
-		flag.CommandLine.PrintDefaults()
-		log.Fatalf("invalid arguments")
+	parseCommandLine()
+
+	log.SetOutput(os.Stderr)
+
+	var (
+		file *os.File
+		err  error
+	)
+
+	if config.Filename != "" {
+		file, err = os.Open(config.Filename)
+		if err != nil {
+			log.Fatalf("failed to open file: %v", err)
+		}
+	} else {
+		file, err = integration.CreateFileOfSize(config.TempDir, config.Size)
+		if err != nil {
+			log.Fatalf("failed to create file: %v", err)
+		}
+		defer os.Remove(file.Name())
 	}
 
-	client := NewClient(config.Client)
-
-	file, err := os.Open(config.Filename)
-	if err != nil {
-		log.Fatalf("unable to open file to upload, %v", err)
-	}
 	defer file.Close()
 
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-			HTTPClient:           client,
-			S3Disable100Continue: aws.Bool(!config.SDK.ExpectContinue),
-		},
-		SharedConfigState: session.SharedConfigEnable,
-	})
-	if err != nil {
-		log.Fatalf("failed to load session, %v", err)
-	}
-
 	traces := make(chan *RequestTrace, config.SDK.Concurrency)
-	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
-		u.PartSize = config.SDK.PartSize
-		u.Concurrency = config.SDK.Concurrency
-
-		u.RequestOptions = append(u.RequestOptions,
-			func(r *request.Request) {
-				id := "op"
-				if v, ok := r.Params.(*s3.UploadPartInput); ok {
-					id = strconv.FormatInt(*v.PartNumber, 10)
-				}
-				tracer := NewRequestTrace(r.Context(), r.Operation.Name, id)
-				r.SetContext(tracer)
-
-				r.Handlers.Send.PushFront(tracer.OnSendAttempt)
-				r.Handlers.CompleteAttempt.PushBack(tracer.OnCompleteAttempt)
-				r.Handlers.CompleteAttempt.PushBack(func(rr *request.Request) {
-				})
-				r.Handlers.Complete.PushBack(tracer.OnComplete)
-				r.Handlers.Complete.PushBack(func(rr *request.Request) {
-					traces <- tracer
-				})
-
-				if config.SDK.WithUnsignedPayload {
-					if r.Operation.Name != "UploadPart" {
-						return
-					}
-					r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
-				}
-			},
-		)
-	})
+	requestTracer := uploadRequestTracer(traces)
+	uploader := newUploader(config.Client, config.SDK, requestTracer)
 
 	metricReportDone := make(chan struct{})
 	go func() {
@@ -108,6 +72,7 @@ func main() {
 			"CreateMultipartUpload",
 			"CompleteMultipartUpload",
 			"UploadPart",
+			"PutObject",
 		} {
 			if trace, ok := metrics[name]; ok {
 				printAttempts(name, trace, config.LogVerbose)
@@ -115,11 +80,11 @@ func main() {
 		}
 	}()
 
-	fmt.Println("Starting upload...")
+	log.Println("starting upload...")
 	start := time.Now()
 	_, err = uploader.Upload(&s3manager.UploadInput{
 		Bucket: &config.Bucket,
-		Key:    &config.Key,
+		Key:    aws.String(filepath.Base(file.Name())),
 		Body:   file,
 	})
 	if err != nil {
@@ -130,29 +95,100 @@ func main() {
 	fileInfo, _ := file.Stat()
 	size := fileInfo.Size()
 	dur := time.Since(start)
-	fmt.Printf("Upload finished, Size: %d, Dur: %s, Throughput: %.5f GB/s\n",
+	log.Printf("Upload finished, Size: %d, Dur: %s, Throughput: %.5f GB/s",
 		size, dur, (float64(size)/(float64(dur)/float64(time.Second)))/float64(1e9),
 	)
 
 	<-metricReportDone
 }
 
-func printAttempts(op string, trace *RequestTrace, verbose bool) {
-	fmt.Println(op+":",
-		"latency:", trace.finish.Sub(trace.start),
-		"requests:", len(trace.attempts),
-		"errors:", len(trace.errs),
-	)
+func parseCommandLine() {
+	config.SetupFlags("", flag.CommandLine)
 
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		flag.CommandLine.PrintDefaults()
+		log.Fatalf("failed to parse CLI commands")
+	}
+	if err := config.Validate(); err != nil {
+		flag.CommandLine.PrintDefaults()
+		log.Fatalf("invalid arguments: %v", err)
+	}
+}
+
+func printAttempts(op string, trace *RequestTrace, verbose bool) {
 	if !verbose {
 		return
 	}
 
+	log.Printf("%s: latency:%s requests:%d errors:%d",
+		op,
+		trace.finish.Sub(trace.start),
+		len(trace.attempts),
+		len(trace.errs),
+	)
+
 	for _, a := range trace.attempts {
-		fmt.Printf("  * %s\n", a)
+		log.Printf("  * %s", a)
 	}
 	if err := trace.Err(); err != nil {
-		fmt.Println("Operation Errors:", err)
+		log.Printf("Operation Errors: %v", err)
 	}
-	fmt.Println()
+	log.Println()
+}
+
+func uploadRequestTracer(traces chan<- *RequestTrace) request.Option {
+	tracerOption := func(r *request.Request) {
+		id := "op"
+		if v, ok := r.Params.(*s3.UploadPartInput); ok {
+			id = strconv.FormatInt(*v.PartNumber, 10)
+		}
+		tracer := NewRequestTrace(r.Context(), r.Operation.Name, id)
+		r.SetContext(tracer)
+
+		r.Handlers.Send.PushFront(tracer.OnSendAttempt)
+		r.Handlers.CompleteAttempt.PushBack(tracer.OnCompleteAttempt)
+		r.Handlers.Complete.PushBack(tracer.OnComplete)
+		r.Handlers.Complete.PushBack(func(rr *request.Request) {
+			traces <- tracer
+		})
+	}
+
+	return tracerOption
+}
+
+func SetUnsignedPayload(r *request.Request) {
+	if r.Operation.Name != "UploadPart" && r.Operation.Name != "PutObject" {
+		return
+	}
+	r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
+}
+
+func newUploader(clientConfig ClientConfig, sdkConfig SDKConfig, options ...request.Option) *s3manager.Uploader {
+	client := NewClient(clientConfig)
+
+	if sdkConfig.WithUnsignedPayload {
+		options = append(options, SetUnsignedPayload)
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			HTTPClient:                    client,
+			S3Disable100Continue:          aws.Bool(!sdkConfig.ExpectContinue),
+			S3DisableContentMD5Validation: aws.Bool(!sdkConfig.WithContentMD5),
+		},
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Fatalf("failed to load session, %v", err)
+	}
+
+	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
+		u.PartSize = sdkConfig.PartSize
+		u.Concurrency = sdkConfig.Concurrency
+		u.BufferProvider = sdkConfig.BufferProvider
+
+		u.RequestOptions = append(u.RequestOptions, options...)
+	})
+
+	return uploader
 }

--- a/awstesting/integration/performance/s3UploadManager/main_test.go
+++ b/awstesting/integration/performance/s3UploadManager/main_test.go
@@ -1,0 +1,139 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+var benchConfig BenchmarkConfig
+
+type BenchmarkConfig struct {
+	bucket       string
+	tempdir      string
+	clientConfig ClientConfig
+}
+
+func (b *BenchmarkConfig) SetupFlags(prefix string, flagSet *flag.FlagSet) {
+	flagSet.StringVar(&b.bucket, "bucket", "", "Bucket to use for benchmark")
+	flagSet.StringVar(&b.tempdir, "temp", os.TempDir(), "location to create temporary files")
+	b.clientConfig.SetupFlags(prefix, flagSet)
+}
+
+var benchStrategies = []struct {
+	name           string
+	bufferProvider s3manager.ReadSeekerWriteToProvider
+}{
+	{name: "Unbuffered", bufferProvider: nil},
+	{name: "Buffered", bufferProvider: s3manager.NewBufferedReadSeekerWriteToPool(1024 * 1024)},
+}
+
+func BenchmarkInMemory(b *testing.B) {
+	memBreader := bytes.NewReader(make([]byte, 1*1024*1024*1024))
+
+	baseSdkConfig := SDKConfig{WithUnsignedPayload: true, ExpectContinue: true, WithContentMD5: false}
+
+	key := integration.UniqueID()
+	// Concurrency: 5, 10, 100
+	for _, concurrency := range []int{s3manager.DefaultUploadConcurrency, 2 * s3manager.DefaultUploadConcurrency, 100} {
+		b.Run(fmt.Sprintf("%d_Concurrency", concurrency), func(b *testing.B) {
+			// PartSize: 5 MB, 25 MB, 100 MB
+			for _, partSize := range []int64{s3manager.DefaultUploadPartSize, 25 * 1024 * 1024, 100 * 1024 * 1024} {
+				b.Run(fmt.Sprintf("%s_PartSize", integration.SizeToName(int(partSize))), func(b *testing.B) {
+					sdkConfig := baseSdkConfig
+
+					sdkConfig.BufferProvider = nil
+					sdkConfig.Concurrency = concurrency
+					sdkConfig.PartSize = partSize
+
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchUpload(b, benchConfig.bucket, key, memBreader, sdkConfig, benchConfig.clientConfig)
+						_, err := memBreader.Seek(0, sdkio.SeekStart)
+						if err != nil {
+							b.Fatalf("failed to seek to start of file: %v", err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkUpload(b *testing.B) {
+	baseSdkConfig := SDKConfig{WithUnsignedPayload: true, ExpectContinue: true, WithContentMD5: false}
+
+	// FileSizes: 5 MB, 1 GB, 10 GB
+	for _, fileSize := range []int64{5 * 1024 * 1024, 1024 * 1024 * 1024, 10 * 1024 * 1024 * 1024} {
+		b.Run(fmt.Sprintf("%s_File", integration.SizeToName(int(fileSize))), func(b *testing.B) {
+			b.Logf("creating file of size: %s", integration.SizeToName(int(fileSize)))
+			file, err := integration.CreateFileOfSize(benchConfig.tempdir, fileSize)
+			if err != nil {
+				b.Fatalf("failed to create file: %v", err)
+			}
+
+			// Concurrency: 5, 10, 100
+			for _, concurrency := range []int{s3manager.DefaultUploadConcurrency, 2 * s3manager.DefaultUploadConcurrency, 100} {
+				b.Run(fmt.Sprintf("%d_Concurrency", concurrency), func(b *testing.B) {
+					// PartSize: 5 MB, 25 MB, 100 MB
+					for _, partSize := range []int64{s3manager.DefaultUploadPartSize, 25 * 1024 * 1024, 100 * 1024 * 1024} {
+						if partSize > fileSize {
+							continue
+						}
+						b.Run(fmt.Sprintf("%s_PartSize", integration.SizeToName(int(partSize))), func(b *testing.B) {
+							for _, strat := range benchStrategies {
+								b.Run(strat.name, func(b *testing.B) {
+									sdkConfig := baseSdkConfig
+
+									sdkConfig.BufferProvider = strat.bufferProvider
+									sdkConfig.Concurrency = concurrency
+									sdkConfig.PartSize = partSize
+
+									b.ResetTimer()
+									for i := 0; i < b.N; i++ {
+										benchUpload(b, benchConfig.bucket, filepath.Base(file.Name()), file, sdkConfig, benchConfig.clientConfig)
+										_, err := file.Seek(0, sdkio.SeekStart)
+										if err != nil {
+											b.Fatalf("failed to seek to start of file: %v", err)
+										}
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+
+			os.Remove(file.Name())
+			file.Close()
+		})
+	}
+}
+
+func benchUpload(b *testing.B, bucket, key string, reader io.ReadSeeker, sdkConfig SDKConfig, clientConfig ClientConfig) {
+	uploader := newUploader(clientConfig, sdkConfig, SetUnsignedPayload)
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: &bucket,
+		Key:    &key,
+		Body:   reader,
+	})
+	if err != nil {
+		b.Fatalf("failed to upload object, %v", err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	benchConfig.SetupFlags("", flag.CommandLine)
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/awstesting/integration/performance/s3UploadManager/metric.go
+++ b/awstesting/integration/performance/s3UploadManager/metric.go
@@ -84,7 +84,9 @@ func (rt *RequestTrace) OnCompleteAttempt(r *request.Request) {
 func (rt *RequestTrace) OnComplete(r *request.Request) {
 	rt.finish = time.Now()
 	// Last attempt includes reading the response body
-	rt.attempts[len(rt.attempts)-1].Finish = rt.finish
+	if len(rt.attempts) > 0 {
+		rt.attempts[len(rt.attempts)-1].Finish = rt.finish
+	}
 }
 
 func (rt *RequestTrace) Err() error {

--- a/service/s3/s3manager/buffered_read_seeker.go
+++ b/service/s3/s3manager/buffered_read_seeker.go
@@ -1,0 +1,81 @@
+package s3manager
+
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+)
+
+// BufferedReadSeeker is buffered io.ReadSeeker
+type BufferedReadSeeker struct {
+	r                 io.ReadSeeker
+	buffer            []byte
+	readIdx, writeIdx int
+}
+
+// NewBufferedReadSeeker returns a new BufferedReadSeeker
+// if len(b) == 0 then the buffer will be initialized to 64 KiB.
+func NewBufferedReadSeeker(r io.ReadSeeker, b []byte) *BufferedReadSeeker {
+	if len(b) == 0 {
+		b = make([]byte, 64*1024)
+	}
+	return &BufferedReadSeeker{r: r, buffer: b}
+}
+
+func (b *BufferedReadSeeker) reset(r io.ReadSeeker) {
+	b.r = r
+	b.readIdx, b.writeIdx = 0, 0
+}
+
+// Read will read up len(p) bytes into p and will return
+// the number of bytes read and any error that occurred.
+// If the len(p) > the buffer size then a single read request
+// will be issued to the underlying io.ReadSeeker for len(p) bytes.
+// A Read request will at most perform a single Read to the underlying
+// io.ReadSeeker, and may return < len(p) if serviced from the buffer.
+func (b *BufferedReadSeeker) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return n, err
+	}
+
+	if b.readIdx == b.writeIdx {
+		if len(p) >= len(b.buffer) {
+			n, err = b.r.Read(p)
+			return n, err
+		}
+		b.readIdx, b.writeIdx = 0, 0
+
+		n, err = b.r.Read(b.buffer)
+		if n == 0 {
+			return n, err
+		}
+
+		b.writeIdx += n
+	}
+
+	n = copy(p, b.buffer[b.readIdx:b.writeIdx])
+	b.readIdx += n
+
+	return n, err
+}
+
+// Seek will position then underlying io.ReadSeeker to the given offset
+// and will clear the buffer.
+func (b *BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	n, err := b.r.Seek(offset, whence)
+
+	b.reset(b.r)
+
+	return n, err
+}
+
+// ReadAt will read up to len(p) bytes at the given file offset.
+// This will result in the buffer being cleared.
+func (b *BufferedReadSeeker) ReadAt(p []byte, off int64) (int, error) {
+	_, err := b.Seek(off, sdkio.SeekStart)
+	if err != nil {
+		return 0, err
+	}
+
+	return b.Read(p)
+}

--- a/service/s3/s3manager/buffered_read_seeker_test.go
+++ b/service/s3/s3manager/buffered_read_seeker_test.go
@@ -1,0 +1,81 @@
+package s3manager
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+)
+
+func TestBufferedReadSeekerRead(t *testing.T) {
+	expected := []byte("testData")
+
+	readSeeker := NewBufferedReadSeeker(bytes.NewReader(expected), make([]byte, 4))
+
+	var (
+		actual []byte
+		buffer = make([]byte, 2)
+	)
+
+	for {
+		n, err := readSeeker.Read(buffer)
+		actual = append(actual, buffer[:n]...)
+		if err != nil && err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("failed to read from reader: %v", err)
+		}
+	}
+
+	if !bytes.Equal(expected, actual) {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestBufferedReadSeekerSeek(t *testing.T) {
+	content := []byte("testData")
+
+	readSeeker := NewBufferedReadSeeker(bytes.NewReader(content), make([]byte, 4))
+
+	_, err := readSeeker.Seek(4, sdkio.SeekStart)
+	if err != nil {
+		t.Fatalf("failed to seek reader: %v", err)
+	}
+
+	var (
+		actual []byte
+		buffer = make([]byte, 4)
+	)
+
+	for {
+		n, err := readSeeker.Read(buffer)
+		actual = append(actual, buffer[:n]...)
+		if err != nil && err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatalf("failed to read from reader: %v", err)
+		}
+	}
+
+	if e := []byte("Data"); !bytes.Equal(e, actual) {
+		t.Errorf("expected %v, got %v", e, actual)
+	}
+}
+
+func TestBufferedReadSeekerReadAt(t *testing.T) {
+	content := []byte("testData")
+
+	readSeeker := NewBufferedReadSeeker(bytes.NewReader(content), make([]byte, 2))
+
+	buffer := make([]byte, 4)
+
+	_, err := readSeeker.ReadAt(buffer, 0)
+	if err != nil {
+		t.Fatalf("failed to seek reader: %v", err)
+	}
+
+	if e := content[:4]; !bytes.Equal(e, buffer) {
+		t.Errorf("expected %v, got %v", e, buffer)
+	}
+}

--- a/service/s3/s3manager/default_read_seeker_write_to.go
+++ b/service/s3/s3manager/default_read_seeker_write_to.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package s3manager
+
+func defaultUploadBufferProvider() ReadSeekerWriteToProvider {
+	return nil
+}

--- a/service/s3/s3manager/default_read_seeker_write_to_windows.go
+++ b/service/s3/s3manager/default_read_seeker_write_to_windows.go
@@ -1,0 +1,5 @@
+package s3manager
+
+func defaultUploadBufferProvider() ReadSeekerWriteToProvider {
+	return NewBufferedReadSeekerWriteToPool(1024 * 1024)
+}

--- a/service/s3/s3manager/exmaples_test.go
+++ b/service/s3/s3manager/exmaples_test.go
@@ -1,0 +1,62 @@
+package s3manager_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+// ExampleNewUploader_overrideReadSeekerProvider gives an example
+// on a custom ReadSeekerWriteToProvider can be provided to Uploader
+// to define how parts will be buffered in memory.
+func ExampleNewUploader_overrideReadSeekerProvider() {
+	sess := session.Must(session.NewSession())
+
+	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
+		// Define a strategy that will buffer 25 MiB in memory
+		u.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(25 * 1024 * 1024)
+	})
+
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String("examplebucket"),
+		Key:    aws.String("largeobject"),
+		Body:   bytes.NewReader([]byte("large_multi_part_upload")),
+	})
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
+// ExampleNewUploader_overrideTransport gives an example
+// on how to override the default HTTP transport. This can
+// be used to tune timeouts such as response headers, or
+// write / read buffer usage when writing or reading respectively
+// from the net/http transport.
+func ExampleNewUploader_overrideTransport() {
+	// Create Transport
+	tr := &http.Transport{
+		ResponseHeaderTimeout: 1 * time.Second,
+		// WriteBufferSize: 1024*1024 // Go 1.13
+		// ReadBufferSize: 1024*1024 // Go 1.13
+	}
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		HTTPClient: &http.Client{Transport: tr},
+	}))
+
+	uploader := s3manager.NewUploader(sess)
+
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String("examplebucket"),
+		Key:    aws.String("largeobject"),
+		Body:   bytes.NewReader([]byte("large_multi_part_upload")),
+	})
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}

--- a/service/s3/s3manager/read_seeker_write_to.go
+++ b/service/s3/s3manager/read_seeker_write_to.go
@@ -1,0 +1,65 @@
+package s3manager
+
+import (
+	"io"
+	"sync"
+)
+
+// ReadSeekerWriteTo defines an interface implementing io.WriteTo and io.ReadSeeker
+type ReadSeekerWriteTo interface {
+	io.ReadSeeker
+	io.WriterTo
+}
+
+// BufferedReadSeekerWriteTo wraps a BufferedReadSeeker with an io.WriteAt
+// implementation.
+type BufferedReadSeekerWriteTo struct {
+	*BufferedReadSeeker
+}
+
+// WriteTo writes to the given io.Writer from BufferedReadSeeker until there's no more data to write or
+// an error occurs. Returns the number of bytes written and any error encountered during the write.
+func (b *BufferedReadSeekerWriteTo) WriteTo(writer io.Writer) (int64, error) {
+	return io.Copy(writer, b.BufferedReadSeeker)
+}
+
+// ReadSeekerWriteToProvider provides an implementation of io.WriteTo for an io.ReadSeeker
+type ReadSeekerWriteToProvider interface {
+	GetWriteTo(seeker io.ReadSeeker) (r ReadSeekerWriteTo, cleanup func())
+}
+
+// BufferedReadSeekerWriteToPool uses a sync.Pool to create and reuse
+// []byte slices for buffering parts in memory
+type BufferedReadSeekerWriteToPool struct {
+	pool sync.Pool
+}
+
+// NewBufferedReadSeekerWriteToPool will return a new BufferedReadSeekerWriteToPool that will create
+// a pool of reusable buffers . If size is less then < 64 KiB then the buffer
+// will default to 64 KiB. Reason: io.Copy from writers or readers that don't support io.WriteTo or io.ReadFrom
+// respectively will default to copying 32 KiB.
+func NewBufferedReadSeekerWriteToPool(size int) *BufferedReadSeekerWriteToPool {
+	if size < 65536 {
+		size = 65536
+	}
+
+	return &BufferedReadSeekerWriteToPool{
+		pool: sync.Pool{New: func() interface{} {
+			return make([]byte, size)
+		}},
+	}
+}
+
+// GetWriteTo will wrap the provided io.ReadSeeker with a BufferedReadSeekerWriteTo.
+// The provided cleanup must be called after operations have been completed on the
+// returned io.ReadSeekerWriteTo in order to signal the return of resources to the pool.
+func (p *BufferedReadSeekerWriteToPool) GetWriteTo(seeker io.ReadSeeker) (r ReadSeekerWriteTo, cleanup func()) {
+	buffer := p.pool.Get().([]byte)
+
+	r = &BufferedReadSeekerWriteTo{BufferedReadSeeker: NewBufferedReadSeeker(seeker, buffer)}
+	cleanup = func() {
+		p.pool.Put(buffer)
+	}
+
+	return r, cleanup
+}

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -162,6 +162,9 @@ type Uploader struct {
 	// List of request options that will be passed down to individual API
 	// operation requests made by the uploader.
 	RequestOptions []request.Option
+
+	// Defines the buffer strategy used when uploading a part
+	BufferProvider ReadSeekerWriteToProvider
 }
 
 // NewUploader creates a new Uploader instance to upload objects to S3. Pass In
@@ -187,6 +190,7 @@ func NewUploader(c client.ConfigProvider, options ...func(*Uploader)) *Uploader 
 		Concurrency:       DefaultUploadConcurrency,
 		LeavePartsOnError: false,
 		MaxUploadParts:    MaxUploadParts,
+		BufferProvider:    defaultUploadBufferProvider(),
 	}
 
 	for _, option := range options {
@@ -221,6 +225,7 @@ func NewUploaderWithClient(svc s3iface.S3API, options ...func(*Uploader)) *Uploa
 		Concurrency:       DefaultUploadConcurrency,
 		LeavePartsOnError: false,
 		MaxUploadParts:    MaxUploadParts,
+		BufferProvider:    defaultUploadBufferProvider(),
 	}
 
 	for _, option := range options {
@@ -357,7 +362,8 @@ type uploader struct {
 	readerPos int64 // current reader position
 	totalSize int64 // set to -1 if the size is not known
 
-	bufferPool sync.Pool
+	bufferPool       sync.Pool
+	bufferUploadPool sync.Pool
 }
 
 // internal logic for deciding whether to upload a single part or use a
@@ -373,15 +379,16 @@ func (u *uploader) upload() (*UploadOutput, error) {
 	}
 
 	// Do one read to determine if we have more than one part
-	reader, _, part, err := u.nextReader()
+	reader, _, part, cleanup, err := u.nextReader()
 	if err == io.EOF { // single part
-		return u.singlePart(reader)
+		return u.singlePart(reader, cleanup)
 	} else if err != nil {
+		cleanup()
 		return nil, awserr.New("ReadRequestBody", "read upload data failed", err)
 	}
 
 	mu := multiuploader{uploader: u}
-	return mu.upload(reader, part)
+	return mu.upload(reader, part, cleanup)
 }
 
 // init will initialize all default options.
@@ -433,7 +440,7 @@ func (u *uploader) initSize() error {
 // This operation increases the shared u.readerPos counter, but note that it
 // does not need to be wrapped in a mutex because nextReader is only called
 // from the main thread.
-func (u *uploader) nextReader() (io.ReadSeeker, int, []byte, error) {
+func (u *uploader) nextReader() (io.ReadSeeker, int, []byte, func(), error) {
 	type readerAtSeeker interface {
 		io.ReaderAt
 		io.ReadSeeker
@@ -452,17 +459,32 @@ func (u *uploader) nextReader() (io.ReadSeeker, int, []byte, error) {
 			}
 		}
 
-		reader := io.NewSectionReader(r, u.readerPos, n)
+		var (
+			reader  io.ReadSeeker
+			cleanup func()
+		)
+
+		reader = io.NewSectionReader(r, u.readerPos, n)
+		if u.cfg.BufferProvider != nil {
+			reader, cleanup = u.cfg.BufferProvider.GetWriteTo(reader)
+		} else {
+			cleanup = func() {}
+		}
+
 		u.readerPos += n
 
-		return reader, int(n), nil, err
+		return reader, int(n), nil, cleanup, err
 
 	default:
 		part := u.bufferPool.Get().([]byte)
 		n, err := readFillBuf(r, part)
 		u.readerPos += int64(n)
 
-		return bytes.NewReader(part[0:n]), n, part, err
+		cleanup := func() {
+			u.bufferPool.Put(part)
+		}
+
+		return bytes.NewReader(part[0:n]), n, part, cleanup, err
 	}
 }
 
@@ -479,10 +501,12 @@ func readFillBuf(r io.Reader, b []byte) (offset int, err error) {
 // singlePart contains upload logic for uploading a single chunk via
 // a regular PutObject request. Multipart requests require at least two
 // parts, or at least 5MB of data.
-func (u *uploader) singlePart(buf io.ReadSeeker) (*UploadOutput, error) {
+func (u *uploader) singlePart(r io.ReadSeeker, cleanup func()) (*UploadOutput, error) {
+	defer cleanup()
+
 	params := &s3.PutObjectInput{}
 	awsutil.Copy(params, u.in)
-	params.Body = buf
+	params.Body = r
 
 	// Need to use request form because URL generated in request is
 	// used in return.
@@ -512,9 +536,10 @@ type multiuploader struct {
 
 // keeps track of a single chunk of data being sent to S3.
 type chunk struct {
-	buf  io.ReadSeeker
-	part []byte
-	num  int64
+	buf     io.ReadSeeker
+	part    []byte
+	num     int64
+	cleanup func()
 }
 
 // completedParts is a wrapper to make parts sortable by their part number,
@@ -527,7 +552,7 @@ func (a completedParts) Less(i, j int) bool { return *a[i].PartNumber < *a[j].Pa
 
 // upload will perform a multipart upload using the firstBuf buffer containing
 // the first chunk of data.
-func (u *multiuploader) upload(firstBuf io.ReadSeeker, firstPart []byte) (*UploadOutput, error) {
+func (u *multiuploader) upload(firstBuf io.ReadSeeker, firstPart []byte, cleanup func()) (*UploadOutput, error) {
 	params := &s3.CreateMultipartUploadInput{}
 	awsutil.Copy(params, u.in)
 
@@ -547,46 +572,30 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, firstPart []byte) (*Uploa
 
 	// Send part 1 to the workers
 	var num int64 = 1
-	ch <- chunk{buf: firstBuf, part: firstPart, num: num}
+	ch <- chunk{buf: firstBuf, part: firstPart, num: num, cleanup: cleanup}
 
 	// Read and queue the rest of the parts
 	for u.geterr() == nil && err == nil {
-		var reader io.ReadSeeker
-		var nextChunkLen int
-		var part []byte
-		reader, nextChunkLen, part, err = u.nextReader()
+		var (
+			reader       io.ReadSeeker
+			nextChunkLen int
+			part         []byte
+			ok           bool
+		)
 
-		if err != nil && err != io.EOF {
-			u.seterr(awserr.New(
-				"ReadRequestBody",
-				"read multipart upload data failed",
-				err))
-			break
-		}
-
-		if nextChunkLen == 0 {
-			// No need to upload empty part, if file was empty to start
-			// with empty single part would of been created and never
-			// started multipart upload.
+		reader, nextChunkLen, part, cleanup, err = u.nextReader()
+		ok, err = u.shouldContinue(num, nextChunkLen, err)
+		if !ok {
+			cleanup()
+			if err != nil {
+				u.seterr(err)
+			}
 			break
 		}
 
 		num++
-		// This upload exceeded maximum number of supported parts, error now.
-		if num > int64(u.cfg.MaxUploadParts) || num > int64(MaxUploadParts) {
-			var msg string
-			if num > int64(u.cfg.MaxUploadParts) {
-				msg = fmt.Sprintf("exceeded total allowed configured MaxUploadParts (%d). Adjust PartSize to fit in this limit",
-					u.cfg.MaxUploadParts)
-			} else {
-				msg = fmt.Sprintf("exceeded total allowed S3 limit MaxUploadParts (%d). Adjust PartSize to fit in this limit",
-					MaxUploadParts)
-			}
-			u.seterr(awserr.New("TotalPartsExceeded", msg, nil))
-			break
-		}
 
-		ch <- chunk{buf: reader, part: part, num: num}
+		ch <- chunk{buf: reader, part: part, num: num, cleanup: cleanup}
 	}
 
 	// Close the channel, wait for workers, and complete upload
@@ -620,6 +629,35 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, firstPart []byte) (*Uploa
 	}, nil
 }
 
+func (u *multiuploader) shouldContinue(part int64, nextChunkLen int, err error) (bool, error) {
+	if err != nil && err != io.EOF {
+		return false, awserr.New("ReadRequestBody", "read multipart upload data failed", err)
+	}
+
+	if nextChunkLen == 0 {
+		// No need to upload empty part, if file was empty to start
+		// with empty single part would of been created and never
+		// started multipart upload.
+		return false, nil
+	}
+
+	part++
+	// This upload exceeded maximum number of supported parts, error now.
+	if part > int64(u.cfg.MaxUploadParts) || part > int64(MaxUploadParts) {
+		var msg string
+		if part > int64(u.cfg.MaxUploadParts) {
+			msg = fmt.Sprintf("exceeded total allowed configured MaxUploadParts (%d). Adjust PartSize to fit in this limit",
+				u.cfg.MaxUploadParts)
+		} else {
+			msg = fmt.Sprintf("exceeded total allowed S3 limit MaxUploadParts (%d). Adjust PartSize to fit in this limit",
+				MaxUploadParts)
+		}
+		return false, awserr.New("TotalPartsExceeded", msg, nil)
+	}
+
+	return true, err
+}
+
 // readChunk runs in worker goroutines to pull chunks off of the ch channel
 // and send() them as UploadPart requests.
 func (u *multiuploader) readChunk(ch chan chunk) {
@@ -651,9 +689,9 @@ func (u *multiuploader) send(c chunk) error {
 		SSECustomerKey:       u.in.SSECustomerKey,
 		PartNumber:           &c.num,
 	}
+
 	resp, err := u.cfg.S3.UploadPartWithContext(u.ctx, params, u.cfg.RequestOptions...)
-	// put the byte array back into the pool to conserve memory
-	u.bufferPool.Put(c.part)
+	c.cleanup()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Purpose
This change is to help address the performance of `s3manager.Uploader` in particular on Windows platforms. This PR defines a new BufferStrategy configuration option to the Upload manager which will allow users to define whether a `[]byte` buffer should be used when uploading each part. The reasoning for this new strategy definition, is due to the fact that each part wraps the provided`io.ReadSeeker` to Uploader in an `io.SectionReader` which is limited to read from a particular offset and number of bytes. On the Windows platform if the underlying `io.ReadSeeker` is an `*os.File` this will result in a large number of blocking events as `*os.File.ReadAt` uses an emulated pread syscall which requires a mutex lock on the file in order to satisfy the read request. Introducing a BufferStrategy, specifically for Windows results in performance increase, especially in cases where the configured concurrency value for part uploads is high. This change will only enable a buffering strategy by default for the Windows platform, and UNIX-like systems will continue to employ an non-buffering strategy.

# Benchmark
## Windows
### Benchmarks
#### Summary
Benchmark | Difference
--- | ---
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize | +0.74%
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize | -0.57%
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize | -2.70%
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize | -24.59%
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize | -23.83%
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize | -13.68%

#### Data
```
goos: windows
goarch: amd64
pkg: github.com/aws/aws-sdk-go/awstesting/integration/performance/s3UploadManager
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize/Unbuffered-32                    100        7074644513 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize/Buffered-32                      100        7127001770 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize/Unbuffered-32                   100        4452512364 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize/Buffered-32                     100        4427085065 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize/Unbuffered-32                  100        4027619587 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize/Buffered-32                    100        3918910259 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize/Unbuffered-32                  100        2503051839 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize/Buffered-32                    100        1887655163 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize/Unbuffered-32                 100        3160688686 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize/Buffered-32                   100        2407384797 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize/Unbuffered-32                100        3101042968 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize/Buffered-32                  100        2676760109 ns/op
PASS
```

## Linux
## Benchmarks
#### Summary
Benchmark | Difference
--- | ---
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize | -0.17%
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize | -1.90%
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize | +1.64%
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize | +6.48%
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize | +0.67%
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize | -7.72%

#### Data
```
goos: linux
goarch: amd64
pkg: github.com/aws/aws-sdk-go/awstesting/integration/performance/s3UploadManager
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize/Unbuffered-32                    100        6857056614 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/5MB_PartSize/Buffered-32                      100        6845176279 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize/Unbuffered-32                   100        4382487123 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/25MB_PartSize/Buffered-32                     100        4299312985 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize/Unbuffered-32                  100        3864865560 ns/op
BenchmarkUpload/1GB_File/5_Concurrency/100MB_PartSize/Buffered-32                    100        3928085242 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize/Unbuffered-32                  100        1651138406 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/5MB_PartSize/Buffered-32                    100        1758210520 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize/Unbuffered-32                 100        2160376327 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/25MB_PartSize/Buffered-32                   100        2174799197 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize/Unbuffered-32                100        2739669395 ns/op
BenchmarkUpload/1GB_File/100_Concurrency/100MB_PartSize/Buffered-32                  100        2528230455 ns/op
```