### PR TITLE
aws/client: Updates logic for request retry delay calculation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+*	`aws/client`: The `Retry-After` duration specified in the request is now added to the Retry delay for throttled exception
+     * Fixes broken test for retry delays for throttled exceptions [#2796](https://github.com/aws/aws-sdk-go/pull/2796)
+  	 * Fixes [#2795](https://github.com/aws/aws-sdk-go/issues/2795)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-*	`aws/client`: The `Retry-After` duration specified in the request is now added to the Retry delay for throttled exception
-     * Fixes broken test for retry delays for throttled exceptions [#2796](https://github.com/aws/aws-sdk-go/pull/2796)
-  	 * Fixes [#2795](https://github.com/aws/aws-sdk-go/issues/2795)
+* `aws/client`: Updates logic for calculating the delay after which a request can be retried. Retry delay now includes the Retry-After duration specified in a request [#2796](https://github.com/aws/aws-sdk-go/pull/2796).
+  * Fixes broken test for retry delays for throttled exceptions. Fixes [#2795](https://github.com/aws/aws-sdk-go/issues/2795)
+  

--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -34,10 +34,12 @@ func (d DefaultRetryer) MaxRetries() int {
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	// Set the upper limit of delay in retrying at ~five minutes
 	var minTime int64 = 30
+	var initialDelay time.Duration
+
 	isThrottle := r.IsErrorThrottle()
 	if isThrottle {
-		if delay, ok := getRetryDelay(r); ok {
-			return delay
+		if delay, ok := getRetryAfterDelay(r); ok {
+			initialDelay = delay
 		}
 
 		minTime = 500
@@ -46,12 +48,13 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 	retryCount := r.RetryCount
 	if isThrottle && retryCount > 8 {
 		retryCount = 8
-	} else if retryCount > 13 {
-		retryCount = 13
+	} else if retryCount > 12 {
+		retryCount = 12
 	}
 
 	delay := (1 << uint(retryCount)) * (sdkrand.SeededRand.Int63n(minTime) + minTime)
-	return time.Duration(delay) * time.Millisecond
+	return (time.Duration(delay) * time.Millisecond) + initialDelay
+
 }
 
 // ShouldRetry returns true if the request should be retried.
@@ -71,7 +74,7 @@ func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
 
 // This will look in the Retry-After header, RFC 7231, for how long
 // it will wait before attempting another request
-func getRetryDelay(r *request.Request) (time.Duration, bool) {
+func getRetryAfterDelay(r *request.Request) (time.Duration, bool) {
 	if !canUseRetryAfterHeader(r) {
 		return 0, false
 	}

--- a/aws/client/default_retryer_test.go
+++ b/aws/client/default_retryer_test.go
@@ -154,7 +154,7 @@ func TestGetRetryDelay(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		a, ok := getRetryDelay(&c.r)
+		a, ok := getRetryAfterDelay(&c.r)
 		if c.ok != ok {
 			t.Errorf("%d: expected %v, but received %v", i, c.ok, ok)
 		}
@@ -166,14 +166,15 @@ func TestGetRetryDelay(t *testing.T) {
 }
 
 func TestRetryDelay(t *testing.T) {
+	d:= DefaultRetryer{100}
 	r := request.Request{}
 	for i := 0; i < 100; i++ {
 		rTemp := r
-		rTemp.HTTPResponse = &http.Response{StatusCode: 500, Header: http.Header{"Retry-After": []string{""}}}
+		rTemp.HTTPResponse = &http.Response{StatusCode: 500, Header: http.Header{"Retry-After": []string{"299"}}}
 		rTemp.RetryCount = i
-		a, _ := getRetryDelay(&rTemp)
+		a := d.RetryRules(&rTemp)
 		if a > 5*time.Minute {
-			t.Errorf("retry delay should never be greater than five minutes, received %d", a)
+			t.Errorf("retry delay should never be greater than five minutes, received %s for retrycount %d", a, i)
 		}
 	}
 
@@ -181,9 +182,20 @@ func TestRetryDelay(t *testing.T) {
 		rTemp := r
 		rTemp.RetryCount = i
 		rTemp.HTTPResponse = &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{""}}}
-		a, _ := getRetryDelay(&rTemp)
+		a := d.RetryRules(&rTemp)
 		if a > 5*time.Minute {
-			t.Errorf("retry delay should never be greater than five minutes, received %d", a)
+			t.Errorf("retry delay should not be greater than five minutes, received %s for retrycount %d", a, i)
+		}
+	}
+
+	for i := 0; i < 100; i++ {
+		rTemp := r
+		rTemp.RetryCount = i
+		rTemp.HTTPResponse = &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{"300"}}}
+		a := d.RetryRules(&rTemp)
+		if a < 5*time.Minute {
+			t.Errorf("retry delay should not be less than retry-after value, received %s for retrycount %d", a, i)
 		}
 	}
 }
+

--- a/aws/client/default_retryer_test.go
+++ b/aws/client/default_retryer_test.go
@@ -166,7 +166,7 @@ func TestGetRetryDelay(t *testing.T) {
 }
 
 func TestRetryDelay(t *testing.T) {
-	d:= DefaultRetryer{100}
+	d := DefaultRetryer{100}
 	r := request.Request{}
 	for i := 0; i < 100; i++ {
 		rTemp := r
@@ -188,14 +188,12 @@ func TestRetryDelay(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 100; i++ {
-		rTemp := r
-		rTemp.RetryCount = i
-		rTemp.HTTPResponse = &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{"300"}}}
-		a := d.RetryRules(&rTemp)
-		if a < 5*time.Minute {
-			t.Errorf("retry delay should not be less than retry-after value, received %s for retrycount %d", a, i)
-		}
+	rTemp := r
+	rTemp.RetryCount = 1
+	rTemp.HTTPResponse = &http.Response{StatusCode: 503, Header: http.Header{"Retry-After": []string{"300"}}}
+	a := d.RetryRules(&rTemp)
+	if a < 5*time.Minute {
+		t.Errorf("retry delay should not be less than retry-after duration, received %s for retrycount %d", a, 1)
 	}
-}
 
+}


### PR DESCRIPTION
Updates logic for calculating the delay after which a request can be retried. Retry delay now includes the `Retry-After` duration specified in a request.

Fixes broken test for Throttle Retry cap. 
Fixes #2795 .

