### PR TITLE
internal/ini: Failing test cases for #2800

### DIFF
--- a/internal/ini/ini_parser_test.go
+++ b/internal/ini/ini_parser_test.go
@@ -270,6 +270,24 @@ region = us-west-2
 				newExprStatement(noQuotesRegionEQRegion),
 			},
 		},
+		{
+			name: "missing section statement",
+			r: bytes.NewBuffer([]byte(`[default]
+s3 =
+[assumerole]
+output = json
+				`)),
+			expectedStack: []AST{
+				newCompletedSectionStatement(
+					defaultProfileStmt,
+				),
+				newSkipStatement(newEqualExpr(newExpression(s3ID), equalOp)),
+				newCompletedSectionStatement(
+					assumeProfileStmt,
+				),
+				newExprStatement(outputEQExpr),
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/internal/ini/testdata/valid/missing_rhs
+++ b/internal/ini/testdata/valid/missing_rhs
@@ -1,0 +1,8 @@
+[foo]
+aws_access_key_id     = 
+aws_secret_access_key = 
+aws_session_token     = 
+[bar]
+aws_access_key_id     = accesskey
+aws_secret_access_key = secret
+aws_session_token     = token

--- a/internal/ini/testdata/valid/missing_rhs_expected
+++ b/internal/ini/testdata/valid/missing_rhs_expected
@@ -1,0 +1,7 @@
+{
+	"bar": {
+		"aws_access_key_id": "accesskey",
+		"aws_secret_access_key": "secret",
+		"aws_session_token": "token"
+	}
+}


### PR DESCRIPTION
Reference: https://github.com/aws/aws-sdk-go/issues/2800

My apologies I won't have time to dive into the INI parsing code for awhile to fully resolve this. It appears anything between the first new line token and next new line token when in the skip state is completely skipped, even if it contains a separator.

```
--- FAIL: TestParser (0.00s)
    --- FAIL: TestParser/complex_section_statement#02 (0.00s)
        ini_parser_test.go:302: expected same length 4, but received 3
        ini_parser_test.go:317: expected:
            	0: {completed_stmt {0 NONE 0 []} false [{section_stmt {1 STRING 0 [100 101 102 97 117 108 116]} true []}]}
            	1: {skip {0 NONE 0 []} false [{ {4 NONE 0 [61]} true [{expr {1 STRING 0 [115 51]} true []}]}]}
            	2: {completed_stmt {0 NONE 0 []} false [{section_stmt {1 STRING 0 [97 115 115 117 109 101 114 111 108 101]} true []}]}
            	3: {expr_stmt {0 NONE 0 []} false [{ {4 NONE 0 [61]} true [{expr {1 STRING 0 [111 117 116 112 117 116]} true []} {expr {1 STRING 0 [106 115 111 110]} true []}]}]}

            received:
            	0: {completed_stmt {0 NONE 0 []} false [{section_stmt {1 STRING 0 [100 101 102 97 117 108 116]} true []}]}
            	1: {skip {0 NONE 0 []} false [{ {4 NONE 0 [61]} true [{expr {1 STRING 0 [115 51]} true []}]}]}
            	2: {expr_stmt {0 NONE 0 []} false [{ {4 NONE 0 [61]} true [{expr {1 STRING 0 [111 117 116 112 117 116]} true []} {expr {1 STRING 0 [106 115 111 110]} true []}]}]}
--- FAIL: TestValidDataFiles (0.01s)
    walker_test.go:59: could not find profile bar
```
