### PR TITLE
Fix failing tests when executed from inside a module

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* Fixed failing tests when executed as a module dependency ([#2817](https://github.com/aws/aws-sdk-go/pull/2817))

--- a/aws/credentials/processcreds/provider_test.go
+++ b/aws/credentials/processcreds/provider_test.go
@@ -1,8 +1,10 @@
 package processcreds_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -385,19 +387,23 @@ func TestProcessProviderNotExpired(t *testing.T) {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 
-	tmpFile := strings.Join(
-		[]string{"testdata", "tmp_expiring.json"},
-		string(os.PathSeparator))
-	if err = ioutil.WriteFile(tmpFile, b, 0644); err != nil {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_expiring")
+	if err != nil {
+		t.Errorf("expected %v, got %v", "no error", err)
+	}
+	if _, err = io.Copy(tmpFile, bytes.NewReader(b)); err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 	defer func() {
-		if err = os.Remove(tmpFile); err != nil {
+		if err = tmpFile.Close(); err != nil {
+			t.Errorf("expected %v, got %v", "no error", err)
+		}
+		if err = os.Remove(tmpFile.Name()); err != nil {
 			t.Errorf("expected %v, got %v", "no error", err)
 		}
 	}()
 	creds := processcreds.NewCredentials(
-		fmt.Sprintf("%s %s", getOSCat(), tmpFile))
+		fmt.Sprintf("%s %s", getOSCat(), tmpFile.Name()))
 	_, err = creds.Get()
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
@@ -422,19 +428,23 @@ func TestProcessProviderExpired(t *testing.T) {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 
-	tmpFile := strings.Join(
-		[]string{"testdata", "tmp_expired.json"},
-		string(os.PathSeparator))
-	if err = ioutil.WriteFile(tmpFile, b, 0644); err != nil {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_expired")
+	if err != nil {
+		t.Errorf("expected %v, got %v", "no error", err)
+	}
+	if _, err = io.Copy(tmpFile, bytes.NewReader(b)); err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 	defer func() {
-		if err = os.Remove(tmpFile); err != nil {
+		if err = tmpFile.Close(); err != nil {
+			t.Errorf("expected %v, got %v", "no error", err)
+		}
+		if err = os.Remove(tmpFile.Name()); err != nil {
 			t.Errorf("expected %v, got %v", "no error", err)
 		}
 	}()
 	creds := processcreds.NewCredentials(
-		fmt.Sprintf("%s %s", getOSCat(), tmpFile))
+		fmt.Sprintf("%s %s", getOSCat(), tmpFile.Name()))
 	_, err = creds.Get()
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
@@ -460,21 +470,25 @@ func TestProcessProviderForceExpire(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
-	tmpFile := strings.Join(
-		[]string{"testdata", "tmp_force_expire.json"},
-		string(os.PathSeparator))
-	if err = ioutil.WriteFile(tmpFile, b, 0644); err != nil {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "tmp_force_expire")
+	if err != nil {
+		t.Errorf("expected %v, got %v", "no error", err)
+	}
+	if _, err = io.Copy(tmpFile, bytes.NewReader(b)); err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}
 	defer func() {
-		if err = os.Remove(tmpFile); err != nil {
+		if err = tmpFile.Close(); err != nil {
+			t.Errorf("expected %v, got %v", "no error", err)
+		}
+		if err = os.Remove(tmpFile.Name()); err != nil {
 			t.Errorf("expected %v, got %v", "no error", err)
 		}
 	}()
 
 	// get credentials from file
 	creds := processcreds.NewCredentials(
-		fmt.Sprintf("%s %s", getOSCat(), tmpFile))
+		fmt.Sprintf("%s %s", getOSCat(), tmpFile.Name()))
 	if _, err = creds.Get(); err != nil {
 		t.Errorf("expected %v, got %v", "no error", err)
 	}

--- a/private/protocol/eventstream/decode_test.go
+++ b/private/protocol/eventstream/decode_test.go
@@ -3,8 +3,8 @@ package eventstream
 import (
 	"bytes"
 	"encoding/hex"
+	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -16,17 +16,23 @@ func TestWriteEncodedFromDecoded(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := os.Create(filepath.Join("testdata", "encoded", "positive", c.Name))
+		f, err := ioutil.TempFile(os.TempDir(), "encoded_positive_"+c.Name)
 		if err != nil {
 			t.Fatalf("failed to open %q, %v", c.Name, err)
 		}
-		defer f.Close()
 
 		encoder := NewEncoder(f)
 
 		msg := c.Decoded.Message()
 		if err := encoder.Encode(msg); err != nil {
 			t.Errorf("failed to encode %q, %v", c.Name, err)
+		}
+
+		if err = f.Close(); err != nil {
+			t.Errorf("expected %v, got %v", "no error", err)
+		}
+		if err = os.Remove(f.Name()); err != nil {
+			t.Errorf("expected %v, got %v", "no error", err)
 		}
 	}
 }


### PR DESCRIPTION
This change addresses the issue reported in https://github.com/aws/aws-sdk-go/issues/2813 which caused unit tests to fail when executed within a go module.