### PR TITLE
service/s3/s3manager: Add DownloadStrategy for buffering downloaded parts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,10 @@
 ### SDK Features
+* `service/s3/s3manager`: Add Download Buffer Provider ([#2823](https://github.com/aws/aws-sdk-go/pull/2823))
+  * Adds a new `BufferProvider` member for specifying how part data can be buffered in memory when copying from the http response body.
+  * Windows platforms will now default to buffering 1MB per part to reduce contention when downloading files.
+  * Non-Windows platforms will continue to employ a non-buffering behavior.
+  * Fixes [#2180](https://github.com/aws/aws-sdk-go/issues/2180)
+  * Fixes [#2662](https://github.com/aws/aws-sdk-go/issues/2662)
 
 ### SDK Enhancements
 

--- a/awstesting/discard.go
+++ b/awstesting/discard.go
@@ -1,0 +1,11 @@
+package awstesting
+
+// DiscardAt is an io.WriteAt that discards
+// the requested bytes to be written
+type DiscardAt struct{}
+
+// WriteAt discards the given []byte slice and returns len(p) bytes
+// as having been written at the given offset. It will never return an error.
+func (d DiscardAt) WriteAt(p []byte, off int64) (n int, err error) {
+	return len(p), nil
+}

--- a/awstesting/endless_reader.go
+++ b/awstesting/endless_reader.go
@@ -1,0 +1,12 @@
+package awstesting
+
+// EndlessReader is an io.Reader that will always return
+// that bytes have been read.
+type EndlessReader struct{}
+
+// Read will report that it has read len(p) bytes in p.
+// The content in the []byte will be unmodified.
+// This will never return an error.
+func (e EndlessReader) Read(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/awstesting/integration/performance/s3DownloadManager/README.md
+++ b/awstesting/integration/performance/s3DownloadManager/README.md
@@ -1,0 +1,39 @@
+## Performance Utility
+
+Downloads a test file from a S3 bucket using the SDK's S3 download manager. Allows passing
+in custom configuration for the HTTP client and SDK's Download Manager behavior.
+
+## Build
+### Standalone
+```sh
+go build -tags "integration perftest" -o s3DownloadManager ./awstesting/integration/performance/s3DownloadManager
+```
+### Benchmarking
+```sh
+go test -tags "integration perftest" -c -o s3DownloadManager ./awstesting/integration/performance/s3DownloadManager
+```
+
+## Usage Example:
+### Standalone
+```sh
+AWS_REGION=us-west-2 AWS_PROFILE=aws-go-sdk-team-test ./s3DownloadManager \
+-bucket aws-sdk-go-data \
+-size 10485760 \
+-client.idle-conns 1000 \
+-client.idle-conns-host 300 \
+-client.timeout.connect=1s \
+-client.timeout.response-header=1s
+```
+
+### Benchmarking
+```sh
+AWS_REGION=us-west-2 AWS_PROFILE=aws-go-sdk-team-test ./s3DownloadManager \
+-test.bench=. \
+-test.benchmem \
+-test.benchtime 1x \
+-bucket aws-sdk-go-data \
+-client.idle-conns 1000 \
+-client.idle-conns-host 300 \
+-client.timeout.connect=1s \
+-client.timeout.response-header=1s
+```

--- a/awstesting/integration/performance/s3DownloadManager/client.go
+++ b/awstesting/integration/performance/s3DownloadManager/client.go
@@ -1,0 +1,32 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func NewClient(cfg ClientConfig) *http.Client {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   cfg.Timeouts.Connect,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:        cfg.MaxIdleConns,
+		MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
+		IdleConnTimeout:     90 * time.Second,
+
+		DisableKeepAlives:     !cfg.KeepAlive,
+		TLSHandshakeTimeout:   cfg.Timeouts.TLSHandshake,
+		ExpectContinueTimeout: cfg.Timeouts.ExpectContinue,
+		ResponseHeaderTimeout: cfg.Timeouts.ResponseHeader,
+	}
+
+	return &http.Client{
+		Transport: tr,
+	}
+}

--- a/awstesting/integration/performance/s3DownloadManager/config.go
+++ b/awstesting/integration/performance/s3DownloadManager/config.go
@@ -1,0 +1,152 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+type Config struct {
+	Bucket     string
+	Size       int64
+	LogVerbose bool
+
+	SDK    SDKConfig
+	Client ClientConfig
+}
+
+func (c *Config) SetupFlags(prefix string, flagset *flag.FlagSet) {
+	flagset.StringVar(&c.Bucket, "bucket", "",
+		"The S3 bucket `name` to download the object from.")
+	flagset.Int64Var(&c.Size, "size", 0,
+		"The S3 object size in bytes to be first uploaded then downloaded")
+	flagset.BoolVar(&c.LogVerbose, "verbose", false,
+		"The output log will include verbose request information")
+
+	c.SDK.SetupFlags(prefix, flagset)
+	c.Client.SetupFlags(prefix, flagset)
+}
+
+func (c *Config) Validate() error {
+	var errs Errors
+
+	if len(c.Bucket) == 0 || c.Size <= 0 {
+		errs = append(errs, fmt.Errorf("bucket and filename/size are required"))
+	}
+
+	if err := c.SDK.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := c.Client.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+type SDKConfig struct {
+	PartSize       int64
+	Concurrency    int
+	BufferProvider s3manager.WriterReadFromProvider
+}
+
+func (c *SDKConfig) SetupFlags(prefix string, flagset *flag.FlagSet) {
+	prefix += "sdk."
+
+	flagset.Int64Var(&c.PartSize, prefix+"part-size", s3manager.DefaultDownloadPartSize,
+		"Specifies the `size` of parts of the object to download.")
+	flagset.IntVar(&c.Concurrency, prefix+"concurrency", s3manager.DefaultDownloadConcurrency,
+		"Specifies the number of parts to download `at once`.")
+}
+
+func (c *SDKConfig) Validate() error {
+	return nil
+}
+
+type ClientConfig struct {
+	KeepAlive bool
+	Timeouts  Timeouts
+
+	MaxIdleConns        int
+	MaxIdleConnsPerHost int
+}
+
+func (c *ClientConfig) SetupFlags(prefix string, flagset *flag.FlagSet) {
+	prefix += "client."
+
+	flagset.BoolVar(&c.KeepAlive, prefix+"http-keep-alive", true,
+		"Specifies if HTTP keep alive is enabled.")
+
+	defTR := http.DefaultTransport.(*http.Transport)
+
+	flagset.IntVar(&c.MaxIdleConns, prefix+"idle-conns", defTR.MaxIdleConns,
+		"Specifies max idle connection pool size.")
+
+	flagset.IntVar(&c.MaxIdleConnsPerHost, prefix+"idle-conns-host", http.DefaultMaxIdleConnsPerHost,
+		"Specifies max idle connection pool per host, will be truncated by idle-conns.")
+
+	c.Timeouts.SetupFlags(prefix, flagset)
+}
+
+func (c *ClientConfig) Validate() error {
+	var errs Errors
+
+	if err := c.Timeouts.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+	return nil
+}
+
+type Timeouts struct {
+	Connect        time.Duration
+	TLSHandshake   time.Duration
+	ExpectContinue time.Duration
+	ResponseHeader time.Duration
+}
+
+func (c *Timeouts) SetupFlags(prefix string, flagset *flag.FlagSet) {
+	prefix += "timeout."
+
+	flagset.DurationVar(&c.Connect, prefix+"connect", 30*time.Second,
+		"The `timeout` connecting to the remote host.")
+
+	defTR := http.DefaultTransport.(*http.Transport)
+
+	flagset.DurationVar(&c.TLSHandshake, prefix+"tls", defTR.TLSHandshakeTimeout,
+		"The `timeout` waiting for the TLS handshake to complete.")
+
+	flagset.DurationVar(&c.ExpectContinue, prefix+"expect-continue", defTR.ExpectContinueTimeout,
+		"The `timeout` waiting for the TLS handshake to complete.")
+
+	flagset.DurationVar(&c.ResponseHeader, prefix+"response-header", defTR.ResponseHeaderTimeout,
+		"The `timeout` waiting for the TLS handshake to complete.")
+}
+
+func (c *Timeouts) Validate() error {
+	return nil
+}
+
+type Errors []error
+
+func (es Errors) Error() string {
+	var buf strings.Builder
+	for _, e := range es {
+		buf.WriteString(e.Error())
+	}
+
+	return buf.String()
+}

--- a/awstesting/integration/performance/s3DownloadManager/main.go
+++ b/awstesting/integration/performance/s3DownloadManager/main.go
@@ -1,0 +1,218 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+var config Config
+
+func main() {
+	parseCommandLine()
+
+	log.SetOutput(os.Stderr)
+
+	log.Printf("uploading %s file to s3://%s\n", integration.SizeToName(int(config.Size)), config.Bucket)
+	key, err := setupDownloadTest(config.Bucket, config.Size)
+	if err != nil {
+		log.Fatalf("failed to setup download testing: %v", err)
+	}
+
+	traces := make(chan *RequestTrace, config.SDK.Concurrency)
+	requestTracer := downloadRequestTracer(traces)
+	downloader := newDownloader(config.Client, config.SDK, requestTracer)
+
+	metricReportDone := startTraceReceiver(traces)
+
+	log.Println("starting download...")
+	start := time.Now()
+	_, err = downloader.Download(&awstesting.DiscardAt{}, &s3.GetObjectInput{
+		Bucket: &config.Bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		log.Fatalf("failed to download object, %v", err)
+	}
+	close(traces)
+
+	dur := time.Since(start)
+	log.Printf("Download finished, Size: %d, Dur: %s, Throughput: %.5f GB/s",
+		config.Size, dur, (float64(config.Size)/(float64(dur)/float64(time.Second)))/float64(1e9),
+	)
+
+	<-metricReportDone
+
+	log.Printf("cleaning up s3://%s/%s\n", config.Bucket, key)
+	if err = teardownDownloadTest(config.Bucket, key); err != nil {
+		log.Fatalf("failed to teardwn test artifacts: %v", err)
+	}
+}
+
+func parseCommandLine() {
+	config.SetupFlags("", flag.CommandLine)
+
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		flag.CommandLine.PrintDefaults()
+		log.Fatalf("failed to parse CLI commands")
+	}
+	if err := config.Validate(); err != nil {
+		flag.CommandLine.PrintDefaults()
+		log.Fatalf("invalid arguments: %v", err)
+	}
+}
+
+func setupDownloadTest(bucket string, size int64) (key string, err error) {
+	er := &awstesting.EndlessReader{}
+	lr := io.LimitReader(er, size)
+
+	key = integration.UniqueID()
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		S3DisableContentMD5Validation: aws.Bool(true),
+		S3Disable100Continue:          aws.Bool(true),
+	}))
+
+	uploader := s3manager.NewUploader(sess, func(u *s3manager.Uploader) {
+		u.PartSize = 100 * sdkio.MebiByte
+		u.RequestOptions = append(u.RequestOptions, func(r *request.Request) {
+			if r.Operation.Name != "UploadPart" && r.Operation.Name != "PutObject" {
+				return
+			}
+
+			r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
+		})
+	})
+
+	_, err = uploader.Upload(&s3manager.UploadInput{
+		Bucket: &bucket,
+		Body:   lr,
+		Key:    &key,
+	})
+	if err != nil {
+		err = fmt.Errorf("failed to upload test object to s3: %v", err)
+	}
+
+	return
+}
+
+func teardownDownloadTest(bucket, key string) error {
+	sess := session.Must(session.NewSession())
+
+	svc := s3.New(sess)
+
+	_, err := svc.DeleteObject(&s3.DeleteObjectInput{Bucket: &bucket, Key: &key})
+	return err
+}
+
+func startTraceReceiver(traces <-chan *RequestTrace) <-chan struct{} {
+	metricReportDone := make(chan struct{})
+
+	go func() {
+		defer close(metricReportDone)
+		metrics := map[string]*RequestTrace{}
+		for trace := range traces {
+			curTrace, ok := metrics[trace.Operation]
+			if !ok {
+				curTrace = trace
+			} else {
+				curTrace.attempts = append(curTrace.attempts, trace.attempts...)
+				if len(trace.errs) != 0 {
+					curTrace.errs = append(curTrace.errs, trace.errs...)
+				}
+				curTrace.finish = trace.finish
+			}
+
+			metrics[trace.Operation] = curTrace
+		}
+
+		for _, name := range []string{
+			"GetObject",
+		} {
+			if trace, ok := metrics[name]; ok {
+				printAttempts(name, trace, config.LogVerbose)
+			}
+		}
+	}()
+
+	return metricReportDone
+}
+
+func printAttempts(op string, trace *RequestTrace, verbose bool) {
+	if !verbose {
+		return
+	}
+
+	log.Printf("%s: latency:%s requests:%d errors:%d",
+		op,
+		trace.finish.Sub(trace.start),
+		len(trace.attempts),
+		len(trace.errs),
+	)
+
+	for _, a := range trace.attempts {
+		log.Printf("  * %s", a)
+	}
+	if err := trace.Err(); err != nil {
+		log.Printf("Operation Errors: %v", err)
+	}
+	log.Println()
+}
+
+func downloadRequestTracer(traces chan<- *RequestTrace) request.Option {
+	tracerOption := func(r *request.Request) {
+		id := "op"
+		if v, ok := r.Params.(*s3.GetObjectInput); ok {
+			if v.Range != nil {
+				id = *v.Range
+			}
+		}
+		tracer := NewRequestTrace(r.Context(), r.Operation.Name, id)
+		r.SetContext(tracer)
+
+		r.Handlers.Send.PushFront(tracer.OnSendAttempt)
+		r.Handlers.CompleteAttempt.PushBack(tracer.OnCompleteAttempt)
+		r.Handlers.Complete.PushBack(tracer.OnComplete)
+		r.Handlers.Complete.PushBack(func(rr *request.Request) {
+			traces <- tracer
+		})
+	}
+
+	return tracerOption
+}
+
+func newDownloader(clientConfig ClientConfig, sdkConfig SDKConfig, options ...request.Option) *s3manager.Downloader {
+	client := NewClient(clientConfig)
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            aws.Config{HTTPClient: client},
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Fatalf("failed to load session, %v", err)
+	}
+
+	downloader := s3manager.NewDownloader(sess, func(d *s3manager.Downloader) {
+		d.PartSize = sdkConfig.PartSize
+		d.Concurrency = sdkConfig.Concurrency
+		d.BufferProvider = sdkConfig.BufferProvider
+
+		d.RequestOptions = append(d.RequestOptions, options...)
+	})
+
+	return downloader
+}

--- a/awstesting/integration/performance/s3DownloadManager/main_test.go
+++ b/awstesting/integration/performance/s3DownloadManager/main_test.go
@@ -1,0 +1,112 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+var benchConfig BenchmarkConfig
+
+type BenchmarkConfig struct {
+	bucket       string
+	tempdir      string
+	clientConfig ClientConfig
+}
+
+func (b *BenchmarkConfig) SetupFlags(prefix string, flagSet *flag.FlagSet) {
+	flagSet.StringVar(&b.bucket, "bucket", "", "Bucket to use for benchmark")
+	flagSet.StringVar(&b.tempdir, "temp", os.TempDir(), "location to create temporary files")
+	b.clientConfig.SetupFlags(prefix, flagSet)
+}
+
+var benchStrategies = map[string]s3manager.WriterReadFromProvider{
+	"Unbuffered": nil,
+	"Buffered":   s3manager.NewPooledBufferedWriterReadFromProvider(int(sdkio.MebiByte)),
+}
+
+func BenchmarkDownload(b *testing.B) {
+	baseSdkConfig := SDKConfig{}
+
+	// FileSizes: 5 MB, 1 GB
+	for _, fileSize := range []int64{5 * sdkio.MebiByte, 1 * sdkio.GibiByte} {
+		key, err := setupDownloadTest(benchConfig.bucket, fileSize)
+		if err != nil {
+			b.Fatalf("failed to setup download test: %v", err)
+		}
+		f, err := ioutil.TempFile(benchConfig.tempdir, "BenchmarkDownload")
+		if err != nil {
+			b.Fatalf("failed to create temporary file: %v", err)
+		}
+		b.Run(fmt.Sprintf("%s File", integration.SizeToName(int(fileSize))), func(b *testing.B) {
+			// Concurrency: 5, 10, 100
+			for _, concurrency := range []int{s3manager.DefaultDownloadConcurrency, 2 * s3manager.DefaultDownloadConcurrency, 100} {
+				b.Run(fmt.Sprintf("%d Concurrency", concurrency), func(b *testing.B) {
+					// PartSize: 5 MB, 25 MB, 100 MB
+					for _, partSize := range []int64{s3manager.DefaultDownloadPartSize, 25 * sdkio.MebiByte, 100 * sdkio.MebiByte} {
+						if partSize > fileSize {
+							continue
+						}
+						b.Run(fmt.Sprintf("%s PartSize", integration.SizeToName(int(partSize))), func(b *testing.B) {
+							for name, strat := range benchStrategies {
+								b.Run(name, func(b *testing.B) {
+									sdkConfig := baseSdkConfig
+									sdkConfig.Concurrency = concurrency
+									sdkConfig.PartSize = partSize
+									sdkConfig.BufferProvider = strat
+
+									b.ResetTimer()
+									for i := 0; i < b.N; i++ {
+										benchDownload(b, benchConfig.bucket, key, f, sdkConfig, benchConfig.clientConfig)
+										_, err := f.Seek(0, io.SeekStart)
+										if err != nil {
+											b.Fatalf("failed to seek file back to beginning: %v", err)
+										}
+									}
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+
+		err = teardownDownloadTest(benchConfig.bucket, key)
+		if err != nil {
+			b.Fatalf("failed to cleanup test file: %v", err)
+		}
+		if err = f.Close(); err != nil {
+			b.Errorf("failed to close file: %v", err)
+		}
+		if err = os.Remove(f.Name()); err != nil {
+			b.Errorf("failed to remove file: %v", err)
+		}
+	}
+}
+
+func benchDownload(b *testing.B, bucket, key string, body io.WriterAt, sdkConfig SDKConfig, clientConfig ClientConfig) {
+	downloader := newDownloader(clientConfig, sdkConfig)
+	_, err := downloader.Download(body, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		b.Fatalf("failed to download object, %v", err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	benchConfig.SetupFlags("", flag.CommandLine)
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/awstesting/integration/performance/s3DownloadManager/metric.go
+++ b/awstesting/integration/performance/s3DownloadManager/metric.go
@@ -1,0 +1,204 @@
+// +build integration,perftest
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http/httptrace"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+type RequestTrace struct {
+	Operation string
+	ID        string
+
+	context.Context
+
+	start, finish time.Time
+
+	errs       Errors
+	attempts   []RequestAttempt
+	curAttempt RequestAttempt
+}
+
+func NewRequestTrace(ctx context.Context, op, id string) *RequestTrace {
+	rt := &RequestTrace{
+		Operation: op,
+		ID:        id,
+		start:     time.Now(),
+		attempts:  []RequestAttempt{},
+		curAttempt: RequestAttempt{
+			ID: id,
+		},
+	}
+
+	trace := &httptrace.ClientTrace{
+		GetConn:              rt.getConn,
+		GotConn:              rt.gotConn,
+		PutIdleConn:          rt.putIdleConn,
+		GotFirstResponseByte: rt.gotFirstResponseByte,
+		Got100Continue:       rt.got100Continue,
+		DNSStart:             rt.dnsStart,
+		DNSDone:              rt.dnsDone,
+		ConnectStart:         rt.connectStart,
+		ConnectDone:          rt.connectDone,
+		TLSHandshakeStart:    rt.tlsHandshakeStart,
+		TLSHandshakeDone:     rt.tlsHandshakeDone,
+		WroteHeaders:         rt.wroteHeaders,
+		Wait100Continue:      rt.wait100Continue,
+		WroteRequest:         rt.wroteRequest,
+	}
+
+	rt.Context = httptrace.WithClientTrace(ctx, trace)
+
+	return rt
+}
+
+func (rt *RequestTrace) AppendError(err error) {
+	rt.errs = append(rt.errs, err)
+}
+func (rt *RequestTrace) OnSendAttempt(r *request.Request) {
+	rt.curAttempt.SendStart = time.Now()
+}
+func (rt *RequestTrace) OnCompleteAttempt(r *request.Request) {
+	rt.curAttempt.Start = r.AttemptTime
+	rt.curAttempt.Finish = time.Now()
+	rt.curAttempt.Err = r.Error
+
+	if r.Error != nil {
+		rt.AppendError(r.Error)
+	}
+
+	rt.attempts = append(rt.attempts, rt.curAttempt)
+	rt.curAttempt = RequestAttempt{
+		ID:         rt.curAttempt.ID,
+		AttemptNum: rt.curAttempt.AttemptNum + 1,
+	}
+}
+func (rt *RequestTrace) OnComplete(r *request.Request) {
+	rt.finish = time.Now()
+	// Last attempt includes reading the response body
+	if len(rt.attempts) > 0 {
+		rt.attempts[len(rt.attempts)-1].Finish = rt.finish
+	}
+}
+
+func (rt *RequestTrace) Err() error {
+	if len(rt.errs) != 0 {
+		return rt.errs
+	}
+	return nil
+}
+func (rt *RequestTrace) TotalLatency() time.Duration {
+	return rt.finish.Sub(rt.start)
+}
+func (rt *RequestTrace) Attempts() []RequestAttempt {
+	return rt.attempts
+}
+func (rt *RequestTrace) Retries() int {
+	return len(rt.attempts) - 1
+}
+
+func (rt *RequestTrace) getConn(hostPort string) {}
+func (rt *RequestTrace) gotConn(info httptrace.GotConnInfo) {
+	rt.curAttempt.Reused = info.Reused
+}
+func (rt *RequestTrace) putIdleConn(err error) {}
+func (rt *RequestTrace) gotFirstResponseByte() {
+	rt.curAttempt.FirstResponseByte = time.Now()
+}
+func (rt *RequestTrace) got100Continue() {}
+func (rt *RequestTrace) dnsStart(info httptrace.DNSStartInfo) {
+	rt.curAttempt.DNSStart = time.Now()
+}
+func (rt *RequestTrace) dnsDone(info httptrace.DNSDoneInfo) {
+	rt.curAttempt.DNSDone = time.Now()
+}
+func (rt *RequestTrace) connectStart(network, addr string) {
+	rt.curAttempt.ConnectStart = time.Now()
+}
+func (rt *RequestTrace) connectDone(network, addr string, err error) {
+	rt.curAttempt.ConnectDone = time.Now()
+}
+func (rt *RequestTrace) tlsHandshakeStart() {
+	rt.curAttempt.TLSHandshakeStart = time.Now()
+}
+func (rt *RequestTrace) tlsHandshakeDone(state tls.ConnectionState, err error) {
+	rt.curAttempt.TLSHandshakeDone = time.Now()
+}
+func (rt *RequestTrace) wroteHeaders() {
+	rt.curAttempt.WroteHeaders = time.Now()
+}
+func (rt *RequestTrace) wait100Continue() {
+	rt.curAttempt.Read100Continue = time.Now()
+}
+func (rt *RequestTrace) wroteRequest(info httptrace.WroteRequestInfo) {
+	rt.curAttempt.RequestWritten = time.Now()
+}
+
+type RequestAttempt struct {
+	Start, Finish time.Time
+	SendStart     time.Time
+	Err           error
+
+	Reused     bool
+	ID         string
+	AttemptNum int
+
+	DNSStart, DNSDone                   time.Time
+	ConnectStart, ConnectDone           time.Time
+	TLSHandshakeStart, TLSHandshakeDone time.Time
+	WroteHeaders                        time.Time
+	RequestWritten                      time.Time
+	Read100Continue                     time.Time
+	FirstResponseByte                   time.Time
+}
+
+func (a RequestAttempt) String() string {
+	const sep = ", "
+
+	var w strings.Builder
+	w.WriteString(a.ID + "-" + strconv.Itoa(a.AttemptNum) + sep)
+	w.WriteString("Latency:" + durToMSString(a.Finish.Sub(a.Start)) + sep)
+	w.WriteString("SDKPreSend:" + durToMSString(a.SendStart.Sub(a.Start)) + sep)
+
+	writeStart := a.SendStart
+	fmt.Fprintf(&w, "ConnReused:%t"+sep, a.Reused)
+	if !a.Reused {
+		w.WriteString("DNS:" + durToMSString(a.DNSDone.Sub(a.DNSStart)) + sep)
+		w.WriteString("Connect:" + durToMSString(a.ConnectDone.Sub(a.ConnectStart)) + sep)
+		w.WriteString("TLS:" + durToMSString(a.TLSHandshakeDone.Sub(a.TLSHandshakeStart)) + sep)
+		writeStart = a.TLSHandshakeDone
+	}
+
+	writeHeader := a.WroteHeaders.Sub(writeStart)
+	w.WriteString("WriteHeader:" + durToMSString(writeHeader) + sep)
+	if !a.Read100Continue.IsZero() {
+		// With 100-continue
+		w.WriteString("Read100Cont:" + durToMSString(a.Read100Continue.Sub(a.WroteHeaders)) + sep)
+		w.WriteString("WritePayload:" + durToMSString(a.FirstResponseByte.Sub(a.RequestWritten)) + sep)
+
+		w.WriteString("RespRead:" + durToMSString(a.Finish.Sub(a.RequestWritten)) + sep)
+	} else {
+		// No 100-continue
+		w.WriteString("WritePayload:" + durToMSString(a.RequestWritten.Sub(a.WroteHeaders)) + sep)
+
+		if !a.FirstResponseByte.IsZero() {
+			w.WriteString("RespFirstByte:" + durToMSString(a.FirstResponseByte.Sub(a.RequestWritten)) + sep)
+			w.WriteString("RespRead:" + durToMSString(a.Finish.Sub(a.FirstResponseByte)) + sep)
+		}
+	}
+
+	return w.String()
+}
+
+func durToMSString(v time.Duration) string {
+	ms := float64(v) / float64(time.Millisecond)
+	return fmt.Sprintf("%0.6f", ms)
+}

--- a/internal/sdkio/byte.go
+++ b/internal/sdkio/byte.go
@@ -1,0 +1,12 @@
+package sdkio
+
+const (
+	// Byte is 8 bits
+	Byte int64 = 1
+	// KibiByte (KiB) is 1024 Bytes
+	KibiByte = Byte * 1024
+	// MebiByte (MiB) is 1024 KiB
+	MebiByte = KibiByte * 1024
+	// GibiByte (GiB) is 1024 MiB
+	GibiByte = MebiByte * 1024
+)

--- a/service/s3/s3manager/default_writer_read_from.go
+++ b/service/s3/s3manager/default_writer_read_from.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package s3manager
+
+func defaultDownloadBufferProvider() WriterReadFromProvider {
+	return nil
+}

--- a/service/s3/s3manager/default_writer_read_from_windows.go
+++ b/service/s3/s3manager/default_writer_read_from_windows.go
@@ -1,0 +1,5 @@
+package s3manager
+
+func defaultDownloadBufferProvider() WriterReadFromProvider {
+	return NewPooledBufferedWriterReadFromProvider(1024 * 1024)
+}

--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -25,13 +25,25 @@ const DefaultDownloadPartSize = 1024 * 1024 * 5
 // when using Download().
 const DefaultDownloadConcurrency = 5
 
+type errReadingBody struct {
+	err error
+}
+
+func (e *errReadingBody) Error() string {
+	return fmt.Sprintf("failed to read part body: %v", e.err)
+}
+
+func (e *errReadingBody) Unwrap() error {
+	return e.err
+}
+
 // The Downloader structure that calls Download(). It is safe to call Download()
 // on this structure for multiple objects and across concurrent goroutines.
 // Mutating the Downloader's properties is not safe to be done concurrently.
 type Downloader struct {
-	// The buffer size (in bytes) to use when buffering data into chunks and
-	// sending them as parts to S3. The minimum allowed part size is 5MB, and
-	// if this value is set to zero, the DefaultDownloadPartSize value will be used.
+	// The size (in bytes) to request from S3 for each part.
+	// The minimum allowed part size is 5MB, and  if this value is set to zero,
+	// the DefaultDownloadPartSize value will be used.
 	//
 	// PartSize is ignored if the Range input parameter is provided.
 	PartSize int64
@@ -50,6 +62,14 @@ type Downloader struct {
 	// List of request options that will be passed down to individual API
 	// operation requests made by the downloader.
 	RequestOptions []request.Option
+
+	// Defines the buffer strategy used when downloading a part.
+	//
+	// If a WriterReadFromProvider is given the Download manager
+	// will pass the io.WriterAt of the Download request to the provider
+	// and will use the returned WriterReadFrom from the provider as the
+	// destination writer when copying from http response body.
+	BufferProvider WriterReadFromProvider
 }
 
 // WithDownloaderRequestOptions appends to the Downloader's API request options.
@@ -77,10 +97,15 @@ func WithDownloaderRequestOptions(opts ...request.Option) func(*Downloader) {
 //          d.PartSize = 64 * 1024 * 1024 // 64MB per part
 //     })
 func NewDownloader(c client.ConfigProvider, options ...func(*Downloader)) *Downloader {
+	return newDownloader(s3.New(c), options...)
+}
+
+func newDownloader(client s3iface.S3API, options ...func(*Downloader)) *Downloader {
 	d := &Downloader{
-		S3:          s3.New(c),
-		PartSize:    DefaultDownloadPartSize,
-		Concurrency: DefaultDownloadConcurrency,
+		S3:             client,
+		PartSize:       DefaultDownloadPartSize,
+		Concurrency:    DefaultDownloadConcurrency,
+		BufferProvider: defaultDownloadBufferProvider(),
 	}
 	for _, option := range options {
 		option(d)
@@ -109,16 +134,7 @@ func NewDownloader(c client.ConfigProvider, options ...func(*Downloader)) *Downl
 //          d.PartSize = 64 * 1024 * 1024 // 64MB per part
 //     })
 func NewDownloaderWithClient(svc s3iface.S3API, options ...func(*Downloader)) *Downloader {
-	d := &Downloader{
-		S3:          svc,
-		PartSize:    DefaultDownloadPartSize,
-		Concurrency: DefaultDownloadConcurrency,
-	}
-	for _, option := range options {
-		option(d)
-	}
-
-	return d
+	return newDownloader(svc, options...)
 }
 
 type maxRetrier interface {
@@ -405,17 +421,19 @@ func (d *downloader) downloadChunk(chunk dlchunk) error {
 	var n int64
 	var err error
 	for retry := 0; retry <= d.partBodyMaxRetries; retry++ {
-		var resp *s3.GetObjectOutput
-		resp, err = d.cfg.S3.GetObjectWithContext(d.ctx, in, d.cfg.RequestOptions...)
-		if err != nil {
-			return err
-		}
-		d.setTotalBytes(resp) // Set total if not yet set.
-
-		n, err = io.Copy(&chunk, resp.Body)
-		resp.Body.Close()
+		n, err = d.tryDownloadChunk(in, &chunk)
 		if err == nil {
 			break
+		}
+		// Check if the returned error is an errReadingBody.
+		// If err is errReadingBody this indicates that an error
+		// occurred while copying the http response body.
+		// If this occurs we unwrap the to set the underling error
+		// and attempt any remaining retries.
+		if bodyErr, ok := err.(*errReadingBody); ok {
+			err = bodyErr.Unwrap()
+		} else {
+			return err
 		}
 
 		chunk.cur = 0
@@ -427,6 +445,28 @@ func (d *downloader) downloadChunk(chunk dlchunk) error {
 	d.incrWritten(n)
 
 	return err
+}
+
+func (d *downloader) tryDownloadChunk(in *s3.GetObjectInput, w io.Writer) (int64, error) {
+	cleanup := func() {}
+	if d.cfg.BufferProvider != nil {
+		w, cleanup = d.cfg.BufferProvider.GetReadFrom(w)
+	}
+	defer cleanup()
+
+	resp, err := d.cfg.S3.GetObjectWithContext(d.ctx, in, d.cfg.RequestOptions...)
+	if err != nil {
+		return 0, err
+	}
+	d.setTotalBytes(resp) // Set total if not yet set.
+
+	n, err := io.Copy(w, resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return n, &errReadingBody{err: err}
+	}
+
+	return n, nil
 }
 
 func logMessage(svc s3iface.S3API, level aws.LogLevelType, msg string) {

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -20,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -642,6 +644,80 @@ func TestDownload_WithFailure(t *testing.T) {
 	}
 }
 
+func TestDownloadBufferStrategy(t *testing.T) {
+	cases := map[string]struct {
+		partSize     int64
+		strategy     *recordedWriterReadFromProvider
+		expectedSize int64
+	}{
+		"no strategy": {
+			partSize:     s3manager.DefaultDownloadPartSize,
+			expectedSize: 10 * sdkio.MebiByte,
+		},
+		"partSize modulo bufferSize == 0": {
+			partSize: 5 * sdkio.MebiByte,
+			strategy: &recordedWriterReadFromProvider{
+				WriterReadFromProvider: s3manager.NewPooledBufferedWriterReadFromProvider(int(sdkio.MebiByte)), // 1 MiB
+			},
+			expectedSize: 10 * sdkio.MebiByte, // 10 MiB
+		},
+		"partSize modulo bufferSize > 0": {
+			partSize: 5 * 1024 * 1204, // 5 MiB
+			strategy: &recordedWriterReadFromProvider{
+				WriterReadFromProvider: s3manager.NewPooledBufferedWriterReadFromProvider(2 * int(sdkio.MebiByte)), // 2 MiB
+			},
+			expectedSize: 10 * sdkio.MebiByte, // 10 MiB
+		},
+	}
+
+	for name, tCase := range cases {
+		t.Logf("starting case: %v", name)
+
+		expected := make([]byte, tCase.expectedSize)
+		fillRandom(expected)
+
+		svc, _, _ := dlLoggingSvc(expected)
+
+		d := s3manager.NewDownloaderWithClient(svc, func(d *s3manager.Downloader) {
+			d.PartSize = tCase.partSize
+			if tCase.strategy != nil {
+				d.BufferProvider = tCase.strategy
+			}
+		})
+
+		buffer := aws.NewWriteAtBuffer(make([]byte, len(expected)))
+
+		n, err := d.Download(buffer, &s3.GetObjectInput{
+			Bucket: aws.String("bucket"),
+			Key:    aws.String("key"),
+		})
+		if err != nil {
+			t.Errorf("failed to download: %v", err)
+		}
+
+		if e, a := len(expected), int(n); e != a {
+			t.Errorf("expected %v, got %v downloaded bytes", e, a)
+		}
+
+		if e, a := expected, buffer.Bytes(); !bytes.Equal(e, a) {
+			t.Errorf("downloaded bytes did not match expected")
+		}
+
+		if tCase.strategy != nil {
+			if e, a := tCase.strategy.callbacksVended, tCase.strategy.callbacksExecuted; e != a {
+				t.Errorf("expected %v, got %v", e, a)
+			}
+		}
+	}
+}
+
+func fillRandom(p []byte) {
+	for i := 0; i < len(p); i++ {
+		val := rand.Int63()
+		p[i] = byte(val)
+	}
+}
+
 type testErrReader struct {
 	Buf []byte
 	Err error
@@ -662,4 +738,97 @@ func (r *testErrReader) Read(p []byte) (int, error) {
 	}
 
 	return n, nil
+}
+
+func TestDownloadBufferStrategy_Errors(t *testing.T) {
+	expected := make([]byte, 10*sdkio.MebiByte)
+	fillRandom(expected)
+
+	svc, _, _ := dlLoggingSvc(expected)
+	strat := &recordedWriterReadFromProvider{WriterReadFromProvider: s3manager.NewPooledBufferedWriterReadFromProvider(2 * 1024 * 1024)}
+
+	d := s3manager.NewDownloaderWithClient(svc, func(d *s3manager.Downloader) {
+		d.PartSize = 5 * 1024 * 1024
+		d.BufferProvider = strat
+		d.Concurrency = 1
+	})
+
+	seenOps := make(map[string]struct{})
+	svc.Handlers.Send.PushFront(func(*request.Request) {})
+	svc.Handlers.Send.AfterEachFn = func(item request.HandlerListRunItem) bool {
+		r := item.Request
+
+		if r.Operation.Name != "GetObject" {
+			return true
+		}
+
+		input := r.Params.(*s3.GetObjectInput)
+
+		fingerPrint := fmt.Sprintf("%s/%s/%s/%s", r.Operation.Name, *input.Bucket, *input.Key, *input.Range)
+		if _, ok := seenOps[fingerPrint]; ok {
+			return true
+		}
+		seenOps[fingerPrint] = struct{}{}
+
+		regex := regexp.MustCompile(`bytes=(\d+)-(\d+)`)
+		rng := regex.FindStringSubmatch(*input.Range)
+		start, _ := strconv.ParseInt(rng[1], 10, 64)
+		fin, _ := strconv.ParseInt(rng[2], 10, 64)
+
+		_, _ = io.Copy(ioutil.Discard, r.Body)
+		r.HTTPResponse = &http.Response{
+			StatusCode:    200,
+			Body:          aws.ReadSeekCloser(&badReader{err: io.ErrUnexpectedEOF}),
+			ContentLength: fin - start,
+		}
+
+		return false
+	}
+
+	buffer := aws.NewWriteAtBuffer(make([]byte, len(expected)))
+
+	n, err := d.Download(buffer, &s3.GetObjectInput{
+		Bucket: aws.String("bucket"),
+		Key:    aws.String("key"),
+	})
+	if err != nil {
+		t.Errorf("failed to download: %v", err)
+	}
+
+	if e, a := len(expected), int(n); e != a {
+		t.Errorf("expected %v, got %v downloaded bytes", e, a)
+	}
+
+	if e, a := expected, buffer.Bytes(); !bytes.Equal(e, a) {
+		t.Errorf("downloaded bytes did not match expected")
+	}
+
+	if e, a := strat.callbacksVended, strat.callbacksExecuted; e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+type recordedWriterReadFromProvider struct {
+	callbacksVended   uint32
+	callbacksExecuted uint32
+	s3manager.WriterReadFromProvider
+}
+
+func (r *recordedWriterReadFromProvider) GetReadFrom(writer io.Writer) (s3manager.WriterReadFrom, func()) {
+	w, cleanup := r.WriterReadFromProvider.GetReadFrom(writer)
+
+	atomic.AddUint32(&r.callbacksVended, 1)
+	return w, func() {
+		atomic.AddUint32(&r.callbacksExecuted, 1)
+		cleanup()
+	}
+}
+
+type badReader struct {
+	err error
+}
+
+func (b *badReader) Read(p []byte) (int, error) {
+	fillRandom(p)
+	return len(p), b.err
 }

--- a/service/s3/s3manager/writer_read_from.go
+++ b/service/s3/s3manager/writer_read_from.go
@@ -1,0 +1,75 @@
+package s3manager
+
+import (
+	"bufio"
+	"io"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+)
+
+// WriterReadFrom defines an interface implementing io.Writer and io.ReaderFrom
+type WriterReadFrom interface {
+	io.Writer
+	io.ReaderFrom
+}
+
+// WriterReadFromProvider provides an implementation of io.ReadFrom for the given io.Writer
+type WriterReadFromProvider interface {
+	GetReadFrom(writer io.Writer) (w WriterReadFrom, cleanup func())
+}
+
+type bufferedWriter interface {
+	WriterReadFrom
+	Flush() error
+	Reset(io.Writer)
+}
+
+type bufferedReadFrom struct {
+	bufferedWriter
+}
+
+func (b *bufferedReadFrom) ReadFrom(r io.Reader) (int64, error) {
+	n, err := b.bufferedWriter.ReadFrom(r)
+	if flushErr := b.Flush(); flushErr != nil && err == nil {
+		err = flushErr
+	}
+	return n, err
+}
+
+// PooledBufferedReadFromProvider is a WriterReadFromProvider that uses a sync.Pool
+// to manage allocation and reuse of *bufio.Writer structures.
+type PooledBufferedReadFromProvider struct {
+	pool sync.Pool
+}
+
+// NewPooledBufferedWriterReadFromProvider returns a new PooledBufferedReadFromProvider
+// Size is used to control the size of the underlying *bufio.Writer created for
+// calls to GetReadFrom.
+func NewPooledBufferedWriterReadFromProvider(size int) *PooledBufferedReadFromProvider {
+	if size < int(32*sdkio.KibiByte) {
+		size = int(64 * sdkio.KibiByte)
+	}
+
+	return &PooledBufferedReadFromProvider{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &bufferedReadFrom{bufferedWriter: bufio.NewWriterSize(nil, size)}
+			},
+		},
+	}
+}
+
+// GetReadFrom takes an io.Writer and wraps it with a type which satisfies the WriterReadFrom
+// interface/ Additionally a cleanup function is provided which must be called after usage of the WriterReadFrom
+// has been completed in order to allow the reuse of the *bufio.Writer
+func (p *PooledBufferedReadFromProvider) GetReadFrom(writer io.Writer) (r WriterReadFrom, cleanup func()) {
+	buffer := p.pool.Get().(*bufferedReadFrom)
+	buffer.Reset(writer)
+	r = buffer
+	cleanup = func() {
+		buffer.Reset(nil) // Reset to nil writer to release reference
+		p.pool.Put(buffer)
+	}
+	return r, cleanup
+}

--- a/service/s3/s3manager/writer_read_from_test.go
+++ b/service/s3/s3manager/writer_read_from_test.go
@@ -1,0 +1,73 @@
+package s3manager
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+type testBufioWriter struct {
+	ReadFromN   int64
+	ReadFromErr error
+	FlushReturn error
+}
+
+func (t testBufioWriter) Write(p []byte) (n int, err error) {
+	panic("unused")
+}
+
+func (t testBufioWriter) ReadFrom(r io.Reader) (n int64, err error) {
+	return t.ReadFromN, t.ReadFromErr
+}
+
+func (t testBufioWriter) Flush() error {
+	return t.FlushReturn
+}
+
+func (t *testBufioWriter) Reset(io.Writer) {
+	panic("unused")
+}
+
+func TestBufferedReadFromFlusher_ReadFrom(t *testing.T) {
+	cases := map[string]struct {
+		w           testBufioWriter
+		expectedErr error
+	}{
+		"no errors": {},
+		"error returned from underlying ReadFrom": {
+			w: testBufioWriter{
+				ReadFromN:   42,
+				ReadFromErr: fmt.Errorf("readfrom"),
+			},
+			expectedErr: fmt.Errorf("readfrom"),
+		},
+		"error returned from Flush": {
+			w: testBufioWriter{
+				ReadFromN:   7,
+				FlushReturn: fmt.Errorf("flush"),
+			},
+			expectedErr: fmt.Errorf("flush"),
+		},
+		"error returned from ReadFrom and Flush": {
+			w: testBufioWriter{
+				ReadFromN:   1337,
+				ReadFromErr: fmt.Errorf("readfrom"),
+				FlushReturn: fmt.Errorf("flush"),
+			},
+			expectedErr: fmt.Errorf("readfrom"),
+		},
+	}
+
+	for name, tCase := range cases {
+		t.Log(name)
+		readFromFlusher := bufferedReadFrom{bufferedWriter: &tCase.w}
+		n, err := readFromFlusher.ReadFrom(nil)
+		if e, a := tCase.w.ReadFromN, n; e != a {
+			t.Errorf("expected %v bytes, got %v", e, a)
+		}
+		if e, a := tCase.expectedErr, err; !reflect.DeepEqual(e, a) {
+			t.Errorf("expected error %v. got %v", e, a)
+		}
+	}
+}


### PR DESCRIPTION
Implements a buffering strategy for the download S3 manager. This is similar to the upload strategy being reviewed as part of https://github.com/aws/aws-sdk-go/pull/2792