### PR TITLE
aws/client: Adds configurations to the default retryer

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,10 @@
 ### SDK Features
 
 ### SDK Enhancements
-
+* `aws/client`: Adds configurations to the default retryer
+  * Exposes members of the default retryer. Adds NoOpRetryer to support no retry behavior. 
+  * Updates the underlying logic used by the default retryer to calculate jittered delay for retry. 
+  * Fixes [#2829](https://github.com/aws/aws-sdk-go/issues/2829)
+  
 ### SDK Bugs
+

--- a/aws/client/client.go
+++ b/aws/client/client.go
@@ -64,7 +64,7 @@ func New(cfg aws.Config, info metadata.ClientInfo, handlers request.Handlers, op
 	default:
 		maxRetries := aws.IntValue(cfg.MaxRetries)
 		if cfg.MaxRetries == nil || maxRetries == aws.UseServiceDefaultRetries {
-			maxRetries = 3
+			maxRetries = DefaultRetryerMaxNumRetries
 		}
 		svc.Retryer = DefaultRetryer{NumMaxRetries: maxRetries}
 	}

--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"math"
 	"strconv"
 	"time"
 
@@ -21,8 +22,29 @@ import (
 //   // This implementation always has 100 max retries
 //   func (d retryer) MaxRetries() int { return 100 }
 type DefaultRetryer struct {
-	NumMaxRetries int
+	NumMaxRetries    int
+	MinRetryDelay    time.Duration
+	MinThrottleDelay time.Duration
+	MaxRetryDelay    time.Duration
+	MaxThrottleDelay time.Duration
 }
+
+const (
+	// DefaultRetryerMaxNumRetries sets maximum number of retries
+	DefaultRetryerMaxNumRetries = 3
+
+	// DefaultRetryerMinRetryDelay sets minimum retry delay
+	DefaultRetryerMinRetryDelay = 30 * time.Millisecond
+
+	// DefaultRetryerMinThrottleDelay sets minimum delay when throttled
+	DefaultRetryerMinThrottleDelay = 500 * time.Millisecond
+
+	// DefaultRetryerMaxRetryDelay sets maximum retry delay
+	DefaultRetryerMaxRetryDelay = 300 * time.Second
+
+	// DefaultRetryerMaxThrottleDelay sets maximum delay when throttled
+	DefaultRetryerMaxThrottleDelay = 300 * time.Second
+)
 
 // MaxRetries returns the number of maximum returns the service will use to make
 // an individual API request.
@@ -30,10 +52,36 @@ func (d DefaultRetryer) MaxRetries() int {
 	return d.NumMaxRetries
 }
 
+// setRetryerDefaults sets the default values of the retryer if not set
+func (d *DefaultRetryer) setRetryerDefaults() {
+	if d.MinRetryDelay == 0 {
+		d.MinRetryDelay = DefaultRetryerMinRetryDelay
+	}
+	if d.MaxRetryDelay == 0 {
+		d.MaxRetryDelay = DefaultRetryerMaxRetryDelay
+	}
+	if d.MinThrottleDelay == 0 {
+		d.MinThrottleDelay = DefaultRetryerMinThrottleDelay
+	}
+	if d.MaxThrottleDelay == 0 {
+		d.MaxThrottleDelay = DefaultRetryerMaxThrottleDelay
+	}
+}
+
 // RetryRules returns the delay duration before retrying this request again
 func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
-	// Set the upper limit of delay in retrying at ~five minutes
-	var minTime int64 = 30
+
+	// if number of max retries is zero, no retries will be performed.
+	if d.NumMaxRetries == 0 {
+		return 0
+	}
+
+	// Sets default value for retryer members
+	d.setRetryerDefaults()
+
+	// minDelay is the minimum retryer delay
+	minDelay := d.MinRetryDelay
+
 	var initialDelay time.Duration
 
 	isThrottle := r.IsErrorThrottle()
@@ -41,20 +89,36 @@ func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
 		if delay, ok := getRetryAfterDelay(r); ok {
 			initialDelay = delay
 		}
-
-		minTime = 500
+		minDelay = d.MinThrottleDelay
 	}
 
 	retryCount := r.RetryCount
-	if isThrottle && retryCount > 8 {
-		retryCount = 8
-	} else if retryCount > 12 {
-		retryCount = 12
+
+	// maxDelay the maximum retryer delay
+	maxDelay := d.MaxRetryDelay
+
+	if isThrottle {
+		maxDelay = d.MaxThrottleDelay
 	}
 
-	delay := (1 << uint(retryCount)) * (sdkrand.SeededRand.Int63n(minTime) + minTime)
-	return (time.Duration(delay) * time.Millisecond) + initialDelay
+	var delay time.Duration
 
+	// Logic to cap the retry count based on the minDelay provided
+	actualRetryCount := int(math.Log2(float64(minDelay))) + 1
+	if actualRetryCount < 63-retryCount {
+		delay = time.Duration(1<<uint64(retryCount)) * getJitterDelay(minDelay)
+		if delay > maxDelay {
+			delay = getJitterDelay(maxDelay / 2)
+		}
+	} else {
+		delay = getJitterDelay(maxDelay / 2)
+	}
+	return delay + initialDelay
+}
+
+// getJitterDelay returns a jittered delay for retry
+func getJitterDelay(duration time.Duration) time.Duration {
+	return time.Duration(sdkrand.SeededRand.Int63n(int64(duration)) + int64(duration))
 }
 
 // ShouldRetry returns true if the request should be retried.

--- a/aws/client/default_retryer_test.go
+++ b/aws/client/default_retryer_test.go
@@ -166,7 +166,7 @@ func TestGetRetryDelay(t *testing.T) {
 }
 
 func TestRetryDelay(t *testing.T) {
-	d := DefaultRetryer{100}
+	d := DefaultRetryer{NumMaxRetries:100}
 	r := request.Request{}
 	for i := 0; i < 100; i++ {
 		rTemp := r

--- a/aws/client/no_op_retryer.go
+++ b/aws/client/no_op_retryer.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// NoOpRetryer provides a retryer that performs no retries.
+// It should be used when we do not want retries to be performed.
+type NoOpRetryer struct{}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API; For NoOpRetryer the MaxRetries will always be zero.
+func (d NoOpRetryer) MaxRetries() int {
+	return 0
+}
+
+// ShouldRetry will always return false for NoOpRetryer, as it should never retry.
+func (d NoOpRetryer) ShouldRetry(_ *request.Request) bool {
+	return false
+}
+
+// RetryRules returns the delay duration before retrying this request again;
+// since NoOpRetryer does not retry, RetryRules always returns 0.
+func (d NoOpRetryer) RetryRules(_ *request.Request) time.Duration {
+	return 0
+}

--- a/aws/client/no_op_retryer_test.go
+++ b/aws/client/no_op_retryer_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+func TestNoOpRetryer(t *testing.T) {
+	cases := []struct {
+		r                request.Request
+		expectMaxRetries int
+		expectRetryDelay time.Duration
+		expectRetry      bool
+	}{
+		{
+			r: request.Request{
+				HTTPResponse: &http.Response{StatusCode: 200},
+			},
+			expectMaxRetries: 0,
+			expectRetryDelay: 0,
+			expectRetry:      false,
+		},
+	}
+
+	d := NoOpRetryer{}
+	for i, c := range cases {
+		maxRetries := d.MaxRetries()
+		retry := d.ShouldRetry(&c.r)
+		retryDelay := d.RetryRules(&c.r)
+
+		if e, a := c.expectMaxRetries, maxRetries; e != a {
+			t.Errorf("%d: expected %v, but received %v for number of max retries", i, e, a)
+		}
+
+		if e, a := c.expectRetry, retry; e != a {
+			t.Errorf("%d: expected %v, but received %v for should retry", i, e, a)
+		}
+
+		if e, a := c.expectRetryDelay, retryDelay; e != a {
+			t.Errorf("%d: expected %v, but received %v as retry delay", i, e, a)
+		}
+	}
+}

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -94,10 +94,6 @@ var validParentCodes = map[string]struct{}{
 	ErrCodeRead:          {},
 }
 
-type temporaryError interface {
-	Temporary() bool
-}
-
 func isNestedErrorRetryable(parentErr awserr.Error) bool {
 	if parentErr == nil {
 		return false
@@ -116,7 +112,7 @@ func isNestedErrorRetryable(parentErr awserr.Error) bool {
 		return isCodeRetryable(aerr.Code())
 	}
 
-	if t, ok := err.(temporaryError); ok {
+	if t, ok := err.(temporary); ok {
 		return t.Temporary() || isErrConnectionReset(err)
 	}
 

--- a/example/aws/request/customRetryer/custom_retryer.go
+++ b/example/aws/request/customRetryer/custom_retryer.go
@@ -20,7 +20,10 @@ func main() {
 	sess := session.Must(
 		session.NewSession(&aws.Config{
 			// Use a custom retryer to provide custom retry rules.
-			Retryer: CustomRetryer{DefaultRetryer: client.DefaultRetryer{NumMaxRetries: 3}},
+			Retryer: CustomRetryer{
+				DefaultRetryer: client.DefaultRetryer{
+					NumMaxRetries: client.DefaultRetryerMaxNumRetries,
+				}},
 
 			// Use the SDK's SharedCredentialsProvider directly instead of the
 			// SDK's default credential chain. This ensures that the

--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -5,7 +5,6 @@ import (
 	"hash/crc32"
 	"io"
 	"io/ioutil"
-	"math"
 	"strconv"
 	"time"
 
@@ -14,15 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
-
-type retryer struct {
-	client.DefaultRetryer
-}
-
-func (d retryer) RetryRules(r *request.Request) time.Duration {
-	delay := time.Duration(math.Pow(2, float64(r.RetryCount))) * 50
-	return delay * time.Millisecond
-}
 
 func init() {
 	initClient = func(c *client.Client) {
@@ -43,10 +33,9 @@ func setCustomRetryer(c *client.Client) {
 		maxRetries = 10
 	}
 
-	c.Retryer = retryer{
-		DefaultRetryer: client.DefaultRetryer{
-			NumMaxRetries: maxRetries,
-		},
+	c.Retryer = client.DefaultRetryer{
+		NumMaxRetries: maxRetries,
+		MinRetryDelay: 50 * time.Millisecond,
 	}
 }
 

--- a/service/ec2/customizations.go
+++ b/service/ec2/customizations.go
@@ -8,64 +8,34 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/internal/sdkrand"
 )
 
-type retryer struct {
-	client.DefaultRetryer
-}
+const (
+	// customRetryerMaxNumRetries sets max number of retries
+	customRetryerMaxNumRetries = 3
 
-func (d retryer) RetryRules(r *request.Request) time.Duration {
-	switch r.Operation.Name {
-	case opModifyNetworkInterfaceAttribute:
-		fallthrough
-	case opAssignPrivateIpAddresses:
-		return customRetryRule(r)
-	default:
-		return d.DefaultRetryer.RetryRules(r)
-	}
-}
+	// customRetryerMinRetryDelay sets min retry delay
+	customRetryerMinRetryDelay = 1 * time.Second
 
-func customRetryRule(r *request.Request) time.Duration {
-	retryTimes := []time.Duration{
-		time.Second,
-		3 * time.Second,
-		5 * time.Second,
-	}
-
-	count := r.RetryCount
-	if count >= len(retryTimes) {
-		count = len(retryTimes) - 1
-	}
-
-	minTime := int64(retryTimes[count])
-	return time.Duration(sdkrand.SeededRand.Int63n(minTime) + minTime)
-}
-
-func setCustomRetryer(c *client.Client) {
-	maxRetries := aws.IntValue(c.Config.MaxRetries)
-	if c.Config.MaxRetries == nil || maxRetries == aws.UseServiceDefaultRetries {
-		maxRetries = 3
-	}
-
-	c.Retryer = retryer{
-		DefaultRetryer: client.DefaultRetryer{
-			NumMaxRetries: maxRetries,
-		},
-	}
-}
+	// customRetryerMaxRetryDelay sets max retry delay
+	customRetryerMaxRetryDelay = 8 * time.Second
+)
 
 func init() {
-	initClient = func(c *client.Client) {
-		if c.Config.Retryer == nil {
-			// Only override the retryer with a custom one if the config
-			// does not already contain a retryer
-			setCustomRetryer(c)
-		}
-	}
 	initRequest = func(r *request.Request) {
 		if r.Operation.Name == opCopySnapshot { // fill the PresignedURL parameter
 			r.Handlers.Build.PushFront(fillPresignedURL)
+		}
+
+		// only set the retryer on request if config doesn't have a retryer
+		if r.Config.Retryer == nil && (r.Operation.Name == opModifyNetworkInterfaceAttribute || r.Operation.Name == opAssignPrivateIpAddresses) {
+			r.Retryer = client.DefaultRetryer{
+				NumMaxRetries:    customRetryerMaxNumRetries,
+				MinRetryDelay:    customRetryerMinRetryDelay,
+				MinThrottleDelay: customRetryerMinRetryDelay,
+				MaxRetryDelay:    customRetryerMaxRetryDelay,
+				MaxThrottleDelay: customRetryerMaxRetryDelay,
+			}
 		}
 	}
 }

--- a/service/ec2/retryer_test.go
+++ b/service/ec2/retryer_test.go
@@ -9,29 +9,92 @@ import (
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 )
 
-func TestCustomRetryer(t *testing.T) {
+func TestCustomRetryRules(t *testing.T) {
 	svc := New(unit.Session, &aws.Config{Region: aws.String("us-west-2")})
-	if _, ok := svc.Client.Retryer.(retryer); !ok {
-		t.Error("expected custom retryer, but received otherwise")
-	}
-
 	req, _ := svc.ModifyNetworkInterfaceAttributeRequest(&ModifyNetworkInterfaceAttributeInput{
 		NetworkInterfaceId: aws.String("foo"),
 	})
 
-	duration := svc.Client.Retryer.RetryRules(req)
+	duration := req.Retryer.RetryRules(req)
 	if duration < time.Second*1 || duration > time.Second*2 {
 		t.Errorf("expected duration to be between 1s and 2s, but received %v", duration)
 	}
 
 	req.RetryCount = 15
-	duration = svc.Client.Retryer.RetryRules(req)
+	duration = req.Retryer.RetryRules(req)
 	if duration < time.Second*5 || duration > time.Second*10 {
 		t.Errorf("expected duration to be between 5s and 10s, but received %v", duration)
 	}
+}
 
-	svc = New(unit.Session, &aws.Config{Region: aws.String("us-west-2"), Retryer: client.DefaultRetryer{}})
+func TestCustomRetryer_WhenRetrierSpecified(t *testing.T) {
+	svc := New(unit.Session, &aws.Config{Region: aws.String("us-west-2"),
+		Retryer: client.DefaultRetryer{
+			NumMaxRetries:    4,
+			MinThrottleDelay: 50 * time.Millisecond,
+			MinRetryDelay:    10 * time.Millisecond,
+			MaxThrottleDelay: 200 * time.Millisecond,
+			MaxRetryDelay:    300 * time.Millisecond,
+		},
+	})
+
 	if _, ok := svc.Client.Retryer.(client.DefaultRetryer); !ok {
 		t.Error("expected default retryer, but received otherwise")
+	}
+
+	req, _ := svc.AssignPrivateIpAddressesRequest(&AssignPrivateIpAddressesInput{
+		NetworkInterfaceId: aws.String("foo"),
+	})
+
+	d := req.Retryer.(client.DefaultRetryer)
+
+	if d.NumMaxRetries != 4 {
+		t.Errorf("expected max retries to be %v, got %v", 4, d.NumMaxRetries)
+	}
+
+	if d.MinRetryDelay != 10*time.Millisecond {
+		t.Errorf("expected min retry delay to be %v, got %v", "10 ms", d.MinRetryDelay)
+	}
+
+	if d.MinThrottleDelay != 50*time.Millisecond {
+		t.Errorf("expected min throttle delay to be %v, got %v", "50 ms", d.MinThrottleDelay)
+	}
+
+	if d.MaxRetryDelay != 300*time.Millisecond {
+		t.Errorf("expected max retry delay to be %v, got %v", "300 ms", d.MaxRetryDelay)
+	}
+
+	if d.MaxThrottleDelay != 200*time.Millisecond {
+		t.Errorf("expected max throttle delay to be %v, got %v", "200 ms", d.MaxThrottleDelay)
+	}
+}
+
+func TestCustomRetryer(t *testing.T) {
+	svc := New(unit.Session, &aws.Config{Region: aws.String("us-west-2")})
+
+	req, _ := svc.AssignPrivateIpAddressesRequest(&AssignPrivateIpAddressesInput{
+		NetworkInterfaceId: aws.String("foo"),
+	})
+
+	d := req.Retryer.(client.DefaultRetryer)
+
+	if d.NumMaxRetries != customRetryerMaxNumRetries {
+		t.Errorf("expected max retries to be %v, got %v", customRetryerMaxNumRetries, d.NumMaxRetries)
+	}
+
+	if d.MinRetryDelay != customRetryerMinRetryDelay {
+		t.Errorf("expected min retry delay to be %v, got %v", customRetryerMinRetryDelay, d.MinRetryDelay)
+	}
+
+	if d.MinThrottleDelay != customRetryerMinRetryDelay {
+		t.Errorf("expected min throttle delay to be %v, got %v", customRetryerMinRetryDelay, d.MinThrottleDelay)
+	}
+
+	if d.MaxRetryDelay != customRetryerMaxRetryDelay {
+		t.Errorf("expected max retry delay to be %v, got %v", customRetryerMaxRetryDelay, d.MaxRetryDelay)
+	}
+
+	if d.MaxThrottleDelay != customRetryerMaxRetryDelay {
+		t.Errorf("expected max throttle delay to be %v, got %v", customRetryerMaxRetryDelay, d.MaxThrottleDelay)
 	}
 }


### PR DESCRIPTION
Exposes members of the default retryer. Adds NoOpRetryer to support no retry behavior. Updates the underlying logic used by the default retryer to calculate jittered delay for retry. 

Fixes #2829