### PR TITLE
service/dynamodb/dynamodbattribute: Support for configuring the marsh…

### DIFF
--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -172,15 +172,15 @@ func (d *Decoder) decode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag 
 	}
 
 	switch {
-	case len(av.B) != 0:
+	case len(av.B) != 0 || (av.B != nil && d.EmptyCollections):
 		return d.decodeBinary(av.B, v)
 	case av.BOOL != nil:
 		return d.decodeBool(av.BOOL, v)
 	case len(av.BS) != 0:
 		return d.decodeBinarySet(av.BS, v)
-	case len(av.L) != 0:
+	case len(av.L) != 0 || (av.L != nil && d.EmptyCollections):
 		return d.decodeList(av.L, v)
-	case len(av.M) != 0:
+	case len(av.M) != 0 || (av.M != nil && d.EmptyCollections):
 		return d.decodeMap(av.M, v)
 	case av.N != nil:
 		return d.decodeNumber(av.N, v, fieldTag)


### PR DESCRIPTION
This adds a new field to `MarshalOptions` named `EmptyCollections`. This new field would allow users can to control the SDK's behavior when (un)marshaling map or slice types that are either empty. The default value of this flag is false, which will result in the current behavior of (un)marshaling empty collections as nil. When this new option is set to true, collections that are  empty will be marshaled as empty values before being sent to DynamoDB.  