### PR TITLE
aws/request: Refactors the http status code handling by the retryer

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -140,11 +140,6 @@ func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
 	if r.Retryable != nil {
 		return *r.Retryable
 	}
-
-	if r.HTTPResponse.StatusCode >= 500 && r.HTTPResponse.StatusCode != 501 {
-		return true
-	}
-
 	return r.IsErrorRetryable() || r.IsErrorThrottle()
 }
 

--- a/aws/request/http_request_retry_test.go
+++ b/aws/request/http_request_retry_test.go
@@ -1,6 +1,7 @@
 package request_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 )
 
 func TestRequestCancelRetry(t *testing.T) {
-	c := make(chan struct{})
 
 	reqNum := 0
 	s := mock.NewMockClient(&aws.Config{
@@ -24,9 +24,10 @@ func TestRequestCancelRetry(t *testing.T) {
 		reqNum++
 	})
 	out := &testData{}
+	ctx, cancelFn := context.WithCancel(context.Background())
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
-	r.HTTPRequest.Cancel = c
-	close(c)
+	r.SetContext(ctx)
+	cancelFn() // cancelling the context associated with the request
 
 	err := r.Send()
 	if !strings.Contains(err.Error(), "canceled") {

--- a/aws/request/http_request_retry_test.go
+++ b/aws/request/http_request_retry_test.go
@@ -1,7 +1,6 @@
 package request_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestRequestCancelRetry(t *testing.T) {
-
+	c := make(chan struct{})
 	reqNum := 0
 	s := mock.NewMockClient(&aws.Config{
 		MaxRetries: aws.Int(1),
@@ -24,10 +23,9 @@ func TestRequestCancelRetry(t *testing.T) {
 		reqNum++
 	})
 	out := &testData{}
-	ctx, cancelFn := context.WithCancel(context.Background())
 	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
-	r.SetContext(ctx)
-	cancelFn() // cancelling the context associated with the request
+	r.HTTPRequest.Cancel = c
+	close(c)
 
 	err := r.Send()
 	if !strings.Contains(err.Error(), "canceled") {

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -219,6 +219,16 @@ func (r *Request) IsErrorRetryable() bool {
 		return true
 	}
 
+	// HTTP response status code 501 should not be retried.
+	// 501 represents Not Implemented which means the request method is not
+	// supported by the server and cannot be handled.
+	if r.HTTPResponse != nil {
+		// HTTP response status code 500 represents internal server error and
+		// should be retried without any throttle.
+		if r.HTTPResponse.StatusCode == 500 {
+			return true
+		}
+	}
 	return IsErrorRetryable(r.Error)
 }
 
@@ -233,7 +243,11 @@ func (r *Request) IsErrorThrottle() bool {
 
 	if r.HTTPResponse != nil {
 		switch r.HTTPResponse.StatusCode {
-		case 429, 502, 503, 504:
+		case
+			429, // error caused due to too many requests
+			502, // Bad Gateway error should be throttled
+			503, // caused when service is unavailable
+			504: // error occurred due to gateway timeout
 			return true
 		}
 	}


### PR DESCRIPTION
Refactors where the HTTP response status code is resolved for whether the request is retryable. 
