### PR TITLE
private/mode/api: Fix codegen of event stream member reference naming

### DIFF
--- a/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
+++ b/private/model/api/codegentest/models/jsonrpc/0000-00-00/api-2.json
@@ -62,7 +62,7 @@
       "members":{
         "StrVal":{"shape":"String"},
         "IntVal":{"shape":"Integer"},
-        "EventStream":{"shape":"EventStream"}
+        "AEventStreamRef":{"shape":"EventStream"}
       }
     },
     "EventStream":{

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -1000,8 +1000,8 @@ func (s *GetEventStreamInput) SetInputVal(v string) *GetEventStreamInput {
 type GetEventStreamOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Use EventStream to use the API's stream.
-	EventStream *GetEventStreamEventStream `type:"structure"`
+	// Use AEventStreamRef to use the API's stream.
+	AEventStreamRef *GetEventStreamEventStream `type:"structure"`
 
 	IntVal *int64 `type:"integer"`
 
@@ -1018,9 +1018,9 @@ func (s GetEventStreamOutput) GoString() string {
 	return s.String()
 }
 
-// SetEventStream sets the EventStream field's value.
-func (s *GetEventStreamOutput) SetEventStream(v *GetEventStreamEventStream) *GetEventStreamOutput {
-	s.EventStream = v
+// SetAEventStreamRef sets the AEventStreamRef field's value.
+func (s *GetEventStreamOutput) SetAEventStreamRef(v *GetEventStreamEventStream) *GetEventStreamOutput {
+	s.AEventStreamRef = v
 	return s
 }
 
@@ -1053,18 +1053,18 @@ func (s *GetEventStreamOutput) runEventStreamLoop(r *request.Request) {
 		StreamCloser: r.HTTPResponse.Body,
 		Reader:       reader,
 	}
-	s.EventStream = eventStream
+	s.AEventStreamRef = eventStream
 }
 
 func (s *GetEventStreamOutput) unmarshalInitialResponse(r *request.Request) {
 	// Wait for the initial response event, which must be the first event to be
 	// received from the API.
 	select {
-	case event, ok := <-s.EventStream.Events():
+	case event, ok := <-s.AEventStreamRef.Events():
 		if !ok {
 			return
 		}
-		es := s.EventStream
+		es := s.AEventStreamRef
 		v, ok := event.(*GetEventStreamOutput)
 		if !ok || v == nil {
 			r.Error = awserr.New(
@@ -1075,7 +1075,7 @@ func (s *GetEventStreamOutput) unmarshalInitialResponse(r *request.Request) {
 			return
 		}
 		*s = *v
-		s.EventStream = es
+		s.AEventStreamRef = es
 	}
 }
 

--- a/private/model/api/codegentest/service/rpcservice/cust_eventstream_tests.go
+++ b/private/model/api/codegentest/service/rpcservice/cust_eventstream_tests.go
@@ -1,0 +1,6 @@
+package rpcservice
+
+// Ensure that the event stream member is renamed.
+var _ = GetEventStreamOutput{
+	AEventStreamRef: nil,
+}

--- a/private/model/api/codegentest/service/rpcservice/eventstream_test.go
+++ b/private/model/api/codegentest/service/rpcservice/eventstream_test.go
@@ -191,7 +191,7 @@ func TestGetEventStream_Read(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expect no error got, %v", err)
 	}
-	defer resp.EventStream.Close()
+	defer resp.AEventStreamRef.Close()
 	expectResp := expectEvents[0].(*GetEventStreamOutput)
 	if e, a := expectResp.IntVal, resp.IntVal; !reflect.DeepEqual(e, a) {
 		t.Errorf("expect %v, got %v", e, a)
@@ -203,7 +203,7 @@ func TestGetEventStream_Read(t *testing.T) {
 	expectEvents = expectEvents[1:]
 
 	var i int
-	for event := range resp.EventStream.Events() {
+	for event := range resp.AEventStreamRef.Events() {
 		if event == nil {
 			t.Errorf("%d, expect event, got nil", i)
 		}
@@ -213,7 +213,7 @@ func TestGetEventStream_Read(t *testing.T) {
 		i++
 	}
 
-	if err := resp.EventStream.Err(); err != nil {
+	if err := resp.AEventStreamRef.Err(); err != nil {
 		t.Errorf("expect no error, %v", err)
 	}
 }
@@ -238,10 +238,10 @@ func TestGetEventStream_ReadClose(t *testing.T) {
 		t.Fatalf("expect no error got, %v", err)
 	}
 
-	resp.EventStream.Close()
-	<-resp.EventStream.Events()
+	resp.AEventStreamRef.Close()
+	<-resp.AEventStreamRef.Events()
 
-	if err := resp.EventStream.Err(); err != nil {
+	if err := resp.AEventStreamRef.Err(); err != nil {
 		t.Errorf("expect no error, %v", err)
 	}
 }
@@ -279,16 +279,16 @@ func BenchmarkGetEventStream_Read(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to create request, %v", err)
 	}
-	defer resp.EventStream.Close()
+	defer resp.AEventStreamRef.Close()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if err = resp.EventStream.Err(); err != nil {
+		if err = resp.AEventStreamRef.Err(); err != nil {
 			b.Fatalf("expect no error, got %v", err)
 		}
-		event := <-resp.EventStream.Events()
+		event := <-resp.AEventStreamRef.Events()
 		if event == nil {
-			b.Fatalf("expect event, got nil, %v, %d", resp.EventStream.Err(), i)
+			b.Fatalf("expect event, got nil, %v, %d", resp.AEventStreamRef.Err(), i)
 		}
 	}
 }
@@ -533,11 +533,11 @@ func TestGetEventStream_ReadException(t *testing.T) {
 		t.Fatalf("expect no error got, %v", err)
 	}
 
-	defer resp.EventStream.Close()
+	defer resp.AEventStreamRef.Close()
 
-	<-resp.EventStream.Events()
+	<-resp.AEventStreamRef.Events()
 
-	err = resp.EventStream.Err()
+	err = resp.AEventStreamRef.Err()
 	if err == nil {
 		t.Fatalf("expect err, got none")
 	}

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -179,6 +179,7 @@ func (a *API) Setup() {
 	a.renameAPIPayloadShapes()
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()
+	a.renameS3EventStreamMember()
 	a.setupEventStreams()
 	a.findEndpointDiscoveryOp()
 	a.injectUnboundedOutputStreaming()

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -360,8 +360,8 @@ func (a *API) makeIOShape(name string) *Shape {
 	return shape
 }
 
-// removeUnusedShapes removes shapes from the API which are not referenced by any
-// other shape in the API.
+// removeUnusedShapes removes shapes from the API which are not referenced by
+// any other shape in the API.
 func (a *API) removeUnusedShapes() {
 	for _, s := range a.Shapes {
 		if len(s.refs) == 0 {


### PR DESCRIPTION
Fixes the operation's Output type's event stream member name being squashed with a baked in `EventStream`. The name of the member now reflects the name given in the model.

Added customization for S3's SelectObjectContent operation to persist the incorrect naming for backwards compatibility.