### PR TITLE
Ensuren SDK's testing HTTP server usage are cleaned up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,20 +57,18 @@ build:
 	go build -o /dev/null -tags ${ALL_TAGS} ${SDK_ALL_PKGS}
 
 unit-no-verify:
-	@echo "go test SDK and vendor packages with no linting"
-	go test -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
-
-unit: verify build
 	@echo "go test SDK and vendor packages"
-	go test -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
+	go test -timeout 20s -v -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
+
+unit: verify build unit-no-verify
 
 unit-with-race-cover: verify build
 	@echo "go test SDK and vendor packages"
-	go test -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
+	go test -timeout 20s -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
 
 unit-old-go-race-cover:
 	@echo "go test SDK only packages for old Go versions"
-	go test -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
+	go test -timeout 20s -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
 
 ci-test: generate unit-with-race-cover ci-test-generate-validate
 

--- a/Makefile
+++ b/Makefile
@@ -58,17 +58,17 @@ build:
 
 unit-no-verify:
 	@echo "go test SDK and vendor packages"
-	go test -timeout 20s -v -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
+	go test -timeout 1m -v -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
 
 unit: verify build unit-no-verify
 
 unit-with-race-cover: verify build
 	@echo "go test SDK and vendor packages"
-	go test -timeout 20s -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
+	go test -timeout 1m -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
 
 unit-old-go-race-cover:
 	@echo "go test SDK only packages for old Go versions"
-	go test -timeout 20s -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
+	go test -timeout 1m -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
 
 ci-test: generate unit-with-race-cover ci-test-generate-validate
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ SDK_TESTING_PKGS=./awstesting/...
 SDK_MODELS_PKGS=./models/...
 SDK_ALL_PKGS=${SDK_COMPA_PKGS} ${SDK_TESTING_PKGS} ${SDK_EXAMPLES_PKGS} ${SDK_MODELS_PKGS}
 
+TEST_TIMEOUT=-timeout 5m
+
 all: generate unit
 
 ###################
@@ -58,17 +60,17 @@ build:
 
 unit-no-verify:
 	@echo "go test SDK and vendor packages"
-	go test -timeout 1m -v -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
+	go test ${TEST_TIMEOUT} -v -count=1 -tags ${UNIT_TEST_TAGS} ${SDK_ALL_PKGS}
 
 unit: verify build unit-no-verify
 
 unit-with-race-cover: verify build
 	@echo "go test SDK and vendor packages"
-	go test -timeout 1m -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
+	go test ${TEST_TIMEOUT} -v -count=1 -tags ${UNIT_TEST_TAGS} -race -cpu=1,2,4 ${SDK_ALL_PKGS}
 
 unit-old-go-race-cover:
 	@echo "go test SDK only packages for old Go versions"
-	go test -timeout 1m -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
+	go test ${TEST_TIMEOUT} -v -count=1 -race -cpu=1,2,4 ${SDK_COMPA_PKGS}
 
 ci-test: generate unit-with-race-cover ci-test-generate-validate
 

--- a/aws/corehandlers/handlers_1_10_test.go
+++ b/aws/corehandlers/handlers_1_10_test.go
@@ -3,50 +3,42 @@
 package corehandlers_test
 
 import (
-	"crypto/tls"
+	"bytes"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/awstesting"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"golang.org/x/net/http2"
 )
 
 func TestSendHandler_HEADNoBody(t *testing.T) {
-	TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile, err := awstesting.CreateTLSBundleFiles()
-	if err != nil {
-		panic(err)
-	}
-	defer awstesting.CleanupTLSBundleFiles(TLSBundleCertFile, TLSBundleKeyFile, TLSBundleCAFile)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if e, a := "HEAD", r.Method; e != a {
+			t.Errorf("expected %v method, got %v", e, a)
+		}
+		var buf bytes.Buffer
+		io.Copy(&buf, r.Body)
 
-	endpoint, err := awstesting.CreateTLSServer(TLSBundleCertFile, TLSBundleKeyFile, nil)
-	if err != nil {
-		t.Fatalf("expect no error, got %v", err)
-	}
+		if n := buf.Len(); n != 0 {
+			t.Errorf("expect empty body, got %d", n)
+		}
 
-	transport := http.DefaultTransport.(*http.Transport)
-	// test server's certificate is self-signed certificate
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	http2.ConfigureTransport(transport)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
 
-	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: aws.Config{
-			HTTPClient:       &http.Client{},
-			Endpoint:         aws.String(endpoint),
-			Region:           aws.String("mock-region"),
-			Credentials:      credentials.AnonymousCredentials,
-			S3ForcePathStyle: aws.Bool(true),
-		},
+	svc := s3.New(unit.Session, &aws.Config{
+		Endpoint:         aws.String(server.URL),
+		Credentials:      credentials.AnonymousCredentials,
+		S3ForcePathStyle: aws.Bool(true),
+		DisableSSL:       aws.Bool(true),
 	})
-	if err != nil {
-		t.Fatalf("expect no error, got %v", err)
-	}
-
-	svc := s3.New(sess)
 
 	req, _ := svc.HeadObjectRequest(&s3.HeadObjectInput{
 		Bucket: aws.String("bucketname"),
@@ -57,8 +49,7 @@ func TestSendHandler_HEADNoBody(t *testing.T) {
 		t.Fatalf("expect %T request body, got %T", e, a)
 	}
 
-	err = req.Send()
-	if err != nil {
+	if err := req.Send(); err != nil {
 		t.Fatalf("expect no error, got %v", err)
 	}
 	if e, a := http.StatusOK, req.HTTPResponse.StatusCode; e != a {

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -239,6 +239,7 @@ func TestSendWithoutFollowRedirects(t *testing.T) {
 			t.Fatalf("expect not to redirect, but was")
 		}
 	}))
+	defer server.Close()
 
 	svc := awstesting.NewClient(&aws.Config{
 		DisableSSL: aws.Bool(true),
@@ -344,6 +345,7 @@ func setupContentLengthTestServer(t *testing.T, hasContentLength bool, contentLe
 
 func TestBuildContentLength_ZeroBody(t *testing.T) {
 	server := setupContentLengthTestServer(t, false, 0)
+	defer server.Close()
 
 	svc := s3.New(unit.Session, &aws.Config{
 		Endpoint:         aws.String(server.URL),
@@ -362,6 +364,7 @@ func TestBuildContentLength_ZeroBody(t *testing.T) {
 
 func TestBuildContentLength_NegativeBody(t *testing.T) {
 	server := setupContentLengthTestServer(t, false, 0)
+	defer server.Close()
 
 	svc := s3.New(unit.Session, &aws.Config{
 		Endpoint:         aws.String(server.URL),
@@ -382,6 +385,7 @@ func TestBuildContentLength_NegativeBody(t *testing.T) {
 
 func TestBuildContentLength_WithBody(t *testing.T) {
 	server := setupContentLengthTestServer(t, true, 1024)
+	defer server.Close()
 
 	svc := s3.New(unit.Session, &aws.Config{
 		Endpoint:         aws.String(server.URL),

--- a/aws/credentials/endpointcreds/provider_test.go
+++ b/aws/credentials/endpointcreds/provider_test.go
@@ -37,6 +37,7 @@ func TestRetrieveRefreshableCredentials(t *testing.T) {
 			fmt.Println("failed to write out creds", err)
 		}
 	}))
+	defer server.Close()
 
 	client := endpointcreds.NewProviderClient(*unit.Session.Config,
 		unit.Session.Handlers,
@@ -82,6 +83,7 @@ func TestRetrieveStaticCredentials(t *testing.T) {
 			fmt.Println("failed to write out creds", err)
 		}
 	}))
+	defer server.Close()
 
 	client := endpointcreds.NewProviderClient(*unit.Session.Config, unit.Session.Handlers, server.URL)
 	creds, err := client.Retrieve()
@@ -117,6 +119,7 @@ func TestFailedRetrieveCredentials(t *testing.T) {
 			fmt.Println("failed to write error", err)
 		}
 	}))
+	defer server.Close()
 
 	client := endpointcreds.NewProviderClient(*unit.Session.Config, unit.Session.Handlers, server.URL)
 	creds, err := client.Retrieve()
@@ -181,6 +184,7 @@ func TestAuthorizationToken(t *testing.T) {
 			fmt.Println("failed to write out creds", err)
 		}
 	}))
+	defer server.Close()
 
 	client := endpointcreds.NewProviderClient(*unit.Session.Config,
 		unit.Session.Handlers,

--- a/aws/csm/reporter_test.go
+++ b/aws/csm/reporter_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/csm"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
@@ -277,6 +277,7 @@ func BenchmarkWithCSM(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("{}")))
 	}))
+	defer server.Close()
 
 	cfg := aws.Config{
 		Endpoint: aws.String(server.URL),
@@ -322,6 +323,7 @@ func BenchmarkWithCSMNoUDPConnection(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("{}")))
 	}))
+	defer server.Close()
 
 	cfg := aws.Config{
 		Endpoint: aws.String(server.URL),
@@ -368,6 +370,7 @@ func BenchmarkWithoutCSM(b *testing.B) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("{}")))
 	}))
+	defer server.Close()
 
 	cfg := aws.Config{
 		Endpoint: aws.String(server.URL),

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -62,6 +62,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRace(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("us-east-1a"))
 	}))
+	defer server.Close()
 
 	cfg := aws.NewConfig().WithEndpoint(server.URL)
 	runEC2MetadataClients(t, cfg, 100)
@@ -71,6 +72,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("us-east-1a"))
 	}))
+	defer server.Close()
 
 	cfg := aws.NewConfig().WithEndpoint(server.URL).WithHTTPClient(&http.Client{
 		Transport: http.DefaultTransport,

--- a/aws/request/request_1_8_test.go
+++ b/aws/request/request_1_8_test.go
@@ -58,6 +58,7 @@ func TestRequest_FollowPUTRedirects(t *testing.T) {
 			t.Fatalf("unexpected endpoint used, %q", r.URL.String())
 		}
 	}))
+	defer server.Close()
 
 	svc := awstesting.NewClient(&aws.Config{
 		Region:     unit.Session.Config.Region,

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -123,7 +123,10 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
+	s := awstesting.NewClient(&aws.Config{
+		MaxRetries: aws.Int(10),
+		SleepDelay: func(time.Duration) {},
+	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -156,7 +159,10 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := awstesting.NewClient(aws.NewConfig().WithMaxRetries(10))
+	s := awstesting.NewClient(&aws.Config{
+		MaxRetries: aws.Int(10),
+		SleepDelay: func(time.Duration) {},
+	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -183,6 +189,7 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 func TestRequest4xxUnretryable(t *testing.T) {
 	s := awstesting.NewClient(&aws.Config{
 		MaxRetries: aws.Int(1),
+		SleepDelay: func(time.Duration) {},
 	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
@@ -229,7 +236,9 @@ func TestRequestExhaustRetries(t *testing.T) {
 		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
 	}
 
-	s := awstesting.NewClient(aws.NewConfig().WithSleepDelay(sleepDelay))
+	s := awstesting.NewClient(&aws.Config{
+		SleepDelay: sleepDelay,
+	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -276,7 +285,11 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := awstesting.NewClient(&aws.Config{MaxRetries: aws.Int(10), Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})
+	s := awstesting.NewClient(&aws.Config{
+		MaxRetries:  aws.Int(10),
+		Credentials: credentials.NewStaticCredentials("AKID", "SECRET", ""),
+		SleepDelay:  func(time.Duration) {},
+	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -345,7 +358,9 @@ func TestMakeAddtoUserAgentFreeFormHandler(t *testing.T) {
 }
 
 func TestRequestUserAgent(t *testing.T) {
-	s := awstesting.NewClient(&aws.Config{Region: aws.String("us-east-1")})
+	s := awstesting.NewClient(&aws.Config{
+		Region: aws.String("us-east-1"),
+	})
 
 	req := s.NewRequest(&request.Operation{Name: "Operation"}, nil, &testData{})
 	req.HTTPRequest.Header.Set("User-Agent", "foo/bar")
@@ -374,7 +389,9 @@ func TestRequestThrottleRetries(t *testing.T) {
 		{StatusCode: 500, Body: body(`{"__type":"Throttling","message":"An error occurred."}`)},
 	}
 
-	s := awstesting.NewClient(aws.NewConfig().WithSleepDelay(sleepDelay))
+	s := awstesting.NewClient(&aws.Config{
+		SleepDelay: sleepDelay,
+	})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)

--- a/aws/session/credentials_test.go
+++ b/aws/session/credentials_test.go
@@ -303,6 +303,7 @@ func TestSessionAssumeRole(t *testing.T) {
 			assumeRoleRespMsg,
 			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
+	defer server.Close()
 
 	s, err := NewSession(&aws.Config{
 		Endpoint:   aws.String(server.URL),
@@ -354,6 +355,7 @@ func TestSessionAssumeRole_WithMFA(t *testing.T) {
 			assumeRoleRespMsg,
 			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
+	defer server.Close()
 
 	customProviderCalled := false
 	sess, err := NewSessionWithOptions(Options{
@@ -488,6 +490,7 @@ func TestSessionAssumeRole_ExtendedDuration(t *testing.T) {
 			assumeRoleRespMsg,
 			time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
+	defer server.Close()
 
 	s, err := NewSessionWithOptions(Options{
 		Profile: "assume_role_w_creds",
@@ -544,6 +547,7 @@ func TestSessionAssumeRole_WithMFA_ExtendedDuration(t *testing.T) {
 			assumeRoleRespMsg,
 			time.Now().Add(30*time.Minute).Format("2006-01-02T15:04:05Z"))))
 	}))
+	defer server.Close()
 
 	customProviderCalled := false
 	sess, err := NewSessionWithOptions(Options{

--- a/aws/signer/v4/v4_test.go
+++ b/aws/signer/v4/v4_test.go
@@ -564,6 +564,7 @@ func TestSignWithRequestBody(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
+	defer server.Close()
 
 	req, err := http.NewRequest("POST", server.URL, nil)
 	if err != nil {
@@ -601,6 +602,7 @@ func TestSignWithRequestBody_Overwrite(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
+	defer server.Close()
 
 	req, err := http.NewRequest("GET", server.URL, strings.NewReader("invalid body"))
 	if err != nil {

--- a/awstesting/unit/unit.go
+++ b/awstesting/unit/unit.go
@@ -2,12 +2,16 @@
 package unit
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // Session is a shared session for unit tests to use.
-var Session = session.Must(session.NewSession(aws.NewConfig().
-	WithCredentials(credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")).
-	WithRegion("mock-region")))
+var Session = session.Must(session.NewSession(&aws.Config{
+	Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
+	Region:      aws.String("mock-region"),
+	SleepDelay:  func(time.Duration) {},
+}))

--- a/internal/sdkrand/read.go
+++ b/internal/sdkrand/read.go
@@ -1,0 +1,11 @@
+// +build go1.6
+
+package sdkrand
+
+import "math/rand"
+
+// Read provides the stub for math.Rand.Read method support for go version's
+// 1.6 and greater.
+func Read(r *rand.Rand, p []byte) (int, error) {
+	return r.Read(p)
+}

--- a/internal/sdkrand/read_1_5.go
+++ b/internal/sdkrand/read_1_5.go
@@ -5,11 +5,11 @@ package sdkrand
 import "math/rand"
 
 // Read backfills Go 1.6's math.Rand.Reader for Go 1.5
-func Read(r *rand.Rand, p []byte) (int, error) {
+func Read(r *rand.Rand, p []byte) (n int, err error) {
 	// Copy of Go standard libraries math package's read function not added to
 	// standard library until Go 1.6.
-	var pos int64
-	var val int8
+	var pos int8
+	var val int64
 	for n = 0; n < len(p); n++ {
 		if pos == 0 {
 			val = r.Int63()
@@ -19,5 +19,6 @@ func Read(r *rand.Rand, p []byte) (int, error) {
 		val >>= 8
 		pos--
 	}
-	return
+
+	return n, err
 }

--- a/internal/sdkrand/read_1_5.go
+++ b/internal/sdkrand/read_1_5.go
@@ -1,0 +1,23 @@
+// +build !go1.6
+
+package sdkrand
+
+import "math/rand"
+
+// Read backfills Go 1.6's math.Rand.Reader for Go 1.5
+func Read(r *rand.Rand, p []byte) (int, error) {
+	// Copy of Go standard libraries math package's read function not added to
+	// standard library until Go 1.6.
+	var pos int64
+	var val int8
+	for n = 0; n < len(p); n++ {
+		if pos == 0 {
+			val = r.Int63()
+			pos = 7
+		}
+		p[n] = byte(val)
+		val >>= 8
+		pos--
+	}
+	return
+}

--- a/service/s3/customizations_test.go
+++ b/service/s3/customizations_test.go
@@ -124,6 +124,8 @@ func TestPutObjectMetadataWithUnicode(t *testing.T) {
 			t.Errorf("expected %s, but received %s", e, a)
 		}
 	}))
+	defer server.Close()
+
 	svc := s3.New(unit.Session, &aws.Config{
 		Endpoint:   aws.String(server.URL),
 		DisableSSL: aws.Bool(true),
@@ -149,6 +151,8 @@ func TestGetObjectMetadataWithUnicode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(metaKeyPrefix+utf8KeySuffix, utf8Value)
 	}))
+	defer server.Close()
+
 	svc := s3.New(unit.Session, &aws.Config{
 		Endpoint:   aws.String(server.URL),
 		DisableSSL: aws.Bool(true),

--- a/service/s3/s3crypto/kms_key_handler_test.go
+++ b/service/s3/s3crypto/kms_key_handler_test.go
@@ -47,6 +47,7 @@ func TestKMSGenerateCipherData(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"CiphertextBlob":"AQEDAHhqBCCY1MSimw8gOGcUma79cn4ANvTtQyv9iuBdbcEF1QAAAH4wfAYJKoZIhvcNAQcGoG8wbQIBADBoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDJ6IcN5E4wVbk38MNAIBEIA7oF1E3lS7FY9DkoxPc/UmJsEwHzL82zMqoLwXIvi8LQHr8If4Lv6zKqY8u0+JRgSVoqCvZDx3p8Cn6nM=","KeyId":"arn:aws:kms:us-west-2:042062605278:key/c80a5cdb-8d09-4f9f-89ee-df01b2e3870a","Plaintext":"6tmyz9JLBE2yIuU7iXpArqpDVle172WSmxjcO6GNT7E="}`)
 	}))
+	defer ts.Close()
 
 	sess := unit.Session.Copy(&aws.Config{
 		MaxRetries:       aws.Int(0),
@@ -80,6 +81,7 @@ func TestKMSDecrypt(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, fmt.Sprintf("%s%s%s", `{"KeyId":"test-key-id","Plaintext":"`, keyB64, `"}`))
 	}))
+	defer ts.Close()
 
 	sess := unit.Session.Copy(&aws.Config{
 		MaxRetries:       aws.Int(0),
@@ -109,6 +111,7 @@ func TestKMSDecryptBadJSON(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, fmt.Sprintf("%s%s%s", `{"KeyId":"test-key-id","Plaintext":"`, keyB64, `"}`))
 	}))
+	defer ts.Close()
 
 	sess := unit.Session.Copy(&aws.Config{
 		MaxRetries:       aws.Int(0),

--- a/service/s3/s3manager/batch_1_7_test.go
+++ b/service/s3/s3manager/batch_1_7_test.go
@@ -87,6 +87,7 @@ func TestBatchDeleteContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 		count++
 	}))
+	defer server.Close()
 
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL)}
 	for i, c := range cases {

--- a/service/s3/s3manager/batch_test.go
+++ b/service/s3/s3manager/batch_test.go
@@ -290,6 +290,7 @@ func TestBatchDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 		count++
 	}))
+	defer server.Close()
 
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL)}
 	for i, c := range cases {
@@ -362,6 +363,7 @@ func TestBatchDeleteError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
+	defer server.Close()
 
 	index := 0
 	svc := &mockS3Client{
@@ -460,6 +462,7 @@ func TestBatchDeleteList(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 		count++
 	}))
+	defer server.Close()
 
 	objects := []*s3.ListObjectsOutput{
 		{
@@ -543,6 +546,7 @@ func TestBatchDeleteList_EmptyListObjects(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 		count++
 	}))
+	defer server.Close()
 
 	svc := &mockS3Client{S3: buildS3SvcClient(server.URL)}
 	batcher := BatchDelete{
@@ -619,6 +623,7 @@ func TestBatchDownload(t *testing.T) {
 		w.Write([]byte(payload[count]))
 		count++
 	}))
+	defer server.Close()
 
 	svc := NewDownloaderWithClient(buildS3SvcClient(server.URL))
 
@@ -738,6 +743,7 @@ func TestBatchUpload(t *testing.T) {
 
 		count++
 	}))
+	defer server.Close()
 
 	svc := NewUploaderWithClient(buildS3SvcClient(server.URL))
 
@@ -838,6 +844,7 @@ func (client *mockClient) ListObjectsRequest(input *s3.ListObjectsInput) (*reque
 func TestBatchError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
+	defer server.Close()
 
 	index := 0
 	responses := []response{
@@ -1038,6 +1045,7 @@ func (iter *testAfterUploadIter) UploadObject() BatchUploadObject {
 func TestAfter(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	}))
+	defer server.Close()
 
 	index := 0
 	responses := []response{

--- a/service/s3/s3manager/bucket_region_test.go
+++ b/service/s3/s3manager/bucket_region_test.go
@@ -35,6 +35,7 @@ var testGetBucketRegionCases = []struct {
 func TestGetBucketRegion_Exists(t *testing.T) {
 	for i, c := range testGetBucketRegionCases {
 		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode, true)
+		defer server.Close()
 
 		sess := unit.Session.Copy()
 		sess.Config.Region = aws.String("default-region")
@@ -54,6 +55,7 @@ func TestGetBucketRegion_Exists(t *testing.T) {
 
 func TestGetBucketRegion_NotExists(t *testing.T) {
 	server := testSetupGetBucketRegionServer("ignore-region", 404, false)
+	defer server.Close()
 
 	sess := unit.Session.Copy()
 	sess.Config.Endpoint = aws.String(server.URL)
@@ -76,6 +78,7 @@ func TestGetBucketRegion_NotExists(t *testing.T) {
 func TestGetBucketRegionWithClient(t *testing.T) {
 	for i, c := range testGetBucketRegionCases {
 		server := testSetupGetBucketRegionServer(c.RespRegion, c.StatusCode, true)
+		defer server.Close()
 
 		svc := s3.New(unit.Session, &aws.Config{
 			Region:     aws.String("hint-region"),

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/internal/sdkrand"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -707,7 +708,7 @@ var randBytes = func() []byte {
 	rr := rand.New(rand.NewSource(0))
 	b := make([]byte, 10*sdkio.MebiByte)
 
-	if _, err := rr.Read(b); err != nil {
+	if _, err := sdkrand.Read(rr, b); err != nil {
 		panic(fmt.Sprintf("failed to read random bytes, %v", err))
 	}
 	return b

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -1113,17 +1113,23 @@ func TestUploadRetry(t *testing.T) {
 			server := httptest.NewServer(mux)
 			defer server.Close()
 
+			var logger aws.Logger
+			var logLevel *aws.LogLevelType
+			if v := os.Getenv("DEBUG_BODY"); len(v) != 0 {
+				logger = t
+				logLevel = aws.LogLevel(
+					aws.LogDebugWithRequestErrors | aws.LogDebugWithRequestRetries,
+				)
+			}
 			sess := unit.Session.Copy(&aws.Config{
 				Endpoint:         aws.String(server.URL),
 				S3ForcePathStyle: aws.Bool(true),
 				DisableSSL:       aws.Bool(true),
-				Logger:           t,
 				MaxRetries:       aws.Int(retries + 1),
 				SleepDelay:       func(time.Duration) {},
 
-				LogLevel: aws.LogLevel(
-					aws.LogDebugWithRequestErrors | aws.LogDebugWithRequestRetries,
-				),
+				Logger:   logger,
+				LogLevel: logLevel,
 				//Credentials: credentials.AnonymousCredentials,
 			})
 

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -743,6 +743,7 @@ func TestUploadZeroLenObject(t *testing.T) {
 		requestMade = true
 		w.WriteHeader(http.StatusOK)
 	}))
+	defer server.Close()
 	mgr := s3manager.NewUploaderWithClient(s3.New(unit.Session, &aws.Config{
 		Endpoint: aws.String(server.URL),
 	}))

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -4,7 +4,6 @@ package s3manager_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1212,15 +1211,8 @@ func TestUploadBufferStrategy(t *testing.T) {
 				u.Concurrency = 1
 			})
 
-			expected := make([]byte, tCase.Size)
-			n, err := rand.Read(expected)
-			if err != nil {
-				t.Fatalf("failed to generate byte slice: %v", err)
-			} else if n != int(tCase.Size) {
-				t.Fatalf("failed to generate sufficient byte slice: expected %d, got %d", tCase.Size, n)
-			}
-
-			_, err = uploader.Upload(&s3manager.UploadInput{
+			expected := getTestBytes(int(tCase.Size))
+			_, err := uploader.Upload(&s3manager.UploadInput{
 				Bucket: aws.String("bucket"),
 				Key:    aws.String("key"),
 				Body:   bytes.NewReader(expected),

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -29,7 +29,7 @@ func TestCopyObjectNoError(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Errorf("expected no error, but received %v", err)
+		t.Fatalf("expected no error, but received %v", err)
 	}
 	if e, a := fmt.Sprintf(`%q`, "1da64c7f13d1e8dbeaea40b905fd586c"), *res.CopyObjectResult.ETag; e != a {
 		t.Errorf("expected %s, but received %s", e, a)
@@ -159,6 +159,7 @@ func newCopyTestSvc(errMsg string) *s3.S3 {
 		http.Error(w, errMsg, http.StatusOK)
 	}))
 	defer server.Close()
+
 	return s3.New(unit.Session, aws.NewConfig().
 		WithEndpoint(server.URL).
 		WithDisableSSL(true).

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -158,6 +158,7 @@ func newCopyTestSvc(errMsg string) *s3.S3 {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, errMsg, http.StatusOK)
 	}))
+	defer server.Close()
 	return s3.New(unit.Session, aws.NewConfig().
 		WithEndpoint(server.URL).
 		WithDisableSSL(true).

--- a/service/s3/statusok_error_test.go
+++ b/service/s3/statusok_error_test.go
@@ -2,13 +2,17 @@ package s3_test
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -110,6 +114,7 @@ func TestCompleteMultipartUploadSuccess(t *testing.T) {
 	const successMsg = `
 <?xml version="1.0" encoding="UTF-8"?>
 <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>locationName</Location><Bucket>bucketName</Bucket><Key>keyName</Key><ETag>"etagVal"</ETag></CompleteMultipartUploadResult>`
+
 	res, err := newCopyTestSvc(successMsg).CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
 		Bucket:   aws.String("bucketname"),
 		Key:      aws.String("key"),
@@ -155,14 +160,27 @@ func TestCompleteMultipartUploadError(t *testing.T) {
 }
 
 func newCopyTestSvc(errMsg string) *s3.S3 {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, errMsg, http.StatusOK)
-	}))
-	defer server.Close()
+	const statusCode = http.StatusOK
 
-	return s3.New(unit.Session, aws.NewConfig().
-		WithEndpoint(server.URL).
-		WithDisableSSL(true).
-		WithMaxRetries(0).
-		WithS3ForcePathStyle(true))
+	svc := s3.New(unit.Session, &aws.Config{
+		MaxRetries: aws.Int(0),
+		SleepDelay: func(time.Duration) {},
+	})
+
+	svc.Handlers.Send.Swap(corehandlers.SendHandler.Name,
+		request.NamedHandler{
+			Name: "newCopyTestSvc",
+			Fn: func(r *request.Request) {
+				io.Copy(ioutil.Discard, r.HTTPRequest.Body)
+				r.HTTPRequest.Body.Close()
+				r.HTTPResponse = &http.Response{
+					Status:     http.StatusText(statusCode),
+					StatusCode: statusCode,
+					Header:     http.Header{},
+					Body:       ioutil.NopCloser(strings.NewReader(errMsg)),
+				}
+			},
+		})
+
+	return svc
 }


### PR DESCRIPTION
Ensure HTTP servers are cleaned up during testing after no longer needed. This was creating excessive noise in testing stack traces due to the number of background goroutines active.

Also updated SDK's unit tests to use verbose logging, and have a timeline of 20s.

Related to https://github.com/aws/aws-sdk-go/issues/2840