### PR TITLE
aws/endpoints: Add EKS service endpoints

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/endpoints`: Add EKS service endpoints
 
 ### SDK Bugs

--- a/aws/endpoints/defaults.go
+++ b/aws/endpoints/defaults.go
@@ -1397,6 +1397,28 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"eks": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"elasticache": service{
 
 			Endpoints: endpoints{

--- a/models/endpoints/endpoints.json
+++ b/models/endpoints/endpoints.json
@@ -1275,6 +1275,28 @@
           "us-west-2" : { }
         }
       },
+      "eks" : {
+        "defaults" : {
+          "protocols" : [ "https" ]
+        },
+        "endpoints" : {
+          "ap-east-1" : { },
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-south-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-north-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "eu-west-3" : { },
+          "me-south-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
+        }
+      },
       "elasticache" : {
         "endpoints" : {
           "ap-east-1" : { },


### PR DESCRIPTION
This PR aims to add missing EKS service endpoint, based on this documentation:

https://docs.aws.amazon.com/general/latest/gr/rande.html#eks_region

Fixes: https://github.com/aws/aws-sdk-go/issues/2846