### PR TITLE
private/model/api: Add skip unsupported API models

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -27,6 +27,8 @@ type API struct {
 	Examples      Examples
 	SmokeTests    SmokeTestSuite
 
+	IgnoreUnsupportedAPIs bool
+
 	// Set to true to avoid removing unused shapes
 	NoRemoveUnusedShapes bool
 

--- a/private/model/api/docstring.go
+++ b/private/model/api/docstring.go
@@ -28,30 +28,29 @@ type shapeDocumentation struct {
 }
 
 // AttachDocs attaches documentation from a JSON filename.
-func (a *API) AttachDocs(filename string) {
+func (a *API) AttachDocs(filename string) error {
 	var d apiDocumentation
 
 	f, err := os.Open(filename)
 	defer f.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = json.NewDecoder(f).Decode(&d)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to decode %s, err: %v", filename, err)
 	}
 
-	d.setup(a)
+	return d.setup(a)
 }
 
-func (d *apiDocumentation) setup(a *API) {
+func (d *apiDocumentation) setup(a *API) error {
 	a.Documentation = docstring(d.Service)
 
 	for opName, doc := range d.Operations {
 		if _, ok := a.Operations[opName]; !ok {
-			panic(fmt.Sprintf("%s, doc op %q not found in API op set",
-				a.name, opName),
-			)
+			return fmt.Errorf("%s, doc op %q not found in API op set",
+				a.name, opName)
 		}
 		a.Operations[opName].Documentation = docstring(doc)
 	}
@@ -81,6 +80,8 @@ func (d *apiDocumentation) setup(a *API) {
 			}
 		}
 	}
+
+	return nil
 }
 
 var reNewline = regexp.MustCompile(`\r?\n`)

--- a/private/model/api/example.go
+++ b/private/model/api/example.go
@@ -194,27 +194,27 @@ func getValue(t, v string) string {
 
 // AttachExamples will create a new ExamplesDefinition from the examples file
 // and reference the API object.
-func (a *API) AttachExamples(filename string) {
+func (a *API) AttachExamples(filename string) error {
 	p := ExamplesDefinition{API: a}
 
 	f, err := os.Open(filename)
 	defer f.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = json.NewDecoder(f).Decode(&p)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to decode %s, err: %v", filename, err)
 	}
 
-	p.setup()
+	return p.setup()
 }
 
 var examplesBuilderCustomizations = map[string]examplesBuilder{
 	"wafregional": NewWAFregionalExamplesBuilder(),
 }
 
-func (p *ExamplesDefinition) setup() {
+func (p *ExamplesDefinition) setup() error {
 	var builder examplesBuilder
 	ok := false
 	if builder, ok = examplesBuilderCustomizations[p.API.PackageName()]; !ok {
@@ -241,6 +241,8 @@ func (p *ExamplesDefinition) setup() {
 	}
 
 	p.API.Examples = p.Examples
+
+	return nil
 }
 
 var exampleHeader = template.Must(template.New("exampleHeader").Parse(`

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -14,16 +14,36 @@ import (
 // APIs provides a set of API models loaded by API package name.
 type APIs map[string]*API
 
-// LoadAPIs loads the API model files from disk returning the map of API
-// package. Returns error if multiple API model resolve to the same package
-// name.
-func LoadAPIs(modelPaths []string, baseImport string) (APIs, error) {
+// Loader provides the loading of APIs from files.
+type Loader struct {
+	// The base Go import path the loaded models will be appended to.
+	BaseImport string
+
+	// Allows ignoring API models that are unsupported by the SDK without
+	// failing the load of other supported APIs.
+	IgnoreUnsupportedAPIs bool
+}
+
+// Load loads the API model files from disk returning the map of API package.
+// Returns error if multiple API model resolve to the same package name.
+func (l Loader) Load(modelPaths []string) (APIs, error) {
 	apis := APIs{}
 	for _, modelPath := range modelPaths {
-		a, err := loadAPI(modelPath, baseImport)
+		a, err := loadAPI(modelPath, l.BaseImport, func(a *API) {
+			a.IgnoreUnsupportedAPIs = l.IgnoreUnsupportedAPIs
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to load API, %v, %v", modelPath, err)
 		}
+
+		if len(a.Operations) == 0 {
+			if l.IgnoreUnsupportedAPIs {
+				fmt.Fprintf(os.Stderr, "API has no operations, ignoring model %s, %v\n",
+					modelPath, a.ImportPath())
+				continue
+			}
+		}
+
 		importPath := a.ImportPath()
 		if _, ok := apis[importPath]; ok {
 			return nil, fmt.Errorf(
@@ -36,7 +56,9 @@ func LoadAPIs(modelPaths []string, baseImport string) (APIs, error) {
 	return apis, nil
 }
 
-func loadAPI(modelPath, baseImport string) (*API, error) {
+// attempts to load a model from disk into the import specified. Additional API
+// options are invoked before to the API's Setup being called.
+func loadAPI(modelPath, baseImport string, opts ...func(*API)) (*API, error) {
 	a := &API{
 		BaseImportPath:   baseImport,
 		BaseCrosslinkURL: "https://docs.aws.amazon.com",
@@ -56,14 +78,20 @@ func loadAPI(modelPath, baseImport string) (*API, error) {
 		return nil, err
 	}
 
-	a.Setup()
+	for _, opt := range opts {
+		opt(a)
+	}
+
+	if err = a.Setup(); err != nil {
+		return nil, err
+	}
 
 	return a, nil
 }
 
 type modelLoader struct {
 	Filename string
-	Loader   func(string)
+	Loader   func(string) error
 	Required bool
 }
 
@@ -77,7 +105,9 @@ func attachModelFiles(modelPath string, modelFiles ...modelLoader) error {
 			return fmt.Errorf("failed to load model file %v, %v", m.Filename, err)
 		}
 
-		m.Loader(filepath)
+		if err = m.Loader(filepath); err != nil {
+			return fmt.Errorf("model load failed, %s, %v", modelPath, err)
+		}
 	}
 
 	return nil
@@ -139,30 +169,35 @@ func TrimModelServiceVersions(modelPaths []string) (include, exclude []string) {
 
 // Attach opens a file by name, and unmarshal its JSON data.
 // Will proceed to setup the API if not already done so.
-func (a *API) Attach(filename string) {
+func (a *API) Attach(filename string) error {
 	a.path = filepath.Dir(filename)
 	f, err := os.Open(filename)
-	defer f.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
+	defer f.Close()
+
 	if err := json.NewDecoder(f).Decode(a); err != nil {
-		panic(fmt.Errorf("failed to decode %s, err: %v", filename, err))
+		return fmt.Errorf("failed to decode %s, err: %v", filename, err)
 	}
+
+	return nil
 }
 
 // AttachString will unmarshal a raw JSON string, and setup the
 // API if not already done so.
-func (a *API) AttachString(str string) {
+func (a *API) AttachString(str string) error {
 	json.Unmarshal([]byte(str), a)
 
-	if !a.initialized {
-		a.Setup()
+	if a.initialized {
+		return nil
 	}
+
+	return a.Setup()
 }
 
 // Setup initializes the API.
-func (a *API) Setup() {
+func (a *API) Setup() error {
 	a.setServiceAliaseName()
 	a.setMetadataEndpointsKey()
 	a.writeShapeNames()
@@ -180,7 +215,10 @@ func (a *API) Setup() {
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()
 	a.renameS3EventStreamMember()
-	a.setupEventStreams()
+	if err := a.setupEventStreams(); err != nil {
+		return err
+	}
+
 	a.findEndpointDiscoveryOp()
 	a.injectUnboundedOutputStreaming()
 	a.customizationPasses()
@@ -194,4 +232,16 @@ func (a *API) Setup() {
 	}
 
 	a.initialized = true
+
+	return nil
+}
+
+// UnsupportedAPIModelError provides wrapping of an error causing the API to
+// fail to load because the SDK does not support the API service defined.
+type UnsupportedAPIModelError struct {
+	Err error
+}
+
+func (e UnsupportedAPIModelError) Error() string {
+	return fmt.Sprintf("service API is not supported, %v", e.Err)
 }

--- a/private/model/api/pagination.go
+++ b/private/model/api/pagination.go
@@ -35,24 +35,24 @@ type paginationDefinitions struct {
 }
 
 // AttachPaginators attaches pagination configuration from filename to the API.
-func (a *API) AttachPaginators(filename string) {
+func (a *API) AttachPaginators(filename string) error {
 	p := paginationDefinitions{API: a}
 
 	f, err := os.Open(filename)
 	defer f.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = json.NewDecoder(f).Decode(&p)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to decode %s, err: %v", filename, err)
 	}
 
-	p.setup()
+	return p.setup()
 }
 
 // setup runs post-processing on the paginator configuration.
-func (p *paginationDefinitions) setup() {
+func (p *paginationDefinitions) setup() error {
 	for n, e := range p.Pagination {
 		if e.InputTokens == nil || e.OutputTokens == nil {
 			continue
@@ -85,9 +85,11 @@ func (p *paginationDefinitions) setup() {
 		if o, ok := p.Operations[n]; ok {
 			o.Paginator = &paginator
 		} else {
-			panic("unknown operation for paginator " + n)
+			return fmt.Errorf("unknown operation for paginator, %s", n)
 		}
 	}
+
+	return nil
 }
 
 func enableStopOnSameToken(service string) bool {

--- a/private/model/api/smoke.go
+++ b/private/model/api/smoke.go
@@ -35,20 +35,22 @@ func (c SmokeTestCase) BuildInputShape(ref *ShapeRef) string {
 }
 
 // AttachSmokeTests attaches the smoke test cases to the API model.
-func (a *API) AttachSmokeTests(filename string) {
+func (a *API) AttachSmokeTests(filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
-		panic(fmt.Sprintf("failed to open smoke tests %s, err: %v", filename, err))
+		return fmt.Errorf("failed to open smoke tests %s, err: %v", filename, err)
 	}
 	defer f.Close()
 
 	if err := json.NewDecoder(f).Decode(&a.SmokeTests); err != nil {
-		panic(fmt.Sprintf("failed to decode smoke tests %s, err: %v", filename, err))
+		return fmt.Errorf("failed to decode smoke tests %s, err: %v", filename, err)
 	}
 
 	if v := a.SmokeTests.Version; v != 1 {
-		panic(fmt.Sprintf("invalid smoke test version, %d", v))
+		return fmt.Errorf("invalid smoke test version, %d", v)
 	}
+
+	return nil
 }
 
 // APISmokeTestsGoCode returns the Go Code string for the smoke tests.

--- a/private/model/api/waiters.go
+++ b/private/model/api/waiters.go
@@ -65,23 +65,23 @@ type waiterDefinitions struct {
 
 // AttachWaiters reads a file of waiter definitions, and adds those to the API.
 // Will panic if an error occurs.
-func (a *API) AttachWaiters(filename string) {
+func (a *API) AttachWaiters(filename string) error {
 	p := waiterDefinitions{API: a}
 
 	f, err := os.Open(filename)
 	defer f.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	err = json.NewDecoder(f).Decode(&p)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	p.setup()
+	return p.setup()
 }
 
-func (p *waiterDefinitions) setup() {
+func (p *waiterDefinitions) setup() error {
 	p.API.Waiters = []Waiter{}
 	i, keys := 0, make([]string, len(p.Waiters))
 	for k := range p.Waiters {
@@ -97,10 +97,13 @@ func (p *waiterDefinitions) setup() {
 		e.OperationName = p.ExportableName(e.OperationName)
 		e.Operation = p.API.Operations[e.OperationName]
 		if e.Operation == nil {
-			panic("unknown operation " + e.OperationName + " for waiter " + n)
+			return fmt.Errorf("unknown operation %s for waiter %s",
+				e.OperationName, n)
 		}
 		p.API.Waiters = append(p.API.Waiters, e)
 	}
+
+	return nil
 }
 
 var waiterTmpls = template.Must(template.New("waiterTmpls").Funcs(

--- a/private/model/cli/gen-api/main.go
+++ b/private/model/cli/gen-api/main.go
@@ -53,6 +53,11 @@ func main() {
 		api.SDKImportRoot+"/service",
 		"The Go `import path` to generate client to be under.",
 	)
+	var ignoreUnsupportedAPIs bool
+	flag.BoolVar(&ignoreUnsupportedAPIs, "ignore-unsupported-apis",
+		true,
+		"Ignores API models that use unsupported features",
+	)
 	flag.Usage = usage
 	flag.Parse()
 
@@ -74,7 +79,12 @@ func main() {
 	}
 	modelPaths, _ = api.TrimModelServiceVersions(modelPaths)
 
-	apis, err := api.LoadAPIs(modelPaths, svcImportPath)
+	loader := api.Loader{
+		BaseImport:            svcImportPath,
+		IgnoreUnsupportedAPIs: ignoreUnsupportedAPIs,
+	}
+
+	apis, err := loader.Load(modelPaths)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "failed to load API models", err)
 		os.Exit(1)


### PR DESCRIPTION
Adds support for removing API modeled operations that use unsupported
features. If a API model results in having no operations it will be
skipped.