### PR TITLE
private/model/api: Write locationName for top-level shapes for rest-xml and ec2 protocols

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `private/protocol/xml/xmlutil`: Support for sorting xml attributes ([#2854](https://github.com/aws/aws-sdk-go/pull/2854))
 
 ### SDK Bugs
+* `private/model/api`: Write locationName for top-level shapes for rest-xml and ec2 protocols ([#2854](https://github.com/aws/aws-sdk-go/pull/2854))
+* `private/mode/api`: Colliding fields should serialize with original name ([#2854](https://github.com/aws/aws-sdk-go/pull/2854))
+  * Fixes [#2806](https://github.com/aws/aws-sdk-go/issues/2806) 

--- a/models/protocol_tests/input/rest-xml.json
+++ b/models/protocol_tests/input/rest-xml.json
@@ -1707,8 +1707,7 @@
       {
         "given": {
           "input": {
-            "shape": "InputShape",
-            "locationName": "OperationRequest"
+            "shape": "InputShape"
           },
           "http": {
             "method": "POST",
@@ -1722,14 +1721,13 @@
         "serialized": {
           "uri": "/path",
           "headers": {},
-          "body": "<OperationRequest><Token>abc123</Token></OperationRequest>"
+          "body": "<InputShape><Token>abc123</Token></InputShape>"
         }
       },
       {
         "given": {
           "input": {
-            "shape": "InputShape",
-            "locationName": "OperationRequest"
+            "shape": "InputShape"
           },
           "http": {
             "method": "POST",
@@ -1742,7 +1740,7 @@
         "serialized": {
           "uri": "/path",
           "headers": {},
-          "body": "<OperationRequest><Token>00000000-0000-4000-8000-000000000000</Token></OperationRequest>"
+          "body": "<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>"
         }
       }
     ]
@@ -1801,8 +1799,7 @@
       {
         "given": {
           "input": {
-            "shape": "InputShape",
-            "locationName": "OperationRequest"
+            "shape": "InputShape"
           },
           "http": {
             "method": "POST",
@@ -1820,7 +1817,7 @@
         "serialized": {
           "uri": "/Enum/bar?ListEnums=0&ListEnums=&ListEnums=1",
           "headers": {"x-amz-enum": "baz"},
-          "body": "<OperationRequest><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></OperationRequest>"
+          "body": "<InputShape><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></InputShape>"
         }
       },
       {

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -922,6 +922,23 @@ func (a *API) removeShapeRef(ref *ShapeRef) {
 	}
 }
 
+// writeInputOutputLocationName writes the ShapeName to the
+// shapes LocationName in the event that there is no LocationName
+// specified.
+func (a *API) writeInputOutputLocationName() {
+	for _, o := range a.Operations {
+		setInput := len(o.InputRef.LocationName) == 0 && a.Metadata.Protocol == "rest-xml"
+		setOutput := len(o.OutputRef.LocationName) == 0 && (a.Metadata.Protocol == "rest-xml" || a.Metadata.Protocol == "ec2")
+
+		if setInput {
+			o.InputRef.LocationName = o.InputRef.Shape.OrigShapeName
+		}
+		if setOutput {
+			o.OutputRef.LocationName = o.OutputRef.Shape.OrigShapeName
+		}
+	}
+}
+
 func getDeprecatedMessage(msg string, name string) string {
 	if len(msg) == 0 {
 		return name + " has been deprecated"

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -462,7 +462,7 @@ func (r *readEmptyStreamEventStream) unmarshalerForEventType(
 }
 
 type EmptyStreamInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"EmptyStreamRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -920,7 +920,7 @@ func (r *readGetEventStreamEventStream) unmarshalerForEventType(
 }
 
 type GetEventStreamInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetEventStreamRequest" type:"structure"`
 
 	InputVal *string `type:"string"`
 }

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -211,6 +211,7 @@ func (a *API) Setup() error {
 	a.renameExportable()
 	a.applyShapeNameAliases()
 	a.createInputOutputShapes()
+	a.writeInputOutputLocationName()
 	a.renameAPIPayloadShapes()
 	a.renameCollidingFields()
 	a.updateTopLevelShapeReferences()

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -220,7 +220,11 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 				"op": aws.String(req.Operation.Name),
 				{{ range $key, $ref := .InputRef.Shape.MemberRefs -}}
 				{{ if $ref.EndpointDiscoveryID -}}
-				"{{ $ref.OrigShapeName }}": input.{{ $key }},
+				{{ if ne (len $ref.LocationName) 0 -}}
+				"{{ $ref.LocationName }}": input.{{ $key }},
+				{{ else -}}
+				"{{ $key }}": input.{{ $key }},
+				{{ end -}}
 				{{ end -}}
 				{{- end }}
 			},

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -268,6 +268,11 @@ func renameCollidingField(name string, v *Shape, field *ShapeRef) {
 	debugLogger.Logf("Shape %s's field %q renamed to %q", v.ShapeName, name, newName)
 	delete(v.MemberRefs, name)
 	v.MemberRefs[newName] = field
+	// Set LocationName to the original field name if it is not already set.
+	// This is to ensure we correctly serialize to the proper member name
+	if len(field.LocationName) == 0 {
+		field.LocationName = name
+	}
 }
 
 // collides will return true if it is a name used by the SDK or Golang.

--- a/private/model/api/passes_test.go
+++ b/private/model/api/passes_test.go
@@ -229,6 +229,49 @@ func TestCollidingFields(t *testing.T) {
 	}
 }
 
+func TestCollidingFields_MaintainOriginalName(t *testing.T) {
+	cases := map[string]struct {
+		MemberRefs map[string]*ShapeRef
+		Expect     map[string]*ShapeRef
+	}{
+		"NoLocationName": {
+			MemberRefs: map[string]*ShapeRef{
+				"String": {},
+			},
+			Expect: map[string]*ShapeRef{
+				"String_": {LocationName: "String"},
+			},
+		},
+		"ExitingLocationName": {
+			MemberRefs: map[string]*ShapeRef{
+				"String": {LocationName: "OtherName"},
+			},
+			Expect: map[string]*ShapeRef{
+				"String_": {LocationName: "OtherName"},
+			},
+		},
+	}
+
+	for k, c := range cases {
+		t.Run(k, func(t *testing.T) {
+			a := &API{
+				Shapes: map[string]*Shape{
+					"shapename": {
+						ShapeName:  k,
+						MemberRefs: c.MemberRefs,
+					},
+				},
+			}
+
+			a.renameCollidingFields()
+
+			if e, a := c.Expect, a.Shapes["shapename"].MemberRefs; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
+	}
+}
+
 func TestCreateInputOutputShapes(t *testing.T) {
 	meta := Metadata{
 		APIVersion:          "0000-00-00",

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -190,12 +190,10 @@ func (s *Shape) Rename(newName string) {
 	}
 
 	for _, r := range s.refs {
-		r.OrigShapeName = r.ShapeName
 		r.ShapeName = newName
 	}
 
 	delete(s.API.Shapes, s.ShapeName)
-	s.OrigShapeName = s.ShapeName
 	s.API.Shapes[newName] = s
 	s.ShapeName = newName
 }
@@ -904,9 +902,9 @@ func (s *Shape) Clone(newName string) *Shape {
 	n.Enum = append([]string{}, n.Enum...)
 	n.EnumConsts = append([]string{}, n.EnumConsts...)
 
-	n.OrigShapeName = n.ShapeName
 	n.API.Shapes[newName] = n
 	n.ShapeName = newName
+	n.OrigShapeName = s.OrigShapeName
 
 	return n
 }

--- a/private/protocol/restxml/build_test.go
+++ b/private/protocol/restxml/build_test.go
@@ -2372,7 +2372,7 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1WithContext
 }
 
 type InputService13TestShapeInputService13TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Items []*string `location:"querystring" locationName:"item" type:"list"`
 }
@@ -2518,7 +2518,7 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1WithContext
 }
 
 type InputService14TestShapeInputService14TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	// PipelineId is a required field
 	PipelineId *string `location:"uri" type:"string" required:"true"`
@@ -2689,7 +2689,7 @@ func (c *InputService15ProtocolTest) InputService15TestCaseOperation1WithContext
 }
 
 type InputService15TestShapeInputService15TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	// PipelineId is a required field
 	PipelineId *string `location:"uri" type:"string" required:"true"`
@@ -2930,7 +2930,7 @@ func (c *InputService16ProtocolTest) InputService16TestCaseOperation2WithContext
 }
 
 type InputService16TestShapeInputService16TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
 }
@@ -2946,7 +2946,7 @@ type InputService16TestShapeInputService16TestCaseOperation1Output struct {
 }
 
 type InputService16TestShapeInputService16TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	BoolQuery *bool `location:"querystring" locationName:"bool-query" type:"boolean"`
 }
@@ -3092,7 +3092,7 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1WithContext
 }
 
 type InputService17TestShapeInputService17TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo *string `locationName:"foo" type:"string"`
 }
@@ -3308,7 +3308,7 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2WithContext
 }
 
 type InputService18TestShapeInputService18TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo []byte `locationName:"foo" type:"blob"`
 }
@@ -3324,7 +3324,7 @@ type InputService18TestShapeInputService18TestCaseOperation1Output struct {
 }
 
 type InputService18TestShapeInputService18TestCaseOperation2Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo []byte `locationName:"foo" type:"blob"`
 }
@@ -3692,7 +3692,7 @@ func (s *InputService19TestShapeFooShape) SetBaz(v string) *InputService19TestSh
 }
 
 type InputService19TestShapeInputService19TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo *InputService19TestShapeFooShape `locationName:"foo" type:"structure"`
 }
@@ -3708,7 +3708,7 @@ type InputService19TestShapeInputService19TestCaseOperation1Output struct {
 }
 
 type InputService19TestShapeInputService19TestCaseOperation2Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo *InputService19TestShapeFooShape `locationName:"foo" type:"structure"`
 }
@@ -3724,7 +3724,7 @@ type InputService19TestShapeInputService19TestCaseOperation2Output struct {
 }
 
 type InputService19TestShapeInputService19TestCaseOperation3Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo *InputService19TestShapeFooShape `locationName:"foo" type:"structure"`
 }
@@ -3740,7 +3740,7 @@ type InputService19TestShapeInputService19TestCaseOperation3Output struct {
 }
 
 type InputService19TestShapeInputService19TestCaseOperation4Input struct {
-	_ struct{} `type:"structure" payload:"Foo"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Foo"`
 
 	Foo *InputService19TestShapeFooShape `locationName:"foo" type:"structure"`
 }
@@ -3918,7 +3918,7 @@ func (s *InputService20TestShapeGrantee) SetType(v string) *InputService20TestSh
 }
 
 type InputService20TestShapeInputService20TestCaseOperation1Input struct {
-	_ struct{} `type:"structure" payload:"Grant"`
+	_ struct{} `locationName:"InputShape" type:"structure" payload:"Grant"`
 
 	Grant *InputService20TestShapeGrant `locationName:"Grant" type:"structure"`
 }
@@ -4064,7 +4064,7 @@ func (c *InputService21ProtocolTest) InputService21TestCaseOperation1WithContext
 }
 
 type InputService21TestShapeInputService21TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" type:"string" required:"true"`
@@ -4312,7 +4312,7 @@ func (c *InputService22ProtocolTest) InputService22TestCaseOperation2WithContext
 }
 
 type InputService22TestShapeInputService22TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
@@ -4328,7 +4328,7 @@ type InputService22TestShapeInputService22TestCaseOperation1Output struct {
 }
 
 type InputService22TestShapeInputService22TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Foo *string `location:"querystring" locationName:"param-name" type:"string"`
 }
@@ -5156,7 +5156,7 @@ func (c *InputService24ProtocolTest) InputService24TestCaseOperation2WithContext
 }
 
 type InputService24TestShapeInputService24TestCaseOperation1Input struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
@@ -5172,7 +5172,7 @@ type InputService24TestShapeInputService24TestCaseOperation1Output struct {
 }
 
 type InputService24TestShapeInputService24TestCaseOperation2Input struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Token *string `type:"string" idempotencyToken:"true"`
 }
@@ -5388,7 +5388,7 @@ func (c *InputService25ProtocolTest) InputService25TestCaseOperation2WithContext
 }
 
 type InputService25TestShapeInputService25TestCaseOperation1Input struct {
-	_ struct{} `locationName:"OperationRequest" type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	FooEnum *string `type:"string" enum:"InputService25TestShapeEnumType"`
 
@@ -5453,7 +5453,7 @@ type InputService25TestShapeInputService25TestCaseOperation1Output struct {
 }
 
 type InputService25TestShapeInputService25TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	FooEnum *string `type:"string" enum:"InputService25TestShapeEnumType"`
 
@@ -5921,7 +5921,7 @@ func (c *InputService27ProtocolTest) InputService27TestCaseOperation1WithContext
 }
 
 type InputService27TestShapeInputService27TestCaseOperation1Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"InputShape" type:"structure"`
 
 	Header1 *string `location:"header" type:"string"`
 
@@ -6740,7 +6740,7 @@ func TestInputService20ProtocolTestXMLAttributeCase1(t *testing.T) {
 		t.Errorf("expect body not to be nil")
 	}
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<Grant xmlns:_xmlns="xmlns" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="CanonicalUser"><Grantee><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(body))
+	awstesting.AssertXML(t, `<Grant xmlns:XMLSchema-instance="http://www.w3.org/2001/XMLSchema-instance" XMLSchema-instance:type="CanonicalUser" xmlns:_xmlns="xmlns" _xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Grantee><EmailAddress>foo@example.com</EmailAddress></Grantee></Grant>`, util.Trim(body))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/", r.URL.String())
@@ -7041,7 +7041,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase1(t *testing.T) {
 		t.Errorf("expect body not to be nil")
 	}
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest><Token>abc123</Token></OperationRequest>`, util.Trim(body))
+	awstesting.AssertXML(t, `<InputShape><Token>abc123</Token></InputShape>`, util.Trim(body))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7067,7 +7067,7 @@ func TestInputService24ProtocolTestIdempotencyTokenAutoFillCase2(t *testing.T) {
 		t.Errorf("expect body not to be nil")
 	}
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest><Token>00000000-0000-4000-8000-000000000000</Token></OperationRequest>`, util.Trim(body))
+	awstesting.AssertXML(t, `<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>`, util.Trim(body))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/path", r.URL.String())
@@ -7107,7 +7107,7 @@ func TestInputService25ProtocolTestEnumCase1(t *testing.T) {
 		t.Errorf("expect body not to be nil")
 	}
 	body := util.SortXML(r.Body)
-	awstesting.AssertXML(t, `<OperationRequest><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></OperationRequest>`, util.Trim(body))
+	awstesting.AssertXML(t, `<InputShape><FooEnum>foo</FooEnum><ListEnums><member>foo</member><member></member><member>bar</member></ListEnums></InputShape>`, util.Trim(body))
 
 	// assert URL
 	awstesting.AssertURL(t, "https://test/Enum/bar?ListEnums=0&ListEnums=&ListEnums=1", r.URL.String())

--- a/private/protocol/restxml/unmarshal_test.go
+++ b/private/protocol/restxml/unmarshal_test.go
@@ -2595,7 +2595,7 @@ func (s *OutputService14TestShapeOutputService14TestCaseOperation1Output) SetLis
 }
 
 type OutputService14TestShapeOutputService14TestCaseOperation2Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"OutputShape" type:"structure"`
 
 	FooEnum *string `type:"string" enum:"OutputService14TestShapeRESTJSONEnumType"`
 

--- a/private/protocol/xml/xmlutil/sort.go
+++ b/private/protocol/xml/xmlutil/sort.go
@@ -1,0 +1,32 @@
+package xmlutil
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+type xmlAttrSlice []xml.Attr
+
+func (x xmlAttrSlice) Len() int {
+	return len(x)
+}
+
+func (x xmlAttrSlice) Less(i, j int) bool {
+	spaceI, spaceJ := x[i].Name.Space, x[j].Name.Space
+	localI, localJ := x[i].Name.Local, x[j].Name.Local
+	valueI, valueJ := x[i].Value, x[j].Value
+
+	spaceCmp := strings.Compare(spaceI, spaceJ)
+	localCmp := strings.Compare(localI, localJ)
+	valueCmp := strings.Compare(valueI, valueJ)
+
+	if spaceCmp == -1 || (spaceCmp == 0 && (localCmp == -1 || (localCmp == 0 && valueCmp == -1))) {
+		return true
+	}
+
+	return false
+}
+
+func (x xmlAttrSlice) Swap(i, j int) {
+	x[i], x[j] = x[j], x[i]
+}

--- a/private/protocol/xml/xmlutil/sort_test.go
+++ b/private/protocol/xml/xmlutil/sort_test.go
@@ -1,0 +1,88 @@
+package xmlutil
+
+import (
+	"encoding/xml"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestXmlAttrSlice(t *testing.T) {
+	tests := []struct {
+		input    []xml.Attr
+		expected []xml.Attr
+	}{
+		{
+			input:    []xml.Attr{},
+			expected: []xml.Attr{},
+		},
+		{
+			input: []xml.Attr{
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "bar",
+					},
+					Value: "baz",
+				},
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "baz",
+					},
+					Value: "bar",
+				},
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "bar",
+					},
+					Value: "bar",
+				},
+				{
+					Name: xml.Name{
+						Space: "baz",
+						Local: "bar",
+					},
+					Value: "foo",
+				},
+			},
+			expected: []xml.Attr{
+				{
+					Name: xml.Name{
+						Space: "baz",
+						Local: "bar",
+					},
+					Value: "foo",
+				},
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "bar",
+					},
+					Value: "bar",
+				},
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "bar",
+					},
+					Value: "baz",
+				},
+				{
+					Name: xml.Name{
+						Space: "foo",
+						Local: "baz",
+					},
+					Value: "bar",
+				},
+			},
+		},
+	}
+	for i, tt := range tests {
+		sort.Sort(xmlAttrSlice(tt.input))
+		if e, a := tt.expected, tt.input; !reflect.DeepEqual(e, a) {
+			t.Errorf("case %d expected %v, got %v", i, e, a)
+		}
+	}
+}

--- a/private/protocol/xml/xmlutil/xml_to_struct.go
+++ b/private/protocol/xml/xmlutil/xml_to_struct.go
@@ -119,7 +119,18 @@ func (n *XMLNode) findElem(name string) (string, bool) {
 
 // StructToXML writes an XMLNode to a xml.Encoder as tokens.
 func StructToXML(e *xml.Encoder, node *XMLNode, sorted bool) error {
-	e.EncodeToken(xml.StartElement{Name: node.Name, Attr: node.Attr})
+	// Sort Attributes
+	attrs := node.Attr
+	if sorted {
+		sortedAttrs := make([]xml.Attr, len(attrs))
+		for _, k := range node.Attr {
+			sortedAttrs = append(sortedAttrs, k)
+		}
+		sort.Sort(xmlAttrSlice(sortedAttrs))
+		attrs = sortedAttrs
+	}
+
+	e.EncodeToken(xml.StartElement{Name: node.Name, Attr: attrs})
 
 	if node.Text != "" {
 		e.EncodeToken(xml.CharData([]byte(node.Text)))

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -5871,7 +5871,7 @@ func (s *CookiePreference) SetWhitelistedNames(v *CookieNames) *CookiePreference
 // an Origin Access Identity (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)
 // in the Amazon CloudFront Developer Guide.
 type CreateCloudFrontOriginAccessIdentityInput struct {
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+	_ struct{} `locationName:"CreateCloudFrontOriginAccessIdentityRequest" type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 
 	// The current configuration information for the identity.
 	//
@@ -5958,7 +5958,7 @@ func (s *CreateCloudFrontOriginAccessIdentityOutput) SetLocation(v string) *Crea
 
 // The request to create a new distribution.
 type CreateDistributionInput struct {
-	_ struct{} `type:"structure" payload:"DistributionConfig"`
+	_ struct{} `locationName:"CreateDistributionRequest" type:"structure" payload:"DistributionConfig"`
 
 	// The distribution's configuration information.
 	//
@@ -6045,7 +6045,7 @@ func (s *CreateDistributionOutput) SetLocation(v string) *CreateDistributionOutp
 
 // The request to create a new distribution with tags.
 type CreateDistributionWithTagsInput struct {
-	_ struct{} `type:"structure" payload:"DistributionConfigWithTags"`
+	_ struct{} `locationName:"CreateDistributionWithTagsRequest" type:"structure" payload:"DistributionConfigWithTags"`
 
 	// The distribution's configuration information.
 	//
@@ -6131,7 +6131,7 @@ func (s *CreateDistributionWithTagsOutput) SetLocation(v string) *CreateDistribu
 }
 
 type CreateFieldLevelEncryptionConfigInput struct {
-	_ struct{} `type:"structure" payload:"FieldLevelEncryptionConfig"`
+	_ struct{} `locationName:"CreateFieldLevelEncryptionConfigRequest" type:"structure" payload:"FieldLevelEncryptionConfig"`
 
 	// The request to create a new field-level encryption configuration.
 	//
@@ -6217,7 +6217,7 @@ func (s *CreateFieldLevelEncryptionConfigOutput) SetLocation(v string) *CreateFi
 }
 
 type CreateFieldLevelEncryptionProfileInput struct {
-	_ struct{} `type:"structure" payload:"FieldLevelEncryptionProfileConfig"`
+	_ struct{} `locationName:"CreateFieldLevelEncryptionProfileRequest" type:"structure" payload:"FieldLevelEncryptionProfileConfig"`
 
 	// The request to create a field-level encryption profile.
 	//
@@ -6303,7 +6303,7 @@ func (s *CreateFieldLevelEncryptionProfileOutput) SetLocation(v string) *CreateF
 
 // The request to create an invalidation.
 type CreateInvalidationInput struct {
-	_ struct{} `type:"structure" payload:"InvalidationBatch"`
+	_ struct{} `locationName:"CreateInvalidationRequest" type:"structure" payload:"InvalidationBatch"`
 
 	// The distribution's id.
 	//
@@ -6397,7 +6397,7 @@ func (s *CreateInvalidationOutput) SetLocation(v string) *CreateInvalidationOutp
 }
 
 type CreatePublicKeyInput struct {
-	_ struct{} `type:"structure" payload:"PublicKeyConfig"`
+	_ struct{} `locationName:"CreatePublicKeyRequest" type:"structure" payload:"PublicKeyConfig"`
 
 	// The request to add a public key to CloudFront.
 	//
@@ -6483,7 +6483,7 @@ func (s *CreatePublicKeyOutput) SetPublicKey(v *PublicKey) *CreatePublicKeyOutpu
 
 // The request to create a new streaming distribution.
 type CreateStreamingDistributionInput struct {
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
+	_ struct{} `locationName:"CreateStreamingDistributionRequest" type:"structure" payload:"StreamingDistributionConfig"`
 
 	// The streaming distribution's configuration information.
 	//
@@ -6570,7 +6570,7 @@ func (s *CreateStreamingDistributionOutput) SetStreamingDistribution(v *Streamin
 
 // The request to create a new streaming distribution with tags.
 type CreateStreamingDistributionWithTagsInput struct {
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfigWithTags"`
+	_ struct{} `locationName:"CreateStreamingDistributionWithTagsRequest" type:"structure" payload:"StreamingDistributionConfigWithTags"`
 
 	// The streaming distribution's configuration information.
 	//
@@ -7290,7 +7290,7 @@ func (s *DefaultCacheBehavior) SetViewerProtocolPolicy(v string) *DefaultCacheBe
 
 // Deletes a origin access identity.
 type DeleteCloudFrontOriginAccessIdentityInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteCloudFrontOriginAccessIdentityRequest" type:"structure"`
 
 	// The origin access identity's ID.
 	//
@@ -7390,7 +7390,7 @@ func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
 // see Deleting a Distribution (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HowToDeleteDistribution.html)
 // in the Amazon CloudFront Developer Guide.
 type DeleteDistributionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteDistributionRequest" type:"structure"`
 
 	// The distribution ID.
 	//
@@ -7455,7 +7455,7 @@ func (s DeleteDistributionOutput) GoString() string {
 }
 
 type DeleteFieldLevelEncryptionConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteFieldLevelEncryptionConfigRequest" type:"structure"`
 
 	// The ID of the configuration you want to delete from CloudFront.
 	//
@@ -7520,7 +7520,7 @@ func (s DeleteFieldLevelEncryptionConfigOutput) GoString() string {
 }
 
 type DeleteFieldLevelEncryptionProfileInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteFieldLevelEncryptionProfileRequest" type:"structure"`
 
 	// Request the ID of the profile you want to delete from CloudFront.
 	//
@@ -7585,7 +7585,7 @@ func (s DeleteFieldLevelEncryptionProfileOutput) GoString() string {
 }
 
 type DeletePublicKeyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeletePublicKeyRequest" type:"structure"`
 
 	// The ID of the public key you want to remove from CloudFront.
 	//
@@ -7651,7 +7651,7 @@ func (s DeletePublicKeyOutput) GoString() string {
 
 // The request to delete a streaming distribution.
 type DeleteStreamingDistributionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteStreamingDistributionRequest" type:"structure"`
 
 	// The distribution ID.
 	//
@@ -9522,7 +9522,7 @@ func (s *GeoRestriction) SetRestrictionType(v string) *GeoRestriction {
 // The origin access identity's configuration information. For more information,
 // see CloudFrontOriginAccessIdentityConfig (https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CloudFrontOriginAccessIdentityConfig.html).
 type GetCloudFrontOriginAccessIdentityConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetCloudFrontOriginAccessIdentityConfigRequest" type:"structure"`
 
 	// The identity's ID.
 	//
@@ -9597,7 +9597,7 @@ func (s *GetCloudFrontOriginAccessIdentityConfigOutput) SetETag(v string) *GetCl
 
 // The request to get an origin access identity's information.
 type GetCloudFrontOriginAccessIdentityInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetCloudFrontOriginAccessIdentityRequest" type:"structure"`
 
 	// The identity's ID.
 	//
@@ -9673,7 +9673,7 @@ func (s *GetCloudFrontOriginAccessIdentityOutput) SetETag(v string) *GetCloudFro
 
 // The request to get a distribution configuration.
 type GetDistributionConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetDistributionConfigRequest" type:"structure"`
 
 	// The distribution's ID. If the ID is empty, an empty distribution configuration
 	// is returned.
@@ -9749,7 +9749,7 @@ func (s *GetDistributionConfigOutput) SetETag(v string) *GetDistributionConfigOu
 
 // The request to get a distribution's information.
 type GetDistributionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetDistributionRequest" type:"structure"`
 
 	// The distribution's ID. If the ID is empty, an empty distribution configuration
 	// is returned.
@@ -9824,7 +9824,7 @@ func (s *GetDistributionOutput) SetETag(v string) *GetDistributionOutput {
 }
 
 type GetFieldLevelEncryptionConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetFieldLevelEncryptionConfigRequest" type:"structure"`
 
 	// Request the ID for the field-level encryption configuration information.
 	//
@@ -9898,7 +9898,7 @@ func (s *GetFieldLevelEncryptionConfigOutput) SetFieldLevelEncryptionConfig(v *F
 }
 
 type GetFieldLevelEncryptionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetFieldLevelEncryptionRequest" type:"structure"`
 
 	// Request the ID for the field-level encryption configuration information.
 	//
@@ -9972,7 +9972,7 @@ func (s *GetFieldLevelEncryptionOutput) SetFieldLevelEncryption(v *FieldLevelEnc
 }
 
 type GetFieldLevelEncryptionProfileConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetFieldLevelEncryptionProfileConfigRequest" type:"structure"`
 
 	// Get the ID for the field-level encryption profile configuration information.
 	//
@@ -10046,7 +10046,7 @@ func (s *GetFieldLevelEncryptionProfileConfigOutput) SetFieldLevelEncryptionProf
 }
 
 type GetFieldLevelEncryptionProfileInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetFieldLevelEncryptionProfileRequest" type:"structure"`
 
 	// Get the ID for the field-level encryption profile information.
 	//
@@ -10120,7 +10120,7 @@ func (s *GetFieldLevelEncryptionProfileOutput) SetFieldLevelEncryptionProfile(v 
 
 // The request to get an invalidation's information.
 type GetInvalidationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetInvalidationRequest" type:"structure"`
 
 	// The distribution's ID.
 	//
@@ -10203,7 +10203,7 @@ func (s *GetInvalidationOutput) SetInvalidation(v *Invalidation) *GetInvalidatio
 }
 
 type GetPublicKeyConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetPublicKeyConfigRequest" type:"structure"`
 
 	// Request the ID for the public key configuration.
 	//
@@ -10276,7 +10276,7 @@ func (s *GetPublicKeyConfigOutput) SetPublicKeyConfig(v *PublicKeyConfig) *GetPu
 }
 
 type GetPublicKeyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetPublicKeyRequest" type:"structure"`
 
 	// Request the ID for the public key.
 	//
@@ -10350,7 +10350,7 @@ func (s *GetPublicKeyOutput) SetPublicKey(v *PublicKey) *GetPublicKeyOutput {
 
 // To request to get a streaming distribution configuration.
 type GetStreamingDistributionConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetStreamingDistributionConfigRequest" type:"structure"`
 
 	// The streaming distribution's ID.
 	//
@@ -10425,7 +10425,7 @@ func (s *GetStreamingDistributionConfigOutput) SetStreamingDistributionConfig(v 
 
 // The request to get a streaming distribution's information.
 type GetStreamingDistributionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetStreamingDistributionRequest" type:"structure"`
 
 	// The streaming distribution's ID.
 	//
@@ -11050,7 +11050,7 @@ func (s *LambdaFunctionAssociations) SetQuantity(v int64) *LambdaFunctionAssocia
 
 // The request to list origin access identities.
 type ListCloudFrontOriginAccessIdentitiesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListCloudFrontOriginAccessIdentitiesRequest" type:"structure"`
 
 	// Use this when paginating results to indicate where to begin in your list
 	// of origin access identities. The results include identities in the list that
@@ -11112,7 +11112,7 @@ func (s *ListCloudFrontOriginAccessIdentitiesOutput) SetCloudFrontOriginAccessId
 // The request to list distributions that are associated with a specified AWS
 // WAF web ACL.
 type ListDistributionsByWebACLIdInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListDistributionsByWebACLIdRequest" type:"structure"`
 
 	// Use Marker and MaxItems to control pagination of results. If you have more
 	// than MaxItems distributions that satisfy the request, the response includes
@@ -11204,7 +11204,7 @@ func (s *ListDistributionsByWebACLIdOutput) SetDistributionList(v *DistributionL
 
 // The request to list your distributions.
 type ListDistributionsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListDistributionsRequest" type:"structure"`
 
 	// Use this when paginating results to indicate where to begin in your list
 	// of distributions. The results include distributions in the list that occur
@@ -11264,7 +11264,7 @@ func (s *ListDistributionsOutput) SetDistributionList(v *DistributionList) *List
 }
 
 type ListFieldLevelEncryptionConfigsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListFieldLevelEncryptionConfigsRequest" type:"structure"`
 
 	// Use this when paginating results to indicate where to begin in your list
 	// of configurations. The results include configurations in the list that occur
@@ -11325,7 +11325,7 @@ func (s *ListFieldLevelEncryptionConfigsOutput) SetFieldLevelEncryptionList(v *F
 }
 
 type ListFieldLevelEncryptionProfilesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListFieldLevelEncryptionProfilesRequest" type:"structure"`
 
 	// Use this when paginating results to indicate where to begin in your list
 	// of profiles. The results include profiles in the list that occur after the
@@ -11387,7 +11387,7 @@ func (s *ListFieldLevelEncryptionProfilesOutput) SetFieldLevelEncryptionProfileL
 
 // The request to list invalidations.
 type ListInvalidationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListInvalidationsRequest" type:"structure"`
 
 	// The distribution's ID.
 	//
@@ -11477,7 +11477,7 @@ func (s *ListInvalidationsOutput) SetInvalidationList(v *InvalidationList) *List
 }
 
 type ListPublicKeysInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListPublicKeysRequest" type:"structure"`
 
 	// Use this when paginating results to indicate where to begin in your list
 	// of public keys. The results include public keys in the list that occur after
@@ -11538,7 +11538,7 @@ func (s *ListPublicKeysOutput) SetPublicKeyList(v *PublicKeyList) *ListPublicKey
 
 // The request to list your streaming distributions.
 type ListStreamingDistributionsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListStreamingDistributionsRequest" type:"structure"`
 
 	// The value that you provided for the Marker request parameter.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
@@ -11595,7 +11595,7 @@ func (s *ListStreamingDistributionsOutput) SetStreamingDistributionList(v *Strea
 
 // The request to list tags for a CloudFront resource.
 type ListTagsForResourceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTagsForResourceRequest" type:"structure"`
 
 	// An ARN of a CloudFront resource.
 	//
@@ -14184,7 +14184,7 @@ func (s *TagKeys) SetItems(v []*string) *TagKeys {
 
 // The request to add tags to a CloudFront resource.
 type TagResourceInput struct {
-	_ struct{} `type:"structure" payload:"Tags"`
+	_ struct{} `locationName:"TagResourceRequest" type:"structure" payload:"Tags"`
 
 	// An ARN of a CloudFront resource.
 	//
@@ -14382,7 +14382,7 @@ func (s *TrustedSigners) SetQuantity(v int64) *TrustedSigners {
 
 // The request to remove tags from a CloudFront resource.
 type UntagResourceInput struct {
-	_ struct{} `type:"structure" payload:"TagKeys"`
+	_ struct{} `locationName:"UntagResourceRequest" type:"structure" payload:"TagKeys"`
 
 	// An ARN of a CloudFront resource.
 	//
@@ -14449,7 +14449,7 @@ func (s UntagResourceOutput) GoString() string {
 
 // The request to update an origin access identity.
 type UpdateCloudFrontOriginAccessIdentityInput struct {
-	_ struct{} `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+	_ struct{} `locationName:"UpdateCloudFrontOriginAccessIdentityRequest" type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 
 	// The identity's configuration information.
 	//
@@ -14553,7 +14553,7 @@ func (s *UpdateCloudFrontOriginAccessIdentityOutput) SetETag(v string) *UpdateCl
 
 // The request to update a distribution.
 type UpdateDistributionInput struct {
-	_ struct{} `type:"structure" payload:"DistributionConfig"`
+	_ struct{} `locationName:"UpdateDistributionRequest" type:"structure" payload:"DistributionConfig"`
 
 	// The distribution's configuration information.
 	//
@@ -14656,7 +14656,7 @@ func (s *UpdateDistributionOutput) SetETag(v string) *UpdateDistributionOutput {
 }
 
 type UpdateFieldLevelEncryptionConfigInput struct {
-	_ struct{} `type:"structure" payload:"FieldLevelEncryptionConfig"`
+	_ struct{} `locationName:"UpdateFieldLevelEncryptionConfigRequest" type:"structure" payload:"FieldLevelEncryptionConfig"`
 
 	// Request to update a field-level encryption configuration.
 	//
@@ -14759,7 +14759,7 @@ func (s *UpdateFieldLevelEncryptionConfigOutput) SetFieldLevelEncryption(v *Fiel
 }
 
 type UpdateFieldLevelEncryptionProfileInput struct {
-	_ struct{} `type:"structure" payload:"FieldLevelEncryptionProfileConfig"`
+	_ struct{} `locationName:"UpdateFieldLevelEncryptionProfileRequest" type:"structure" payload:"FieldLevelEncryptionProfileConfig"`
 
 	// Request to update a field-level encryption profile.
 	//
@@ -14861,7 +14861,7 @@ func (s *UpdateFieldLevelEncryptionProfileOutput) SetFieldLevelEncryptionProfile
 }
 
 type UpdatePublicKeyInput struct {
-	_ struct{} `type:"structure" payload:"PublicKeyConfig"`
+	_ struct{} `locationName:"UpdatePublicKeyRequest" type:"structure" payload:"PublicKeyConfig"`
 
 	// ID of the public key to be updated.
 	//
@@ -14964,7 +14964,7 @@ func (s *UpdatePublicKeyOutput) SetPublicKey(v *PublicKey) *UpdatePublicKeyOutpu
 
 // The request to update a streaming distribution.
 type UpdateStreamingDistributionInput struct {
-	_ struct{} `type:"structure" payload:"StreamingDistributionConfig"`
+	_ struct{} `locationName:"UpdateStreamingDistributionRequest" type:"structure" payload:"StreamingDistributionConfig"`
 
 	// The streaming distribution's id.
 	//

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -7916,7 +7916,7 @@ func (s *DelegationSet) SetNameServers(v []*string) *DelegationSet {
 
 // This action deletes a health check.
 type DeleteHealthCheckInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteHealthCheckRequest" type:"structure"`
 
 	// The ID of the health check that you want to delete.
 	//
@@ -7973,7 +7973,7 @@ func (s DeleteHealthCheckOutput) GoString() string {
 
 // A request to delete a hosted zone.
 type DeleteHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone you want to delete.
 	//
@@ -8041,7 +8041,7 @@ func (s *DeleteHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DeleteHostedZoneO
 }
 
 type DeleteQueryLoggingConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteQueryLoggingConfigRequest" type:"structure"`
 
 	// The ID of the configuration that you want to delete.
 	//
@@ -8097,7 +8097,7 @@ func (s DeleteQueryLoggingConfigOutput) GoString() string {
 
 // A request to delete a reusable delegation set.
 type DeleteReusableDelegationSetInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteReusableDelegationSetRequest" type:"structure"`
 
 	// The ID of the reusable delegation set that you want to delete.
 	//
@@ -8154,7 +8154,7 @@ func (s DeleteReusableDelegationSetOutput) GoString() string {
 
 // A request to delete a specified traffic policy version.
 type DeleteTrafficPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteTrafficPolicyRequest" type:"structure"`
 
 	// The ID of the traffic policy that you want to delete.
 	//
@@ -8213,7 +8213,7 @@ func (s *DeleteTrafficPolicyInput) SetVersion(v int64) *DeleteTrafficPolicyInput
 
 // A request to delete a specified traffic policy instance.
 type DeleteTrafficPolicyInstanceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteTrafficPolicyInstanceRequest" type:"structure"`
 
 	// The ID of the traffic policy instance that you want to delete.
 	//
@@ -8651,7 +8651,7 @@ func (s *GeoLocationDetails) SetSubdivisionName(v string) *GeoLocationDetails {
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetAccountLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetAccountLimitRequest" type:"structure"`
 
 	// The limit that you want to get. Valid values include the following:
 	//
@@ -8753,7 +8753,7 @@ func (s *GetAccountLimitOutput) SetLimit(v *AccountLimit) *GetAccountLimitOutput
 
 // The input for a GetChange request.
 type GetChangeInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetChangeRequest" type:"structure"`
 
 	// The ID of the change batch request. The value that you specify here is the
 	// value that ChangeResourceRecordSets returned in the Id element when you submitted
@@ -8823,7 +8823,7 @@ func (s *GetChangeOutput) SetChangeInfo(v *ChangeInfo) *GetChangeOutput {
 
 // Empty request.
 type GetCheckerIpRangesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetCheckerIpRangesRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -8866,7 +8866,7 @@ func (s *GetCheckerIpRangesOutput) SetCheckerIpRanges(v []*string) *GetCheckerIp
 // A request for information about whether a specified geographic location is
 // supported for Amazon Route 53 geolocation resource record sets.
 type GetGeoLocationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetGeoLocationRequest" type:"structure"`
 
 	// Amazon Route 53 supports the following continent codes:
 	//
@@ -8974,7 +8974,7 @@ func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *Get
 // A request for the number of health checks that are associated with the current
 // AWS account.
 type GetHealthCheckCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9015,7 +9015,7 @@ func (s *GetHealthCheckCountOutput) SetHealthCheckCount(v int64) *GetHealthCheck
 
 // A request to get information about a specified health check.
 type GetHealthCheckInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckRequest" type:"structure"`
 
 	// The identifier that Amazon Route 53 assigned to the health check when you
 	// created it. When you add or update a resource record set, you use this value
@@ -9060,7 +9060,7 @@ func (s *GetHealthCheckInput) SetHealthCheckId(v string) *GetHealthCheckInput {
 
 // A request for the reason that a health check failed most recently.
 type GetHealthCheckLastFailureReasonInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckLastFailureReasonRequest" type:"structure"`
 
 	// The ID for the health check for which you want the last failure reason. When
 	// you created the health check, CreateHealthCheck returned the ID in the response,
@@ -9163,7 +9163,7 @@ func (s *GetHealthCheckOutput) SetHealthCheck(v *HealthCheck) *GetHealthCheckOut
 
 // A request to get the status for a health check.
 type GetHealthCheckStatusInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckStatusRequest" type:"structure"`
 
 	// The ID for the health check that you want the current status for. When you
 	// created the health check, CreateHealthCheck returned the ID in the response,
@@ -9239,7 +9239,7 @@ func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheck
 // A request to retrieve a count of all the hosted zones that are associated
 // with the current AWS account.
 type GetHostedZoneCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9281,7 +9281,7 @@ func (s *GetHostedZoneCountOutput) SetHostedZoneCount(v int64) *GetHostedZoneCou
 
 // A request to get information about a specified hosted zone.
 type GetHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to get information about.
 	//
@@ -9324,7 +9324,7 @@ func (s *GetHostedZoneInput) SetId(v string) *GetHostedZoneInput {
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetHostedZoneLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneLimitRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to get a limit for.
 	//
@@ -9478,7 +9478,7 @@ func (s *GetHostedZoneOutput) SetVPCs(v []*VPC) *GetHostedZoneOutput {
 }
 
 type GetQueryLoggingConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetQueryLoggingConfigRequest" type:"structure"`
 
 	// The ID of the configuration for DNS query logging that you want to get information
 	// about.
@@ -9548,7 +9548,7 @@ func (s *GetQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfi
 
 // A request to get information about a specified reusable delegation set.
 type GetReusableDelegationSetInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetReusableDelegationSetRequest" type:"structure"`
 
 	// The ID of the reusable delegation set that you want to get a list of name
 	// servers for.
@@ -9592,7 +9592,7 @@ func (s *GetReusableDelegationSetInput) SetId(v string) *GetReusableDelegationSe
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetReusableDelegationSetLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetReusableDelegationSetLimitRequest" type:"structure"`
 
 	// The ID of the delegation set that you want to get the limit for.
 	//
@@ -9719,7 +9719,7 @@ func (s *GetReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *Get
 
 // Gets information about a specific traffic policy version.
 type GetTrafficPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyRequest" type:"structure"`
 
 	// The ID of the traffic policy that you want to get information about.
 	//
@@ -9780,7 +9780,7 @@ func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
 // Request to get the number of traffic policy instances that are associated
 // with the current AWS account.
 type GetTrafficPolicyInstanceCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyInstanceCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9823,7 +9823,7 @@ func (s *GetTrafficPolicyInstanceCountOutput) SetTrafficPolicyInstanceCount(v in
 
 // Gets information about a specified traffic policy instance.
 type GetTrafficPolicyInstanceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyInstanceRequest" type:"structure"`
 
 	// The ID of the traffic policy instance that you want to get information about.
 	//
@@ -10690,7 +10690,7 @@ func (s *LinkedService) SetServicePrincipal(v string) *LinkedService {
 // A request to get a list of geographic locations that Amazon Route 53 supports
 // for geolocation resource record sets.
 type ListGeoLocationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListGeoLocationsRequest" type:"structure"`
 
 	// (Optional) The maximum number of geolocations to be included in the response
 	// body for this request. If more than maxitems geolocations remain to be listed,
@@ -10871,7 +10871,7 @@ func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocati
 // A request to retrieve a list of the health checks that are associated with
 // the current AWS account.
 type ListHealthChecksInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHealthChecksRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// health checks. To get another group, submit another ListHealthChecks request.
@@ -10992,7 +10992,7 @@ func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput
 // Retrieves a list of the public and private hosted zones that are associated
 // with the current AWS account in ASCII order by domain name.
 type ListHostedZonesByNameInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHostedZonesByNameRequest" type:"structure"`
 
 	// (Optional) For your first request to ListHostedZonesByName, include the dnsname
 	// parameter only if you want to specify the name of the first hosted zone in
@@ -11154,7 +11154,7 @@ func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZ
 // A request to retrieve a list of the public and private hosted zones that
 // are associated with the current AWS account.
 type ListHostedZonesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHostedZonesRequest" type:"structure"`
 
 	// If you're using reusable delegation sets and you want to list all of the
 	// hosted zones that are associated with a reusable delegation set, specify
@@ -11286,7 +11286,7 @@ func (s *ListHostedZonesOutput) SetNextMarker(v string) *ListHostedZonesOutput {
 }
 
 type ListQueryLoggingConfigsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListQueryLoggingConfigsRequest" type:"structure"`
 
 	// (Optional) If you want to list the query logging configuration that is associated
 	// with a hosted zone, specify the ID in HostedZoneId.
@@ -11388,7 +11388,7 @@ func (s *ListQueryLoggingConfigsOutput) SetQueryLoggingConfigs(v []*QueryLogging
 // A request for the resource record sets that are associated with a specified
 // hosted zone.
 type ListResourceRecordSetsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListResourceRecordSetsRequest" type:"structure"`
 
 	// The ID of the hosted zone that contains the resource record sets that you
 	// want to list.
@@ -11592,7 +11592,7 @@ func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecord
 // A request to get a list of the reusable delegation sets that are associated
 // with the current AWS account.
 type ListReusableDelegationSetsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListReusableDelegationSetsRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// reusable delegation sets. To get another group, submit another ListReusableDelegationSets
@@ -11713,7 +11713,7 @@ func (s *ListReusableDelegationSetsOutput) SetNextMarker(v string) *ListReusable
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 type ListTagsForResourceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTagsForResourceRequest" type:"structure"`
 
 	// The ID of the resource for which you want to retrieve tags.
 	//
@@ -11895,7 +11895,7 @@ func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *Li
 // A complex type that contains the information about the request to list the
 // traffic policies that are associated with the current AWS account.
 type ListTrafficPoliciesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPoliciesRequest" type:"structure"`
 
 	// (Optional) The maximum number of traffic policies that you want Amazon Route
 	// 53 to return in response to this request. If you have more than MaxItems
@@ -12018,7 +12018,7 @@ func (s *ListTrafficPoliciesOutput) SetTrafficPolicySummaries(v []*TrafficPolicy
 // A request for the traffic policy instances that you created in a specified
 // hosted zone.
 type ListTrafficPolicyInstancesByHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesByHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to list traffic policy instances
 	// for.
@@ -12182,7 +12182,7 @@ func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstances
 // A complex type that contains the information about the request to list your
 // traffic policy instances.
 type ListTrafficPolicyInstancesByPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesByPolicyRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// traffic policy instances. To get more traffic policy instances, submit another
@@ -12399,7 +12399,7 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v [
 // A request to get information about the traffic policy instances that you
 // created by using the current AWS account.
 type ListTrafficPolicyInstancesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// traffic policy instances. To get more traffic policy instances, submit another
@@ -12568,7 +12568,7 @@ func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstances(v []*Traffi
 // A complex type that contains the information about the request to list your
 // traffic policies.
 type ListTrafficPolicyVersionsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyVersionsRequest" type:"structure"`
 
 	// Specify the value of Id of the traffic policy for which you want to list
 	// all versions.
@@ -12710,7 +12710,7 @@ func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicyVersionMarker(v string
 // A complex type that contains information about that can be associated with
 // your hosted zone.
 type ListVPCAssociationAuthorizationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListVPCAssociationAuthorizationsRequest" type:"structure"`
 
 	// The ID of the hosted zone for which you want a list of VPCs that can be associated
 	// with the hosted zone.
@@ -13672,7 +13672,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // for a specified record name and type. You can optionally specify the IP address
 // of a DNS resolver, an EDNS0 client subnet IP address, and a subnet mask.
 type TestDNSAnswerInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"TestDNSAnswerRequest" type:"structure"`
 
 	// If the resolver that you specified for resolverip supports EDNS0, specify
 	// the IPv4 or IPv6 address of a client in the applicable location, for example,

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -7043,7 +7043,7 @@ func (s *AbortIncompleteMultipartUpload) SetDaysAfterInitiation(v int64) *AbortI
 }
 
 type AbortMultipartUploadInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"AbortMultipartUploadRequest" type:"structure"`
 
 	// Name of the bucket to which the multipart upload was initiated.
 	//
@@ -8084,7 +8084,7 @@ func (s *CommonPrefix) SetPrefix(v string) *CommonPrefix {
 }
 
 type CompleteMultipartUploadInput struct {
-	_ struct{} `type:"structure" payload:"MultipartUpload"`
+	_ struct{} `locationName:"CompleteMultipartUploadRequest" type:"structure" payload:"MultipartUpload"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -8404,7 +8404,7 @@ func (s *ContinuationEvent) UnmarshalEvent(
 }
 
 type CopyObjectInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"CopyObjectRequest" type:"structure"`
 
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
@@ -9025,7 +9025,7 @@ func (s *CreateBucketConfiguration) SetLocationConstraint(v string) *CreateBucke
 }
 
 type CreateBucketInput struct {
-	_ struct{} `type:"structure" payload:"CreateBucketConfiguration"`
+	_ struct{} `locationName:"CreateBucketRequest" type:"structure" payload:"CreateBucketConfiguration"`
 
 	// The canned ACL to apply to the bucket.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"BucketCannedACL"`
@@ -9166,7 +9166,7 @@ func (s *CreateBucketOutput) SetLocation(v string) *CreateBucketOutput {
 }
 
 type CreateMultipartUploadInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"CreateMultipartUploadRequest" type:"structure"`
 
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
@@ -9708,7 +9708,7 @@ func (s *Delete) SetQuiet(v bool) *Delete {
 }
 
 type DeleteBucketAnalyticsConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketAnalyticsConfigurationRequest" type:"structure"`
 
 	// The name of the bucket from which an analytics configuration is deleted.
 	//
@@ -9784,7 +9784,7 @@ func (s DeleteBucketAnalyticsConfigurationOutput) GoString() string {
 }
 
 type DeleteBucketCorsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketCorsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -9844,7 +9844,7 @@ func (s DeleteBucketCorsOutput) GoString() string {
 }
 
 type DeleteBucketEncryptionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketEncryptionRequest" type:"structure"`
 
 	// The name of the bucket containing the server-side encryption configuration
 	// to delete.
@@ -9907,7 +9907,7 @@ func (s DeleteBucketEncryptionOutput) GoString() string {
 }
 
 type DeleteBucketInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -9953,7 +9953,7 @@ func (s *DeleteBucketInput) getBucket() (v string) {
 }
 
 type DeleteBucketInventoryConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketInventoryConfigurationRequest" type:"structure"`
 
 	// The name of the bucket containing the inventory configuration to delete.
 	//
@@ -10029,7 +10029,7 @@ func (s DeleteBucketInventoryConfigurationOutput) GoString() string {
 }
 
 type DeleteBucketLifecycleInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketLifecycleRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10089,7 +10089,7 @@ func (s DeleteBucketLifecycleOutput) GoString() string {
 }
 
 type DeleteBucketMetricsConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketMetricsConfigurationRequest" type:"structure"`
 
 	// The name of the bucket containing the metrics configuration to delete.
 	//
@@ -10179,7 +10179,7 @@ func (s DeleteBucketOutput) GoString() string {
 }
 
 type DeleteBucketPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketPolicyRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10239,7 +10239,7 @@ func (s DeleteBucketPolicyOutput) GoString() string {
 }
 
 type DeleteBucketReplicationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketReplicationRequest" type:"structure"`
 
 	// The bucket name.
 	//
@@ -10304,7 +10304,7 @@ func (s DeleteBucketReplicationOutput) GoString() string {
 }
 
 type DeleteBucketTaggingInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketTaggingRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10364,7 +10364,7 @@ func (s DeleteBucketTaggingOutput) GoString() string {
 }
 
 type DeleteBucketWebsiteInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteBucketWebsiteRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10510,7 +10510,7 @@ func (s *DeleteMarkerReplication) SetStatus(v string) *DeleteMarkerReplication {
 }
 
 type DeleteObjectInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteObjectRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10656,7 +10656,7 @@ func (s *DeleteObjectOutput) SetVersionId(v string) *DeleteObjectOutput {
 }
 
 type DeleteObjectTaggingInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteObjectTaggingRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10749,7 +10749,7 @@ func (s *DeleteObjectTaggingOutput) SetVersionId(v string) *DeleteObjectTaggingO
 }
 
 type DeleteObjectsInput struct {
-	_ struct{} `type:"structure" payload:"Delete"`
+	_ struct{} `locationName:"DeleteObjectsRequest" type:"structure" payload:"Delete"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -10885,7 +10885,7 @@ func (s *DeleteObjectsOutput) SetRequestCharged(v string) *DeleteObjectsOutput {
 }
 
 type DeletePublicAccessBlockInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeletePublicAccessBlockRequest" type:"structure"`
 
 	// The Amazon S3 bucket whose PublicAccessBlock configuration you want to delete.
 	//
@@ -11341,7 +11341,7 @@ func (s *FilterRule) SetValue(v string) *FilterRule {
 }
 
 type GetBucketAccelerateConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketAccelerateConfigurationRequest" type:"structure"`
 
 	// Name of the bucket for which the accelerate configuration is retrieved.
 	//
@@ -11412,7 +11412,7 @@ func (s *GetBucketAccelerateConfigurationOutput) SetStatus(v string) *GetBucketA
 }
 
 type GetBucketAclInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketAclRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -11489,7 +11489,7 @@ func (s *GetBucketAclOutput) SetOwner(v *Owner) *GetBucketAclOutput {
 }
 
 type GetBucketAnalyticsConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketAnalyticsConfigurationRequest" type:"structure"`
 
 	// The name of the bucket from which an analytics configuration is retrieved.
 	//
@@ -11574,7 +11574,7 @@ func (s *GetBucketAnalyticsConfigurationOutput) SetAnalyticsConfiguration(v *Ana
 }
 
 type GetBucketCorsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketCorsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -11642,7 +11642,7 @@ func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
 }
 
 type GetBucketEncryptionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketEncryptionRequest" type:"structure"`
 
 	// The name of the bucket from which the server-side encryption configuration
 	// is retrieved.
@@ -11714,7 +11714,7 @@ func (s *GetBucketEncryptionOutput) SetServerSideEncryptionConfiguration(v *Serv
 }
 
 type GetBucketInventoryConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketInventoryConfigurationRequest" type:"structure"`
 
 	// The name of the bucket containing the inventory configuration to retrieve.
 	//
@@ -11799,7 +11799,7 @@ func (s *GetBucketInventoryConfigurationOutput) SetInventoryConfiguration(v *Inv
 }
 
 type GetBucketLifecycleConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketLifecycleConfigurationRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -11867,7 +11867,7 @@ func (s *GetBucketLifecycleConfigurationOutput) SetRules(v []*LifecycleRule) *Ge
 }
 
 type GetBucketLifecycleInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketLifecycleRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -11935,7 +11935,7 @@ func (s *GetBucketLifecycleOutput) SetRules(v []*Rule) *GetBucketLifecycleOutput
 }
 
 type GetBucketLocationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketLocationRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12003,7 +12003,7 @@ func (s *GetBucketLocationOutput) SetLocationConstraint(v string) *GetBucketLoca
 }
 
 type GetBucketLoggingInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketLoggingRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12075,7 +12075,7 @@ func (s *GetBucketLoggingOutput) SetLoggingEnabled(v *LoggingEnabled) *GetBucket
 }
 
 type GetBucketMetricsConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketMetricsConfigurationRequest" type:"structure"`
 
 	// The name of the bucket containing the metrics configuration to retrieve.
 	//
@@ -12160,7 +12160,7 @@ func (s *GetBucketMetricsConfigurationOutput) SetMetricsConfiguration(v *Metrics
 }
 
 type GetBucketNotificationConfigurationRequest struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketNotificationConfigurationRequest" type:"structure"`
 
 	// Name of the bucket to get the notification configuration for.
 	//
@@ -12208,7 +12208,7 @@ func (s *GetBucketNotificationConfigurationRequest) getBucket() (v string) {
 }
 
 type GetBucketPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketPolicyRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12277,7 +12277,7 @@ func (s *GetBucketPolicyOutput) SetPolicy(v string) *GetBucketPolicyOutput {
 }
 
 type GetBucketPolicyStatusInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketPolicyStatusRequest" type:"structure"`
 
 	// The name of the Amazon S3 bucket whose policy status you want to retrieve.
 	//
@@ -12348,7 +12348,7 @@ func (s *GetBucketPolicyStatusOutput) SetPolicyStatus(v *PolicyStatus) *GetBucke
 }
 
 type GetBucketReplicationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketReplicationRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12418,7 +12418,7 @@ func (s *GetBucketReplicationOutput) SetReplicationConfiguration(v *ReplicationC
 }
 
 type GetBucketRequestPaymentInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketRequestPaymentRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12487,7 +12487,7 @@ func (s *GetBucketRequestPaymentOutput) SetPayer(v string) *GetBucketRequestPaym
 }
 
 type GetBucketTaggingInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketTaggingRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12556,7 +12556,7 @@ func (s *GetBucketTaggingOutput) SetTagSet(v []*Tag) *GetBucketTaggingOutput {
 }
 
 type GetBucketVersioningInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketVersioningRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12636,7 +12636,7 @@ func (s *GetBucketVersioningOutput) SetStatus(v string) *GetBucketVersioningOutp
 }
 
 type GetBucketWebsiteInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetBucketWebsiteRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12730,7 +12730,7 @@ func (s *GetBucketWebsiteOutput) SetRoutingRules(v []*RoutingRule) *GetBucketWeb
 }
 
 type GetObjectAclInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectAclRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12853,7 +12853,7 @@ func (s *GetObjectAclOutput) SetRequestCharged(v string) *GetObjectAclOutput {
 }
 
 type GetObjectInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -13090,7 +13090,7 @@ func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
 }
 
 type GetObjectLegalHoldInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectLegalHoldRequest" type:"structure"`
 
 	// The bucket containing the object whose Legal Hold status you want to retrieve.
 	//
@@ -13199,7 +13199,7 @@ func (s *GetObjectLegalHoldOutput) SetLegalHold(v *ObjectLockLegalHold) *GetObje
 }
 
 type GetObjectLockConfigurationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectLockConfigurationRequest" type:"structure"`
 
 	// The bucket whose object lock configuration you want to retrieve.
 	//
@@ -13581,7 +13581,7 @@ func (s *GetObjectOutput) SetWebsiteRedirectLocation(v string) *GetObjectOutput 
 }
 
 type GetObjectRetentionInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectRetentionRequest" type:"structure"`
 
 	// The bucket containing the object whose retention settings you want to retrieve.
 	//
@@ -13690,7 +13690,7 @@ func (s *GetObjectRetentionOutput) SetRetention(v *ObjectLockRetention) *GetObje
 }
 
 type GetObjectTaggingInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectTaggingRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -13790,7 +13790,7 @@ func (s *GetObjectTaggingOutput) SetVersionId(v string) *GetObjectTaggingOutput 
 }
 
 type GetObjectTorrentInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetObjectTorrentRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -13895,7 +13895,7 @@ func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOu
 }
 
 type GetPublicAccessBlockInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetPublicAccessBlockRequest" type:"structure"`
 
 	// The name of the Amazon S3 bucket whose PublicAccessBlock configuration you
 	// want to retrieve.
@@ -14126,7 +14126,7 @@ func (s *Grantee) SetURI(v string) *Grantee {
 }
 
 type HeadBucketInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"HeadBucketRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -14186,7 +14186,7 @@ func (s HeadBucketOutput) GoString() string {
 }
 
 type HeadObjectInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"HeadObjectRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -15661,7 +15661,7 @@ func (s *LifecycleRuleFilter) SetTag(v *Tag) *LifecycleRuleFilter {
 }
 
 type ListBucketAnalyticsConfigurationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListBucketAnalyticsConfigurationsRequest" type:"structure"`
 
 	// The name of the bucket from which analytics configurations are retrieved.
 	//
@@ -15773,7 +15773,7 @@ func (s *ListBucketAnalyticsConfigurationsOutput) SetNextContinuationToken(v str
 }
 
 type ListBucketInventoryConfigurationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListBucketInventoryConfigurationsRequest" type:"structure"`
 
 	// The name of the bucket containing the inventory configurations to retrieve.
 	//
@@ -15887,7 +15887,7 @@ func (s *ListBucketInventoryConfigurationsOutput) SetNextContinuationToken(v str
 }
 
 type ListBucketMetricsConfigurationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListBucketMetricsConfigurationsRequest" type:"structure"`
 
 	// The name of the bucket containing the metrics configurations to retrieve.
 	//
@@ -16047,7 +16047,7 @@ func (s *ListBucketsOutput) SetOwner(v *Owner) *ListBucketsOutput {
 }
 
 type ListMultipartUploadsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListMultipartUploadsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -16291,7 +16291,7 @@ func (s *ListMultipartUploadsOutput) SetUploads(v []*MultipartUpload) *ListMulti
 }
 
 type ListObjectVersionsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListObjectVersionsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -16524,7 +16524,7 @@ func (s *ListObjectVersionsOutput) SetVersions(v []*ObjectVersion) *ListObjectVe
 }
 
 type ListObjectsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListObjectsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -16736,7 +16736,7 @@ func (s *ListObjectsOutput) SetPrefix(v string) *ListObjectsOutput {
 }
 
 type ListObjectsV2Input struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListObjectsV2Request" type:"structure"`
 
 	// Name of the bucket to list.
 	//
@@ -16997,7 +16997,7 @@ func (s *ListObjectsV2Output) SetStartAfter(v string) *ListObjectsV2Output {
 }
 
 type ListPartsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListPartsRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -18622,7 +18622,7 @@ func (s *PublicAccessBlockConfiguration) SetRestrictPublicBuckets(v bool) *Publi
 }
 
 type PutBucketAccelerateConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"AccelerateConfiguration"`
+	_ struct{} `locationName:"PutBucketAccelerateConfigurationRequest" type:"structure" payload:"AccelerateConfiguration"`
 
 	// Specifies the Accelerate Configuration you want to set for the bucket.
 	//
@@ -18698,7 +18698,7 @@ func (s PutBucketAccelerateConfigurationOutput) GoString() string {
 }
 
 type PutBucketAclInput struct {
-	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
+	_ struct{} `locationName:"PutBucketAclRequest" type:"structure" payload:"AccessControlPolicy"`
 
 	// The canned ACL to apply to the bucket.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"BucketCannedACL"`
@@ -18827,7 +18827,7 @@ func (s PutBucketAclOutput) GoString() string {
 }
 
 type PutBucketAnalyticsConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
+	_ struct{} `locationName:"PutBucketAnalyticsConfigurationRequest" type:"structure" payload:"AnalyticsConfiguration"`
 
 	// The configuration and any analyses for the analytics filter.
 	//
@@ -18922,7 +18922,7 @@ func (s PutBucketAnalyticsConfigurationOutput) GoString() string {
 }
 
 type PutBucketCorsInput struct {
-	_ struct{} `type:"structure" payload:"CORSConfiguration"`
+	_ struct{} `locationName:"PutBucketCorsRequest" type:"structure" payload:"CORSConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19004,7 +19004,7 @@ func (s PutBucketCorsOutput) GoString() string {
 }
 
 type PutBucketEncryptionInput struct {
-	_ struct{} `type:"structure" payload:"ServerSideEncryptionConfiguration"`
+	_ struct{} `locationName:"PutBucketEncryptionRequest" type:"structure" payload:"ServerSideEncryptionConfiguration"`
 
 	// Specifies default encryption for a bucket using server-side encryption with
 	// Amazon S3-managed keys (SSE-S3) or AWS KMS-managed keys (SSE-KMS). For information
@@ -19089,7 +19089,7 @@ func (s PutBucketEncryptionOutput) GoString() string {
 }
 
 type PutBucketInventoryConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
+	_ struct{} `locationName:"PutBucketInventoryConfigurationRequest" type:"structure" payload:"InventoryConfiguration"`
 
 	// The name of the bucket where the inventory configuration will be stored.
 	//
@@ -19184,7 +19184,7 @@ func (s PutBucketInventoryConfigurationOutput) GoString() string {
 }
 
 type PutBucketLifecycleConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
+	_ struct{} `locationName:"PutBucketLifecycleConfigurationRequest" type:"structure" payload:"LifecycleConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19260,7 +19260,7 @@ func (s PutBucketLifecycleConfigurationOutput) GoString() string {
 }
 
 type PutBucketLifecycleInput struct {
-	_ struct{} `type:"structure" payload:"LifecycleConfiguration"`
+	_ struct{} `locationName:"PutBucketLifecycleRequest" type:"structure" payload:"LifecycleConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19333,7 +19333,7 @@ func (s PutBucketLifecycleOutput) GoString() string {
 }
 
 type PutBucketLoggingInput struct {
-	_ struct{} `type:"structure" payload:"BucketLoggingStatus"`
+	_ struct{} `locationName:"PutBucketLoggingRequest" type:"structure" payload:"BucketLoggingStatus"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19410,7 +19410,7 @@ func (s PutBucketLoggingOutput) GoString() string {
 }
 
 type PutBucketMetricsConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
+	_ struct{} `locationName:"PutBucketMetricsConfigurationRequest" type:"structure" payload:"MetricsConfiguration"`
 
 	// The name of the bucket for which the metrics configuration is set.
 	//
@@ -19505,7 +19505,7 @@ func (s PutBucketMetricsConfigurationOutput) GoString() string {
 }
 
 type PutBucketNotificationConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
+	_ struct{} `locationName:"PutBucketNotificationConfigurationRequest" type:"structure" payload:"NotificationConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19585,7 +19585,7 @@ func (s PutBucketNotificationConfigurationOutput) GoString() string {
 }
 
 type PutBucketNotificationInput struct {
-	_ struct{} `type:"structure" payload:"NotificationConfiguration"`
+	_ struct{} `locationName:"PutBucketNotificationRequest" type:"structure" payload:"NotificationConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19657,7 +19657,7 @@ func (s PutBucketNotificationOutput) GoString() string {
 }
 
 type PutBucketPolicyInput struct {
-	_ struct{} `type:"structure" payload:"Policy"`
+	_ struct{} `locationName:"PutBucketPolicyRequest" type:"structure" payload:"Policy"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19741,7 +19741,7 @@ func (s PutBucketPolicyOutput) GoString() string {
 }
 
 type PutBucketReplicationInput struct {
-	_ struct{} `type:"structure" payload:"ReplicationConfiguration"`
+	_ struct{} `locationName:"PutBucketReplicationRequest" type:"structure" payload:"ReplicationConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19830,7 +19830,7 @@ func (s PutBucketReplicationOutput) GoString() string {
 }
 
 type PutBucketRequestPaymentInput struct {
-	_ struct{} `type:"structure" payload:"RequestPaymentConfiguration"`
+	_ struct{} `locationName:"PutBucketRequestPaymentRequest" type:"structure" payload:"RequestPaymentConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19907,7 +19907,7 @@ func (s PutBucketRequestPaymentOutput) GoString() string {
 }
 
 type PutBucketTaggingInput struct {
-	_ struct{} `type:"structure" payload:"Tagging"`
+	_ struct{} `locationName:"PutBucketTaggingRequest" type:"structure" payload:"Tagging"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -19984,7 +19984,7 @@ func (s PutBucketTaggingOutput) GoString() string {
 }
 
 type PutBucketVersioningInput struct {
-	_ struct{} `type:"structure" payload:"VersioningConfiguration"`
+	_ struct{} `locationName:"PutBucketVersioningRequest" type:"structure" payload:"VersioningConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -20070,7 +20070,7 @@ func (s PutBucketVersioningOutput) GoString() string {
 }
 
 type PutBucketWebsiteInput struct {
-	_ struct{} `type:"structure" payload:"WebsiteConfiguration"`
+	_ struct{} `locationName:"PutBucketWebsiteRequest" type:"structure" payload:"WebsiteConfiguration"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -20149,7 +20149,7 @@ func (s PutBucketWebsiteOutput) GoString() string {
 }
 
 type PutObjectAclInput struct {
-	_ struct{} `type:"structure" payload:"AccessControlPolicy"`
+	_ struct{} `locationName:"PutObjectAclRequest" type:"structure" payload:"AccessControlPolicy"`
 
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
@@ -20324,7 +20324,7 @@ func (s *PutObjectAclOutput) SetRequestCharged(v string) *PutObjectAclOutput {
 }
 
 type PutObjectInput struct {
-	_ struct{} `type:"structure" payload:"Body"`
+	_ struct{} `locationName:"PutObjectRequest" type:"structure" payload:"Body"`
 
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`
@@ -20671,7 +20671,7 @@ func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
 }
 
 type PutObjectLegalHoldInput struct {
-	_ struct{} `type:"structure" payload:"LegalHold"`
+	_ struct{} `locationName:"PutObjectLegalHoldRequest" type:"structure" payload:"LegalHold"`
 
 	// The bucket containing the object that you want to place a Legal Hold on.
 	//
@@ -20791,7 +20791,7 @@ func (s *PutObjectLegalHoldOutput) SetRequestCharged(v string) *PutObjectLegalHo
 }
 
 type PutObjectLockConfigurationInput struct {
-	_ struct{} `type:"structure" payload:"ObjectLockConfiguration"`
+	_ struct{} `locationName:"PutObjectLockConfigurationRequest" type:"structure" payload:"ObjectLockConfiguration"`
 
 	// The bucket whose object lock configuration you want to create or replace.
 	//
@@ -20998,7 +20998,7 @@ func (s *PutObjectOutput) SetVersionId(v string) *PutObjectOutput {
 }
 
 type PutObjectRetentionInput struct {
-	_ struct{} `type:"structure" payload:"Retention"`
+	_ struct{} `locationName:"PutObjectRetentionRequest" type:"structure" payload:"Retention"`
 
 	// The bucket that contains the object you want to apply this Object Retention
 	// configuration to.
@@ -21129,7 +21129,7 @@ func (s *PutObjectRetentionOutput) SetRequestCharged(v string) *PutObjectRetenti
 }
 
 type PutObjectTaggingInput struct {
-	_ struct{} `type:"structure" payload:"Tagging"`
+	_ struct{} `locationName:"PutObjectTaggingRequest" type:"structure" payload:"Tagging"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -21237,7 +21237,7 @@ func (s *PutObjectTaggingOutput) SetVersionId(v string) *PutObjectTaggingOutput 
 }
 
 type PutPublicAccessBlockInput struct {
-	_ struct{} `type:"structure" payload:"PublicAccessBlockConfiguration"`
+	_ struct{} `locationName:"PutPublicAccessBlockRequest" type:"structure" payload:"PublicAccessBlockConfiguration"`
 
 	// The name of the Amazon S3 bucket whose PublicAccessBlock configuration you
 	// want to set.
@@ -21999,7 +21999,7 @@ func (s *RequestProgress) SetEnabled(v bool) *RequestProgress {
 }
 
 type RestoreObjectInput struct {
-	_ struct{} `type:"structure" payload:"RestoreRequest"`
+	_ struct{} `locationName:"RestoreObjectRequest" type:"structure" payload:"RestoreRequest"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -23715,7 +23715,7 @@ func (s *Transition) SetStorageClass(v string) *Transition {
 }
 
 type UploadPartCopyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"UploadPartCopyRequest" type:"structure"`
 
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -24045,7 +24045,7 @@ func (s *UploadPartCopyOutput) SetServerSideEncryption(v string) *UploadPartCopy
 }
 
 type UploadPartInput struct {
-	_ struct{} `type:"structure" payload:"Body"`
+	_ struct{} `locationName:"UploadPartRequest" type:"structure" payload:"Body"`
 
 	// Object data.
 	Body io.ReadSeeker `type:"blob"`

--- a/service/s3/s3manager/upload_input.go
+++ b/service/s3/s3manager/upload_input.go
@@ -12,7 +12,7 @@ import (
 // package's PutObjectInput with the exception that the Body member is an
 // io.Reader instead of an io.ReadSeeker.
 type UploadInput struct {
-	_ struct{} `type:"structure" payload:"Body"`
+	_ struct{} `locationName:"PutObjectRequest" type:"structure" payload:"Body"`
 
 	// The canned ACL to apply to the object.
 	ACL *string `location:"header" locationName:"x-amz-acl" type:"string" enum:"ObjectCannedACL"`

--- a/service/s3control/api.go
+++ b/service/s3control/api.go
@@ -931,7 +931,7 @@ func (s *CreateJobOutput) SetJobId(v string) *CreateJobOutput {
 }
 
 type DeletePublicAccessBlockInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeletePublicAccessBlockRequest" type:"structure"`
 
 	// The account ID for the AWS account whose block public access configuration
 	// you want to delete.
@@ -993,7 +993,7 @@ func (s DeletePublicAccessBlockOutput) GoString() string {
 }
 
 type DescribeJobInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DescribeJobRequest" type:"structure"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
@@ -1079,7 +1079,7 @@ func (s *DescribeJobOutput) SetJob(v *JobDescriptor) *DescribeJobOutput {
 }
 
 type GetPublicAccessBlockInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetPublicAccessBlockRequest" type:"structure"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
@@ -1896,7 +1896,7 @@ func (s *LambdaInvokeOperation) SetFunctionArn(v string) *LambdaInvokeOperation 
 }
 
 type ListJobsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListJobsRequest" type:"structure"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
@@ -2059,7 +2059,7 @@ func (s *PublicAccessBlockConfiguration) SetRestrictPublicBuckets(v bool) *Publi
 }
 
 type PutPublicAccessBlockInput struct {
-	_ struct{} `type:"structure" payload:"PublicAccessBlockConfiguration"`
+	_ struct{} `locationName:"PutPublicAccessBlockRequest" type:"structure" payload:"PublicAccessBlockConfiguration"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
@@ -2874,7 +2874,7 @@ func (s *S3Tag) SetValue(v string) *S3Tag {
 }
 
 type UpdateJobPriorityInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"UpdateJobPriorityRequest" type:"structure"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
@@ -2986,7 +2986,7 @@ func (s *UpdateJobPriorityOutput) SetPriority(v int64) *UpdateJobPriorityOutput 
 }
 
 type UpdateJobStatusInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"UpdateJobStatusRequest" type:"structure"`
 
 	// AccountId is a required field
 	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`


### PR DESCRIPTION
* `private/protocol/xml/xmlutil`: Support for sorting xml attributes
* `models/protocol_tests/input`: Revert changes to rest-xml protocol tests for marshaling top-level shapes
* `private/model/api`: Write locationName for top-level shapes for rest-xml and ec2 protocols
* Regenerated Service, Protocol, and CodeGen Tests

Fixes: #2806 


