### PR TITLE
private/model/api: Fixes broken test for code generation example

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
   * Adds support for removing API modeled operations that use unsupported features. If a API model results in having no operations it will be skipped.
 
 ### SDK Bugs
+* `private/model/api` : Fixes broken test for code generation example ([#2855](https://github.com/aws/aws-sdk-go/pull/2855))
+    

--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,7 @@ get-deps: get-deps-tests get-deps-x-tests get-deps-codegen get-deps-verify
 
 get-deps-tests:
 	@echo "go get SDK testing dependencies"
-	go get github.com/stretchr/testify
-	go get github.com/google/go-cmp/...
+	go get github.com/google/go-cmp/cmp
 
 get-deps-x-tests:
 	@echo "go get SDK testing golang.org/x dependencies"

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ get-deps: get-deps-tests get-deps-x-tests get-deps-codegen get-deps-verify
 get-deps-tests:
 	@echo "go get SDK testing dependencies"
 	go get github.com/stretchr/testify
+	go get github.com/google/go-cmp/...
 
 get-deps-x-tests:
 	@echo "go get SDK testing golang.org/x dependencies"

--- a/private/model/api/example_test.go
+++ b/private/model/api/example_test.go
@@ -1,10 +1,12 @@
-// +build 1.6,codegen
+// +build go1.10,codegen
 
 package api
 
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func buildAPI() *API {
@@ -132,7 +134,7 @@ func buildAPI() *API {
 	}
 	outputRef := ShapeRef{
 		API:       a,
-		ShapeName: "Foooutput",
+		ShapeName: "FooOutput",
 		Shape:     output,
 	}
 
@@ -150,10 +152,19 @@ func buildAPI() *API {
 	a.Shapes = map[string]*Shape{
 		"FooInput":  input,
 		"FooOutput": output,
+		"string":    stringShape,
+		"int":       intShape,
+		"NestedComplexShape": nestedComplexShape,
+		"NestedListShape": nestedListShape,
+		"ComplexShape": complexShape,
+		"ListShape": listShape,
+		"ListsShape":listsShape,
 	}
 	a.Metadata = Metadata{
 		ServiceAbbreviation: "FooService",
 	}
+
+	a.BaseImportPath = "github.com/aws/aws-sdk-go/service/"
 
 	a.Setup()
 	return a
@@ -224,6 +235,7 @@ import (
 	"` + SDKImportRoot + `/aws/awserr"
 	"` + SDKImportRoot + `/aws/session"
 	"` + SDKImportRoot + `/service/fooservice"
+	
 )
 
 var _ time.Duration
@@ -285,10 +297,8 @@ func ExampleFooService_Foo_shared00() {
 	fmt.Println(result)
 }
 `
-	if expected != a.ExamplesGoCode() {
-		t.Log([]byte(expected))
-		t.Log([]byte(a.ExamplesGoCode()))
-		t.Errorf("Expected:\n%s\nReceived:\n%s\n", expected, a.ExamplesGoCode())
+	if v := cmp.Diff(expected, a.ExamplesGoCode()); len(v) != 0 {
+		t.Errorf(v)
 	}
 }
 


### PR DESCRIPTION
Fixes broken TestExampleGeneration test to correctly test code generation for example. 