### PR TITLE
service/s3/s3manager: Simplify Upload manager internal interfaces

### DIFF
--- a/service/s3/s3manager/download.go
+++ b/service/s3/s3manager/download.go
@@ -428,7 +428,7 @@ func (d *downloader) downloadChunk(chunk dlchunk) error {
 		// Check if the returned error is an errReadingBody.
 		// If err is errReadingBody this indicates that an error
 		// occurred while copying the http response body.
-		// If this occurs we unwrap the to set the underling error
+		// If this occurs we unwrap the err to set the underlying error
 		// and attempt any remaining retries.
 		if bodyErr, ok := err.(*errReadingBody); ok {
 			err = bodyErr.Unwrap()


### PR DESCRIPTION
This change performs some oppurtunistic cleanup of the internal Uploader interfaces discovered while porting changes to the V2 SDK.