### PR TITLE
service/s3/s3manager: Move part buffer pool upwards to allow reuse.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/s3/s3manager`: Allow reuse of Uploader buffer `sync.Pool` amongst multiple Upload calls ([#2863](https://github.com/aws/aws-sdk-go/pull/2863)) 
+  * The `sync.Pool` used for the reuse of `[]byte` slices when handling streaming payloads will now be shared across multiple Upload calls when the upload part size remains constant. 
 
 ### SDK Bugs


### PR DESCRIPTION
Fixes #2036 by allowing the reuse/sharing of the part buffer pools for same-sized PartSize upload requests.