### PR TITLE
Implement Wrapper interface for baseError

### DIFF
--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -87,6 +87,13 @@ func (b baseError) Message() string {
 	return b.message
 }
 
+// Unwrap returns the original error so as to satisfy the Wrapper interface.
+// This provides support for errors and xerrors and go 1.13's Is/As functions.
+// As OrigErr is basically the same, we can just alias it here.
+func (b baseError) Unwrap() error {
+	return b.OrigErr()
+}
+
 // OrigErr returns the original error if one was set. Nil is returned if no
 // error was set. This only returns the first element in the list. If the full
 // list is needed, use BatchedErrors.


### PR DESCRIPTION
I've gone ahead and added Unwrap on baseError in order to implement the Wrapper interface for go.1.13's error as well as xerror so that clients of aws-sdk-go can utilise `errors.Is` and `errors.As` with the awserror package.

This comes from the idea #2820 

I left `OrigErr` for backwards compatibility.