### PR TITLE
example/service/s3/loggingUploadObjectReadBehavior: Add example buid tag

### DIFF
--- a/example/service/s3/loggingUploadObjectReadBehavior/main.go
+++ b/example/service/s3/loggingUploadObjectReadBehavior/main.go
@@ -1,3 +1,5 @@
+// +build example
+
 package main
 
 import (


### PR DESCRIPTION
Adds the example build tag to the loggingUploadObjectReadBehavior example to prevent the binary from being built by default.