### PR TITLE
 example/service/s3/presignUR: Example error message should be 'PUT' not GET'

### DIFF
--- a/example/service/s3/presignURL/client/client.go
+++ b/example/service/s3/presignURL/client/client.go
@@ -172,14 +172,14 @@ func uploadFile(serverURL, key, filename string) error {
 	// to be used with the size of content requested.
 	req, err := getPresignedRequest(serverURL, "PUT", key, size)
 	if err != nil {
-		return fmt.Errorf("failed to get get presigned request, %v", err)
+		return fmt.Errorf("failed to get put presigned request, %v", err)
 	}
 	req.Body = r
 
 	// Upload the file contents to S3.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to do GET request, %v", err)
+		return fmt.Errorf("failed to do PUT request, %v", err)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Problem: Example for PutObjectPresigned should display error messages with 'PUT' instead of 'GET'.

Solution: This PR fixes the error messages replacing 'get'/'GET' with 'put'/'PUT' when applicable.