### PR TITLE
example/service/s3: Fix typo in example documentation

### DIFF
--- a/example/service/s3/concatObjects/README.md
+++ b/example/service/s3/concatObjects/README.md
@@ -10,5 +10,5 @@ two objects that we want to concatenate together.
 The example uses the bucket name provided, two keys for each object, and lastly the output key.
 
 ```sh
-AWS_REGION=<region> go run -tags example concatenateObjects.go <bucket> <key for object 1> <key for object 2> <key for output>
+AWS_REGION=<region> go run -tags example concatObjects.go <bucket> <key for object 1> <key for object 2> <key for output>
 ```

--- a/example/service/s3/listObjectsConcurrently/README.md
+++ b/example/service/s3/listObjectsConcurrently/README.md
@@ -7,7 +7,7 @@ This is an example using the AWS SDK for Go concurrently to list the encrypted o
 The example's `accounts` string slice contains a list of the SharedCredentials profiles which will be used to look up the buckets owned by each profile. Each bucket's objects will be queried.
 
 ```
-AWS_REGION=us-east-1 go run -tags example listObjectsConcurrentlv.go
+AWS_REGION=us-east-1 go run -tags example listObjectsConcurrently.go
 ```
 
 


### PR DESCRIPTION
Some very minor typo fixes within the `example/service/s3` README files
