### PR TITLE
aws/endpoints: Fix resolve endpoint with empty region

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/endpoints`: Fix resolve endpoint with empty region ([#2911](https://github.com/aws/aws-sdk-go/pull/2911))
+  * Fixes the SDK's behavior when attempting to resolve a service's endpoint when no region was provided. Adds legacy support for services that were able to resolve a valid endpoint. No new service will support resolving an endpoint without an region.
+  * Fixes [#2909](https://github.com/aws/aws-sdk-go/issues/2909)

--- a/aws/endpoints/sts_legacy_regions.go
+++ b/aws/endpoints/sts_legacy_regions.go
@@ -5,7 +5,6 @@ var stsLegacyGlobalRegions = map[string]struct{}{
 	"ap-south-1":     {},
 	"ap-southeast-1": {},
 	"ap-southeast-2": {},
-	"aws-global":     {},
 	"ca-central-1":   {},
 	"eu-central-1":   {},
 	"eu-north-1":     {},

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -75,9 +75,40 @@ func (p partition) canResolveEndpoint(service, region string, strictMatch bool) 
 	return p.RegionRegex.MatchString(region)
 }
 
+func allowLegacyEmptyRegion(service string) bool {
+	legacy := map[string]struct{}{
+		"budgets":       struct{}{},
+		"ce":            struct{}{},
+		"chime":         struct{}{},
+		"cloudfront":    struct{}{},
+		"ec2metadata":   struct{}{},
+		"iam":           struct{}{},
+		"importexport":  struct{}{},
+		"organizations": struct{}{},
+		"route53":       struct{}{},
+		"sts":           struct{}{},
+		"support":       struct{}{},
+		"waf":           struct{}{},
+	}
+
+	_, allowed := legacy[service]
+	return allowed
+}
+
 func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (resolved ResolvedEndpoint, err error) {
 	var opt Options
 	opt.Set(opts...)
+
+	s, hasService := p.Services[service]
+	if len(service) == 0 || !(hasService || opt.ResolveUnknownService) {
+		// Only return error if the resolver will not fallback to creating
+		// endpoint based on service endpoint ID passed in.
+		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
+	}
+
+	if len(region) == 0 && allowLegacyEmptyRegion(service) && len(s.PartitionEndpoint) != 0 {
+		region = s.PartitionEndpoint
+	}
 
 	if service == "sts" && opt.STSRegionalEndpoint != RegionalSTSEndpoint {
 		if _, ok := stsLegacyGlobalRegions[region]; ok {
@@ -85,15 +116,8 @@ func (p partition) EndpointFor(service, region string, opts ...func(*Options)) (
 		}
 	}
 
-	s, hasService := p.Services[service]
-	if !(hasService || opt.ResolveUnknownService) {
-		// Only return error if the resolver will not fallback to creating
-		// endpoint based on service endpoint ID passed in.
-		return resolved, NewUnknownServiceError(p.ID, service, serviceList(p.Services))
-	}
-
 	e, hasEndpoint := s.endpointForRegion(region)
-	if !hasEndpoint && opt.StrictMatching {
+	if len(region) == 0 || (!hasEndpoint && opt.StrictMatching) {
 		return resolved, NewUnknownEndpointError(p.ID, service, region, endpointList(s.Endpoints))
 	}
 

--- a/aws/endpoints/v3model.go
+++ b/aws/endpoints/v3model.go
@@ -77,18 +77,18 @@ func (p partition) canResolveEndpoint(service, region string, strictMatch bool) 
 
 func allowLegacyEmptyRegion(service string) bool {
 	legacy := map[string]struct{}{
-		"budgets":       struct{}{},
-		"ce":            struct{}{},
-		"chime":         struct{}{},
-		"cloudfront":    struct{}{},
-		"ec2metadata":   struct{}{},
-		"iam":           struct{}{},
-		"importexport":  struct{}{},
-		"organizations": struct{}{},
-		"route53":       struct{}{},
-		"sts":           struct{}{},
-		"support":       struct{}{},
-		"waf":           struct{}{},
+		"budgets":       {},
+		"ce":            {},
+		"chime":         {},
+		"cloudfront":    {},
+		"ec2metadata":   {},
+		"iam":           {},
+		"importexport":  {},
+		"organizations": {},
+		"route53":       {},
+		"sts":           {},
+		"support":       {},
+		"waf":           {},
 	}
 
 	_, allowed := legacy[service]

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -614,40 +614,18 @@ func (s *Session) Copy(cfgs ...*aws.Config) *Session {
 // ClientConfig satisfies the client.ConfigProvider interface and is used to
 // configure the service client instances. Passing the Session to the service
 // client's constructor (New) will use this method to configure the client.
-func (s *Session) ClientConfig(serviceName string, cfgs ...*aws.Config) client.Config {
-	// Backwards compatibility, the error will be eaten if user calls ClientConfig
-	// directly. All SDK services will use ClientconfigWithError.
-	cfg, _ := s.clientConfigWithErr(serviceName, cfgs...)
-
-	return cfg
-}
-
-func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (client.Config, error) {
+func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Config {
 	s = s.Copy(cfgs...)
 
-	var resolved endpoints.ResolvedEndpoint
-	var err error
-
 	region := aws.StringValue(s.Config.Region)
-
-	if endpoint := aws.StringValue(s.Config.Endpoint); len(endpoint) != 0 {
-		resolved.URL = endpoints.AddScheme(endpoint, aws.BoolValue(s.Config.DisableSSL))
-		resolved.SigningRegion = region
-	} else {
-		resolved, err = s.Config.EndpointResolver.EndpointFor(
-			serviceName, region,
-			func(opt *endpoints.Options) {
-				opt.DisableSSL = aws.BoolValue(s.Config.DisableSSL)
-				opt.UseDualStack = aws.BoolValue(s.Config.UseDualStack)
-				// Support for STSRegionalEndpoint where the STSRegionalEndpoint is
-				// provided in envconfig or sharedconfig with envconfig getting precedence.
-				opt.STSRegionalEndpoint = s.Config.STSRegionalEndpoint
-
-				// Support the condition where the service is modeled but its
-				// endpoint metadata is not available.
-				opt.ResolveUnknownService = true
-			},
-		)
+	resolved, err := s.resolveEndpoint(service, region, s.Config)
+	if err != nil && s.Config.Logger != nil {
+		s.Config.Logger.Log(fmt.Sprintf(
+			"ERROR: unable to resolve endpoint for service %q, region %q, err: %v",
+			service, region, err))
+		//		s.Handlers.Validate.PushFront(func(r *request.Request) {
+		//			r.Error = err
+		//		})
 	}
 
 	return client.Config{
@@ -657,7 +635,37 @@ func (s *Session) clientConfigWithErr(serviceName string, cfgs ...*aws.Config) (
 		SigningRegion:      resolved.SigningRegion,
 		SigningNameDerived: resolved.SigningNameDerived,
 		SigningName:        resolved.SigningName,
-	}, err
+	}
+}
+
+func (s *Session) resolveEndpoint(service, region string, cfg *aws.Config) (endpoints.ResolvedEndpoint, error) {
+
+	if ep := aws.StringValue(cfg.Endpoint); len(ep) != 0 {
+		return endpoints.ResolvedEndpoint{
+			URL:           endpoints.AddScheme(ep, aws.BoolValue(cfg.DisableSSL)),
+			SigningRegion: region,
+		}, nil
+	}
+
+	resolved, err := cfg.EndpointResolver.EndpointFor(service, region,
+		func(opt *endpoints.Options) {
+			opt.DisableSSL = aws.BoolValue(cfg.DisableSSL)
+			opt.UseDualStack = aws.BoolValue(cfg.UseDualStack)
+			// Support for STSRegionalEndpoint where the STSRegionalEndpoint is
+			// provided in envConfig or sharedConfig with envConfig getting
+			// precedence.
+			opt.STSRegionalEndpoint = cfg.STSRegionalEndpoint
+
+			// Support the condition where the service is modeled but its
+			// endpoint metadata is not available.
+			opt.ResolveUnknownService = true
+		},
+	)
+	if err != nil {
+		return endpoints.ResolvedEndpoint{}, err
+	}
+
+	return resolved, nil
 }
 
 // ClientConfigNoResolveEndpoint is the same as ClientConfig with the exception
@@ -667,12 +675,9 @@ func (s *Session) ClientConfigNoResolveEndpoint(cfgs ...*aws.Config) client.Conf
 	s = s.Copy(cfgs...)
 
 	var resolved endpoints.ResolvedEndpoint
-
-	region := aws.StringValue(s.Config.Region)
-
 	if ep := aws.StringValue(s.Config.Endpoint); len(ep) > 0 {
 		resolved.URL = endpoints.AddScheme(ep, aws.BoolValue(s.Config.DisableSSL))
-		resolved.SigningRegion = region
+		resolved.SigningRegion = aws.StringValue(s.Config.Region)
 	}
 
 	return client.Config{

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -623,9 +623,6 @@ func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Confi
 		s.Config.Logger.Log(fmt.Sprintf(
 			"ERROR: unable to resolve endpoint for service %q, region %q, err: %v",
 			service, region, err))
-		//		s.Handlers.Validate.PushFront(func(r *request.Request) {
-		//			r.Error = err
-		//		})
 	}
 
 	return client.Config{


### PR DESCRIPTION
Fixes the SDK's behavior when attempting to resolve a service's endpoint when no region was provided. Adds legacy support for services that were able to resolve a valid endpoint. No new service will support resolving an endpoint without an region.

Fixes #2909