### PR TITLE
service/s3/s3crypto: Added X-Ray support to s3crypto decryption client

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,8 @@
   * For Go 1.9 and above, adds struct field caching to the SDK's DynamoDB AttributeValue marshalers and unmarshalers. This significantly reduces time, and overall allocations of the (un)marshalers by caching the reflected structure's fields. This should improve the performance of applications using DynamoDB AttributeValue (un)marshalers.
 
 ### SDK Enhancements
+* `service/s3/s3crypto`: Added X-Ray support to encrypt/decrypt clients ([#2912](https://github.com/aws/aws-sdk-go/pull/2912))
+  * Adds support for passing Context down to the crypto client's KMS client enabling tracing for tools like X-Ray, and metrics.
 
 ### SDK Bugs
 * `service/s3/s3manager`: Fix resource leak on failed CreateMultipartUpload calls ([#3069](https://github.com/aws/aws-sdk-go/pull/3069))

--- a/service/s3/s3crypto/cipher_builder.go
+++ b/service/s3/s3crypto/cipher_builder.go
@@ -1,11 +1,21 @@
 package s3crypto
 
-import "io"
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
 
 // ContentCipherBuilder is a builder interface that builds
 // ciphers for each request.
 type ContentCipherBuilder interface {
 	ContentCipher() (ContentCipher, error)
+}
+
+// ContentCipherBuilderWithContext is a builder interface that builds
+// ciphers for each request.
+type ContentCipherBuilderWithContext interface {
+	ContentCipherWithContext(aws.Context) (ContentCipher, error)
 }
 
 // ContentCipher deals with encrypting and decrypting content

--- a/service/s3/s3crypto/cipher_util.go
+++ b/service/s3/s3crypto/cipher_util.go
@@ -55,7 +55,13 @@ func (client *DecryptionClient) cekFromEnvelope(env Envelope, decrypter CipherDa
 	if err != nil {
 		return nil, err
 	}
-	key, err = decrypter.DecryptKey(key)
+
+	if d, ok := decrypter.(CipherDataDecrypterWithContext); ok {
+		key, err = d.DecryptKeyWithContext(ctx, key)
+	} else {
+		key, err = decrypter.DecryptKey(key)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/service/s3/s3crypto/cipher_util.go
+++ b/service/s3/s3crypto/cipher_util.go
@@ -5,16 +5,17 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func (client *DecryptionClient) contentCipherFromEnvelope(env Envelope) (ContentCipher, error) {
+func (client *DecryptionClient) contentCipherFromEnvelope(ctx aws.Context, env Envelope) (ContentCipher, error) {
 	wrap, err := client.wrapFromEnvelope(env)
 	if err != nil {
 		return nil, err
 	}
 
-	return client.cekFromEnvelope(env, wrap)
+	return client.cekFromEnvelope(ctx, env, wrap)
 }
 
 func (client *DecryptionClient) wrapFromEnvelope(env Envelope) (CipherDataDecrypter, error) {
@@ -36,7 +37,7 @@ const AESGCMNoPadding = "AES/GCM/NoPadding"
 // AESCBC is the string constant that signifies the AES CBC algorithm cipher.
 const AESCBC = "AES/CBC"
 
-func (client *DecryptionClient) cekFromEnvelope(env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
+func (client *DecryptionClient) cekFromEnvelope(ctx aws.Context, env Envelope, decrypter CipherDataDecrypter) (ContentCipher, error) {
 	f, ok := client.CEKRegistry[env.CEKAlg]
 	if !ok || f == nil {
 		return nil, awserr.New(

--- a/service/s3/s3crypto/cipher_util_test.go
+++ b/service/s3/s3crypto/cipher_util_test.go
@@ -140,7 +140,7 @@ func TestCEKFactory(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(aws.BackgroundContext(), env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -199,7 +199,7 @@ func TestCEKFactoryNoCEK(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(aws.BackgroundContext(), env, wrap)
 
 	if err == nil {
 		t.Error("expected error, but received none")
@@ -256,7 +256,7 @@ func TestCEKFactoryCustomEntry(t *testing.T) {
 		MatDesc:   `{"kms_cmk_id":""}`,
 	}
 	wrap, err := c.wrapFromEnvelope(env)
-	cek, err := c.cekFromEnvelope(env, wrap)
+	cek, err := c.cekFromEnvelope(aws.BackgroundContext(), env, wrap)
 
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -131,6 +131,5 @@ func (c *DecryptionClient) GetObjectWithContext(ctx aws.Context, input *s3.GetOb
 	req, out := c.GetObjectRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
-	req.SetContext(ctx)
 	return out, req.Send()
 }

--- a/service/s3/s3crypto/decryption_client.go
+++ b/service/s3/s3crypto/decryption_client.go
@@ -96,7 +96,7 @@ func (c *DecryptionClient) GetObjectRequest(input *s3.GetObjectInput) (*request.
 
 		// If KMS should return the correct CEK algorithm with the proper
 		// KMS key provider
-		cipher, err := c.contentCipherFromEnvelope(env)
+		cipher, err := c.contentCipherFromEnvelope(r.Context(), env)
 		if err != nil {
 			r.Error = err
 			out.Body.Close()
@@ -131,5 +131,6 @@ func (c *DecryptionClient) GetObjectWithContext(ctx aws.Context, input *s3.GetOb
 	req, out := c.GetObjectRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
+	req.SetContext(ctx)
 	return out, req.Send()
 }

--- a/service/s3/s3crypto/key_handler.go
+++ b/service/s3/s3crypto/key_handler.go
@@ -13,6 +13,13 @@ type CipherDataGenerator interface {
 	GenerateCipherData(int, int) (CipherData, error)
 }
 
+// CipherDataGeneratorWithContext handles generating proper key and IVs of
+// proper size for the content cipher. CipherDataGenerator will also encrypt
+// the key and store it in the CipherData.
+type CipherDataGeneratorWithContext interface {
+	GenerateCipherDataWithContext(aws.Context, int, int) (CipherData, error)
+}
+
 // CipherDataDecrypter is a handler to decrypt keys from the envelope.
 type CipherDataDecrypter interface {
 	DecryptKey([]byte) ([]byte, error)

--- a/service/s3/s3crypto/key_handler.go
+++ b/service/s3/s3crypto/key_handler.go
@@ -1,6 +1,10 @@
 package s3crypto
 
-import "crypto/rand"
+import (
+	"crypto/rand"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
 
 // CipherDataGenerator handles generating proper key and IVs of proper size for the
 // content cipher. CipherDataGenerator will also encrypt the key and store it in
@@ -12,6 +16,11 @@ type CipherDataGenerator interface {
 // CipherDataDecrypter is a handler to decrypt keys from the envelope.
 type CipherDataDecrypter interface {
 	DecryptKey([]byte) ([]byte, error)
+}
+
+// CipherDataDecrypterWithContext is a handler to decrypt keys from the envelope with request context.
+type CipherDataDecrypterWithContext interface {
+	DecryptKeyWithContext(aws.Context, []byte) ([]byte, error)
 }
 
 func generateBytes(n int) []byte {

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -109,6 +109,19 @@ func (kp *kmsKeyHandler) DecryptKey(key []byte) ([]byte, error) {
 	return out.Plaintext, nil
 }
 
+// DecryptKeyWithContext makes a call to KMS to decrypt the key with request context.
+func (kp *kmsKeyHandler) DecryptKeyWithContext(ctx aws.Context, key []byte) ([]byte, error) {
+	out, err := kp.kms.DecryptWithContext(ctx, &kms.DecryptInput{
+		EncryptionContext: kp.CipherData.MaterialDescription,
+		CiphertextBlob:    key,
+		GrantTokens:       []*string{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Plaintext, nil
+}
+
 // GenerateCipherData makes a call to KMS to generate a data key, Upon making
 // the call, it also sets the encrypted key.
 func (kp *kmsKeyHandler) GenerateCipherData(keySize, ivSize int) (CipherData, error) {

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -99,7 +99,7 @@ func (kp kmsKeyHandler) decryptHandler(env Envelope) (CipherDataDecrypter, error
 // DecryptKey makes a call to KMS to decrypt the key.
 func (kp *kmsKeyHandler) DecryptKey(key []byte) ([]byte, error) {
 	out, err := kp.kms.Decrypt(&kms.DecryptInput{
-		EncryptionContext: map[string]*string(kp.CipherData.MaterialDescription),
+		EncryptionContext: kp.CipherData.MaterialDescription,
 		CiphertextBlob:    key,
 		GrantTokens:       []*string{},
 	})

--- a/service/s3/s3crypto/kms_key_handler.go
+++ b/service/s3/s3crypto/kms_key_handler.go
@@ -98,24 +98,17 @@ func (kp kmsKeyHandler) decryptHandler(env Envelope) (CipherDataDecrypter, error
 
 // DecryptKey makes a call to KMS to decrypt the key.
 func (kp *kmsKeyHandler) DecryptKey(key []byte) ([]byte, error) {
-	out, err := kp.kms.Decrypt(&kms.DecryptInput{
-		EncryptionContext: kp.CipherData.MaterialDescription,
-		CiphertextBlob:    key,
-		GrantTokens:       []*string{},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out.Plaintext, nil
+	return kp.DecryptKeyWithContext(aws.BackgroundContext(), key)
 }
 
 // DecryptKeyWithContext makes a call to KMS to decrypt the key with request context.
 func (kp *kmsKeyHandler) DecryptKeyWithContext(ctx aws.Context, key []byte) ([]byte, error) {
-	out, err := kp.kms.DecryptWithContext(ctx, &kms.DecryptInput{
-		EncryptionContext: kp.CipherData.MaterialDescription,
-		CiphertextBlob:    key,
-		GrantTokens:       []*string{},
-	})
+	out, err := kp.kms.DecryptWithContext(ctx,
+		&kms.DecryptInput{
+			EncryptionContext: kp.CipherData.MaterialDescription,
+			CiphertextBlob:    key,
+			GrantTokens:       []*string{},
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -125,11 +118,18 @@ func (kp *kmsKeyHandler) DecryptKeyWithContext(ctx aws.Context, key []byte) ([]b
 // GenerateCipherData makes a call to KMS to generate a data key, Upon making
 // the call, it also sets the encrypted key.
 func (kp *kmsKeyHandler) GenerateCipherData(keySize, ivSize int) (CipherData, error) {
-	out, err := kp.kms.GenerateDataKey(&kms.GenerateDataKeyInput{
-		EncryptionContext: kp.CipherData.MaterialDescription,
-		KeyId:             kp.cmkID,
-		KeySpec:           aws.String("AES_256"),
-	})
+	return kp.GenerateCipherDataWithContext(aws.BackgroundContext(), keySize, ivSize)
+}
+
+// GenerateCipherDataWithContext makes a call to KMS to generate a data key,
+// Upon making the call, it also sets the encrypted key.
+func (kp *kmsKeyHandler) GenerateCipherDataWithContext(ctx aws.Context, keySize, ivSize int) (CipherData, error) {
+	out, err := kp.kms.GenerateDataKeyWithContext(ctx,
+		&kms.GenerateDataKeyInput{
+			EncryptionContext: kp.CipherData.MaterialDescription,
+			KeyId:             kp.cmkID,
+			KeySpec:           aws.String("AES_256"),
+		})
 	if err != nil {
 		return CipherData{}, err
 	}


### PR DESCRIPTION
The s3crypto package is not passing a context object down to the KMS client calls so panics were being emitted by the X-Ray SDK.

This replaces my original PR #2783 in which @jasdel pointed out I'd break backwards compatibility.

I've found a relatively simple method of passing the request to the KMS client by introducing an additional interface `CipherDataDecrypterWithContext` which the KMS key handler conforms to. The decryption client then checks if the decrypter is of this type and if so calls the alternative method exposed in this interface.

I've not attempted to implement this for the `PutObject` method on the encryption client as I just couldn't find a simple way of introducing new code without breaking backwards compatibility.

I've tested my changes successfully:

<img width="1250" alt="Screenshot 2019-10-27 at 22 34 18" src="https://user-images.githubusercontent.com/77991/67643022-25c27180-f90a-11e9-9570-b18d30bfd915.png">
