### PR TITLE
aws/endpoints: Fix testing bug in partitions other than `aws`.

### DIFF
--- a/aws/endpoints/v3model_test.go
+++ b/aws/endpoints/v3model_test.go
@@ -542,6 +542,11 @@ func TestEndpointFor_RegionalFlag(t *testing.T) {
 }
 
 func TestEndpointFor_EmptyRegion(t *testing.T) {
+	// skip this test for partitions outside `aws` partition
+	if DefaultPartitions()[0].id != "aws" {
+		t.Skip()
+	}
+
 	cases := map[string]struct {
 		Service    string
 		Region     string


### PR DESCRIPTION
`TestEndpointFor_EmptyRegion` breaks due to an unknown service called by the test. The fix runs this test only for aws partitions, and skips others. 