### PR TITLE
Using strings.EqualFold() for efficient string comparison

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* Replaced case-insensitive string comparisons with `strings.EqualFold(...)` ([#2922](https://github.com/aws/aws-sdk-go/pull/2922))
 
 ### SDK Bugs

--- a/aws/awsutil/path_value.go
+++ b/aws/awsutil/path_value.go
@@ -70,7 +70,7 @@ func rValuesAtPath(v interface{}, path string, createPath, caseSensitive, nilTer
 			value = value.FieldByNameFunc(func(name string) bool {
 				if c == name {
 					return true
-				} else if !caseSensitive && strings.ToLower(name) == strings.ToLower(c) {
+				} else if !caseSensitive && strings.EqualFold(name, c) {
 					return true
 				}
 				return false

--- a/awsmigrate/awsmigrate-renamer/gen/gen.go
+++ b/awsmigrate/awsmigrate-renamer/gen/gen.go
@@ -114,7 +114,7 @@ func (p *pkg) buildRenames() {
 
 			for _, n := range entry.oldShape.MemberNames() {
 				for _, m := range entry.newShape.MemberNames() {
-					if n != m && strings.ToLower(n) == strings.ToLower(m) {
+					if n != m && strings.EqualFold(n, m) {
 						exportMap[pkgName].Fields[n] = m
 					}
 				}

--- a/models/protocol_tests/generate.go
+++ b/models/protocol_tests/generate.go
@@ -461,7 +461,7 @@ func generateTestSuite(filename string) string {
 // findMember searches the shape for the member with the matching key name.
 func findMember(shape *api.Shape, key string) string {
 	for actualKey := range shape.MemberRefs {
-		if strings.ToLower(key) == strings.ToLower(actualKey) {
+		if strings.EqualFold(key, actualKey) {
 			return actualKey
 		}
 	}

--- a/private/model/api/param_filler.go
+++ b/private/model/api/param_filler.go
@@ -139,7 +139,7 @@ func (f paramFiller) paramsStructList(value []interface{}, shape *Shape) string 
 // findParamMember searches a map for a key ignoring case. Returns the map key if found.
 func findParamMember(value map[string]interface{}, key string) string {
 	for actualKey := range value {
-		if strings.ToLower(key) == strings.ToLower(actualKey) {
+		if strings.EqualFold(key, actualKey) {
 			return actualKey
 		}
 	}


### PR DESCRIPTION
Advantages -

1. Efficient and more optimal in all cases, refer [https://www.digitalocean.com/community/questions/how-to-efficiently-compare-strings-in-go](url) for benchmarks.
2. More readable code.
3. Still uses the standard library.