### PR TITLE
Make read "connection reset" errors retryable.

### DIFF
--- a/aws/request/connection_reset_error.go
+++ b/aws/request/connection_reset_error.go
@@ -5,10 +5,6 @@ import (
 )
 
 func isErrConnectionReset(err error) bool {
-	if strings.Contains(err.Error(), "read: connection reset") {
-		return false
-	}
-
 	if strings.Contains(err.Error(), "connection reset") ||
 		strings.Contains(err.Error(), "broken pipe") {
 		return true

--- a/aws/request/connection_reset_error_test.go
+++ b/aws/request/connection_reset_error_test.go
@@ -42,7 +42,7 @@ func TestSerializationErrConnectionReset_accept(t *testing.T) {
 		},
 		"read not temporary": {
 			Err:            errReadConnectionResetStub,
-			ExpectAttempts: 1,
+			ExpectAttempts: 6,
 		},
 		"write with temporary": {
 			Err:            errWriteConnectionResetStub,

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -48,18 +48,19 @@ var (
 		isTemp: true, op: "accept", msg: "connection reset",
 	}
 
-	// net.OpError read for ECONNRESET is not temporary.
+	// net.OpError read for ECONNRESET may not be temporary, but is treated as
+	// temporary by the SDK.
 	errReadConnectionResetStub = &tempNetworkError{
 		isTemp: false, op: "read", msg: "connection reset",
 	}
 
-	// net.OpError write for ECONNRESET may not be temporary, but is treaded as
+	// net.OpError write for ECONNRESET may not be temporary, but is treated as
 	// temporary by the SDK.
 	errWriteConnectionResetStub = &tempNetworkError{
 		isTemp: false, op: "write", msg: "connection reset",
 	}
 
-	// net.OpError write for broken pipe may not be temporary, but is treaded as
+	// net.OpError write for broken pipe may not be temporary, but is treated as
 	// temporary by the SDK.
 	errWriteBrokenPipeStub = &tempNetworkError{
 		isTemp: false, op: "write", msg: "broken pipe",


### PR DESCRIPTION
Commit 2a801855816c6d4cdc9116035315bbfa8cbb9836 stopped making send
request errors automatically retryable and deferred to the default
retryer to determine whether a request should be retryable.

Then in commit c3d27102088451890a9ba5be0dc1f2e0425f0fc3 a distinction
was made between read and write "connection reset" errors with the
former now not being retryable. There is no explanation in the commmit
or the PR why the distinction was made, but this change in SDK behavior
is causing sporadic fatal errors for us in production when connecting to
AWS services such as S3 and DynamoDB.

Related: #2908

cc @jasdel 
