### PR TITLE
aws/endpoints: reverts incorrect testing bug fix #2920

### DIFF
--- a/aws/endpoints/v3model_test.go
+++ b/aws/endpoints/v3model_test.go
@@ -542,10 +542,6 @@ func TestEndpointFor_RegionalFlag(t *testing.T) {
 }
 
 func TestEndpointFor_EmptyRegion(t *testing.T) {
-	// skip this test for partitions outside `aws` partition
-	if DefaultPartitions()[0].id != "aws" {
-		t.Skip()
-	}
 
 	cases := map[string]struct {
 		Service    string


### PR DESCRIPTION
TestEndpointFor_EmptyRegion breaks due to an unknown service called by the test. This PR reverts the incorrect bug fix #2920 