### PR TITLE
Error constant for HeadObjects "NotFound" response

### DIFF
--- a/service/s3/errors.go
+++ b/service/s3/errors.go
@@ -32,6 +32,12 @@ const (
 	//
 	// The specified multipart upload does not exist.
 	ErrCodeNoSuchUpload = "NoSuchUpload"
+	
+	// ErrCodeNotFound for service response error code
+	// "NotFound".
+	//
+	// Not Found.
+	ErrCodeNotFound = "NotFound"
 
 	// ErrCodeObjectAlreadyInActiveTierError for service response error code
 	// "ObjectAlreadyInActiveTierError".


### PR DESCRIPTION
HeadObject does not return the expected NoSuchKey or NoSuchBucket, rather it returns a generic not found error.   It would be nice to have a constant to check against rather than folks hard coding this in their code base as a work around.

Addresses issue #1208
