### PR TITLE
Add go1.13 Docker Sandbox, Update gotip sandbox, and remove Ubuntu usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,13 @@ sandbox-go1.12: sandbox-build-go1.12
 sandbox-test-go1.12: sandbox-build-go1.12
 	docker run -t aws-sdk-go-1.12
 
+sandbox-build-go1.13:
+	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.13 -t "aws-sdk-go-1.13" .
+sandbox-go1.13: sandbox-build-go1.13
+	docker run -i -t aws-sdk-go-1.13 bash
+sandbox-test-go1.13: sandbox-build-go1.13
+	docker run -t aws-sdk-go-1.13
+
 sandbox-build-gotip:
 	@echo "Run make update-aws-golang-tip, if this test fails because missing aws-golang:tip container"
 	docker build -f ./awstesting/sandbox/Dockerfile.test.gotip -t "aws-sdk-go-tip" .

--- a/awstesting/sandbox/Dockerfile.golang-tip
+++ b/awstesting/sandbox/Dockerfile.golang-tip
@@ -1,7 +1,7 @@
 # Based on docker-library's golang 1.6 alpine and wheezy docker files.
 # https://github.com/docker-library/golang/blob/master/1.6/alpine/Dockerfile
 # https://github.com/docker-library/golang/blob/master/1.6/wheezy/Dockerfile
-FROM buildpack-deps:wheezy-scm
+FROM buildpack-deps:buster-scm
 
 ENV GOLANG_SRC_REPO_URL https://github.com/golang/go
 

--- a/awstesting/sandbox/Dockerfile.test.go1.10
+++ b/awstesting/sandbox/Dockerfile.test.go1.10
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.10
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.12
+++ b/awstesting/sandbox/Dockerfile.test.go1.12
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.12
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.13
+++ b/awstesting/sandbox/Dockerfile.test.go1.13
@@ -1,4 +1,6 @@
-FROM golang:1.11
+FROM golang:1.13
+
+ENV GOPROXY=direct
 
 ADD . /go/src/github.com/aws/aws-sdk-go
 

--- a/awstesting/sandbox/Dockerfile.test.go1.5
+++ b/awstesting/sandbox/Dockerfile.test.go1.5
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.5
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.5-novendorexp
+++ b/awstesting/sandbox/Dockerfile.test.go1.5-novendorexp
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.5
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.6
+++ b/awstesting/sandbox/Dockerfile.test.go1.6
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.6
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.7
+++ b/awstesting/sandbox/Dockerfile.test.go1.7
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.7
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.8
+++ b/awstesting/sandbox/Dockerfile.test.go1.8
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.8
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.go1.9
+++ b/awstesting/sandbox/Dockerfile.test.go1.9
@@ -1,4 +1,3 @@
-FROM ubuntu:12.04
 FROM golang:1.9
 
 ADD . /go/src/github.com/aws/aws-sdk-go

--- a/awstesting/sandbox/Dockerfile.test.gotip
+++ b/awstesting/sandbox/Dockerfile.test.gotip
@@ -1,5 +1,6 @@
-FROM ubuntu:12.04
 FROM aws-golang:tip
+
+ENV GOPROXY=direct
 
 ADD . /go/src/github.com/aws/aws-sdk-go
 


### PR DESCRIPTION
Adds a go 1.13 docker sandbox file, updates gotip to use Debian Buster, and removes unnecessary Ubuntu image usage declarations.