### PR TITLE
private/model/api: Remove validation handlers for smoke tests

### DIFF
--- a/private/model/api/smoke.go
+++ b/private/model/api/smoke.go
@@ -99,7 +99,9 @@ var smokeTestTmpl = template.Must(template.New(`smokeTestTmpl`).Parse(`
 		sess := integration.SessionWithDefaultRegion("{{ $.DefaultRegion }}")
 		svc := {{ $.API.PackageName }}.New(sess)
 		params := {{ $testCase.BuildInputShape $op.InputRef }}
-		_, err := svc.{{ $op.ExportedName }}WithContext(ctx, params)
+		_, err := svc.{{ $op.ExportedName }}WithContext(ctx, params, func(r *request.Request) {
+			r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+		})
 		{{- if $testCase.ExpectErr }}
 			if err == nil {
 				t.Fatalf("expect request to fail")

--- a/service/acm/integ_test.go
+++ b/service/acm/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListCertificates(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := acm.New(sess)
 	params := &acm.ListCertificatesInput{}
-	_, err := svc.ListCertificatesWithContext(ctx, params)
+	_, err := svc.ListCertificatesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetCertificate(t *testing.T) {
 	params := &acm.GetCertificateInput{
 		CertificateArn: aws.String("arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012"),
 	}
-	_, err := svc.GetCertificateWithContext(ctx, params)
+	_, err := svc.GetCertificateWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/apigateway/integ_test.go
+++ b/service/apigateway/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_GetDomainNames(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := apigateway.New(sess)
 	params := &apigateway.GetDomainNamesInput{}
-	_, err := svc.GetDomainNamesWithContext(ctx, params)
+	_, err := svc.GetDomainNamesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_CreateUsagePlanKey(t *testing.T) {
 		KeyType:     aws.String("fixx"),
 		UsagePlanId: aws.String("foo"),
 	}
-	_, err := svc.CreateUsagePlanKeyWithContext(ctx, params)
+	_, err := svc.CreateUsagePlanKeyWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/applicationautoscaling/integ_test.go
+++ b/service/applicationautoscaling/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_DescribeScalableTargets(t *testing.T) {
 	params := &applicationautoscaling.DescribeScalableTargetsInput{
 		ServiceNamespace: aws.String("ec2"),
 	}
-	_, err := svc.DescribeScalableTargetsWithContext(ctx, params)
+	_, err := svc.DescribeScalableTargetsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/applicationdiscoveryservice/integ_test.go
+++ b/service/applicationdiscoveryservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeAgents(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := applicationdiscoveryservice.New(sess)
 	params := &applicationdiscoveryservice.DescribeAgentsInput{}
-	_, err := svc.DescribeAgentsWithContext(ctx, params)
+	_, err := svc.DescribeAgentsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/appstream/integ_test.go
+++ b/service/appstream/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeStacks(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := appstream.New(sess)
 	params := &appstream.DescribeStacksInput{}
-	_, err := svc.DescribeStacksWithContext(ctx, params)
+	_, err := svc.DescribeStacksWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/athena/integ_test.go
+++ b/service/athena/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListNamedQueries(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := athena.New(sess)
 	params := &athena.ListNamedQueriesInput{}
-	_, err := svc.ListNamedQueriesWithContext(ctx, params)
+	_, err := svc.ListNamedQueriesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/autoscaling/integ_test.go
+++ b/service/autoscaling/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeScalingProcessTypes(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := autoscaling.New(sess)
 	params := &autoscaling.DescribeScalingProcessTypesInput{}
-	_, err := svc.DescribeScalingProcessTypesWithContext(ctx, params)
+	_, err := svc.DescribeScalingProcessTypesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_CreateLaunchConfiguration(t *testing.T) {
 		InstanceType:            aws.String("m1.small"),
 		LaunchConfigurationName: aws.String("hello, world"),
 	}
-	_, err := svc.CreateLaunchConfigurationWithContext(ctx, params)
+	_, err := svc.CreateLaunchConfigurationWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/batch/integ_test.go
+++ b/service/batch/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeComputeEnvironments(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := batch.New(sess)
 	params := &batch.DescribeComputeEnvironmentsInput{}
-	_, err := svc.DescribeComputeEnvironmentsWithContext(ctx, params)
+	_, err := svc.DescribeComputeEnvironmentsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/cloudformation/integ_test.go
+++ b/service/cloudformation/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListStacks(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudformation.New(sess)
 	params := &cloudformation.ListStacksInput{}
-	_, err := svc.ListStacksWithContext(ctx, params)
+	_, err := svc.ListStacksWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_CreateStack(t *testing.T) {
 		StackName:   aws.String("fakestack"),
 		TemplateURL: aws.String("http://s3.amazonaws.com/foo/bar"),
 	}
-	_, err := svc.CreateStackWithContext(ctx, params)
+	_, err := svc.CreateStackWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudfront/integ_test.go
+++ b/service/cloudfront/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_ListCloudFrontOriginAccessIdentities(t *testing.T) {
 	params := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{
 		MaxItems: aws.Int64(1),
 	}
-	_, err := svc.ListCloudFrontOriginAccessIdentitiesWithContext(ctx, params)
+	_, err := svc.ListCloudFrontOriginAccessIdentitiesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_GetDistribution(t *testing.T) {
 	params := &cloudfront.GetDistributionInput{
 		Id: aws.String("fake-id"),
 	}
-	_, err := svc.GetDistributionWithContext(ctx, params)
+	_, err := svc.GetDistributionWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudhsmv2/integ_test.go
+++ b/service/cloudhsmv2/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeClusters(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudhsmv2.New(sess)
 	params := &cloudhsmv2.DescribeClustersInput{}
-	_, err := svc.DescribeClustersWithContext(ctx, params)
+	_, err := svc.DescribeClustersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ListTags(t *testing.T) {
 	params := &cloudhsmv2.ListTagsInput{
 		ResourceId: aws.String("bogus-arn"),
 	}
-	_, err := svc.ListTagsWithContext(ctx, params)
+	_, err := svc.ListTagsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudsearch/integ_test.go
+++ b/service/cloudsearch/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeDomains(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudsearch.New(sess)
 	params := &cloudsearch.DescribeDomainsInput{}
-	_, err := svc.DescribeDomainsWithContext(ctx, params)
+	_, err := svc.DescribeDomainsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeIndexFields(t *testing.T) {
 	params := &cloudsearch.DescribeIndexFieldsInput{
 		DomainName: aws.String("fakedomain"),
 	}
-	_, err := svc.DescribeIndexFieldsWithContext(ctx, params)
+	_, err := svc.DescribeIndexFieldsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudtrail/integ_test.go
+++ b/service/cloudtrail/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeTrails(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudtrail.New(sess)
 	params := &cloudtrail.DescribeTrailsInput{}
-	_, err := svc.DescribeTrailsWithContext(ctx, params)
+	_, err := svc.DescribeTrailsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DeleteTrail(t *testing.T) {
 	params := &cloudtrail.DeleteTrailInput{
 		Name: aws.String("faketrail"),
 	}
-	_, err := svc.DeleteTrailWithContext(ctx, params)
+	_, err := svc.DeleteTrailWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudwatch/integ_test.go
+++ b/service/cloudwatch/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_ListMetrics(t *testing.T) {
 	params := &cloudwatch.ListMetricsInput{
 		Namespace: aws.String("AWS/EC2"),
 	}
-	_, err := svc.ListMetricsWithContext(ctx, params)
+	_, err := svc.ListMetricsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -45,7 +47,9 @@ func TestInteg_01_SetAlarmState(t *testing.T) {
 		StateReason: aws.String("xyz"),
 		StateValue:  aws.String("mno"),
 	}
-	_, err := svc.SetAlarmStateWithContext(ctx, params)
+	_, err := svc.SetAlarmStateWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudwatchevents/integ_test.go
+++ b/service/cloudwatchevents/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListRules(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudwatchevents.New(sess)
 	params := &cloudwatchevents.ListRulesInput{}
-	_, err := svc.ListRulesWithContext(ctx, params)
+	_, err := svc.ListRulesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeRule(t *testing.T) {
 	params := &cloudwatchevents.DescribeRuleInput{
 		Name: aws.String("fake-rule"),
 	}
-	_, err := svc.DescribeRuleWithContext(ctx, params)
+	_, err := svc.DescribeRuleWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/cloudwatchlogs/integ_test.go
+++ b/service/cloudwatchlogs/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeLogGroups(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := cloudwatchlogs.New(sess)
 	params := &cloudwatchlogs.DescribeLogGroupsInput{}
-	_, err := svc.DescribeLogGroupsWithContext(ctx, params)
+	_, err := svc.DescribeLogGroupsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_GetLogEvents(t *testing.T) {
 		LogGroupName:  aws.String("fakegroup"),
 		LogStreamName: aws.String("fakestream"),
 	}
-	_, err := svc.GetLogEventsWithContext(ctx, params)
+	_, err := svc.GetLogEventsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/codebuild/integ_test.go
+++ b/service/codebuild/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListBuilds(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := codebuild.New(sess)
 	params := &codebuild.ListBuildsInput{}
-	_, err := svc.ListBuildsWithContext(ctx, params)
+	_, err := svc.ListBuildsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/codecommit/integ_test.go
+++ b/service/codecommit/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListRepositories(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := codecommit.New(sess)
 	params := &codecommit.ListRepositoriesInput{}
-	_, err := svc.ListRepositoriesWithContext(ctx, params)
+	_, err := svc.ListRepositoriesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ListBranches(t *testing.T) {
 	params := &codecommit.ListBranchesInput{
 		RepositoryName: aws.String("fake-repo"),
 	}
-	_, err := svc.ListBranchesWithContext(ctx, params)
+	_, err := svc.ListBranchesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/codedeploy/integ_test.go
+++ b/service/codedeploy/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListApplications(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := codedeploy.New(sess)
 	params := &codedeploy.ListApplicationsInput{}
-	_, err := svc.ListApplicationsWithContext(ctx, params)
+	_, err := svc.ListApplicationsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetDeployment(t *testing.T) {
 	params := &codedeploy.GetDeploymentInput{
 		DeploymentId: aws.String("d-USUAELQEX"),
 	}
-	_, err := svc.GetDeploymentWithContext(ctx, params)
+	_, err := svc.GetDeploymentWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/codepipeline/integ_test.go
+++ b/service/codepipeline/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListPipelines(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := codepipeline.New(sess)
 	params := &codepipeline.ListPipelinesInput{}
-	_, err := svc.ListPipelinesWithContext(ctx, params)
+	_, err := svc.ListPipelinesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetPipeline(t *testing.T) {
 	params := &codepipeline.GetPipelineInput{
 		Name: aws.String("fake-pipeline"),
 	}
-	_, err := svc.GetPipelineWithContext(ctx, params)
+	_, err := svc.GetPipelineWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/codestar/integ_test.go
+++ b/service/codestar/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListProjects(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := codestar.New(sess)
 	params := &codestar.ListProjectsInput{}
-	_, err := svc.ListProjectsWithContext(ctx, params)
+	_, err := svc.ListProjectsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/cognitoidentityprovider/integ_test.go
+++ b/service/cognitoidentityprovider/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_ListUserPools(t *testing.T) {
 	params := &cognitoidentityprovider.ListUserPoolsInput{
 		MaxResults: aws.Int64(10),
 	}
-	_, err := svc.ListUserPoolsWithContext(ctx, params)
+	_, err := svc.ListUserPoolsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_DescribeUserPool(t *testing.T) {
 	params := &cognitoidentityprovider.DescribeUserPoolInput{
 		UserPoolId: aws.String("us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
 	}
-	_, err := svc.DescribeUserPoolWithContext(ctx, params)
+	_, err := svc.DescribeUserPoolWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/configservice/integ_test.go
+++ b/service/configservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeConfigurationRecorders(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := configservice.New(sess)
 	params := &configservice.DescribeConfigurationRecordersInput{}
-	_, err := svc.DescribeConfigurationRecordersWithContext(ctx, params)
+	_, err := svc.DescribeConfigurationRecordersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_GetResourceConfigHistory(t *testing.T) {
 		ResourceId:   aws.String("fake-id"),
 		ResourceType: aws.String("fake-type"),
 	}
-	_, err := svc.GetResourceConfigHistoryWithContext(ctx, params)
+	_, err := svc.GetResourceConfigHistoryWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/costandusagereportservice/integ_test.go
+++ b/service/costandusagereportservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeReportDefinitions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := costandusagereportservice.New(sess)
 	params := &costandusagereportservice.DescribeReportDefinitionsInput{}
-	_, err := svc.DescribeReportDefinitionsWithContext(ctx, params)
+	_, err := svc.DescribeReportDefinitionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/databasemigrationservice/integ_test.go
+++ b/service/databasemigrationservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeEndpoints(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := databasemigrationservice.New(sess)
 	params := &databasemigrationservice.DescribeEndpointsInput{}
-	_, err := svc.DescribeEndpointsWithContext(ctx, params)
+	_, err := svc.DescribeEndpointsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeTableStatistics(t *testing.T) {
 	params := &databasemigrationservice.DescribeTableStatisticsInput{
 		ReplicationTaskArn: aws.String("arn:aws:acm:region:123456789012"),
 	}
-	_, err := svc.DescribeTableStatisticsWithContext(ctx, params)
+	_, err := svc.DescribeTableStatisticsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/devicefarm/integ_test.go
+++ b/service/devicefarm/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListDevices(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := devicefarm.New(sess)
 	params := &devicefarm.ListDevicesInput{}
-	_, err := svc.ListDevicesWithContext(ctx, params)
+	_, err := svc.ListDevicesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetDevice(t *testing.T) {
 	params := &devicefarm.GetDeviceInput{
 		Arn: aws.String("arn:aws:devicefarm:us-west-2::device:000000000000000000000000fake-arn"),
 	}
-	_, err := svc.GetDeviceWithContext(ctx, params)
+	_, err := svc.GetDeviceWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/directconnect/integ_test.go
+++ b/service/directconnect/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeConnections(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := directconnect.New(sess)
 	params := &directconnect.DescribeConnectionsInput{}
-	_, err := svc.DescribeConnectionsWithContext(ctx, params)
+	_, err := svc.DescribeConnectionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeConnections(t *testing.T) {
 	params := &directconnect.DescribeConnectionsInput{
 		ConnectionId: aws.String("fake-connection"),
 	}
-	_, err := svc.DescribeConnectionsWithContext(ctx, params)
+	_, err := svc.DescribeConnectionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/directoryservice/integ_test.go
+++ b/service/directoryservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeDirectories(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := directoryservice.New(sess)
 	params := &directoryservice.DescribeDirectoriesInput{}
-	_, err := svc.DescribeDirectoriesWithContext(ctx, params)
+	_, err := svc.DescribeDirectoriesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_CreateDirectory(t *testing.T) {
 		Password: aws.String(""),
 		Size:     aws.String(""),
 	}
-	_, err := svc.CreateDirectoryWithContext(ctx, params)
+	_, err := svc.CreateDirectoryWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/docdb/integ_test.go
+++ b/service/docdb/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeDBEngineVersions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := docdb.New(sess)
 	params := &docdb.DescribeDBEngineVersionsInput{}
-	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params)
+	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	params := &docdb.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String("fake-id"),
 	}
-	_, err := svc.DescribeDBInstancesWithContext(ctx, params)
+	_, err := svc.DescribeDBInstancesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/dynamodb/integ_test.go
+++ b/service/dynamodb/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_ListTables(t *testing.T) {
 	params := &dynamodb.ListTablesInput{
 		Limit: aws.Int64(1),
 	}
-	_, err := svc.ListTablesWithContext(ctx, params)
+	_, err := svc.ListTablesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_DescribeTable(t *testing.T) {
 	params := &dynamodb.DescribeTableInput{
 		TableName: aws.String("fake-table"),
 	}
-	_, err := svc.DescribeTableWithContext(ctx, params)
+	_, err := svc.DescribeTableWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/ec2/integ_test.go
+++ b/service/ec2/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeRegions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := ec2.New(sess)
 	params := &ec2.DescribeRegionsInput{}
-	_, err := svc.DescribeRegionsWithContext(ctx, params)
+	_, err := svc.DescribeRegionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_DescribeInstances(t *testing.T) {
 			aws.String("i-12345678"),
 		},
 	}
-	_, err := svc.DescribeInstancesWithContext(ctx, params)
+	_, err := svc.DescribeInstancesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/ecr/integ_test.go
+++ b/service/ecr/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeRepositories(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := ecr.New(sess)
 	params := &ecr.DescribeRepositoriesInput{}
-	_, err := svc.DescribeRepositoriesWithContext(ctx, params)
+	_, err := svc.DescribeRepositoriesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ListImages(t *testing.T) {
 	params := &ecr.ListImagesInput{
 		RepositoryName: aws.String("not-a-real-repository"),
 	}
-	_, err := svc.ListImagesWithContext(ctx, params)
+	_, err := svc.ListImagesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/ecs/integ_test.go
+++ b/service/ecs/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListClusters(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := ecs.New(sess)
 	params := &ecs.ListClustersInput{}
-	_, err := svc.ListClustersWithContext(ctx, params)
+	_, err := svc.ListClustersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_StopTask(t *testing.T) {
 	params := &ecs.StopTaskInput{
 		Task: aws.String("xxxxxxxxxxx-xxxxxxxxxxxx-xxxxxxxxxxx"),
 	}
-	_, err := svc.StopTaskWithContext(ctx, params)
+	_, err := svc.StopTaskWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/efs/integ_test.go
+++ b/service/efs/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeFileSystems(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := efs.New(sess)
 	params := &efs.DescribeFileSystemsInput{}
-	_, err := svc.DescribeFileSystemsWithContext(ctx, params)
+	_, err := svc.DescribeFileSystemsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DeleteFileSystem(t *testing.T) {
 	params := &efs.DeleteFileSystemInput{
 		FileSystemId: aws.String("fs-c5a1446c"),
 	}
-	_, err := svc.DeleteFileSystemWithContext(ctx, params)
+	_, err := svc.DeleteFileSystemWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elasticache/integ_test.go
+++ b/service/elasticache/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeEvents(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elasticache.New(sess)
 	params := &elasticache.DescribeEventsInput{}
-	_, err := svc.DescribeEventsWithContext(ctx, params)
+	_, err := svc.DescribeEventsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeCacheClusters(t *testing.T) {
 	params := &elasticache.DescribeCacheClustersInput{
 		CacheClusterId: aws.String("fake_cluster"),
 	}
-	_, err := svc.DescribeCacheClustersWithContext(ctx, params)
+	_, err := svc.DescribeCacheClustersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elasticbeanstalk/integ_test.go
+++ b/service/elasticbeanstalk/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListAvailableSolutionStacks(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elasticbeanstalk.New(sess)
 	params := &elasticbeanstalk.ListAvailableSolutionStacksInput{}
-	_, err := svc.ListAvailableSolutionStacksWithContext(ctx, params)
+	_, err := svc.ListAvailableSolutionStacksWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeEnvironmentResources(t *testing.T) {
 	params := &elasticbeanstalk.DescribeEnvironmentResourcesInput{
 		EnvironmentId: aws.String("fake_environment"),
 	}
-	_, err := svc.DescribeEnvironmentResourcesWithContext(ctx, params)
+	_, err := svc.DescribeEnvironmentResourcesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elasticsearchservice/integ_test.go
+++ b/service/elasticsearchservice/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListDomainNames(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elasticsearchservice.New(sess)
 	params := &elasticsearchservice.ListDomainNamesInput{}
-	_, err := svc.ListDomainNamesWithContext(ctx, params)
+	_, err := svc.ListDomainNamesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeElasticsearchDomain(t *testing.T) {
 	params := &elasticsearchservice.DescribeElasticsearchDomainInput{
 		DomainName: aws.String("not-a-domain"),
 	}
-	_, err := svc.DescribeElasticsearchDomainWithContext(ctx, params)
+	_, err := svc.DescribeElasticsearchDomainWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elastictranscoder/integ_test.go
+++ b/service/elastictranscoder/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListPresets(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elastictranscoder.New(sess)
 	params := &elastictranscoder.ListPresetsInput{}
-	_, err := svc.ListPresetsWithContext(ctx, params)
+	_, err := svc.ListPresetsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ReadJob(t *testing.T) {
 	params := &elastictranscoder.ReadJobInput{
 		Id: aws.String("fake_job"),
 	}
-	_, err := svc.ReadJobWithContext(ctx, params)
+	_, err := svc.ReadJobWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elb/integ_test.go
+++ b/service/elb/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeLoadBalancers(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elb.New(sess)
 	params := &elb.DescribeLoadBalancersInput{}
-	_, err := svc.DescribeLoadBalancersWithContext(ctx, params)
+	_, err := svc.DescribeLoadBalancersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 			aws.String("fake_load_balancer"),
 		},
 	}
-	_, err := svc.DescribeLoadBalancersWithContext(ctx, params)
+	_, err := svc.DescribeLoadBalancersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/elbv2/integ_test.go
+++ b/service/elbv2/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeLoadBalancers(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := elbv2.New(sess)
 	params := &elbv2.DescribeLoadBalancersInput{}
-	_, err := svc.DescribeLoadBalancersWithContext(ctx, params)
+	_, err := svc.DescribeLoadBalancersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -43,7 +45,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 			aws.String("fake_load_balancer"),
 		},
 	}
-	_, err := svc.DescribeLoadBalancersWithContext(ctx, params)
+	_, err := svc.DescribeLoadBalancersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/emr/integ_test.go
+++ b/service/emr/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListClusters(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := emr.New(sess)
 	params := &emr.ListClustersInput{}
-	_, err := svc.ListClustersWithContext(ctx, params)
+	_, err := svc.ListClustersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeCluster(t *testing.T) {
 	params := &emr.DescribeClusterInput{
 		ClusterId: aws.String("fake_cluster"),
 	}
-	_, err := svc.DescribeClusterWithContext(ctx, params)
+	_, err := svc.DescribeClusterWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/eventbridge/integ_test.go
+++ b/service/eventbridge/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListRules(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := eventbridge.New(sess)
 	params := &eventbridge.ListRulesInput{}
-	_, err := svc.ListRulesWithContext(ctx, params)
+	_, err := svc.ListRulesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeRule(t *testing.T) {
 	params := &eventbridge.DescribeRuleInput{
 		Name: aws.String("fake-rule"),
 	}
-	_, err := svc.DescribeRuleWithContext(ctx, params)
+	_, err := svc.DescribeRuleWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/firehose/integ_test.go
+++ b/service/firehose/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListDeliveryStreams(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := firehose.New(sess)
 	params := &firehose.ListDeliveryStreamsInput{}
-	_, err := svc.ListDeliveryStreamsWithContext(ctx, params)
+	_, err := svc.ListDeliveryStreamsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeDeliveryStream(t *testing.T) {
 	params := &firehose.DescribeDeliveryStreamInput{
 		DeliveryStreamName: aws.String("bogus-stream-name"),
 	}
-	_, err := svc.DescribeDeliveryStreamWithContext(ctx, params)
+	_, err := svc.DescribeDeliveryStreamWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/gamelift/integ_test.go
+++ b/service/gamelift/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListBuilds(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := gamelift.New(sess)
 	params := &gamelift.ListBuildsInput{}
-	_, err := svc.ListBuildsWithContext(ctx, params)
+	_, err := svc.ListBuildsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribePlayerSessions(t *testing.T) {
 	params := &gamelift.DescribePlayerSessionsInput{
 		PlayerSessionId: aws.String("psess-fakeSessionId"),
 	}
-	_, err := svc.DescribePlayerSessionsWithContext(ctx, params)
+	_, err := svc.DescribePlayerSessionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/glacier/integ_test.go
+++ b/service/glacier/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListVaults(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := glacier.New(sess)
 	params := &glacier.ListVaultsInput{}
-	_, err := svc.ListVaultsWithContext(ctx, params)
+	_, err := svc.ListVaultsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ListVaults(t *testing.T) {
 	params := &glacier.ListVaultsInput{
 		AccountId: aws.String("abcmnoxyz"),
 	}
-	_, err := svc.ListVaultsWithContext(ctx, params)
+	_, err := svc.ListVaultsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/glue/integ_test.go
+++ b/service/glue/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_GetCatalogImportStatus(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := glue.New(sess)
 	params := &glue.GetCatalogImportStatusInput{}
-	_, err := svc.GetCatalogImportStatusWithContext(ctx, params)
+	_, err := svc.GetCatalogImportStatusWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/health/integ_test.go
+++ b/service/health/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeEntityAggregates(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := health.New(sess)
 	params := &health.DescribeEntityAggregatesInput{}
-	_, err := svc.DescribeEntityAggregatesWithContext(ctx, params)
+	_, err := svc.DescribeEntityAggregatesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/iam/integ_test.go
+++ b/service/iam/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListUsers(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := iam.New(sess)
 	params := &iam.ListUsersInput{}
-	_, err := svc.ListUsersWithContext(ctx, params)
+	_, err := svc.ListUsersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetUser(t *testing.T) {
 	params := &iam.GetUserInput{
 		UserName: aws.String("fake_user"),
 	}
-	_, err := svc.GetUserWithContext(ctx, params)
+	_, err := svc.GetUserWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/inspector/integ_test.go
+++ b/service/inspector/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListAssessmentTemplates(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := inspector.New(sess)
 	params := &inspector.ListAssessmentTemplatesInput{}
-	_, err := svc.ListAssessmentTemplatesWithContext(ctx, params)
+	_, err := svc.ListAssessmentTemplatesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_ListTagsForResource(t *testing.T) {
 	params := &inspector.ListTagsForResourceInput{
 		ResourceArn: aws.String("fake-arn"),
 	}
-	_, err := svc.ListTagsForResourceWithContext(ctx, params)
+	_, err := svc.ListTagsForResourceWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/iot/integ_test.go
+++ b/service/iot/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListPolicies(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := iot.New(sess)
 	params := &iot.ListPoliciesInput{}
-	_, err := svc.ListPoliciesWithContext(ctx, params)
+	_, err := svc.ListPoliciesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeThing(t *testing.T) {
 	params := &iot.DescribeThingInput{
 		ThingName: aws.String("fake-thing"),
 	}
-	_, err := svc.DescribeThingWithContext(ctx, params)
+	_, err := svc.DescribeThingWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/kinesis/integ_test.go
+++ b/service/kinesis/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListStreams(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := kinesis.New(sess)
 	params := &kinesis.ListStreamsInput{}
-	_, err := svc.ListStreamsWithContext(ctx, params)
+	_, err := svc.ListStreamsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeStream(t *testing.T) {
 	params := &kinesis.DescribeStreamInput{
 		StreamName: aws.String("bogus-stream-name"),
 	}
-	_, err := svc.DescribeStreamWithContext(ctx, params)
+	_, err := svc.DescribeStreamWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/kms/integ_test.go
+++ b/service/kms/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListAliases(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := kms.New(sess)
 	params := &kms.ListAliasesInput{}
-	_, err := svc.ListAliasesWithContext(ctx, params)
+	_, err := svc.ListAliasesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_GetKeyPolicy(t *testing.T) {
 		KeyId:      aws.String("12345678-1234-1234-1234-123456789012"),
 		PolicyName: aws.String("fakePolicy"),
 	}
-	_, err := svc.GetKeyPolicyWithContext(ctx, params)
+	_, err := svc.GetKeyPolicyWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/lambda/integ_test.go
+++ b/service/lambda/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListFunctions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := lambda.New(sess)
 	params := &lambda.ListFunctionsInput{}
-	_, err := svc.ListFunctionsWithContext(ctx, params)
+	_, err := svc.ListFunctionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_Invoke(t *testing.T) {
 	params := &lambda.InvokeInput{
 		FunctionName: aws.String("bogus-function"),
 	}
-	_, err := svc.InvokeWithContext(ctx, params)
+	_, err := svc.InvokeWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/lightsail/integ_test.go
+++ b/service/lightsail/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_GetActiveNames(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := lightsail.New(sess)
 	params := &lightsail.GetActiveNamesInput{}
-	_, err := svc.GetActiveNamesWithContext(ctx, params)
+	_, err := svc.GetActiveNamesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/marketplacecommerceanalytics/integ_test.go
+++ b/service/marketplacecommerceanalytics/integ_test.go
@@ -40,7 +40,9 @@ func TestInteg_00_GenerateDataSet(t *testing.T) {
 		RoleNameArn:             aws.String("fake-arn"),
 		SnsTopicArn:             aws.String("fake-arn"),
 	}
-	_, err := svc.GenerateDataSetWithContext(ctx, params)
+	_, err := svc.GenerateDataSetWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/neptune/integ_test.go
+++ b/service/neptune/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeDBEngineVersions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := neptune.New(sess)
 	params := &neptune.DescribeDBEngineVersionsInput{}
-	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params)
+	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	params := &neptune.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String("fake-id"),
 	}
-	_, err := svc.DescribeDBInstancesWithContext(ctx, params)
+	_, err := svc.DescribeDBInstancesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/opsworks/integ_test.go
+++ b/service/opsworks/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeStacks(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := opsworks.New(sess)
 	params := &opsworks.DescribeStacksInput{}
-	_, err := svc.DescribeStacksWithContext(ctx, params)
+	_, err := svc.DescribeStacksWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeLayers(t *testing.T) {
 	params := &opsworks.DescribeLayersInput{
 		StackId: aws.String("fake_stack"),
 	}
-	_, err := svc.DescribeLayersWithContext(ctx, params)
+	_, err := svc.DescribeLayersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/pinpointemail/integ_test.go
+++ b/service/pinpointemail/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListConfigurationSets(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := pinpointemail.New(sess)
 	params := &pinpointemail.ListConfigurationSetsInput{}
-	_, err := svc.ListConfigurationSetsWithContext(ctx, params)
+	_, err := svc.ListConfigurationSetsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_PutConfigurationSetTrackingOptions(t *testing.T) {
 	params := &pinpointemail.PutConfigurationSetTrackingOptionsInput{
 		ConfigurationSetName: aws.String("config-set-name-not-exists"),
 	}
-	_, err := svc.PutConfigurationSetTrackingOptionsWithContext(ctx, params)
+	_, err := svc.PutConfigurationSetTrackingOptionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/polly/integ_test.go
+++ b/service/polly/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeVoices(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := polly.New(sess)
 	params := &polly.DescribeVoicesInput{}
-	_, err := svc.DescribeVoicesWithContext(ctx, params)
+	_, err := svc.DescribeVoicesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/rds/integ_test.go
+++ b/service/rds/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeDBEngineVersions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := rds.New(sess)
 	params := &rds.DescribeDBEngineVersionsInput{}
-	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params)
+	_, err := svc.DescribeDBEngineVersionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	params := &rds.DescribeDBInstancesInput{
 		DBInstanceIdentifier: aws.String("fake-id"),
 	}
-	_, err := svc.DescribeDBInstancesWithContext(ctx, params)
+	_, err := svc.DescribeDBInstancesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/redshift/integ_test.go
+++ b/service/redshift/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeClusterVersions(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := redshift.New(sess)
 	params := &redshift.DescribeClusterVersionsInput{}
-	_, err := svc.DescribeClusterVersionsWithContext(ctx, params)
+	_, err := svc.DescribeClusterVersionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeClusters(t *testing.T) {
 	params := &redshift.DescribeClustersInput{
 		ClusterIdentifier: aws.String("fake-cluster"),
 	}
-	_, err := svc.DescribeClustersWithContext(ctx, params)
+	_, err := svc.DescribeClustersWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/rekognition/integ_test.go
+++ b/service/rekognition/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListCollections(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := rekognition.New(sess)
 	params := &rekognition.ListCollectionsInput{}
-	_, err := svc.ListCollectionsWithContext(ctx, params)
+	_, err := svc.ListCollectionsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/route53/integ_test.go
+++ b/service/route53/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListHostedZones(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := route53.New(sess)
 	params := &route53.ListHostedZonesInput{}
-	_, err := svc.ListHostedZonesWithContext(ctx, params)
+	_, err := svc.ListHostedZonesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetHostedZone(t *testing.T) {
 	params := &route53.GetHostedZoneInput{
 		Id: aws.String("fake-zone"),
 	}
-	_, err := svc.GetHostedZoneWithContext(ctx, params)
+	_, err := svc.GetHostedZoneWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/route53resolver/integ_test.go
+++ b/service/route53resolver/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListResolverEndpoints(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := route53resolver.New(sess)
 	params := &route53resolver.ListResolverEndpointsInput{}
-	_, err := svc.ListResolverEndpointsWithContext(ctx, params)
+	_, err := svc.ListResolverEndpointsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetResolverRule(t *testing.T) {
 	params := &route53resolver.GetResolverRuleInput{
 		ResolverRuleId: aws.String("fake-id"),
 	}
-	_, err := svc.GetResolverRuleWithContext(ctx, params)
+	_, err := svc.GetResolverRuleWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/s3/integ_test.go
+++ b/service/s3/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListBuckets(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := s3.New(sess)
 	params := &s3.ListBucketsInput{}
-	_, err := svc.ListBucketsWithContext(ctx, params)
+	_, err := svc.ListBucketsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/s3control/cust_integ_shared_test.go
+++ b/service/s3control/cust_integ_shared_test.go
@@ -39,12 +39,11 @@ func init() {
 	flag.StringVar(&accountID, "account", "",
 		"The AWS account `ID`.",
 	)
-	flag.Parse()
 }
 
 func TestMain(m *testing.M) {
 	setup()
-
+	flag.Parse()
 	os.Exit(m.Run())
 }
 

--- a/service/secretsmanager/integ_test.go
+++ b/service/secretsmanager/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListSecrets(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := secretsmanager.New(sess)
 	params := &secretsmanager.ListSecretsInput{}
-	_, err := svc.ListSecretsWithContext(ctx, params)
+	_, err := svc.ListSecretsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeSecret(t *testing.T) {
 	params := &secretsmanager.DescribeSecretInput{
 		SecretId: aws.String("fake-secret-id"),
 	}
-	_, err := svc.DescribeSecretWithContext(ctx, params)
+	_, err := svc.DescribeSecretWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/servicecatalog/integ_test.go
+++ b/service/servicecatalog/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListAcceptedPortfolioShares(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := servicecatalog.New(sess)
 	params := &servicecatalog.ListAcceptedPortfolioSharesInput{}
-	_, err := svc.ListAcceptedPortfolioSharesWithContext(ctx, params)
+	_, err := svc.ListAcceptedPortfolioSharesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/ses/integ_test.go
+++ b/service/ses/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListIdentities(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := ses.New(sess)
 	params := &ses.ListIdentitiesInput{}
-	_, err := svc.ListIdentitiesWithContext(ctx, params)
+	_, err := svc.ListIdentitiesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_VerifyEmailIdentity(t *testing.T) {
 	params := &ses.VerifyEmailIdentityInput{
 		EmailAddress: aws.String("fake_email"),
 	}
-	_, err := svc.VerifyEmailIdentityWithContext(ctx, params)
+	_, err := svc.VerifyEmailIdentityWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/sfn/integ_test.go
+++ b/service/sfn/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListActivities(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := sfn.New(sess)
 	params := &sfn.ListActivitiesInput{}
-	_, err := svc.ListActivitiesWithContext(ctx, params)
+	_, err := svc.ListActivitiesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/shield/integ_test.go
+++ b/service/shield/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListAttacks(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := shield.New(sess)
 	params := &shield.ListAttacksInput{}
-	_, err := svc.ListAttacksWithContext(ctx, params)
+	_, err := svc.ListAttacksWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/sms/integ_test.go
+++ b/service/sms/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_GetConnectors(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := sms.New(sess)
 	params := &sms.GetConnectorsInput{}
-	_, err := svc.GetConnectorsWithContext(ctx, params)
+	_, err := svc.GetConnectorsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DeleteReplicationJob(t *testing.T) {
 	params := &sms.DeleteReplicationJobInput{
 		ReplicationJobId: aws.String("invalidId"),
 	}
-	_, err := svc.DeleteReplicationJobWithContext(ctx, params)
+	_, err := svc.DeleteReplicationJobWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/snowball/integ_test.go
+++ b/service/snowball/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeAddresses(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := snowball.New(sess)
 	params := &snowball.DescribeAddressesInput{}
-	_, err := svc.DescribeAddressesWithContext(ctx, params)
+	_, err := svc.DescribeAddressesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}

--- a/service/sns/integ_test.go
+++ b/service/sns/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListTopics(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := sns.New(sess)
 	params := &sns.ListTopicsInput{}
-	_, err := svc.ListTopicsWithContext(ctx, params)
+	_, err := svc.ListTopicsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_Publish(t *testing.T) {
 		Message:  aws.String("hello"),
 		TopicArn: aws.String("fake_topic"),
 	}
-	_, err := svc.PublishWithContext(ctx, params)
+	_, err := svc.PublishWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/sqs/integ_test.go
+++ b/service/sqs/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListQueues(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := sqs.New(sess)
 	params := &sqs.ListQueuesInput{}
-	_, err := svc.ListQueuesWithContext(ctx, params)
+	_, err := svc.ListQueuesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetQueueUrl(t *testing.T) {
 	params := &sqs.GetQueueUrlInput{
 		QueueName: aws.String("fake_queue"),
 	}
-	_, err := svc.GetQueueUrlWithContext(ctx, params)
+	_, err := svc.GetQueueUrlWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/ssm/integ_test.go
+++ b/service/ssm/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_ListDocuments(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := ssm.New(sess)
 	params := &ssm.ListDocumentsInput{}
-	_, err := svc.ListDocumentsWithContext(ctx, params)
+	_, err := svc.ListDocumentsWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_GetDocument(t *testing.T) {
 	params := &ssm.GetDocumentInput{
 		Name: aws.String("'fake-name'"),
 	}
-	_, err := svc.GetDocumentWithContext(ctx, params)
+	_, err := svc.GetDocumentWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/sts/integ_test.go
+++ b/service/sts/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_GetSessionToken(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := sts.New(sess)
 	params := &sts.GetSessionTokenInput{}
-	_, err := svc.GetSessionTokenWithContext(ctx, params)
+	_, err := svc.GetSessionTokenWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -42,7 +44,9 @@ func TestInteg_01_GetFederationToken(t *testing.T) {
 		Name:   aws.String("temp"),
 		Policy: aws.String("{\\\"temp\\\":true}"),
 	}
-	_, err := svc.GetFederationTokenWithContext(ctx, params)
+	_, err := svc.GetFederationTokenWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/support/integ_test.go
+++ b/service/support/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeServices(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-east-1")
 	svc := support.New(sess)
 	params := &support.DescribeServicesInput{}
-	_, err := svc.DescribeServicesWithContext(ctx, params)
+	_, err := svc.DescribeServicesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -45,7 +47,9 @@ func TestInteg_01_CreateCase(t *testing.T) {
 		SeverityCode:      aws.String("low"),
 		Subject:           aws.String("subject"),
 	}
-	_, err := svc.CreateCaseWithContext(ctx, params)
+	_, err := svc.CreateCaseWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/waf/integ_test.go
+++ b/service/waf/integ_test.go
@@ -29,7 +29,9 @@ func TestInteg_00_ListRules(t *testing.T) {
 	params := &waf.ListRulesInput{
 		Limit: aws.Int64(20),
 	}
-	_, err := svc.ListRulesWithContext(ctx, params)
+	_, err := svc.ListRulesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -44,7 +46,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 		ChangeToken: aws.String("fake_token"),
 		Name:        aws.String("fake_name"),
 	}
-	_, err := svc.CreateSqlInjectionMatchSetWithContext(ctx, params)
+	_, err := svc.CreateSqlInjectionMatchSetWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/wafregional/integ_test.go
+++ b/service/wafregional/integ_test.go
@@ -30,7 +30,9 @@ func TestInteg_00_ListRules(t *testing.T) {
 	params := &waf.ListRulesInput{
 		Limit: aws.Int64(20),
 	}
-	_, err := svc.ListRulesWithContext(ctx, params)
+	_, err := svc.ListRulesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -45,7 +47,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 		ChangeToken: aws.String("fake_token"),
 		Name:        aws.String("fake_name"),
 	}
-	_, err := svc.CreateSqlInjectionMatchSetWithContext(ctx, params)
+	_, err := svc.CreateSqlInjectionMatchSetWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}

--- a/service/workspaces/integ_test.go
+++ b/service/workspaces/integ_test.go
@@ -27,7 +27,9 @@ func TestInteg_00_DescribeWorkspaces(t *testing.T) {
 	sess := integration.SessionWithDefaultRegion("us-west-2")
 	svc := workspaces.New(sess)
 	params := &workspaces.DescribeWorkspacesInput{}
-	_, err := svc.DescribeWorkspacesWithContext(ctx, params)
+	_, err := svc.DescribeWorkspacesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
 	}
@@ -41,7 +43,9 @@ func TestInteg_01_DescribeWorkspaces(t *testing.T) {
 	params := &workspaces.DescribeWorkspacesInput{
 		DirectoryId: aws.String("fake-id"),
 	}
-	_, err := svc.DescribeWorkspacesWithContext(ctx, params)
+	_, err := svc.DescribeWorkspacesWithContext(ctx, params, func(r *request.Request) {
+		r.Handlers.Validate.RemoveByName("core.ValidateParametersHandler")
+	})
 	if err == nil {
 		t.Fatalf("expect request to fail")
 	}


### PR DESCRIPTION
Fixes smoke tests to not fail on client side validation.