### PR TITLE
aws/credentials/processcreds: Increase the default max buffer size

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/credentials/processcreds`: Increase the default max buffer size ([#2957](https://github.com/aws/aws-sdk-go/pull/2957))
+  * Fixes [#2875](https://github.com/aws/aws-sdk-go/issues/2875)
 
 ### SDK Bugs

--- a/aws/credentials/processcreds/provider.go
+++ b/aws/credentials/processcreds/provider.go
@@ -90,6 +90,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
 const (
@@ -142,7 +143,7 @@ const (
 
 	// DefaultBufSize limits buffer size from growing to an enormous
 	// amount due to a faulty process.
-	DefaultBufSize = 1024
+	DefaultBufSize = int(8 * sdkio.KibiByte)
 
 	// DefaultTimeout default limit on time a process can run.
 	DefaultTimeout = time.Duration(1) * time.Minute


### PR DESCRIPTION
Increase the default maximum buffer size used by the process credential provider.

Fixes: https://github.com/aws/aws-sdk-go/issues/2875