### PR TITLE
aws/ec2metadata: Add support for EC2Metadata client secure token

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
-
+* `aws/ec2metadata`: Adds support for EC2Metadata client to use secure tokens provided by the IMDS ([#2958](https://github.com/aws/aws-sdk-go/pull/2958))
+  * Modifies and adds tests to verify the behavior of the EC2Metadata client.
+  
 ### SDK Bugs

--- a/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+++ b/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
@@ -2,8 +2,10 @@ package ec2rolecreds_test
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -46,6 +48,57 @@ func initTestServer(expireOn string, failAssume bool) *httptest.Server {
 	}))
 
 	return server
+}
+
+func TestEC2CredentialRetrieverWithToken(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// returns a random token each time `/latest/api/token` endpoint is hit
+	mux.HandleFunc("/latest/api/token", func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method == "PUT" && r.Header.Get("x-aws-ec2-metadata-token-ttl-seconds") != "" {
+			i := rand.Intn(10)
+			if i < 5 {
+				w.Header().Set("X-aws-ec2-metadata-token-ttl-seconds", "0")
+				t.Log("Received expired token, fetching token again")
+			} else {
+				w.Header().Set("X-aws-ec2-metadata-token-ttl-seconds", "200")
+			}
+			w.Write([]byte(strconv.Itoa(i)))
+			return
+		}
+		http.Error(w, "bad request", http.StatusBadRequest)
+	})
+
+	// meta-data endpoint for this test, just returns the token
+	mux.HandleFunc("/latest/meta-data/iam/security-credentials/RoleName", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, credsRespTmpl, "2014-12-16T01:51:37Z")
+	})
+
+	// meta-data endpoint for this test, just returns the token
+	mux.HandleFunc("/latest/meta-data/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "RoleName")
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	p := &ec2rolecreds.EC2RoleProvider{
+		Client: ec2metadata.New(unit.Session, &aws.Config{Endpoint: aws.String(server.URL + "/latest")}),
+	}
+
+	creds, err := p.Retrieve()
+	if err != nil {
+		t.Errorf("Expect no error, got %v", err)
+	}
+	if e, a := "accessKey", creds.AccessKeyID; e != a {
+		t.Errorf("Expect access key ID to match, %v got %v", e, a)
+	}
+	if e, a := "secret", creds.SecretAccessKey; e != a {
+		t.Errorf("Expect secret access key to match, %v got %v", e, a)
+	}
+	if e, a := "token", creds.SessionToken; e != a {
+		t.Errorf("Expect session token to match, %v got %v", e, a)
+	}
 }
 
 func TestEC2RoleProvider(t *testing.T) {

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -3,6 +3,7 @@ package ec2metadata
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -39,7 +40,7 @@ func (c *EC2Metadata) getToken(duration time.Duration) (tokenOutput, error) {
 	// Errors with bad request status should be returned.
 	if err != nil {
 		err = awserr.NewRequestFailure(
-			awserr.New(req.HTTPResponse.Status, "Fetch token failed", err),
+			awserr.New(req.HTTPResponse.Status, http.StatusText(req.HTTPResponse.StatusCode), err),
 			req.HTTPResponse.StatusCode, req.RequestID)
 	}
 

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -16,7 +16,6 @@ import (
 // getToken uses the duration to return a token for EC2 metadata service,
 // or an error if the request failed.
 func (c *EC2Metadata) getToken(duration time.Duration) (tokenOutput, error) {
-
 	op := &request.Operation{
 		Name:       "GetToken",
 		HTTPMethod: "PUT",
@@ -32,7 +31,7 @@ func (c *EC2Metadata) getToken(duration time.Duration) (tokenOutput, error) {
 	// Swap the unmarshalMetadataHandler with unmarshalTokenHandler on this request.
 	req.Handlers.Unmarshal.Swap(unmarshalMetadataHandlerName, unmarshalTokenHandler)
 
-	ttl := strconv.Itoa(int(duration / time.Second))
+	ttl := strconv.FormatInt(int64(duration / time.Second),10)
 	req.HTTPRequest.Header.Set(ttlHeader, ttl)
 
 	err := req.Send()
@@ -51,7 +50,6 @@ func (c *EC2Metadata) getToken(duration time.Duration) (tokenOutput, error) {
 // instance metadata service. The content will be returned as a string, or
 // error if the request failed.
 func (c *EC2Metadata) GetMetadata(p string) (string, error) {
-
 	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -12,20 +12,61 @@ import (
 	"github.com/aws/aws-sdk-go/internal/sdkuri"
 )
 
+func (c *EC2Metadata) getToken() error {
+	// check if token exists and is not expired
+	if c.token != nil && !c.token.IsExpired() {
+		return nil
+	}
+
+	op := &request.Operation{
+		Name:       "GetToken",
+		HTTPMethod: "PUT",
+		HTTPPath:   sdkuri.PathJoin("/api/token"),
+	}
+
+	output := &tokenOutput{}
+
+	c.Handlers.Unmarshal.Swap("unmarshalMetadataHandler", unmarshalTokenHandler)
+	defer c.Handlers.Unmarshal.Swap("unmarshalTokenHandler", unmarshalHandler)
+
+	req := c.NewRequest(op, nil, output)
+	req.HTTPRequest.Header.Set("x-aws-ec2-metadata-token-ttl-seconds", "21600")
+	err := req.Send()
+
+	c.token = &ec2Token{}
+	c.token.content = output.Content
+	c.token.SetExpiration(time.Now().Add(output.ttl), 10*time.Second)
+	return err
+}
+
 // GetMetadata uses the path provided to request information from the EC2
-// instance metdata service. The content will be returned as a string, or
+// instance metadata service. The content will be returned as a string, or
 // error if the request failed.
 func (c *EC2Metadata) GetMetadata(p string) (string, error) {
+
 	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
 		HTTPPath:   sdkuri.PathJoin("/meta-data", p),
 	}
-
 	output := &metadataOutput{}
 	req := c.NewRequest(op, nil, output)
-	err := req.Send()
 
+	err := c.getToken()
+	if err == nil {
+		req.HTTPRequest.Header.Set("x-aws-ec2-metadata-token", c.token.content)
+	}
+
+	req.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
+		switch r.HTTPResponse.StatusCode {
+		case http.StatusUnauthorized:
+			r.Error = awserr.New("Unauthorized", "request status unauthorized", r.Error)
+		case http.StatusBadRequest:
+			r.Error = awserr.New("BadRequest", "bad request", r.Error)
+		}
+	})
+
+	err = req.Send()
 	return output.Content, err
 }
 
@@ -42,12 +83,23 @@ func (c *EC2Metadata) GetUserData() (string, error) {
 	output := &metadataOutput{}
 	req := c.NewRequest(op, nil, output)
 	req.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
-		if r.HTTPResponse.StatusCode == http.StatusNotFound {
+		switch r.HTTPResponse.StatusCode {
+		case http.StatusNotFound:
 			r.Error = awserr.New("NotFoundError", "user-data not found", r.Error)
+		case http.StatusBadRequest:
+			r.Error = awserr.New("BadRequest", "bad request", r.Error)
+		case http.StatusUnauthorized:
+			r.Error = awserr.New("Unauthorized", "Unauthorized for an expired, invalid, or missing token header", r.Error)
 		}
 	})
-	err := req.Send()
 
+	err := c.getToken()
+
+	if err == nil {
+		req.HTTPRequest.Header.Set("x-aws-ec2-metadata-token", c.token.content)
+	}
+
+	err = req.Send()
 	return output.Content, err
 }
 
@@ -63,8 +115,22 @@ func (c *EC2Metadata) GetDynamicData(p string) (string, error) {
 
 	output := &metadataOutput{}
 	req := c.NewRequest(op, nil, output)
-	err := req.Send()
 
+	err := c.getToken()
+	if err == nil {
+		req.HTTPRequest.Header.Set("x-aws-ec2-metadata-token", c.token.content)
+	}
+
+	req.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
+		switch r.HTTPResponse.StatusCode {
+		case http.StatusUnauthorized:
+			r.Error = awserr.New("RequestTokenExpired", "request status unauthorized", r.Error)
+		case http.StatusBadRequest:
+			r.Error = awserr.New("BadRequest", "bad request", r.Error)
+		}
+	})
+
+	err = req.Send()
 	return output.Content, err
 }
 

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -170,7 +170,6 @@ var unmarshalHandler = request.NamedHandler{
 
 		if data, ok := r.Data.(*metadataOutput); ok {
 			data.Content = b.String()
-
 		}
 	},
 }

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -65,7 +65,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRace(t *testing.T) {
 	defer server.Close()
 
 	cfg := aws.NewConfig().WithEndpoint(server.URL)
-	runEC2MetadataClients(t, cfg, 100)
+	runEC2MetadataClients(t, cfg, 2)
 }
 
 func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
@@ -78,7 +78,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
 		Transport: http.DefaultTransport,
 	})
 
-	runEC2MetadataClients(t, cfg, 100)
+	runEC2MetadataClients(t, cfg, 2)
 }
 
 func TestClientDisableIMDS(t *testing.T) {

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -65,7 +65,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRace(t *testing.T) {
 	defer server.Close()
 
 	cfg := aws.NewConfig().WithEndpoint(server.URL)
-	runEC2MetadataClients(t, cfg, 2)
+	runEC2MetadataClients(t, cfg, 100)
 }
 
 func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
@@ -78,7 +78,7 @@ func TestClientOverrideDefaultHTTPClientTimeoutRaceWithTransport(t *testing.T) {
 		Transport: http.DefaultTransport,
 	})
 
-	runEC2MetadataClients(t, cfg, 2)
+	runEC2MetadataClients(t, cfg, 100)
 }
 
 func TestClientDisableIMDS(t *testing.T) {

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -1,0 +1,103 @@
+package ec2metadata
+
+import (
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+// Error constant
+const errTimeOutError = "net/http: request canceled (Client.Timeout exceeded while awaiting headers)"
+
+// A tokenProvider struct provides access to EC2Metadata client
+// and atomic instance of a token, along with ttl for it.
+// tokenProvider also provides an atomic flag to disable the
+// fetch token operation.
+// The disabled member will use 0 as false, and 1 as true.
+type tokenProvider struct {
+	client   *EC2Metadata
+	token    atomic.Value
+	ttl      time.Duration
+	disabled uint32
+}
+
+// A ec2Token struct helps use of token in EC2 Metadata service ops
+type ec2Token struct {
+	token string
+	credentials.Expiry
+}
+
+// newTokenProvider provides a pointer to a tokenProvider instance
+func newTokenProvider(c *EC2Metadata, duration time.Duration) *tokenProvider {
+	return &tokenProvider{client: c, ttl: duration}
+}
+
+// fetchTokenHandler fetches token for EC2Metadata service client by default.
+func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
+
+	// short-circuits to insecure data flow if tokenProvider is disabled.
+	if v := atomic.LoadUint32(&t.disabled); v == 1 {
+		return
+	}
+
+	if ec2Token, ok := t.token.Load().(ec2Token); ok {
+		if !ec2Token.IsExpired() {
+			r.HTTPRequest.Header.Set(tokenHeader, ec2Token.token)
+			return
+		}
+	}
+
+	output, err := t.client.getToken(t.ttl)
+
+	if err != nil {
+
+		// change the disabled flag on token provider to true,
+		// when error is request timeout error.
+		if requestFailureError, ok := err.(awserr.RequestFailure); ok {
+			switch requestFailureError.StatusCode() {
+			case http.StatusForbidden:
+				fallthrough
+			case http.StatusNotFound:
+				fallthrough
+			case http.StatusMethodNotAllowed:
+				atomic.StoreUint32(&t.disabled, 1)
+			case http.StatusBadRequest:
+				r.Error = requestFailureError
+			}
+
+			// Check if request timed out while waiting for response
+			if e, ok := requestFailureError.OrigErr().(awserr.Error); ok {
+				if timeoutError := e.OrigErr(); timeoutError != nil &&
+					strings.Contains(timeoutError.Error(), errTimeOutError) {
+					atomic.StoreUint32(&t.disabled, 1)
+				}
+			}
+		}
+		return
+	}
+
+	newToken := ec2Token{
+		token: output.Token,
+	}
+	newToken.SetExpiration(time.Now().Add(output.TTL), ttlExpirationWindow)
+	t.token.Store(newToken)
+
+	// Inject token header to the request.
+	if ec2Token, ok := t.token.Load().(ec2Token); ok {
+		r.HTTPRequest.Header.Set(tokenHeader, ec2Token.token)
+	}
+}
+
+// enableTokenProviderHandler enables the token provider
+func (t *tokenProvider) enableTokenProviderHandler(r *request.Request) {
+	// If the error code status is 401, we enable the token provider
+	if e, ok := r.Error.(awserr.RequestFailure); ok && e != nil &&
+		e.StatusCode() == http.StatusUnauthorized {
+		atomic.StoreUint32(&t.disabled, 0)
+	}
+}


### PR DESCRIPTION
`aws/ec2metadata`: Adds support for EC2Metadata client to use secure tokens provided by the IMDS. Modifies and adds tests to verify the behavior of the EC2Metadata client.