### PR TITLE
aws/ec2metadata: fix ec2metadata client to retrieve region from dynamic data

### DIFF
--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -31,7 +31,7 @@ func (c *EC2Metadata) getToken(duration time.Duration) (tokenOutput, error) {
 	// Swap the unmarshalMetadataHandler with unmarshalTokenHandler on this request.
 	req.Handlers.Unmarshal.Swap(unmarshalMetadataHandlerName, unmarshalTokenHandler)
 
-	ttl := strconv.FormatInt(int64(duration / time.Second),10)
+	ttl := strconv.FormatInt(int64(duration/time.Second), 10)
 	req.HTTPRequest.Header.Set(ttlHeader, ttl)
 
 	err := req.Send()
@@ -145,17 +145,17 @@ func (c *EC2Metadata) IAMInfo() (EC2IAMInfo, error) {
 
 // Region returns the region the instance is running in.
 func (c *EC2Metadata) Region() (string, error) {
-	resp, err := c.GetMetadata("placement/availability-zone")
+	ec2InstanceIdentityDocument, err := c.GetInstanceIdentityDocument()
 	if err != nil {
 		return "", err
 	}
-
-	if len(resp) == 0 {
-		return "", awserr.New("EC2MetadataError", "invalid Region response", nil)
+	// extract region from the ec2InstanceIdentityDocument
+	region := ec2InstanceIdentityDocument.Region
+	if len(region) == 0 {
+		return "", awserr.New("EC2MetadataError", "invalid region received for ec2metadata instance", nil)
 	}
-
-	// returns region without the suffix. Eg: us-west-2a becomes us-west-2
-	return resp[:len(resp)-1], nil
+	// returns region
+	return region, nil
 }
 
 // Available returns if the application has access to the EC2 Metadata service.

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -369,12 +369,12 @@ func TestGetRegion(t *testing.T) {
 				testType := InsecureTestType
 				Ts := &testServer{
 					t:    t,
-					data: "us-west-2a",
+					data: instanceIdentityDocument,
 				}
 				return newTestServer(t, testType, Ts)
 			},
-			expectedData:                "us-west-2",
-			expectedOperationsPerformed: []string{"GetToken", "GetMetadata"},
+			expectedData:                "us-east-1",
+			expectedOperationsPerformed: []string{"GetToken", "GetDynamicData"},
 		},
 		"Secure server success case": {
 			NewServer: func(t *testing.T) *httptest.Server {
@@ -382,12 +382,12 @@ func TestGetRegion(t *testing.T) {
 				Ts := &testServer{
 					t:      t,
 					tokens: []string{"firstToken", "secondToken", "thirdToken"},
-					data:   "us-west-2a",
+					data:   instanceIdentityDocument,
 				}
 				return newTestServer(t, testType, Ts)
 			},
-			expectedData:                "us-west-2",
-			expectedOperationsPerformed: []string{"GetToken", "GetMetadata"},
+			expectedData:                "us-east-1",
+			expectedOperationsPerformed: []string{"GetToken", "GetDynamicData"},
 		},
 		"Bad request case": {
 			NewServer: func(t *testing.T) *httptest.Server {
@@ -395,12 +395,12 @@ func TestGetRegion(t *testing.T) {
 				Ts := &testServer{
 					t:      t,
 					tokens: []string{"firstToken", "secondToken", "thirdToken"},
-					data:   "us-west-2a",
+					data:   instanceIdentityDocument,
 				}
 				return newTestServer(t, testType, Ts)
 			},
 			expectedError:               "400",
-			expectedOperationsPerformed: []string{"GetToken", "GetMetadata"},
+			expectedOperationsPerformed: []string{"GetToken", "GetDynamicData"},
 		},
 		"ServerErrorForTokenTestType": {
 			NewServer: func(t *testing.T) *httptest.Server {
@@ -408,12 +408,12 @@ func TestGetRegion(t *testing.T) {
 				Ts := &testServer{
 					t:      t,
 					tokens: []string{},
-					data:   "us-west-2a",
+					data:   instanceIdentityDocument,
 				}
 				return newTestServer(t, testType, Ts)
 			},
-			expectedData:                "us-west-2",
-			expectedOperationsPerformed: []string{"GetToken", "GetMetadata"},
+			expectedData:                "us-east-1",
+			expectedOperationsPerformed: []string{"GetToken", "GetDynamicData"},
 		},
 	}
 

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -92,7 +92,7 @@ func TestClientDisableIMDS(t *testing.T) {
 	svc := ec2metadata.New(unit.Session, &aws.Config{
 		LogLevel: aws.LogLevel(aws.LogDebugWithHTTPBody),
 	})
-	resp, err := svc.Region()
+	resp, err := svc.GetUserData()
 	if err == nil {
 		t.Fatalf("expect error, got none")
 	}
@@ -116,7 +116,7 @@ func runEC2MetadataClients(t *testing.T, cfg *aws.Config, atOnce int) {
 	for i := 0; i < atOnce; i++ {
 		go func() {
 			defer wg.Done()
-			_, err := svc.Region()
+			_, err := svc.GetUserData()
 			if err != nil {
 				t.Errorf("expect no error, got %v", err)
 			}


### PR DESCRIPTION
SDK's ec2metadata client now uses dynamic data from instance identity document, to retrieve region info. 