### PR TITLE
aws/ec2metadata : Adds changelog entry highlighting a resource leak was fixed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Release v1.25.41 (2019-11-22)
 
 ### SDK Bugs
 * `aws/ec2metadata`: Fix failing concurrency test for ec2metadata client ([#2960](https://github.com/aws/aws-sdk-go/pull/2960))
+  * Fixes a resource leak  in ec2metadata client, where response body was not closed after reading
 
 Release v1.25.40 (2019-11-21)
 ===


### PR DESCRIPTION
Adds changelog entry highlighting a resource leak was fixed in PR #2960 . 