### PR TITLE
private/model/api: Fix spelling typo in service documenation

### DIFF
--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -515,7 +515,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "{{ ServiceNameConstValue . }}" // Name of service.
 	EndpointsID = {{ EndpointsIDConstValue . }} // ID to lookup a service endpoint with.
-	ServiceID = "{{ ServiceID . }}" // ServiceID is a unique identifer of a specific service.
+	ServiceID = "{{ ServiceID . }}" // ServiceID is a unique identifier of a specific service.
 )
 {{- end }}
 

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/service.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/service.go
@@ -33,7 +33,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "AwsEndpointDiscoveryTest"        // Name of service.
 	EndpointsID = "awsendpointdiscoverytestservice" // ID to lookup a service endpoint with.
-	ServiceID   = "AwsEndpointDiscoveryTest"        // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AwsEndpointDiscoveryTest"        // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AwsEndpointDiscoveryTest client with a session.

--- a/private/model/api/codegentest/service/restjsonservice/service.go
+++ b/private/model/api/codegentest/service/restjsonservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RESTJSONService" // Name of service.
 	EndpointsID = "restjsonservice" // ID to lookup a service endpoint with.
-	ServiceID   = "RESTJSONService" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RESTJSONService" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RESTJSONService client with a session.

--- a/private/model/api/codegentest/service/restxmlservice/service.go
+++ b/private/model/api/codegentest/service/restxmlservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RESTXMLService" // Name of service.
 	EndpointsID = "restxmlservice" // ID to lookup a service endpoint with.
-	ServiceID   = "RESTXMLService" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RESTXMLService" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RESTXMLService client with a session.

--- a/private/model/api/codegentest/service/rpcservice/service.go
+++ b/private/model/api/codegentest/service/rpcservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RPCService" // Name of service.
 	EndpointsID = "rpcservice" // ID to lookup a service endpoint with.
-	ServiceID   = "RPCService" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RPCService" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RPCService client with a session.

--- a/service/accessanalyzer/service.go
+++ b/service/accessanalyzer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "AccessAnalyzer"  // Name of service.
 	EndpointsID = "access-analyzer" // ID to lookup a service endpoint with.
-	ServiceID   = "AccessAnalyzer"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AccessAnalyzer"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AccessAnalyzer client with a session.

--- a/service/acm/service.go
+++ b/service/acm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "acm"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "ACM"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ACM"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ACM client with a session.

--- a/service/acmpca/service.go
+++ b/service/acmpca/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "acm-pca"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "ACM PCA"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ACM PCA"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ACMPCA client with a session.

--- a/service/alexaforbusiness/service.go
+++ b/service/alexaforbusiness/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "a4b"                // Name of service.
 	EndpointsID = ServiceName          // ID to lookup a service endpoint with.
-	ServiceID   = "Alexa For Business" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Alexa For Business" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AlexaForBusiness client with a session.

--- a/service/amplify/service.go
+++ b/service/amplify/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Amplify" // Name of service.
 	EndpointsID = "amplify" // ID to lookup a service endpoint with.
-	ServiceID   = "Amplify" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Amplify" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Amplify client with a session.

--- a/service/apigateway/service.go
+++ b/service/apigateway/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "apigateway"  // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "API Gateway" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "API Gateway" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the APIGateway client with a session.

--- a/service/apigatewaymanagementapi/service.go
+++ b/service/apigatewaymanagementapi/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ApiGatewayManagementApi" // Name of service.
 	EndpointsID = "execute-api"             // ID to lookup a service endpoint with.
-	ServiceID   = "ApiGatewayManagementApi" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ApiGatewayManagementApi" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ApiGatewayManagementApi client with a session.

--- a/service/apigatewayv2/service.go
+++ b/service/apigatewayv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ApiGatewayV2" // Name of service.
 	EndpointsID = "apigateway"   // ID to lookup a service endpoint with.
-	ServiceID   = "ApiGatewayV2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ApiGatewayV2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ApiGatewayV2 client with a session.

--- a/service/appconfig/service.go
+++ b/service/appconfig/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "AppConfig" // Name of service.
 	EndpointsID = "appconfig" // ID to lookup a service endpoint with.
-	ServiceID   = "AppConfig" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AppConfig" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AppConfig client with a session.

--- a/service/applicationautoscaling/service.go
+++ b/service/applicationautoscaling/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "autoscaling"              // Name of service.
 	EndpointsID = "application-autoscaling"  // ID to lookup a service endpoint with.
-	ServiceID   = "Application Auto Scaling" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Application Auto Scaling" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ApplicationAutoScaling client with a session.

--- a/service/applicationdiscoveryservice/service.go
+++ b/service/applicationdiscoveryservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "discovery"                     // Name of service.
 	EndpointsID = ServiceName                     // ID to lookup a service endpoint with.
-	ServiceID   = "Application Discovery Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Application Discovery Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ApplicationDiscoveryService client with a session.

--- a/service/applicationinsights/service.go
+++ b/service/applicationinsights/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Application Insights" // Name of service.
 	EndpointsID = "applicationinsights"  // ID to lookup a service endpoint with.
-	ServiceID   = "Application Insights" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Application Insights" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ApplicationInsights client with a session.

--- a/service/appmesh/service.go
+++ b/service/appmesh/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "App Mesh" // Name of service.
 	EndpointsID = "appmesh"  // ID to lookup a service endpoint with.
-	ServiceID   = "App Mesh" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "App Mesh" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AppMesh client with a session.

--- a/service/appstream/service.go
+++ b/service/appstream/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "appstream2" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "AppStream"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AppStream"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AppStream client with a session.

--- a/service/appsync/service.go
+++ b/service/appsync/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "appsync"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "AppSync"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "AppSync"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AppSync client with a session.

--- a/service/athena/service.go
+++ b/service/athena/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "athena"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Athena"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Athena"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Athena client with a session.

--- a/service/augmentedairuntime/service.go
+++ b/service/augmentedairuntime/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "SageMaker A2I Runtime" // Name of service.
 	EndpointsID = "a2i-runtime.sagemaker" // ID to lookup a service endpoint with.
-	ServiceID   = "SageMaker A2I Runtime" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SageMaker A2I Runtime" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AugmentedAIRuntime client with a session.

--- a/service/autoscaling/service.go
+++ b/service/autoscaling/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "autoscaling"  // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "Auto Scaling" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Auto Scaling" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AutoScaling client with a session.

--- a/service/autoscalingplans/service.go
+++ b/service/autoscalingplans/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "autoscaling"        // Name of service.
 	EndpointsID = "autoscaling-plans"  // ID to lookup a service endpoint with.
-	ServiceID   = "Auto Scaling Plans" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Auto Scaling Plans" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the AutoScalingPlans client with a session.

--- a/service/backup/service.go
+++ b/service/backup/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Backup" // Name of service.
 	EndpointsID = "backup" // ID to lookup a service endpoint with.
-	ServiceID   = "Backup" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Backup" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Backup client with a session.

--- a/service/batch/service.go
+++ b/service/batch/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "batch"     // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Batch"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Batch"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Batch client with a session.

--- a/service/budgets/service.go
+++ b/service/budgets/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "budgets"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Budgets"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Budgets"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Budgets client with a session.

--- a/service/chime/service.go
+++ b/service/chime/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Chime" // Name of service.
 	EndpointsID = "chime" // ID to lookup a service endpoint with.
-	ServiceID   = "Chime" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Chime" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Chime client with a session.

--- a/service/cloud9/service.go
+++ b/service/cloud9/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloud9"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Cloud9"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cloud9"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Cloud9 client with a session.

--- a/service/clouddirectory/service.go
+++ b/service/clouddirectory/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "clouddirectory" // Name of service.
 	EndpointsID = ServiceName      // ID to lookup a service endpoint with.
-	ServiceID   = "CloudDirectory" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudDirectory" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudDirectory client with a session.

--- a/service/cloudformation/service.go
+++ b/service/cloudformation/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudformation" // Name of service.
 	EndpointsID = ServiceName      // ID to lookup a service endpoint with.
-	ServiceID   = "CloudFormation" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudFormation" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudFormation client with a session.

--- a/service/cloudfront/service.go
+++ b/service/cloudfront/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudfront" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "CloudFront" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudFront" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudFront client with a session.

--- a/service/cloudhsm/service.go
+++ b/service/cloudhsm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudhsm"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "CloudHSM"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudHSM"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudHSM client with a session.

--- a/service/cloudhsmv2/service.go
+++ b/service/cloudhsmv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudhsmv2"  // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "CloudHSM V2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudHSM V2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudHSMV2 client with a session.

--- a/service/cloudsearch/service.go
+++ b/service/cloudsearch/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudsearch" // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "CloudSearch" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudSearch" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudSearch client with a session.

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudsearchdomain"  // Name of service.
 	EndpointsID = ServiceName          // ID to lookup a service endpoint with.
-	ServiceID   = "CloudSearch Domain" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudSearch Domain" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudSearchDomain client with a session.

--- a/service/cloudtrail/service.go
+++ b/service/cloudtrail/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cloudtrail" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "CloudTrail" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudTrail" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudTrail client with a session.

--- a/service/cloudwatch/service.go
+++ b/service/cloudwatch/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "monitoring" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "CloudWatch" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudWatch" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudWatch client with a session.

--- a/service/cloudwatchevents/service.go
+++ b/service/cloudwatchevents/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "events"            // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "CloudWatch Events" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudWatch Events" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudWatchEvents client with a session.

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "logs"            // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "CloudWatch Logs" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CloudWatch Logs" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CloudWatchLogs client with a session.

--- a/service/codebuild/service.go
+++ b/service/codebuild/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codebuild" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "CodeBuild" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeBuild" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeBuild client with a session.

--- a/service/codecommit/service.go
+++ b/service/codecommit/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codecommit" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "CodeCommit" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeCommit" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeCommit client with a session.

--- a/service/codedeploy/service.go
+++ b/service/codedeploy/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codedeploy" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "CodeDeploy" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeDeploy" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeDeploy client with a session.

--- a/service/codeguruprofiler/service.go
+++ b/service/codeguruprofiler/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "CodeGuruProfiler"  // Name of service.
 	EndpointsID = "codeguru-profiler" // ID to lookup a service endpoint with.
-	ServiceID   = "CodeGuruProfiler"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeGuruProfiler"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeGuruProfiler client with a session.

--- a/service/codegurureviewer/service.go
+++ b/service/codegurureviewer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "CodeGuru Reviewer" // Name of service.
 	EndpointsID = "codeguru-reviewer" // ID to lookup a service endpoint with.
-	ServiceID   = "CodeGuru Reviewer" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeGuru Reviewer" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeGuruReviewer client with a session.

--- a/service/codepipeline/service.go
+++ b/service/codepipeline/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codepipeline" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "CodePipeline" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodePipeline" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodePipeline client with a session.

--- a/service/codestar/service.go
+++ b/service/codestar/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codestar"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "CodeStar"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "CodeStar"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeStar client with a session.

--- a/service/codestarnotifications/service.go
+++ b/service/codestarnotifications/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "codestar notifications" // Name of service.
 	EndpointsID = "codestar-notifications" // ID to lookup a service endpoint with.
-	ServiceID   = "codestar notifications" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "codestar notifications" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CodeStarNotifications client with a session.

--- a/service/cognitoidentity/service.go
+++ b/service/cognitoidentity/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cognito-identity" // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "Cognito Identity" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cognito Identity" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CognitoIdentity client with a session.

--- a/service/cognitoidentityprovider/service.go
+++ b/service/cognitoidentityprovider/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cognito-idp"               // Name of service.
 	EndpointsID = ServiceName                 // ID to lookup a service endpoint with.
-	ServiceID   = "Cognito Identity Provider" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cognito Identity Provider" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CognitoIdentityProvider client with a session.

--- a/service/cognitosync/service.go
+++ b/service/cognitosync/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cognito-sync" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "Cognito Sync" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cognito Sync" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CognitoSync client with a session.

--- a/service/comprehend/service.go
+++ b/service/comprehend/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "comprehend" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "Comprehend" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Comprehend" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Comprehend client with a session.

--- a/service/comprehendmedical/service.go
+++ b/service/comprehendmedical/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ComprehendMedical" // Name of service.
 	EndpointsID = "comprehendmedical" // ID to lookup a service endpoint with.
-	ServiceID   = "ComprehendMedical" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ComprehendMedical" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ComprehendMedical client with a session.

--- a/service/computeoptimizer/service.go
+++ b/service/computeoptimizer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Compute Optimizer" // Name of service.
 	EndpointsID = "compute-optimizer" // ID to lookup a service endpoint with.
-	ServiceID   = "Compute Optimizer" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Compute Optimizer" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ComputeOptimizer client with a session.

--- a/service/configservice/service.go
+++ b/service/configservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "config"         // Name of service.
 	EndpointsID = ServiceName      // ID to lookup a service endpoint with.
-	ServiceID   = "Config Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Config Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ConfigService client with a session.

--- a/service/connect/service.go
+++ b/service/connect/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "connect"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Connect"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Connect"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Connect client with a session.

--- a/service/connectparticipant/service.go
+++ b/service/connectparticipant/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ConnectParticipant"  // Name of service.
 	EndpointsID = "participant.connect" // ID to lookup a service endpoint with.
-	ServiceID   = "ConnectParticipant"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ConnectParticipant"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ConnectParticipant client with a session.

--- a/service/costandusagereportservice/service.go
+++ b/service/costandusagereportservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "cur"                           // Name of service.
 	EndpointsID = ServiceName                     // ID to lookup a service endpoint with.
-	ServiceID   = "Cost and Usage Report Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cost and Usage Report Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CostandUsageReportService client with a session.

--- a/service/costexplorer/service.go
+++ b/service/costexplorer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ce"            // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "Cost Explorer" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Cost Explorer" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the CostExplorer client with a session.

--- a/service/databasemigrationservice/service.go
+++ b/service/databasemigrationservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "dms"                        // Name of service.
 	EndpointsID = ServiceName                  // ID to lookup a service endpoint with.
-	ServiceID   = "Database Migration Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Database Migration Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DatabaseMigrationService client with a session.

--- a/service/dataexchange/service.go
+++ b/service/dataexchange/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "DataExchange" // Name of service.
 	EndpointsID = "dataexchange" // ID to lookup a service endpoint with.
-	ServiceID   = "DataExchange" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DataExchange" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DataExchange client with a session.

--- a/service/datapipeline/service.go
+++ b/service/datapipeline/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "datapipeline"  // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "Data Pipeline" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Data Pipeline" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DataPipeline client with a session.

--- a/service/datasync/service.go
+++ b/service/datasync/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "DataSync" // Name of service.
 	EndpointsID = "datasync" // ID to lookup a service endpoint with.
-	ServiceID   = "DataSync" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DataSync" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DataSync client with a session.

--- a/service/dax/service.go
+++ b/service/dax/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "dax"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "DAX"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DAX"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DAX client with a session.

--- a/service/devicefarm/service.go
+++ b/service/devicefarm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "devicefarm"  // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "Device Farm" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Device Farm" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DeviceFarm client with a session.

--- a/service/directconnect/service.go
+++ b/service/directconnect/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "directconnect"  // Name of service.
 	EndpointsID = ServiceName      // ID to lookup a service endpoint with.
-	ServiceID   = "Direct Connect" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Direct Connect" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DirectConnect client with a session.

--- a/service/directoryservice/service.go
+++ b/service/directoryservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ds"                // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "Directory Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Directory Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DirectoryService client with a session.

--- a/service/dlm/service.go
+++ b/service/dlm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "DLM" // Name of service.
 	EndpointsID = "dlm" // ID to lookup a service endpoint with.
-	ServiceID   = "DLM" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DLM" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DLM client with a session.

--- a/service/docdb/service.go
+++ b/service/docdb/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "DocDB" // Name of service.
 	EndpointsID = "rds"   // ID to lookup a service endpoint with.
-	ServiceID   = "DocDB" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DocDB" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DocDB client with a session.

--- a/service/dynamodb/service.go
+++ b/service/dynamodb/service.go
@@ -33,7 +33,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "dynamodb"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "DynamoDB"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DynamoDB"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DynamoDB client with a session.

--- a/service/dynamodbstreams/service.go
+++ b/service/dynamodbstreams/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "streams.dynamodb" // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "DynamoDB Streams" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "DynamoDB Streams" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the DynamoDBStreams client with a session.

--- a/service/ebs/service.go
+++ b/service/ebs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "EBS" // Name of service.
 	EndpointsID = "ebs" // ID to lookup a service endpoint with.
-	ServiceID   = "EBS" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EBS" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EBS client with a session.

--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ec2"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "EC2"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EC2"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EC2 client with a session.

--- a/service/ec2instanceconnect/service.go
+++ b/service/ec2instanceconnect/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "EC2 Instance Connect" // Name of service.
 	EndpointsID = "ec2-instance-connect" // ID to lookup a service endpoint with.
-	ServiceID   = "EC2 Instance Connect" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EC2 Instance Connect" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EC2InstanceConnect client with a session.

--- a/service/ecr/service.go
+++ b/service/ecr/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ecr"     // Name of service.
 	EndpointsID = "api.ecr" // ID to lookup a service endpoint with.
-	ServiceID   = "ECR"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ECR"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ECR client with a session.

--- a/service/ecs/service.go
+++ b/service/ecs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ecs"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "ECS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ECS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ECS client with a session.

--- a/service/efs/service.go
+++ b/service/efs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticfilesystem" // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "EFS"               // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EFS"               // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EFS client with a session.

--- a/service/eks/service.go
+++ b/service/eks/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "eks"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "EKS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EKS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EKS client with a session.

--- a/service/elasticache/service.go
+++ b/service/elasticache/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticache" // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "ElastiCache" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ElastiCache" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ElastiCache client with a session.

--- a/service/elasticbeanstalk/service.go
+++ b/service/elasticbeanstalk/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticbeanstalk"  // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Beanstalk" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Beanstalk" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ElasticBeanstalk client with a session.

--- a/service/elasticinference/service.go
+++ b/service/elasticinference/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Elastic Inference"     // Name of service.
 	EndpointsID = "api.elastic-inference" // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Inference"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Inference"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ElasticInference client with a session.

--- a/service/elasticsearchservice/service.go
+++ b/service/elasticsearchservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "es"                    // Name of service.
 	EndpointsID = ServiceName             // ID to lookup a service endpoint with.
-	ServiceID   = "Elasticsearch Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elasticsearch Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ElasticsearchService client with a session.

--- a/service/elastictranscoder/service.go
+++ b/service/elastictranscoder/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elastictranscoder"  // Name of service.
 	EndpointsID = ServiceName          // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Transcoder" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Transcoder" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ElasticTranscoder client with a session.

--- a/service/elb/service.go
+++ b/service/elb/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticloadbalancing"   // Name of service.
 	EndpointsID = ServiceName              // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Load Balancing" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Load Balancing" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ELB client with a session.

--- a/service/elbv2/service.go
+++ b/service/elbv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticloadbalancing"      // Name of service.
 	EndpointsID = ServiceName                 // ID to lookup a service endpoint with.
-	ServiceID   = "Elastic Load Balancing v2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Elastic Load Balancing v2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ELBV2 client with a session.

--- a/service/emr/service.go
+++ b/service/emr/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "elasticmapreduce" // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "EMR"              // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EMR"              // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EMR client with a session.

--- a/service/eventbridge/service.go
+++ b/service/eventbridge/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "EventBridge" // Name of service.
 	EndpointsID = "events"      // ID to lookup a service endpoint with.
-	ServiceID   = "EventBridge" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "EventBridge" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the EventBridge client with a session.

--- a/service/firehose/service.go
+++ b/service/firehose/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "firehose"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Firehose"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Firehose"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Firehose client with a session.

--- a/service/fms/service.go
+++ b/service/fms/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "fms"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "FMS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "FMS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the FMS client with a session.

--- a/service/forecastqueryservice/service.go
+++ b/service/forecastqueryservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "forecastquery" // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "forecastquery" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "forecastquery" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ForecastQueryService client with a session.

--- a/service/forecastservice/service.go
+++ b/service/forecastservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "forecast"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "forecast"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "forecast"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ForecastService client with a session.

--- a/service/frauddetector/service.go
+++ b/service/frauddetector/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "FraudDetector" // Name of service.
 	EndpointsID = "frauddetector" // ID to lookup a service endpoint with.
-	ServiceID   = "FraudDetector" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "FraudDetector" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the FraudDetector client with a session.

--- a/service/fsx/service.go
+++ b/service/fsx/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "FSx" // Name of service.
 	EndpointsID = "fsx" // ID to lookup a service endpoint with.
-	ServiceID   = "FSx" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "FSx" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the FSx client with a session.

--- a/service/gamelift/service.go
+++ b/service/gamelift/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "gamelift"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "GameLift"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "GameLift"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the GameLift client with a session.

--- a/service/glacier/service.go
+++ b/service/glacier/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "glacier"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Glacier"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Glacier"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Glacier client with a session.

--- a/service/globalaccelerator/service.go
+++ b/service/globalaccelerator/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Global Accelerator" // Name of service.
 	EndpointsID = "globalaccelerator"  // ID to lookup a service endpoint with.
-	ServiceID   = "Global Accelerator" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Global Accelerator" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the GlobalAccelerator client with a session.

--- a/service/glue/service.go
+++ b/service/glue/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "glue"      // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Glue"      // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Glue"      // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Glue client with a session.

--- a/service/greengrass/service.go
+++ b/service/greengrass/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "greengrass" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "Greengrass" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Greengrass" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Greengrass client with a session.

--- a/service/groundstation/service.go
+++ b/service/groundstation/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "GroundStation" // Name of service.
 	EndpointsID = "groundstation" // ID to lookup a service endpoint with.
-	ServiceID   = "GroundStation" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "GroundStation" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the GroundStation client with a session.

--- a/service/guardduty/service.go
+++ b/service/guardduty/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "guardduty" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "GuardDuty" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "GuardDuty" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the GuardDuty client with a session.

--- a/service/health/service.go
+++ b/service/health/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "health"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Health"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Health"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Health client with a session.

--- a/service/iam/service.go
+++ b/service/iam/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "iam"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "IAM"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IAM"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IAM client with a session.

--- a/service/imagebuilder/service.go
+++ b/service/imagebuilder/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "imagebuilder" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "imagebuilder" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "imagebuilder" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Imagebuilder client with a session.

--- a/service/inspector/service.go
+++ b/service/inspector/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "inspector" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Inspector" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Inspector" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Inspector client with a session.

--- a/service/iot/service.go
+++ b/service/iot/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "iot"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "IoT"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoT client with a session.

--- a/service/iot1clickdevicesservice/service.go
+++ b/service/iot1clickdevicesservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "devices.iot1click"          // Name of service.
 	EndpointsID = ServiceName                  // ID to lookup a service endpoint with.
-	ServiceID   = "IoT 1Click Devices Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT 1Click Devices Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoT1ClickDevicesService client with a session.

--- a/service/iot1clickprojects/service.go
+++ b/service/iot1clickprojects/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "projects.iot1click"  // Name of service.
 	EndpointsID = ServiceName           // ID to lookup a service endpoint with.
-	ServiceID   = "IoT 1Click Projects" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT 1Click Projects" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoT1ClickProjects client with a session.

--- a/service/iotanalytics/service.go
+++ b/service/iotanalytics/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "iotanalytics" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "IoTAnalytics" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoTAnalytics" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTAnalytics client with a session.

--- a/service/iotdataplane/service.go
+++ b/service/iotdataplane/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "data.iot"       // Name of service.
 	EndpointsID = ServiceName      // ID to lookup a service endpoint with.
-	ServiceID   = "IoT Data Plane" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT Data Plane" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTDataPlane client with a session.

--- a/service/iotevents/service.go
+++ b/service/iotevents/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "IoT Events" // Name of service.
 	EndpointsID = "iotevents"  // ID to lookup a service endpoint with.
-	ServiceID   = "IoT Events" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT Events" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTEvents client with a session.

--- a/service/ioteventsdata/service.go
+++ b/service/ioteventsdata/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "IoT Events Data" // Name of service.
 	EndpointsID = "data.iotevents"  // ID to lookup a service endpoint with.
-	ServiceID   = "IoT Events Data" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT Events Data" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTEventsData client with a session.

--- a/service/iotjobsdataplane/service.go
+++ b/service/iotjobsdataplane/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "data.jobs.iot"       // Name of service.
 	EndpointsID = ServiceName           // ID to lookup a service endpoint with.
-	ServiceID   = "IoT Jobs Data Plane" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoT Jobs Data Plane" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTJobsDataPlane client with a session.

--- a/service/iotsecuretunneling/service.go
+++ b/service/iotsecuretunneling/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "IoTSecureTunneling" // Name of service.
 	EndpointsID = "api.tunneling.iot"  // ID to lookup a service endpoint with.
-	ServiceID   = "IoTSecureTunneling" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoTSecureTunneling" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTSecureTunneling client with a session.

--- a/service/iotthingsgraph/service.go
+++ b/service/iotthingsgraph/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "IoTThingsGraph" // Name of service.
 	EndpointsID = "iotthingsgraph" // ID to lookup a service endpoint with.
-	ServiceID   = "IoTThingsGraph" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "IoTThingsGraph" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the IoTThingsGraph client with a session.

--- a/service/kafka/service.go
+++ b/service/kafka/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Kafka" // Name of service.
 	EndpointsID = "kafka" // ID to lookup a service endpoint with.
-	ServiceID   = "Kafka" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kafka" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Kafka client with a session.

--- a/service/kendra/service.go
+++ b/service/kendra/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kendra"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "kendra"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "kendra"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Kendra client with a session.

--- a/service/kinesis/service.go
+++ b/service/kinesis/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kinesis"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Kinesis client with a session.

--- a/service/kinesisanalytics/service.go
+++ b/service/kinesisanalytics/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kinesisanalytics"  // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Analytics" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Analytics" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisAnalytics client with a session.

--- a/service/kinesisanalyticsv2/service.go
+++ b/service/kinesisanalyticsv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Kinesis Analytics V2" // Name of service.
 	EndpointsID = "kinesisanalytics"     // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Analytics V2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Analytics V2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisAnalyticsV2 client with a session.

--- a/service/kinesisvideo/service.go
+++ b/service/kinesisvideo/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kinesisvideo"  // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Video" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Video" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisVideo client with a session.

--- a/service/kinesisvideoarchivedmedia/service.go
+++ b/service/kinesisvideoarchivedmedia/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kinesisvideo"                 // Name of service.
 	EndpointsID = ServiceName                    // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Video Archived Media" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Video Archived Media" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisVideoArchivedMedia client with a session.

--- a/service/kinesisvideomedia/service.go
+++ b/service/kinesisvideomedia/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kinesisvideo"        // Name of service.
 	EndpointsID = ServiceName           // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Video Media" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Video Media" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisVideoMedia client with a session.

--- a/service/kinesisvideosignalingchannels/service.go
+++ b/service/kinesisvideosignalingchannels/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Kinesis Video Signaling" // Name of service.
 	EndpointsID = "kinesisvideo"            // ID to lookup a service endpoint with.
-	ServiceID   = "Kinesis Video Signaling" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Kinesis Video Signaling" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KinesisVideoSignalingChannels client with a session.

--- a/service/kms/service.go
+++ b/service/kms/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "kms"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "KMS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "KMS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the KMS client with a session.

--- a/service/lakeformation/service.go
+++ b/service/lakeformation/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "LakeFormation" // Name of service.
 	EndpointsID = "lakeformation" // ID to lookup a service endpoint with.
-	ServiceID   = "LakeFormation" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "LakeFormation" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the LakeFormation client with a session.

--- a/service/lambda/service.go
+++ b/service/lambda/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "lambda"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Lambda"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Lambda"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Lambda client with a session.

--- a/service/lexmodelbuildingservice/service.go
+++ b/service/lexmodelbuildingservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "models.lex"                 // Name of service.
 	EndpointsID = ServiceName                  // ID to lookup a service endpoint with.
-	ServiceID   = "Lex Model Building Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Lex Model Building Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the LexModelBuildingService client with a session.

--- a/service/lexruntimeservice/service.go
+++ b/service/lexruntimeservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "runtime.lex"         // Name of service.
 	EndpointsID = ServiceName           // ID to lookup a service endpoint with.
-	ServiceID   = "Lex Runtime Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Lex Runtime Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the LexRuntimeService client with a session.

--- a/service/licensemanager/service.go
+++ b/service/licensemanager/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "License Manager" // Name of service.
 	EndpointsID = "license-manager" // ID to lookup a service endpoint with.
-	ServiceID   = "License Manager" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "License Manager" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the LicenseManager client with a session.

--- a/service/lightsail/service.go
+++ b/service/lightsail/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "lightsail" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Lightsail" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Lightsail" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Lightsail client with a session.

--- a/service/machinelearning/service.go
+++ b/service/machinelearning/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "machinelearning"  // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "Machine Learning" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Machine Learning" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MachineLearning client with a session.

--- a/service/macie/service.go
+++ b/service/macie/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Macie" // Name of service.
 	EndpointsID = "macie" // ID to lookup a service endpoint with.
-	ServiceID   = "Macie" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Macie" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Macie client with a session.

--- a/service/managedblockchain/service.go
+++ b/service/managedblockchain/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ManagedBlockchain" // Name of service.
 	EndpointsID = "managedblockchain" // ID to lookup a service endpoint with.
-	ServiceID   = "ManagedBlockchain" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ManagedBlockchain" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ManagedBlockchain client with a session.

--- a/service/marketplacecatalog/service.go
+++ b/service/marketplacecatalog/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Marketplace Catalog" // Name of service.
 	EndpointsID = "catalog.marketplace" // ID to lookup a service endpoint with.
-	ServiceID   = "Marketplace Catalog" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Marketplace Catalog" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MarketplaceCatalog client with a session.

--- a/service/marketplacecommerceanalytics/service.go
+++ b/service/marketplacecommerceanalytics/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "marketplacecommerceanalytics"   // Name of service.
 	EndpointsID = ServiceName                      // ID to lookup a service endpoint with.
-	ServiceID   = "Marketplace Commerce Analytics" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Marketplace Commerce Analytics" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MarketplaceCommerceAnalytics client with a session.

--- a/service/marketplaceentitlementservice/service.go
+++ b/service/marketplaceentitlementservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "entitlement.marketplace"         // Name of service.
 	EndpointsID = ServiceName                       // ID to lookup a service endpoint with.
-	ServiceID   = "Marketplace Entitlement Service" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Marketplace Entitlement Service" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MarketplaceEntitlementService client with a session.

--- a/service/marketplacemetering/service.go
+++ b/service/marketplacemetering/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "metering.marketplace" // Name of service.
 	EndpointsID = ServiceName            // ID to lookup a service endpoint with.
-	ServiceID   = "Marketplace Metering" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Marketplace Metering" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MarketplaceMetering client with a session.

--- a/service/mediaconnect/service.go
+++ b/service/mediaconnect/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "MediaConnect" // Name of service.
 	EndpointsID = "mediaconnect" // ID to lookup a service endpoint with.
-	ServiceID   = "MediaConnect" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaConnect" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaConnect client with a session.

--- a/service/mediaconvert/service.go
+++ b/service/mediaconvert/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mediaconvert" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "MediaConvert" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaConvert" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaConvert client with a session.

--- a/service/medialive/service.go
+++ b/service/medialive/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "medialive" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "MediaLive" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaLive" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaLive client with a session.

--- a/service/mediapackage/service.go
+++ b/service/mediapackage/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mediapackage" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "MediaPackage" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaPackage" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaPackage client with a session.

--- a/service/mediapackagevod/service.go
+++ b/service/mediapackagevod/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "MediaPackage Vod" // Name of service.
 	EndpointsID = "mediapackage-vod" // ID to lookup a service endpoint with.
-	ServiceID   = "MediaPackage Vod" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaPackage Vod" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaPackageVod client with a session.

--- a/service/mediastore/service.go
+++ b/service/mediastore/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mediastore" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "MediaStore" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaStore" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaStore client with a session.

--- a/service/mediastoredata/service.go
+++ b/service/mediastoredata/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "data.mediastore" // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "MediaStore Data" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaStore Data" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaStoreData client with a session.

--- a/service/mediatailor/service.go
+++ b/service/mediatailor/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "api.mediatailor" // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "MediaTailor"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MediaTailor"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MediaTailor client with a session.

--- a/service/migrationhub/service.go
+++ b/service/migrationhub/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mgh"           // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "Migration Hub" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Migration Hub" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MigrationHub client with a session.

--- a/service/migrationhubconfig/service.go
+++ b/service/migrationhubconfig/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "MigrationHub Config" // Name of service.
 	EndpointsID = "migrationhub-config" // ID to lookup a service endpoint with.
-	ServiceID   = "MigrationHub Config" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MigrationHub Config" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MigrationHubConfig client with a session.

--- a/service/mobile/service.go
+++ b/service/mobile/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mobile"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Mobile"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Mobile"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Mobile client with a session.

--- a/service/mobileanalytics/service.go
+++ b/service/mobileanalytics/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mobileanalytics"  // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "Mobile Analytics" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Mobile Analytics" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MobileAnalytics client with a session.

--- a/service/mq/service.go
+++ b/service/mq/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mq"        // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "mq"        // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "mq"        // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MQ client with a session.

--- a/service/mturk/service.go
+++ b/service/mturk/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "mturk-requester" // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "MTurk"           // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "MTurk"           // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the MTurk client with a session.

--- a/service/neptune/service.go
+++ b/service/neptune/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "rds"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Neptune"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Neptune"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Neptune client with a session.

--- a/service/networkmanager/service.go
+++ b/service/networkmanager/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "NetworkManager" // Name of service.
 	EndpointsID = "networkmanager" // ID to lookup a service endpoint with.
-	ServiceID   = "NetworkManager" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "NetworkManager" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the NetworkManager client with a session.

--- a/service/opsworks/service.go
+++ b/service/opsworks/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "opsworks"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "OpsWorks"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "OpsWorks"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the OpsWorks client with a session.

--- a/service/opsworkscm/service.go
+++ b/service/opsworkscm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "opsworks-cm" // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "OpsWorksCM"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "OpsWorksCM"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the OpsWorksCM client with a session.

--- a/service/organizations/service.go
+++ b/service/organizations/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "organizations" // Name of service.
 	EndpointsID = ServiceName     // ID to lookup a service endpoint with.
-	ServiceID   = "Organizations" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Organizations" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Organizations client with a session.

--- a/service/outposts/service.go
+++ b/service/outposts/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Outposts" // Name of service.
 	EndpointsID = "outposts" // ID to lookup a service endpoint with.
-	ServiceID   = "Outposts" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Outposts" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Outposts client with a session.

--- a/service/personalize/service.go
+++ b/service/personalize/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Personalize" // Name of service.
 	EndpointsID = "personalize" // ID to lookup a service endpoint with.
-	ServiceID   = "Personalize" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Personalize" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Personalize client with a session.

--- a/service/personalizeevents/service.go
+++ b/service/personalizeevents/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Personalize Events" // Name of service.
 	EndpointsID = "personalize-events" // ID to lookup a service endpoint with.
-	ServiceID   = "Personalize Events" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Personalize Events" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the PersonalizeEvents client with a session.

--- a/service/personalizeruntime/service.go
+++ b/service/personalizeruntime/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Personalize Runtime" // Name of service.
 	EndpointsID = "personalize-runtime" // ID to lookup a service endpoint with.
-	ServiceID   = "Personalize Runtime" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Personalize Runtime" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the PersonalizeRuntime client with a session.

--- a/service/pi/service.go
+++ b/service/pi/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "pi"        // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "PI"        // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "PI"        // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the PI client with a session.

--- a/service/pinpoint/service.go
+++ b/service/pinpoint/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "pinpoint"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Pinpoint"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Pinpoint"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Pinpoint client with a session.

--- a/service/pinpointemail/service.go
+++ b/service/pinpointemail/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Pinpoint Email" // Name of service.
 	EndpointsID = "email"          // ID to lookup a service endpoint with.
-	ServiceID   = "Pinpoint Email" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Pinpoint Email" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the PinpointEmail client with a session.

--- a/service/pinpointsmsvoice/service.go
+++ b/service/pinpointsmsvoice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Pinpoint SMS Voice" // Name of service.
 	EndpointsID = "sms-voice.pinpoint" // ID to lookup a service endpoint with.
-	ServiceID   = "Pinpoint SMS Voice" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Pinpoint SMS Voice" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the PinpointSMSVoice client with a session.

--- a/service/polly/service.go
+++ b/service/polly/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "polly"     // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Polly"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Polly"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Polly client with a session.

--- a/service/pricing/service.go
+++ b/service/pricing/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "api.pricing" // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "Pricing"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Pricing"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Pricing client with a session.

--- a/service/qldb/service.go
+++ b/service/qldb/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "QLDB" // Name of service.
 	EndpointsID = "qldb" // ID to lookup a service endpoint with.
-	ServiceID   = "QLDB" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "QLDB" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the QLDB client with a session.

--- a/service/qldbsession/service.go
+++ b/service/qldbsession/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "QLDB Session" // Name of service.
 	EndpointsID = "session.qldb" // ID to lookup a service endpoint with.
-	ServiceID   = "QLDB Session" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "QLDB Session" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the QLDBSession client with a session.

--- a/service/quicksight/service.go
+++ b/service/quicksight/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "QuickSight" // Name of service.
 	EndpointsID = "quicksight" // ID to lookup a service endpoint with.
-	ServiceID   = "QuickSight" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "QuickSight" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the QuickSight client with a session.

--- a/service/ram/service.go
+++ b/service/ram/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RAM" // Name of service.
 	EndpointsID = "ram" // ID to lookup a service endpoint with.
-	ServiceID   = "RAM" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RAM" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RAM client with a session.

--- a/service/rds/service.go
+++ b/service/rds/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "rds"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "RDS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RDS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RDS client with a session.

--- a/service/rdsdataservice/service.go
+++ b/service/rdsdataservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RDS Data" // Name of service.
 	EndpointsID = "rds-data" // ID to lookup a service endpoint with.
-	ServiceID   = "RDS Data" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RDS Data" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RDSDataService client with a session.

--- a/service/redshift/service.go
+++ b/service/redshift/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "redshift"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Redshift"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Redshift"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Redshift client with a session.

--- a/service/rekognition/service.go
+++ b/service/rekognition/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "rekognition" // Name of service.
 	EndpointsID = ServiceName   // ID to lookup a service endpoint with.
-	ServiceID   = "Rekognition" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Rekognition" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Rekognition client with a session.

--- a/service/resourcegroups/service.go
+++ b/service/resourcegroups/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "resource-groups" // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "Resource Groups" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Resource Groups" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ResourceGroups client with a session.

--- a/service/resourcegroupstaggingapi/service.go
+++ b/service/resourcegroupstaggingapi/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "tagging"                     // Name of service.
 	EndpointsID = ServiceName                   // ID to lookup a service endpoint with.
-	ServiceID   = "Resource Groups Tagging API" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Resource Groups Tagging API" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ResourceGroupsTaggingAPI client with a session.

--- a/service/robomaker/service.go
+++ b/service/robomaker/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "RoboMaker" // Name of service.
 	EndpointsID = "robomaker" // ID to lookup a service endpoint with.
-	ServiceID   = "RoboMaker" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "RoboMaker" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the RoboMaker client with a session.

--- a/service/route53/service.go
+++ b/service/route53/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "route53"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Route 53"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Route 53"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Route53 client with a session.

--- a/service/route53domains/service.go
+++ b/service/route53domains/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "route53domains"   // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "Route 53 Domains" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Route 53 Domains" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Route53Domains client with a session.

--- a/service/route53resolver/service.go
+++ b/service/route53resolver/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Route53Resolver" // Name of service.
 	EndpointsID = "route53resolver" // ID to lookup a service endpoint with.
-	ServiceID   = "Route53Resolver" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Route53Resolver" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Route53Resolver client with a session.

--- a/service/s3/service.go
+++ b/service/s3/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "s3"        // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "S3"        // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "S3"        // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the S3 client with a session.

--- a/service/s3control/service.go
+++ b/service/s3control/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "S3 Control" // Name of service.
 	EndpointsID = "s3-control" // ID to lookup a service endpoint with.
-	ServiceID   = "S3 Control" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "S3 Control" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the S3Control client with a session.

--- a/service/sagemaker/service.go
+++ b/service/sagemaker/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sagemaker"     // Name of service.
 	EndpointsID = "api.sagemaker" // ID to lookup a service endpoint with.
-	ServiceID   = "SageMaker"     // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SageMaker"     // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SageMaker client with a session.

--- a/service/sagemakerruntime/service.go
+++ b/service/sagemakerruntime/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "runtime.sagemaker" // Name of service.
 	EndpointsID = ServiceName         // ID to lookup a service endpoint with.
-	ServiceID   = "SageMaker Runtime" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SageMaker Runtime" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SageMakerRuntime client with a session.

--- a/service/savingsplans/service.go
+++ b/service/savingsplans/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "savingsplans" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "savingsplans" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "savingsplans" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SavingsPlans client with a session.

--- a/service/schemas/service.go
+++ b/service/schemas/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "schemas"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "schemas"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "schemas"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Schemas client with a session.

--- a/service/secretsmanager/service.go
+++ b/service/secretsmanager/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "secretsmanager"  // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "Secrets Manager" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Secrets Manager" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SecretsManager client with a session.

--- a/service/securityhub/service.go
+++ b/service/securityhub/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "SecurityHub" // Name of service.
 	EndpointsID = "securityhub" // ID to lookup a service endpoint with.
-	ServiceID   = "SecurityHub" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SecurityHub" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SecurityHub client with a session.

--- a/service/serverlessapplicationrepository/service.go
+++ b/service/serverlessapplicationrepository/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "serverlessrepo"                  // Name of service.
 	EndpointsID = ServiceName                       // ID to lookup a service endpoint with.
-	ServiceID   = "ServerlessApplicationRepository" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ServerlessApplicationRepository" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ServerlessApplicationRepository client with a session.

--- a/service/servicecatalog/service.go
+++ b/service/servicecatalog/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "servicecatalog"  // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "Service Catalog" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Service Catalog" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ServiceCatalog client with a session.

--- a/service/servicediscovery/service.go
+++ b/service/servicediscovery/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "servicediscovery" // Name of service.
 	EndpointsID = ServiceName        // ID to lookup a service endpoint with.
-	ServiceID   = "ServiceDiscovery" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "ServiceDiscovery" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ServiceDiscovery client with a session.

--- a/service/servicequotas/service.go
+++ b/service/servicequotas/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Service Quotas" // Name of service.
 	EndpointsID = "servicequotas"  // ID to lookup a service endpoint with.
-	ServiceID   = "Service Quotas" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Service Quotas" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the ServiceQuotas client with a session.

--- a/service/ses/service.go
+++ b/service/ses/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "email"     // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SES"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SES"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SES client with a session.

--- a/service/sesv2/service.go
+++ b/service/sesv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "SESv2" // Name of service.
 	EndpointsID = "email" // ID to lookup a service endpoint with.
-	ServiceID   = "SESv2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SESv2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SESV2 client with a session.

--- a/service/sfn/service.go
+++ b/service/sfn/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "states"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SFN"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SFN"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SFN client with a session.

--- a/service/shield/service.go
+++ b/service/shield/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "shield"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Shield"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Shield"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Shield client with a session.

--- a/service/signer/service.go
+++ b/service/signer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "signer"    // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "signer"    // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "signer"    // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Signer client with a session.

--- a/service/simpledb/service.go
+++ b/service/simpledb/service.go
@@ -32,7 +32,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sdb"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SimpleDB"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SimpleDB"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SimpleDB client with a session.

--- a/service/sms/service.go
+++ b/service/sms/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sms"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SMS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SMS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SMS client with a session.

--- a/service/snowball/service.go
+++ b/service/snowball/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "snowball"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Snowball"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Snowball"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Snowball client with a session.

--- a/service/sns/service.go
+++ b/service/sns/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sns"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SNS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SNS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SNS client with a session.

--- a/service/sqs/service.go
+++ b/service/sqs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sqs"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SQS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SQS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SQS client with a session.

--- a/service/ssm/service.go
+++ b/service/ssm/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "ssm"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SSM"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SSM"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SSM client with a session.

--- a/service/sso/service.go
+++ b/service/sso/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "SSO"        // Name of service.
 	EndpointsID = "portal.sso" // ID to lookup a service endpoint with.
-	ServiceID   = "SSO"        // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SSO"        // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SSO client with a session.

--- a/service/ssooidc/service.go
+++ b/service/ssooidc/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "SSO OIDC" // Name of service.
 	EndpointsID = "oidc"     // ID to lookup a service endpoint with.
-	ServiceID   = "SSO OIDC" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SSO OIDC" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SSOOIDC client with a session.

--- a/service/storagegateway/service.go
+++ b/service/storagegateway/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "storagegateway"  // Name of service.
 	EndpointsID = ServiceName       // ID to lookup a service endpoint with.
-	ServiceID   = "Storage Gateway" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Storage Gateway" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the StorageGateway client with a session.

--- a/service/sts/service.go
+++ b/service/sts/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "sts"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "STS"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "STS"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the STS client with a session.

--- a/service/support/service.go
+++ b/service/support/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "support"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Support"   // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Support"   // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Support client with a session.

--- a/service/swf/service.go
+++ b/service/swf/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "swf"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SWF"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "SWF"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the SWF client with a session.

--- a/service/textract/service.go
+++ b/service/textract/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Textract" // Name of service.
 	EndpointsID = "textract" // ID to lookup a service endpoint with.
-	ServiceID   = "Textract" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Textract" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Textract client with a session.

--- a/service/transcribeservice/service.go
+++ b/service/transcribeservice/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "transcribe" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "Transcribe" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Transcribe" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the TranscribeService client with a session.

--- a/service/transfer/service.go
+++ b/service/transfer/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "Transfer" // Name of service.
 	EndpointsID = "transfer" // ID to lookup a service endpoint with.
-	ServiceID   = "Transfer" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Transfer" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Transfer client with a session.

--- a/service/translate/service.go
+++ b/service/translate/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "translate" // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Translate" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Translate" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Translate client with a session.

--- a/service/waf/service.go
+++ b/service/waf/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "waf"       // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "WAF"       // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WAF"       // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WAF client with a session.

--- a/service/wafregional/service.go
+++ b/service/wafregional/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "waf-regional" // Name of service.
 	EndpointsID = ServiceName    // ID to lookup a service endpoint with.
-	ServiceID   = "WAF Regional" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WAF Regional" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WAFRegional client with a session.

--- a/service/wafv2/service.go
+++ b/service/wafv2/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "WAFV2" // Name of service.
 	EndpointsID = "wafv2" // ID to lookup a service endpoint with.
-	ServiceID   = "WAFV2" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WAFV2" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WAFV2 client with a session.

--- a/service/workdocs/service.go
+++ b/service/workdocs/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "workdocs"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "WorkDocs"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WorkDocs"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WorkDocs client with a session.

--- a/service/worklink/service.go
+++ b/service/worklink/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "WorkLink" // Name of service.
 	EndpointsID = "worklink" // ID to lookup a service endpoint with.
-	ServiceID   = "WorkLink" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WorkLink" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WorkLink client with a session.

--- a/service/workmail/service.go
+++ b/service/workmail/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "workmail"  // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "WorkMail"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WorkMail"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WorkMail client with a session.

--- a/service/workmailmessageflow/service.go
+++ b/service/workmailmessageflow/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "WorkMailMessageFlow" // Name of service.
 	EndpointsID = "workmailmessageflow" // ID to lookup a service endpoint with.
-	ServiceID   = "WorkMailMessageFlow" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WorkMailMessageFlow" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WorkMailMessageFlow client with a session.

--- a/service/workspaces/service.go
+++ b/service/workspaces/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "workspaces" // Name of service.
 	EndpointsID = ServiceName  // ID to lookup a service endpoint with.
-	ServiceID   = "WorkSpaces" // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "WorkSpaces" // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the WorkSpaces client with a session.

--- a/service/xray/service.go
+++ b/service/xray/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "xray"      // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "XRay"      // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "XRay"      // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the XRay client with a session.


### PR DESCRIPTION
Fixes spelling typo in service API's documentation.