### PR TITLE
private/model: removes customization for application-autoscaling endpoint prefix

### DIFF
--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -383,24 +383,13 @@ func (a *API) removeUnusedShapes() {
 	}
 }
 
-// Represents the service package name to EndpointsID mapping
-var custEndpointsKey = map[string]string{
-	"applicationautoscaling": "application-autoscaling",
-}
-
-// Sents the EndpointsID field of Metadata  with the value of the
-// EndpointPrefix if EndpointsID is not set. Also adds
-// customizations for services if EndpointPrefix is not a valid key.
+// Sets the EndpointsID field of Metadata  with the value of the
+// EndpointPrefix if EndpointsID is not set.
 func (a *API) setMetadataEndpointsKey() {
 	if len(a.Metadata.EndpointsID) != 0 {
 		return
 	}
-
-	if v, ok := custEndpointsKey[a.PackageName()]; ok {
-		a.Metadata.EndpointsID = v
-	} else {
-		a.Metadata.EndpointsID = a.Metadata.EndpointPrefix
-	}
+	a.Metadata.EndpointsID = a.Metadata.EndpointPrefix
 }
 
 func (a *API) findEndpointDiscoveryOp() {
@@ -411,6 +400,7 @@ func (a *API) findEndpointDiscoveryOp() {
 		}
 	}
 }
+
 func (a *API) injectUnboundedOutputStreaming() {
 	for _, op := range a.Operations {
 		if op.AuthType != V4UnsignedBodyAuthType {


### PR DESCRIPTION
SDK has a customization for correcting incorrectly modeled endpoint prefix for `Application Auto-Scaling` service. The service has corrected the endpoint prefix in [Release v1.25.42](https://github.com/aws/aws-sdk-go/compare/v1.25.40...v1.25.41#diff-1f6436c45fb6acc4d0b4e66a583fb1f5R5). This PR removes the no longer needed customization.