### PR TITLE
service/s3: Add support for Access Point resources

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `service/s3`: Add support for Access Point resources
+  * Adds support for using Access Point resource with Amazon S3 API operation calls. The Access Point resource are identified by an Amazon Resource Name (ARN).
+  * To make operation calls to an S3 Access Point instead of a S3 Bucket, provide the Access Point ARN string as the value of the Bucket parameter. You can create an Access Point for your bucket with the Amazon S3 Control API. The Access Point ARN can be obtained from the S3 Control API. You should avoid building the ARN directly.
 
 ### SDK Bugs

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ sandbox-test-go1.6: sandbox-build-go1.6
 
 sandbox-build-go1.7:
 	docker build -f ./awstesting/sandbox/Dockerfile.test.go1.7 -t "aws-sdk-go-1.7" .
-sandbox-go1.7: sandbox-build-go17
+sandbox-go1.7: sandbox-build-go1.7
 	docker run -i -t aws-sdk-go-1.7 bash
-sandbox-test-go1.7: sandbox-build-go17
+sandbox-test-go1.7: sandbox-build-go1.7
 	docker run -t aws-sdk-go-1.7
 
 sandbox-build-go1.8:

--- a/aws/arn/arn.go
+++ b/aws/arn/arn.go
@@ -75,6 +75,12 @@ func Parse(arn string) (ARN, error) {
 	}, nil
 }
 
+// IsARN returns whether the given string is an arn
+// by looking for whether the string starts with arn:
+func IsARN(arn string) bool {
+	return strings.HasPrefix(arn, arnPrefix) && strings.Count(arn, ":") > arnSections-1
+}
+
 // String returns the canonical representation of the ARN
 func (arn ARN) String() string {
 	return arnPrefix +

--- a/aws/config.go
+++ b/aws/config.go
@@ -161,6 +161,10 @@ type Config struct {
 	// on GetObject API calls.
 	S3DisableContentMD5Validation *bool
 
+	// Set this to `true` to have the S3 service client to use the region specified
+	// in the ARN, when an ARN is provided as an argument to a bucket parameter.
+	S3UseARNRegion *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the
 	// EC2Metadata client to create a new http.Client. This options is only
@@ -385,6 +389,13 @@ func (c *Config) WithS3DisableContentMD5Validation(enable bool) *Config {
 
 }
 
+// WithS3UseARNRegion sets a config S3UseARNRegion value and
+// returning a Config pointer for chaining
+func (c *Config) WithS3UseARNRegion(enable bool) *Config {
+	c.S3UseARNRegion = &enable
+	return c
+}
+
 // WithUseDualStack sets a config UseDualStack value returning a Config
 // pointer for chaining.
 func (c *Config) WithUseDualStack(enable bool) *Config {
@@ -511,6 +522,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.S3DisableContentMD5Validation != nil {
 		dst.S3DisableContentMD5Validation = other.S3DisableContentMD5Validation
+	}
+
+	if other.S3UseARNRegion != nil {
+		dst.S3UseARNRegion = other.S3UseARNRegion
 	}
 
 	if other.UseDualStack != nil {

--- a/aws/session/env_config_test.go
+++ b/aws/session/env_config_test.go
@@ -292,6 +292,16 @@ func TestLoadEnvConfig(t *testing.T) {
 				SharedConfigFile:          shareddefaults.SharedConfigFilename(),
 			},
 		},
+		{
+			Env: map[string]string{
+				"AWS_S3_USE_ARN_REGION": "true",
+			},
+			Config: envConfig{
+				S3UseARNRegion:        true,
+				SharedCredentialsFile: shareddefaults.SharedCredentialsFilename(),
+				SharedConfigFile:      shareddefaults.SharedConfigFilename(),
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -580,6 +580,14 @@ func mergeConfigSrcs(cfg, userCfg *aws.Config,
 		cfg.Credentials = creds
 	}
 
+	cfg.S3UseARNRegion = userCfg.S3UseARNRegion
+	if cfg.S3UseARNRegion == nil {
+		cfg.S3UseARNRegion = &envCfg.S3UseARNRegion
+	}
+	if cfg.S3UseARNRegion == nil {
+		cfg.S3UseARNRegion = &sharedCfg.S3UseARNRegion
+	}
+
 	return nil
 }
 
@@ -643,6 +651,7 @@ func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Confi
 	return client.Config{
 		Config:             s.Config,
 		Handlers:           s.Handlers,
+		PartitionID:        resolved.PartitionID,
 		Endpoint:           resolved.URL,
 		SigningRegion:      resolved.SigningRegion,
 		SigningNameDerived: resolved.SigningNameDerived,

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -51,6 +51,9 @@ const (
 	// loading configuration from the config files if another profile name
 	// is not provided.
 	DefaultSharedConfigProfile = `default`
+
+	// S3 ARN Region Usage
+	s3UseARNRegionKey = "s3_use_arn_region"
 )
 
 // sharedConfig represents the configuration fields of the SDK config files.
@@ -89,6 +92,7 @@ type sharedConfig struct {
 	//
 	//	endpoint_discovery_enabled = true
 	EnableEndpointDiscovery *bool
+
 	// CSM Options
 	CSMEnabled  *bool
 	CSMHost     string
@@ -106,6 +110,12 @@ type sharedConfig struct {
 	// s3_us_east_1_regional_endpoint = regional
 	// This can take value as `LegacyS3UsEast1Endpoint` or `RegionalS3UsEast1Endpoint`
 	S3UsEast1RegionalEndpoint endpoints.S3UsEast1RegionalEndpoint
+
+	// Specifies if the S3 service should allow ARNs to direct the region
+	// the client's requests are sent to.
+	//
+	// s3_use_arn_region=true
+	S3UseARNRegion bool
 }
 
 type sharedConfigFile struct {
@@ -306,6 +316,8 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 	updateString(&cfg.CSMPort, section, csmPortKey)
 	updateString(&cfg.CSMClientID, section, csmClientIDKey)
 
+	updateBool(&cfg.S3UseARNRegion, section, s3UseARNRegionKey)
+
 	return nil
 }
 
@@ -396,6 +408,15 @@ func updateString(dst *string, section ini.Section, key string) {
 		return
 	}
 	*dst = section.String(key)
+}
+
+// updateBool will only update the dst with the value in the section key, key
+// is present in the section.
+func updateBool(dst *bool, section ini.Section, key string) {
+	if !section.Has(key) {
+		return
+	}
+	*dst = section.Bool(key)
 }
 
 // updateBoolPtr will only update the dst with the value in the section key,

--- a/aws/session/shared_config_test.go
+++ b/aws/session/shared_config_test.go
@@ -303,6 +303,12 @@ func TestLoadSharedConfigFromFile(t *testing.T) {
 			Profile: "does_not_exists",
 			Err:     SharedConfigProfileNotExistsError{Profile: "does_not_exists"},
 		},
+		{
+			Profile: "valid_arn_region",
+			Expected: sharedConfig{
+				S3UseARNRegion: true,
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -85,3 +85,6 @@ sts_regional_endpoints = regional
 
 [with_s3_us_east_1_regional]
 s3_us_east_1_regional_endpoint = regional
+
+[valid_arn_region]
+s3_use_arn_region=true

--- a/awstesting/integration/integration.go
+++ b/awstesting/integration/integration.go
@@ -16,7 +16,9 @@ import (
 )
 
 // Session is a shared session for all integration tests to use.
-var Session = session.Must(session.NewSession())
+var Session = session.Must(session.NewSession(&aws.Config{
+	CredentialsChainVerboseErrors: aws.Bool(true),
+}))
 
 func init() {
 	logLevel := Session.Config.LogLevel

--- a/example/service/s3/usingAccessPoints/README.md
+++ b/example/service/s3/usingAccessPoints/README.md
@@ -1,0 +1,12 @@
+# Example
+
+This example demonstrates how you can use the AWS SDK for Go's Amazon S3 client
+to create and use S3 Access Points resources for working with to S3 buckets.
+
+# Usage
+
+The example will create a bucket of the name provided in code. Replace the value of the `accountID` const with the account ID for your AWS account. The `bucket`, `keyName`, and `accessPoint` const variables need to be updated to match the name of the Bucket, Object Key, and Access Point that will be created by the example.
+
+```sh
+AWS_REGION=<region> go run -tags example usingAccessPoints.go
+```

--- a/example/service/s3/usingAccessPoints/usingAccessPoints.go
+++ b/example/service/s3/usingAccessPoints/usingAccessPoints.go
@@ -1,0 +1,81 @@
+// +build example
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3control"
+)
+
+const (
+	bucketName  = "myBucketName"
+	keyName     = "myKeyName"
+	accountID   = "123456789012"
+	accessPoint = "accesspointname"
+)
+
+func main() {
+	sess := session.Must(session.NewSession())
+
+	s3Svc := s3.New(sess)
+	s3ControlSvc := s3control.New(sess)
+
+	// Create an S3 Bucket
+	fmt.Println("create s3 bucket")
+	_, err := s3Svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to create bucket: %v", err))
+	}
+
+	// Wait for S3 Bucket to Exist
+	fmt.Println("wait for s3 bucket to exist")
+	err = s3Svc.WaitUntilBucketExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("bucket failed to materialize: %v", err))
+	}
+
+	// Create an Access Point referring to the bucket
+	fmt.Println("create an access point")
+	_, err = s3ControlSvc.CreateAccessPoint(&s3control.CreateAccessPointInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucketName),
+		Name:      aws.String(accessPoint),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create access point: %v", err))
+	}
+
+	// Use the SDK's ARN builder to create an ARN for the Access Point.
+	apARN := arn.ARN{
+		Partition: "aws",
+		Service:   "s3",
+		Region:    aws.StringValue(sess.Config.Region),
+		AccountID: accountID,
+		Resource:  "accesspoint/" + accessPoint,
+	}
+
+	// And Use Access Point ARN where bucket parameters are accepted
+	fmt.Println("get object using access point")
+	getObjectOutput, err := s3Svc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(apARN.String()),
+		Key:    aws.String("somekey"),
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed get object request: %v", err))
+	}
+
+	_, err = ioutil.ReadAll(getObjectOutput.Body)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read object body: %v", err))
+	}
+}

--- a/models/apis/s3control/2018-08-20/api-2.json
+++ b/models/apis/s3control/2018-08-20/api-2.json
@@ -11,6 +11,18 @@
     "uid":"s3control-2018-08-20"
   },
   "operations":{
+    "CreateAccessPoint":{
+      "name":"CreateAccessPoint",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/v20180820/accesspoint/{name}"
+      },
+      "input":{
+        "shape":"CreateAccessPointRequest",
+        "locationName":"CreateAccessPointRequest",
+        "xmlNamespace":{"uri":"http://awss3control.amazonaws.com/doc/2018-08-20/"}
+      }
+    },
     "CreateJob":{
       "name":"CreateJob",
       "http":{
@@ -29,6 +41,22 @@
         {"shape":"IdempotencyException"},
         {"shape":"InternalServiceException"}
       ]
+    },
+    "DeleteAccessPoint":{
+      "name":"DeleteAccessPoint",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/v20180820/accesspoint/{name}"
+      },
+      "input":{"shape":"DeleteAccessPointRequest"}
+    },
+    "DeleteAccessPointPolicy":{
+      "name":"DeleteAccessPointPolicy",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/v20180820/accesspoint/{name}/policy"
+      },
+      "input":{"shape":"DeleteAccessPointPolicyRequest"}
     },
     "DeletePublicAccessBlock":{
       "name":"DeletePublicAccessBlock",
@@ -53,6 +81,33 @@
         {"shape":"InternalServiceException"}
       ]
     },
+    "GetAccessPoint":{
+      "name":"GetAccessPoint",
+      "http":{
+        "method":"GET",
+        "requestUri":"/v20180820/accesspoint/{name}"
+      },
+      "input":{"shape":"GetAccessPointRequest"},
+      "output":{"shape":"GetAccessPointResult"}
+    },
+    "GetAccessPointPolicy":{
+      "name":"GetAccessPointPolicy",
+      "http":{
+        "method":"GET",
+        "requestUri":"/v20180820/accesspoint/{name}/policy"
+      },
+      "input":{"shape":"GetAccessPointPolicyRequest"},
+      "output":{"shape":"GetAccessPointPolicyResult"}
+    },
+    "GetAccessPointPolicyStatus":{
+      "name":"GetAccessPointPolicyStatus",
+      "http":{
+        "method":"GET",
+        "requestUri":"/v20180820/accesspoint/{name}/policyStatus"
+      },
+      "input":{"shape":"GetAccessPointPolicyStatusRequest"},
+      "output":{"shape":"GetAccessPointPolicyStatusResult"}
+    },
     "GetPublicAccessBlock":{
       "name":"GetPublicAccessBlock",
       "http":{
@@ -64,6 +119,15 @@
       "errors":[
         {"shape":"NoSuchPublicAccessBlockConfiguration"}
       ]
+    },
+    "ListAccessPoints":{
+      "name":"ListAccessPoints",
+      "http":{
+        "method":"GET",
+        "requestUri":"/v20180820/accesspoint"
+      },
+      "input":{"shape":"ListAccessPointsRequest"},
+      "output":{"shape":"ListAccessPointsResult"}
     },
     "ListJobs":{
       "name":"ListJobs",
@@ -78,6 +142,18 @@
         {"shape":"InternalServiceException"},
         {"shape":"InvalidNextTokenException"}
       ]
+    },
+    "PutAccessPointPolicy":{
+      "name":"PutAccessPointPolicy",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/v20180820/accesspoint/{name}/policy"
+      },
+      "input":{
+        "shape":"PutAccessPointPolicyRequest",
+        "locationName":"PutAccessPointPolicyRequest",
+        "xmlNamespace":{"uri":"http://awss3control.amazonaws.com/doc/2018-08-20/"}
+      }
     },
     "PutPublicAccessBlock":{
       "name":"PutPublicAccessBlock",
@@ -120,6 +196,32 @@
     }
   },
   "shapes":{
+    "AccessPoint":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "NetworkOrigin",
+        "Bucket"
+      ],
+      "members":{
+        "Name":{"shape":"AccessPointName"},
+        "NetworkOrigin":{"shape":"NetworkOrigin"},
+        "VpcConfiguration":{"shape":"VpcConfiguration"},
+        "Bucket":{"shape":"BucketName"}
+      }
+    },
+    "AccessPointList":{
+      "type":"list",
+      "member":{
+        "shape":"AccessPoint",
+        "locationName":"AccessPoint"
+      }
+    },
+    "AccessPointName":{
+      "type":"string",
+      "max":50,
+      "min":3
+    },
     "AccountId":{
       "type":"string",
       "max":64
@@ -132,7 +234,35 @@
       "exception":true
     },
     "Boolean":{"type":"boolean"},
+    "BucketName":{
+      "type":"string",
+      "max":255,
+      "min":3
+    },
     "ConfirmationRequired":{"type":"boolean"},
+    "CreateAccessPointRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name",
+        "Bucket"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        },
+        "Bucket":{"shape":"BucketName"},
+        "VpcConfiguration":{"shape":"VpcConfiguration"},
+        "PublicAccessBlockConfiguration":{"shape":"PublicAccessBlockConfiguration"}
+      }
+    },
     "CreateJobRequest":{
       "type":"structure",
       "required":[
@@ -175,6 +305,45 @@
         "JobId":{"shape":"JobId"}
       }
     },
+    "CreationDate":{"type":"timestamp"},
+    "DeleteAccessPointPolicyRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        }
+      }
+    },
+    "DeleteAccessPointRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        }
+      }
+    },
     "DeletePublicAccessBlockRequest":{
       "type":"structure",
       "required":["AccountId"],
@@ -215,6 +384,86 @@
       "type":"string",
       "max":1024,
       "min":1
+    },
+    "GetAccessPointPolicyRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        }
+      }
+    },
+    "GetAccessPointPolicyResult":{
+      "type":"structure",
+      "members":{
+        "Policy":{"shape":"Policy"}
+      }
+    },
+    "GetAccessPointPolicyStatusRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        }
+      }
+    },
+    "GetAccessPointPolicyStatusResult":{
+      "type":"structure",
+      "members":{
+        "PolicyStatus":{"shape":"PolicyStatus"}
+      }
+    },
+    "GetAccessPointRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        }
+      }
+    },
+    "GetAccessPointResult":{
+      "type":"structure",
+      "members":{
+        "Name":{"shape":"AccessPointName"},
+        "Bucket":{"shape":"BucketName"},
+        "NetworkOrigin":{"shape":"NetworkOrigin"},
+        "VpcConfiguration":{"shape":"VpcConfiguration"},
+        "PublicAccessBlockConfiguration":{"shape":"PublicAccessBlockConfiguration"},
+        "CreationDate":{"shape":"CreationDate"}
+      }
     },
     "GetPublicAccessBlockOutput":{
       "type":"structure",
@@ -268,6 +517,7 @@
       },
       "exception":true
     },
+    "IsPublic":{"type":"boolean"},
     "JobArn":{
       "type":"string",
       "max":1024,
@@ -574,6 +824,39 @@
         "FunctionArn":{"shape":"NonEmptyMaxLength1024String"}
       }
     },
+    "ListAccessPointsRequest":{
+      "type":"structure",
+      "required":["AccountId"],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Bucket":{
+          "shape":"BucketName",
+          "location":"querystring",
+          "locationName":"bucket"
+        },
+        "NextToken":{
+          "shape":"NonEmptyMaxLength1024String",
+          "location":"querystring",
+          "locationName":"nextToken"
+        },
+        "MaxResults":{
+          "shape":"MaxResults",
+          "location":"querystring",
+          "locationName":"maxResults"
+        }
+      }
+    },
+    "ListAccessPointsResult":{
+      "type":"structure",
+      "members":{
+        "AccessPointList":{"shape":"AccessPointList"},
+        "NextToken":{"shape":"NonEmptyMaxLength1024String"}
+      }
+    },
     "ListJobsRequest":{
       "type":"structure",
       "required":["AccountId"],
@@ -616,6 +899,13 @@
       "type":"integer",
       "max":1000,
       "min":1
+    },
+    "NetworkOrigin":{
+      "type":"string",
+      "enum":[
+        "Internet",
+        "VPC"
+      ]
     },
     "NoSuchPublicAccessBlockConfiguration":{
       "type":"structure",
@@ -663,6 +953,16 @@
         "S3InitiateRestoreObject"
       ]
     },
+    "Policy":{"type":"string"},
+    "PolicyStatus":{
+      "type":"structure",
+      "members":{
+        "IsPublic":{
+          "shape":"IsPublic",
+          "locationName":"IsPublic"
+        }
+      }
+    },
     "PublicAccessBlockConfiguration":{
       "type":"structure",
       "members":{
@@ -682,6 +982,27 @@
           "shape":"Setting",
           "locationName":"RestrictPublicBuckets"
         }
+      }
+    },
+    "PutAccessPointPolicyRequest":{
+      "type":"structure",
+      "required":[
+        "AccountId",
+        "Name",
+        "Policy"
+      ],
+      "members":{
+        "AccountId":{
+          "shape":"AccountId",
+          "location":"header",
+          "locationName":"x-amz-account-id"
+        },
+        "Name":{
+          "shape":"AccessPointName",
+          "location":"uri",
+          "locationName":"name"
+        },
+        "Policy":{"shape":"Policy"}
       }
     },
     "PutPublicAccessBlockRequest":{
@@ -1039,6 +1360,18 @@
         "Status":{"shape":"JobStatus"},
         "StatusUpdateReason":{"shape":"JobStatusUpdateReason"}
       }
+    },
+    "VpcConfiguration":{
+      "type":"structure",
+      "required":["VpcId"],
+      "members":{
+        "VpcId":{"shape":"VpcId"}
+      }
+    },
+    "VpcId":{
+      "type":"string",
+      "max":1024,
+      "min":1
     }
   }
 }

--- a/models/apis/s3control/2018-08-20/paginators-1.json
+++ b/models/apis/s3control/2018-08-20/paginators-1.json
@@ -1,5 +1,10 @@
 {
   "pagination": {
+    "ListAccessPoints": {
+      "input_token": "NextToken",
+      "output_token": "NextToken",
+      "limit_key": "MaxResults"
+    },
     "ListJobs": {
       "input_token": "NextToken",
       "output_token": "NextToken",

--- a/private/model/api/api.go
+++ b/private/model/api/api.go
@@ -62,6 +62,8 @@ type API struct {
 	HasEventStream bool `json:"-"`
 
 	EndpointDiscoveryOp *Operation
+
+	HasEndpointARN bool `json:"-"`
 }
 
 // A Metadata is the metadata about an API's definition.
@@ -318,6 +320,11 @@ func (a *API) APIGoCode() string {
 	a.AddSDKImport("aws")
 	a.AddSDKImport("aws/awsutil")
 	a.AddSDKImport("aws/request")
+
+	if a.HasEndpointARN {
+		a.AddImport("fmt")
+		a.AddSDKImport("service", a.PackageName(), "internal", "arn")
+	}
 
 	var buf bytes.Buffer
 	err := tplAPI.Execute(&buf, a)

--- a/private/model/api/customization_passes.go
+++ b/private/model/api/customization_passes.go
@@ -43,8 +43,8 @@ func (a *API) setServiceAliaseName() {
 }
 
 // customizationPasses Executes customization logic for the API by package name.
-func (a *API) customizationPasses() {
-	var svcCustomizations = map[string]func(*API){
+func (a *API) customizationPasses() error {
+	var svcCustomizations = map[string]func(*API) error{
 		"s3":         s3Customizations,
 		"s3control":  s3ControlCustomizations,
 		"cloudfront": cloudfrontCustomizations,
@@ -78,16 +78,22 @@ func (a *API) customizationPasses() {
 	}
 
 	if fn := svcCustomizations[a.PackageName()]; fn != nil {
-		fn(a)
+		err := fn(a)
+		if err != nil {
+			return fmt.Errorf("service customization pass failure for %s: %v", a.PackageName(), err)
+		}
 	}
+
+	return nil
 }
 
-func supressSmokeTest(a *API) {
+func supressSmokeTest(a *API) error {
 	a.SmokeTests.TestCases = []SmokeTestCase{}
+	return nil
 }
 
 // Customizes the API generation to replace values specific to S3.
-func s3Customizations(a *API) {
+func s3Customizations(a *API) error {
 	var strExpires *Shape
 
 	var keepContentMD5Ref = map[string]struct{}{
@@ -107,6 +113,30 @@ func s3Customizations(a *API) {
 		for _, refName := range []string{"Bucket", "SSECustomerKey", "CopySourceSSECustomerKey"} {
 			if ref, ok := s.MemberRefs[refName]; ok {
 				ref.GenerateGetter = true
+			}
+		}
+
+		// Generate a endpointARN method for the BucketName shape if this is used as an operation input
+		if s.UsedAsInput {
+			if s.ShapeName == "CreateBucketInput" {
+				// For all operations but CreateBucket the BucketName shape
+				// needs to be decorated.
+				continue
+			}
+			var endpointARNShape *ShapeRef
+			for _, ref := range s.MemberRefs {
+				if ref.OrigShapeName != "BucketName" || ref.Shape.Type != "string" {
+					continue
+				}
+				if endpointARNShape != nil {
+					return fmt.Errorf("more then one BucketName shape present on shape")
+				}
+				ref.EndpointARN = true
+				endpointARNShape = ref
+			}
+			if endpointARNShape != nil {
+				s.HasEndpointARNMember = true
+				a.HasEndpointARN = true
 			}
 		}
 
@@ -143,6 +173,8 @@ func s3Customizations(a *API) {
 		}
 	}
 	s3CustRemoveHeadObjectModeledErrors(a)
+
+	return nil
 }
 
 // S3 HeadObject API call incorrect models NoSuchKey as valid
@@ -165,7 +197,7 @@ func s3CustRemoveHeadObjectModeledErrors(a *API) {
 
 // S3 service operations with an AccountId need accessors to be generated for
 // them so the fields can be dynamically accessed without reflection.
-func s3ControlCustomizations(a *API) {
+func s3ControlCustomizations(a *API) error {
 	for opName, op := range a.Operations {
 		// Add moving AccountId into the hostname instead of header.
 		if ref, ok := op.InputRef.Shape.MemberRefs["AccountId"]; ok {
@@ -177,11 +209,13 @@ func s3ControlCustomizations(a *API) {
 			ref.HostLabel = true
 		}
 	}
+
+	return nil
 }
 
 // cloudfrontCustomizations customized the API generation to replace values
 // specific to CloudFront.
-func cloudfrontCustomizations(a *API) {
+func cloudfrontCustomizations(a *API) error {
 	// MaxItems members should always be integers
 	for _, s := range a.Shapes {
 		if ref, ok := s.MemberRefs["MaxItems"]; ok {
@@ -189,10 +223,11 @@ func cloudfrontCustomizations(a *API) {
 			ref.Shape = a.Shapes["Integer"]
 		}
 	}
+	return nil
 }
 
 // mergeServicesCustomizations references any duplicate shapes from DynamoDB
-func mergeServicesCustomizations(a *API) {
+func mergeServicesCustomizations(a *API) error {
 	info := mergeServices[a.PackageName()]
 
 	p := strings.Replace(a.path, info.srcName, info.dstName, -1)
@@ -217,10 +252,12 @@ func mergeServicesCustomizations(a *API) {
 			a.Shapes[n].resolvePkg = SDKImportRoot + "/service/" + info.dstName
 		}
 	}
+
+	return nil
 }
 
 // rdsCustomizations are customization for the service/rds. This adds non-modeled fields used for presigning.
-func rdsCustomizations(a *API) {
+func rdsCustomizations(a *API) error {
 	inputs := []string{
 		"CopyDBSnapshotInput",
 		"CreateDBInstanceReadReplicaInput",
@@ -242,14 +279,17 @@ func rdsCustomizations(a *API) {
 			}
 		}
 	}
+
+	return nil
 }
 
-func disableEndpointResolving(a *API) {
+func disableEndpointResolving(a *API) error {
 	a.Metadata.NoResolveEndpoint = true
+	return nil
 }
 
-func backfillAuthType(typ AuthType, opNames ...string) func(*API) {
-	return func(a *API) {
+func backfillAuthType(typ AuthType, opNames ...string) func(*API) error {
+	return func(a *API) error {
 		for _, opName := range opNames {
 			op, ok := a.Operations[opName]
 			if !ok {
@@ -262,6 +302,8 @@ func backfillAuthType(typ AuthType, opNames ...string) func(*API) {
 
 			op.AuthType = typ
 		}
+
+		return nil
 	}
 }
 

--- a/private/model/api/endpoint_arn.go
+++ b/private/model/api/endpoint_arn.go
@@ -1,0 +1,31 @@
+package api
+
+import "text/template"
+
+const endpointARNShapeTmplDef = `
+{{- define "endpointARNShapeTmpl" }}
+{{ range $_, $name := $.MemberNames -}}
+	{{ $elem := index $.MemberRefs $name -}}
+	{{ if $elem.EndpointARN -}}
+		func (s *{{ $.ShapeName }}) getEndpointARN() (arn.Resource, error) {
+			if s.{{ $name }} == nil {
+				return nil, fmt.Errorf("member {{ $name }} is nil")
+			}
+			return parseEndpointARN(*s.{{ $name }})
+		}
+
+		func (s *{{ $.ShapeName }}) hasEndpointARN() bool {
+			if s.{{ $name }} == nil {
+				return false
+			}
+			return arn.IsARN(*s.{{ $name }})
+		}
+	{{ end -}}
+{{ end }}
+{{ end }}
+`
+
+var endpointARNShapeTmpl = template.Must(
+	template.New("endpointARNShapeTmpl").
+		Parse(endpointARNShapeTmplDef),
+)

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -222,7 +222,9 @@ func (a *API) Setup() error {
 
 	a.findEndpointDiscoveryOp()
 	a.injectUnboundedOutputStreaming()
-	a.customizationPasses()
+	if err := a.customizationPasses(); err != nil {
+		return err
+	}
 
 	if !a.NoRemoveUnusedShapes {
 		a.removeUnusedShapes()

--- a/private/model/api/passes.go
+++ b/private/model/api/passes.go
@@ -319,9 +319,12 @@ func (a *API) createInputOutputShapes() {
 		createAPIParamShape(a, op.Name, &op.InputRef, op.ExportedName+"Input",
 			shamelist.Input,
 		)
+		op.InputRef.Shape.UsedAsInput = true
+
 		createAPIParamShape(a, op.Name, &op.OutputRef, op.ExportedName+"Output",
 			shamelist.Output,
 		)
+		op.OutputRef.Shape.UsedAsOutput = true
 	}
 }
 

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -60,6 +60,9 @@ type ShapeRef struct {
 
 	// Collection of custom tags the shape reference includes.
 	CustomTags ShapeTags
+
+	// Flags whether the member reference is a endpoint ARN
+	EndpointARN bool
 }
 
 // A Shape defines the definition of a shape type
@@ -115,6 +118,15 @@ type Shape struct {
 
 	// Sensitive types should not be logged by SDK type loggers.
 	Sensitive bool `json:"sensitive"`
+
+	// Flags that a member of the shape is an EndpointARN
+	HasEndpointARNMember bool
+
+	// Indicates the Shape is used as an operation input
+	UsedAsInput bool
+
+	// Indicates the Shape is used as an operation output
+	UsedAsOutput bool
 }
 
 // CanBeEmpty returns if the shape value can sent request as an empty value.
@@ -650,6 +662,12 @@ var structShapeTmpl = func() *template.Template {
 			hostLabelsShapeTmpl.Tree),
 	)
 
+	template.Must(
+		shapeTmpl.AddParseTree(
+			"endpointARNShapeTmpl",
+			endpointARNShapeTmpl.Tree),
+	)
+
 	return shapeTmpl
 }()
 
@@ -747,6 +765,10 @@ type {{ .ShapeName }} struct {
 
 {{ if $.HasHostLabelMembers }}
 	{{ template "hostLabelsShapeTmpl" $ }}
+{{ end }}
+
+{{ if $.HasEndpointARNMember }}
+	{{ template "endpointARNShapeTmpl" $ }}
 {{ end }}
 `
 

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi"
 	"github.com/aws/aws-sdk-go/private/protocol/rest"
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
+	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
 )
 
 const opAbortMultipartUpload = "AbortMultipartUpload"
@@ -10051,6 +10052,20 @@ func (s *AbortMultipartUploadInput) SetUploadId(v string) *AbortMultipartUploadI
 	return s
 }
 
+func (s *AbortMultipartUploadInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *AbortMultipartUploadInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type AbortMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11148,6 +11163,20 @@ func (s *CompleteMultipartUploadInput) SetUploadId(v string) *CompleteMultipartU
 	return s
 }
 
+func (s *CompleteMultipartUploadInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *CompleteMultipartUploadInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type CompleteMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -11820,6 +11849,20 @@ func (s *CopyObjectInput) SetWebsiteRedirectLocation(v string) *CopyObjectInput 
 	return s
 }
 
+func (s *CopyObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *CopyObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 
@@ -12488,6 +12531,20 @@ func (s *CreateMultipartUploadInput) SetWebsiteRedirectLocation(v string) *Creat
 	return s
 }
 
+func (s *CreateMultipartUploadInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *CreateMultipartUploadInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type CreateMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -12792,6 +12849,20 @@ func (s *DeleteBucketAnalyticsConfigurationInput) SetId(v string) *DeleteBucketA
 	return s
 }
 
+func (s *DeleteBucketAnalyticsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketAnalyticsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12852,6 +12923,20 @@ func (s *DeleteBucketCorsInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeleteBucketCorsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketCorsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteBucketCorsOutput struct {
@@ -12917,6 +13002,20 @@ func (s *DeleteBucketEncryptionInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *DeleteBucketEncryptionInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketEncryptionInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketEncryptionOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -12977,6 +13076,20 @@ func (s *DeleteBucketInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeleteBucketInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteBucketInventoryConfigurationInput struct {
@@ -13041,6 +13154,20 @@ func (s *DeleteBucketInventoryConfigurationInput) SetId(v string) *DeleteBucketI
 	return s
 }
 
+func (s *DeleteBucketInventoryConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketInventoryConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13101,6 +13228,20 @@ func (s *DeleteBucketLifecycleInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeleteBucketLifecycleInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketLifecycleInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteBucketLifecycleOutput struct {
@@ -13179,6 +13320,20 @@ func (s *DeleteBucketMetricsConfigurationInput) SetId(v string) *DeleteBucketMet
 	return s
 }
 
+func (s *DeleteBucketMetricsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketMetricsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13255,6 +13410,20 @@ func (s *DeleteBucketPolicyInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *DeleteBucketPolicyInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketPolicyInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketPolicyOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13315,6 +13484,20 @@ func (s *DeleteBucketReplicationInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeleteBucketReplicationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketReplicationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteBucketReplicationOutput struct {
@@ -13379,6 +13562,20 @@ func (s *DeleteBucketTaggingInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *DeleteBucketTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteBucketTaggingOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -13439,6 +13636,20 @@ func (s *DeleteBucketWebsiteInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeleteBucketWebsiteInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteBucketWebsiteInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteBucketWebsiteOutput struct {
@@ -13661,6 +13872,20 @@ func (s *DeleteObjectInput) SetVersionId(v string) *DeleteObjectInput {
 	return s
 }
 
+func (s *DeleteObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13777,6 +14002,20 @@ func (s *DeleteObjectTaggingInput) SetKey(v string) *DeleteObjectTaggingInput {
 func (s *DeleteObjectTaggingInput) SetVersionId(v string) *DeleteObjectTaggingInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *DeleteObjectTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteObjectTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeleteObjectTaggingOutput struct {
@@ -13904,6 +14143,20 @@ func (s *DeleteObjectsInput) SetRequestPayer(v string) *DeleteObjectsInput {
 	return s
 }
 
+func (s *DeleteObjectsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeleteObjectsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type DeleteObjectsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -13994,6 +14247,20 @@ func (s *DeletePublicAccessBlockInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *DeletePublicAccessBlockInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *DeletePublicAccessBlockInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type DeletePublicAccessBlockOutput struct {
@@ -14891,6 +15158,20 @@ func (s *GetBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *GetBucketAccelerateConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketAccelerateConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -14960,6 +15241,20 @@ func (s *GetBucketAclInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketAclInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketAclInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketAclOutput struct {
@@ -15056,6 +15351,20 @@ func (s *GetBucketAnalyticsConfigurationInput) SetId(v string) *GetBucketAnalyti
 	return s
 }
 
+func (s *GetBucketAnalyticsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketAnalyticsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
 
@@ -15125,6 +15434,20 @@ func (s *GetBucketCorsInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketCorsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketCorsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketCorsOutput struct {
@@ -15198,6 +15521,20 @@ func (s *GetBucketEncryptionInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketEncryptionInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketEncryptionInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketEncryptionOutput struct {
@@ -15285,6 +15622,20 @@ func (s *GetBucketInventoryConfigurationInput) SetId(v string) *GetBucketInvento
 	return s
 }
 
+func (s *GetBucketInventoryConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketInventoryConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
 
@@ -15354,6 +15705,20 @@ func (s *GetBucketLifecycleConfigurationInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketLifecycleConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketLifecycleConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketLifecycleConfigurationOutput struct {
@@ -15427,6 +15792,20 @@ func (s *GetBucketLifecycleInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *GetBucketLifecycleInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketLifecycleInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketLifecycleOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -15496,6 +15875,20 @@ func (s *GetBucketLocationInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketLocationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketLocationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketLocationOutput struct {
@@ -15568,6 +15961,20 @@ func (s *GetBucketLoggingInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketLoggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketLoggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketLoggingOutput struct {
@@ -15658,6 +16065,20 @@ func (s *GetBucketMetricsConfigurationInput) SetId(v string) *GetBucketMetricsCo
 	return s
 }
 
+func (s *GetBucketMetricsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketMetricsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
 
@@ -15729,6 +16150,20 @@ func (s *GetBucketNotificationConfigurationRequest) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *GetBucketNotificationConfigurationRequest) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketNotificationConfigurationRequest) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketPolicyInput struct {
 	_ struct{} `locationName:"GetBucketPolicyRequest" type:"structure"`
 
@@ -15775,6 +16210,20 @@ func (s *GetBucketPolicyInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketPolicyInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketPolicyInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketPolicyOutput struct {
@@ -15848,6 +16297,20 @@ func (s *GetBucketPolicyStatusInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *GetBucketPolicyStatusInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketPolicyStatusInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketPolicyStatusOutput struct {
 	_ struct{} `type:"structure" payload:"PolicyStatus"`
 
@@ -15917,6 +16380,20 @@ func (s *GetBucketReplicationInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketReplicationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketReplicationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketReplicationOutput struct {
@@ -15991,6 +16468,20 @@ func (s *GetBucketRequestPaymentInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *GetBucketRequestPaymentInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketRequestPaymentInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -16060,6 +16551,20 @@ func (s *GetBucketTaggingInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketTaggingOutput struct {
@@ -16133,6 +16638,20 @@ func (s *GetBucketVersioningInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketVersioningInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketVersioningInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketVersioningOutput struct {
@@ -16215,6 +16734,20 @@ func (s *GetBucketWebsiteInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetBucketWebsiteInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetBucketWebsiteInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetBucketWebsiteOutput struct {
@@ -16352,6 +16885,20 @@ func (s *GetObjectAclInput) SetRequestPayer(v string) *GetObjectAclInput {
 func (s *GetObjectAclInput) SetVersionId(v string) *GetObjectAclInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *GetObjectAclInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectAclInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetObjectAclOutput struct {
@@ -16637,6 +17184,20 @@ func (s *GetObjectInput) SetVersionId(v string) *GetObjectInput {
 	return s
 }
 
+func (s *GetObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetObjectLegalHoldInput struct {
 	_ struct{} `locationName:"GetObjectLegalHoldRequest" type:"structure"`
 
@@ -16723,6 +17284,20 @@ func (s *GetObjectLegalHoldInput) SetVersionId(v string) *GetObjectLegalHoldInpu
 	return s
 }
 
+func (s *GetObjectLegalHoldInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectLegalHoldInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetObjectLegalHoldOutput struct {
 	_ struct{} `type:"structure" payload:"LegalHold"`
 
@@ -16792,6 +17367,20 @@ func (s *GetObjectLockConfigurationInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetObjectLockConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectLockConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetObjectLockConfigurationOutput struct {
@@ -17219,6 +17808,20 @@ func (s *GetObjectRetentionInput) SetVersionId(v string) *GetObjectRetentionInpu
 	return s
 }
 
+func (s *GetObjectRetentionInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectRetentionInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetObjectRetentionOutput struct {
 	_ struct{} `type:"structure" payload:"Retention"`
 
@@ -17314,6 +17917,20 @@ func (s *GetObjectTaggingInput) SetKey(v string) *GetObjectTaggingInput {
 func (s *GetObjectTaggingInput) SetVersionId(v string) *GetObjectTaggingInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *GetObjectTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetObjectTaggingOutput struct {
@@ -17428,6 +18045,20 @@ func (s *GetObjectTorrentInput) SetRequestPayer(v string) *GetObjectTorrentInput
 	return s
 }
 
+func (s *GetObjectTorrentInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetObjectTorrentInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type GetObjectTorrentOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
@@ -17508,6 +18139,20 @@ func (s *GetPublicAccessBlockInput) getBucket() (v string) {
 		return v
 	}
 	return *s.Bucket
+}
+
+func (s *GetPublicAccessBlockInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *GetPublicAccessBlockInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type GetPublicAccessBlockOutput struct {
@@ -17744,6 +18389,20 @@ func (s *HeadBucketInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *HeadBucketInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *HeadBucketInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type HeadBucketOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -17944,6 +18603,20 @@ func (s *HeadObjectInput) SetSSECustomerKeyMD5(v string) *HeadObjectInput {
 func (s *HeadObjectInput) SetVersionId(v string) *HeadObjectInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *HeadObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *HeadObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type HeadObjectOutput struct {
@@ -19369,6 +20042,20 @@ func (s *ListBucketAnalyticsConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+func (s *ListBucketAnalyticsConfigurationsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListBucketAnalyticsConfigurationsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type ListBucketAnalyticsConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -19484,6 +20171,20 @@ func (s *ListBucketInventoryConfigurationsInput) SetContinuationToken(v string) 
 	return s
 }
 
+func (s *ListBucketInventoryConfigurationsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListBucketInventoryConfigurationsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type ListBucketInventoryConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -19597,6 +20298,20 @@ func (s *ListBucketMetricsConfigurationsInput) getBucket() (v string) {
 func (s *ListBucketMetricsConfigurationsInput) SetContinuationToken(v string) *ListBucketMetricsConfigurationsInput {
 	s.ContinuationToken = &v
 	return s
+}
+
+func (s *ListBucketMetricsConfigurationsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListBucketMetricsConfigurationsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type ListBucketMetricsConfigurationsOutput struct {
@@ -19830,6 +20545,20 @@ func (s *ListMultipartUploadsInput) SetPrefix(v string) *ListMultipartUploadsInp
 func (s *ListMultipartUploadsInput) SetUploadIdMarker(v string) *ListMultipartUploadsInput {
 	s.UploadIdMarker = &v
 	return s
+}
+
+func (s *ListMultipartUploadsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListMultipartUploadsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type ListMultipartUploadsOutput struct {
@@ -20097,6 +20826,20 @@ func (s *ListObjectVersionsInput) SetVersionIdMarker(v string) *ListObjectVersio
 	return s
 }
 
+func (s *ListObjectVersionsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListObjectVersionsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type ListObjectVersionsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -20359,6 +21102,20 @@ func (s *ListObjectsInput) SetRequestPayer(v string) *ListObjectsInput {
 	return s
 }
 
+func (s *ListObjectsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListObjectsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type ListObjectsOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -20615,6 +21372,20 @@ func (s *ListObjectsV2Input) SetRequestPayer(v string) *ListObjectsV2Input {
 func (s *ListObjectsV2Input) SetStartAfter(v string) *ListObjectsV2Input {
 	s.StartAfter = &v
 	return s
+}
+
+func (s *ListObjectsV2Input) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListObjectsV2Input) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type ListObjectsV2Output struct {
@@ -20879,6 +21650,20 @@ func (s *ListPartsInput) SetRequestPayer(v string) *ListPartsInput {
 func (s *ListPartsInput) SetUploadId(v string) *ListPartsInput {
 	s.UploadId = &v
 	return s
+}
+
+func (s *ListPartsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *ListPartsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type ListPartsOutput struct {
@@ -22583,6 +23368,20 @@ func (s *PutBucketAccelerateConfigurationInput) getBucket() (v string) {
 	return *s.Bucket
 }
 
+func (s *PutBucketAccelerateConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketAccelerateConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketAccelerateConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -22714,6 +23513,20 @@ func (s *PutBucketAclInput) SetGrantWriteACP(v string) *PutBucketAclInput {
 	return s
 }
 
+func (s *PutBucketAclInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketAclInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketAclOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -22809,6 +23622,20 @@ func (s *PutBucketAnalyticsConfigurationInput) SetId(v string) *PutBucketAnalyti
 	return s
 }
 
+func (s *PutBucketAnalyticsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketAnalyticsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketAnalyticsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -22891,6 +23718,20 @@ func (s *PutBucketCorsInput) getBucket() (v string) {
 func (s *PutBucketCorsInput) SetCORSConfiguration(v *CORSConfiguration) *PutBucketCorsInput {
 	s.CORSConfiguration = v
 	return s
+}
+
+func (s *PutBucketCorsInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketCorsInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketCorsOutput struct {
@@ -22976,6 +23817,20 @@ func (s *PutBucketEncryptionInput) getBucket() (v string) {
 func (s *PutBucketEncryptionInput) SetServerSideEncryptionConfiguration(v *ServerSideEncryptionConfiguration) *PutBucketEncryptionInput {
 	s.ServerSideEncryptionConfiguration = v
 	return s
+}
+
+func (s *PutBucketEncryptionInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketEncryptionInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketEncryptionOutput struct {
@@ -23073,6 +23928,20 @@ func (s *PutBucketInventoryConfigurationInput) SetInventoryConfiguration(v *Inve
 	return s
 }
 
+func (s *PutBucketInventoryConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketInventoryConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketInventoryConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23149,6 +24018,20 @@ func (s *PutBucketLifecycleConfigurationInput) SetLifecycleConfiguration(v *Buck
 	return s
 }
 
+func (s *PutBucketLifecycleConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketLifecycleConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketLifecycleConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23221,6 +24104,20 @@ func (s *PutBucketLifecycleInput) getBucket() (v string) {
 func (s *PutBucketLifecycleInput) SetLifecycleConfiguration(v *LifecycleConfiguration) *PutBucketLifecycleInput {
 	s.LifecycleConfiguration = v
 	return s
+}
+
+func (s *PutBucketLifecycleInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketLifecycleInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketLifecycleOutput struct {
@@ -23302,6 +24199,20 @@ func (s *PutBucketLoggingInput) getBucket() (v string) {
 func (s *PutBucketLoggingInput) SetBucketLoggingStatus(v *BucketLoggingStatus) *PutBucketLoggingInput {
 	s.BucketLoggingStatus = v
 	return s
+}
+
+func (s *PutBucketLoggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketLoggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketLoggingOutput struct {
@@ -23399,6 +24310,20 @@ func (s *PutBucketMetricsConfigurationInput) SetMetricsConfiguration(v *MetricsC
 	return s
 }
 
+func (s *PutBucketMetricsConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketMetricsConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketMetricsConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23481,6 +24406,20 @@ func (s *PutBucketNotificationConfigurationInput) SetNotificationConfiguration(v
 	return s
 }
 
+func (s *PutBucketNotificationConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketNotificationConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketNotificationConfigurationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23555,6 +24494,20 @@ func (s *PutBucketNotificationInput) getBucket() (v string) {
 func (s *PutBucketNotificationInput) SetNotificationConfiguration(v *NotificationConfigurationDeprecated) *PutBucketNotificationInput {
 	s.NotificationConfiguration = v
 	return s
+}
+
+func (s *PutBucketNotificationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketNotificationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketNotificationOutput struct {
@@ -23641,6 +24594,20 @@ func (s *PutBucketPolicyInput) SetConfirmRemoveSelfBucketAccess(v bool) *PutBuck
 func (s *PutBucketPolicyInput) SetPolicy(v string) *PutBucketPolicyInput {
 	s.Policy = &v
 	return s
+}
+
+func (s *PutBucketPolicyInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketPolicyInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketPolicyOutput struct {
@@ -23733,6 +24700,20 @@ func (s *PutBucketReplicationInput) SetToken(v string) *PutBucketReplicationInpu
 	return s
 }
 
+func (s *PutBucketReplicationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketReplicationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketReplicationOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23814,6 +24795,20 @@ func (s *PutBucketRequestPaymentInput) SetRequestPaymentConfiguration(v *Request
 	return s
 }
 
+func (s *PutBucketRequestPaymentInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketRequestPaymentInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketRequestPaymentOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -23893,6 +24888,20 @@ func (s *PutBucketTaggingInput) getBucket() (v string) {
 func (s *PutBucketTaggingInput) SetTagging(v *Tagging) *PutBucketTaggingInput {
 	s.Tagging = v
 	return s
+}
+
+func (s *PutBucketTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketTaggingOutput struct {
@@ -23981,6 +24990,20 @@ func (s *PutBucketVersioningInput) SetVersioningConfiguration(v *VersioningConfi
 	return s
 }
 
+func (s *PutBucketVersioningInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketVersioningInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutBucketVersioningOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -24060,6 +25083,20 @@ func (s *PutBucketWebsiteInput) getBucket() (v string) {
 func (s *PutBucketWebsiteInput) SetWebsiteConfiguration(v *WebsiteConfiguration) *PutBucketWebsiteInput {
 	s.WebsiteConfiguration = v
 	return s
+}
+
+func (s *PutBucketWebsiteInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutBucketWebsiteInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutBucketWebsiteOutput struct {
@@ -24230,6 +25267,20 @@ func (s *PutObjectAclInput) SetRequestPayer(v string) *PutObjectAclInput {
 func (s *PutObjectAclInput) SetVersionId(v string) *PutObjectAclInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *PutObjectAclInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectAclInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutObjectAclOutput struct {
@@ -24635,6 +25686,20 @@ func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
 	return s
 }
 
+func (s *PutObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutObjectLegalHoldInput struct {
 	_ struct{} `locationName:"PutObjectLegalHoldRequest" type:"structure" payload:"LegalHold"`
 
@@ -24729,6 +25794,20 @@ func (s *PutObjectLegalHoldInput) SetRequestPayer(v string) *PutObjectLegalHoldI
 func (s *PutObjectLegalHoldInput) SetVersionId(v string) *PutObjectLegalHoldInput {
 	s.VersionId = &v
 	return s
+}
+
+func (s *PutObjectLegalHoldInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectLegalHoldInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutObjectLegalHoldOutput struct {
@@ -24831,6 +25910,20 @@ func (s *PutObjectLockConfigurationInput) SetRequestPayer(v string) *PutObjectLo
 func (s *PutObjectLockConfigurationInput) SetToken(v string) *PutObjectLockConfigurationInput {
 	s.Token = &v
 	return s
+}
+
+func (s *PutObjectLockConfigurationInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectLockConfigurationInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutObjectLockConfigurationOutput struct {
@@ -25074,6 +26167,20 @@ func (s *PutObjectRetentionInput) SetVersionId(v string) *PutObjectRetentionInpu
 	return s
 }
 
+func (s *PutObjectRetentionInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectRetentionInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutObjectRetentionOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -25191,6 +26298,20 @@ func (s *PutObjectTaggingInput) SetVersionId(v string) *PutObjectTaggingInput {
 	return s
 }
 
+func (s *PutObjectTaggingInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutObjectTaggingInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type PutObjectTaggingOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -25279,6 +26400,20 @@ func (s *PutPublicAccessBlockInput) getBucket() (v string) {
 func (s *PutPublicAccessBlockInput) SetPublicAccessBlockConfiguration(v *PublicAccessBlockConfiguration) *PutPublicAccessBlockInput {
 	s.PublicAccessBlockConfiguration = v
 	return s
+}
+
+func (s *PutPublicAccessBlockInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *PutPublicAccessBlockInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type PutPublicAccessBlockOutput struct {
@@ -26206,6 +27341,20 @@ func (s *RestoreObjectInput) SetVersionId(v string) *RestoreObjectInput {
 	return s
 }
 
+func (s *RestoreObjectInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *RestoreObjectInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type RestoreObjectOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -27033,6 +28182,20 @@ func (s *SelectObjectContentInput) SetSSECustomerKeyMD5(v string) *SelectObjectC
 func (s *SelectObjectContentInput) SetScanRange(v *ScanRange) *SelectObjectContentInput {
 	s.ScanRange = v
 	return s
+}
+
+func (s *SelectObjectContentInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *SelectObjectContentInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type SelectObjectContentOutput struct {
@@ -28156,6 +29319,20 @@ func (s *UploadPartCopyInput) SetUploadId(v string) *UploadPartCopyInput {
 	return s
 }
 
+func (s *UploadPartCopyInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *UploadPartCopyInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
+}
+
 type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
 
@@ -28416,6 +29593,20 @@ func (s *UploadPartInput) SetSSECustomerKeyMD5(v string) *UploadPartInput {
 func (s *UploadPartInput) SetUploadId(v string) *UploadPartInput {
 	s.UploadId = &v
 	return s
+}
+
+func (s *UploadPartInput) getEndpointARN() (arn.Resource, error) {
+	if s.Bucket == nil {
+		return nil, fmt.Errorf("member Bucket is nil")
+	}
+	return parseEndpointARN(*s.Bucket)
+}
+
+func (s *UploadPartInput) hasEndpointARN() bool {
+	if s.Bucket == nil {
+		return false
+	}
+	return arn.IsARN(*s.Bucket)
 }
 
 type UploadPartOutput struct {

--- a/service/s3/cust_integ_endpoint_test.go
+++ b/service/s3/cust_integ_endpoint_test.go
@@ -1,0 +1,22 @@
+// +build integration
+
+package s3_test
+
+import (
+	"testing"
+)
+
+func TestInteg_AccessPoint_WriteToObject(t *testing.T) {
+	testWriteToObject(t, integMetadata.AccessPoints.Source.ARN)
+}
+
+func TestInteg_AccessPoint_PresignedGetPut(t *testing.T) {
+	testPresignedGetPut(t, integMetadata.AccessPoints.Source.ARN)
+}
+
+func TestInteg_AccessPoint_CopyObject(t *testing.T) {
+	t.Skip("API does not support access point")
+	testCopyObject(t,
+		integMetadata.AccessPoints.Source.ARN,
+		integMetadata.AccessPoints.Target.ARN)
+}

--- a/service/s3/cust_integ_eventstream_test.go
+++ b/service/s3/cust_integ_eventstream_test.go
@@ -31,8 +31,8 @@ func TestInteg_SelectObjectContent(t *testing.T) {
 	// selected.
 	putTestContent(t, bytes.NewReader(buf), keyName)
 
-	resp, err := svc.SelectObjectContent(&s3.SelectObjectContentInput{
-		Bucket:         bucketName,
+	resp, err := s3Svc.SelectObjectContent(&s3.SelectObjectContentInput{
+		Bucket:         &integMetadata.Buckets.Source.Name,
 		Key:            &keyName,
 		Expression:     aws.String("Select * from S3Object"),
 		ExpressionType: aws.String(s3.ExpressionTypeSql),
@@ -160,8 +160,8 @@ func TestInteg_SelectObjectContent_Error(t *testing.T) {
 
 	putTestContent(t, bytes.NewReader(buf), keyName)
 
-	resp, err := svc.SelectObjectContent(&s3.SelectObjectContentInput{
-		Bucket:         bucketName,
+	resp, err := s3Svc.SelectObjectContent(&s3.SelectObjectContentInput{
+		Bucket:         &integMetadata.Buckets.Source.Name,
 		Key:            &keyName,
 		Expression:     aws.String("SELECT name FROM S3Object WHERE cast(number as int) < 1"),
 		ExpressionType: aws.String(s3.ExpressionTypeSql),
@@ -219,8 +219,8 @@ gopher,0
 	putTestContent(t, strings.NewReader(buf), keyName)
 
 	// Make the Select Object Content API request using the object uploaded.
-	resp, err := svc.SelectObjectContent(&s3.SelectObjectContentInput{
-		Bucket:         bucketName,
+	resp, err := s3Svc.SelectObjectContent(&s3.SelectObjectContentInput{
+		Bucket:         &integMetadata.Buckets.Source.Name,
 		Key:            &keyName,
 		Expression:     aws.String("SELECT name FROM S3Object WHERE cast(number as int) < 1"),
 		ExpressionType: aws.String(s3.ExpressionTypeSql),

--- a/service/s3/cust_integ_object_checksum_test.go
+++ b/service/s3/cust_integ_object_checksum_test.go
@@ -48,8 +48,8 @@ func SkipTestContentMD5Validate(t *testing.T) {
 
 	for i, c := range cases {
 		keyName := aws.String(c.Name)
-		req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
-			Bucket: bucketName,
+		req, _ := s3Svc.PutObjectRequest(&s3.PutObjectInput{
+			Bucket: &integMetadata.Buckets.Source.Name,
 			Key:    keyName,
 			Body:   bytes.NewReader(c.Body),
 		})
@@ -64,7 +64,7 @@ func SkipTestContentMD5Validate(t *testing.T) {
 		}
 
 		getObjIn := &s3.GetObjectInput{
-			Bucket: bucketName,
+			Bucket: &integMetadata.Buckets.Source.Name,
 			Key:    keyName,
 		}
 
@@ -74,7 +74,7 @@ func SkipTestContentMD5Validate(t *testing.T) {
 			expectBody = c.Body[c.RangeGet[0]:c.RangeGet[1]]
 		}
 
-		getReq, getOut := svc.GetObjectRequest(getObjIn)
+		getReq, getOut := s3Svc.GetObjectRequest(getObjIn)
 
 		getReq.Build()
 		if e, a := "append-md5", getReq.HTTPRequest.Header.Get("X-Amz-Te"); e != a {

--- a/service/s3/cust_integ_shared_test.go
+++ b/service/s3/cust_integ_shared_test.go
@@ -3,63 +3,430 @@
 package s3_test
 
 import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/awstesting/integration"
 	"github.com/aws/aws-sdk-go/awstesting/integration/s3integ"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3control"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 const integBucketPrefix = "aws-sdk-go-integration"
 
-var bucketName *string
-var svc *s3.S3
-
-func TestMain(m *testing.M) {
-	sess := integration.SessionWithDefaultRegion("us-west-2")
-	svc = s3.New(sess)
-	bucketName = aws.String(s3integ.GenerateBucketName())
-	if err := s3integ.SetupTest(svc, *bucketName); err != nil {
-		panic(err)
+var integMetadata = struct {
+	AccountID string
+	Region    string
+	Buckets   struct {
+		Source struct {
+			Name string
+			ARN  string
+		}
+		Target struct {
+			Name string
+			ARN  string
+		}
 	}
 
+	AccessPoints struct {
+		Source struct {
+			Name string
+			ARN  string
+		}
+		Target struct {
+			Name string
+			ARN  string
+		}
+	}
+}{}
+
+var s3Svc *s3.S3
+var s3ControlSvc *s3control.S3Control
+var stsSvc *sts.STS
+var httpClient *http.Client
+
+// TODO: (Westeros) Remove Custom Resolver Usage Before Launch
+type customS3Resolver struct {
+	endpoint string
+	withTLS  bool
+	region   string
+}
+
+func (r customS3Resolver) EndpointFor(service, _ string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	switch strings.ToLower(service) {
+	case "s3-control":
+	case "s3":
+	default:
+		return endpoints.ResolvedEndpoint{}, fmt.Errorf("unsupported in custom resolver")
+	}
+
+	return endpoints.ResolvedEndpoint{
+		PartitionID:   "aws",
+		SigningRegion: r.region,
+		SigningName:   "s3",
+		SigningMethod: "s3v4",
+		URL:           endpoints.AddScheme(r.endpoint, r.withTLS),
+	}, nil
+}
+
+func TestMain(m *testing.M) {
 	var result int
 	defer func() {
-		if err := s3integ.CleanupTest(svc, *bucketName); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		}
 		if r := recover(); r != nil {
-			fmt.Fprintln(os.Stderr, "S3 integrationt tests paniced,", r)
+			fmt.Fprintln(os.Stderr, "S3 integration tests paniced,", r)
 			result = 1
 		}
 		os.Exit(result)
 	}()
 
+	var verifyTLS bool
+	var s3Endpoint, s3ControlEndpoint string
+	var s3EnableTLS, s3ControlEnableTLS bool
+
+	flag.StringVar(&s3Endpoint, "s3-endpoint", "", "integration endpoint for S3")
+	flag.BoolVar(&s3EnableTLS, "s3-tls", true, "enable TLS for S3 endpoint")
+
+	flag.StringVar(&s3ControlEndpoint, "s3-control-endpoint", "", "integration endpoint for S3")
+	flag.BoolVar(&s3ControlEnableTLS, "s3-control-tls", true, "enable TLS for S3 control endpoint")
+
+	flag.StringVar(&integMetadata.AccountID, "account", "", "integration account id")
+	flag.BoolVar(&verifyTLS, "verify-tls", true, "verify server TLS certificate")
+	flag.Parse()
+
+	httpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: verifyTLS},
+		}}
+
+	sess := integration.SessionWithDefaultRegion("us-west-2").Copy(&aws.Config{
+		HTTPClient: httpClient,
+	})
+
+	var s3EndpointResolver endpoints.Resolver
+	if len(s3Endpoint) != 0 {
+		s3EndpointResolver = customS3Resolver{
+			endpoint: s3Endpoint,
+			withTLS:  s3EnableTLS,
+			region:   aws.StringValue(sess.Config.Region),
+		}
+	}
+	s3Svc = s3.New(sess, &aws.Config{
+		DisableSSL:       aws.Bool(!s3EnableTLS),
+		EndpointResolver: s3EndpointResolver,
+	})
+
+	var s3ControlEndpointResolver endpoints.Resolver
+	if len(s3Endpoint) != 0 {
+		s3ControlEndpointResolver = customS3Resolver{
+			endpoint: s3ControlEndpoint,
+			withTLS:  s3ControlEnableTLS,
+			region:   aws.StringValue(sess.Config.Region),
+		}
+	}
+	s3ControlSvc = s3control.New(sess, &aws.Config{
+		DisableSSL:       aws.Bool(!s3ControlEnableTLS),
+		EndpointResolver: s3ControlEndpointResolver,
+	})
+	stsSvc = sts.New(sess)
+
+	var err error
+	integMetadata.AccountID, err = getAccountID()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get integration aws account id: %v\n", err)
+		result = 1
+		return
+	}
+
+	bucketCleanup, err := setupBuckets()
+	defer bucketCleanup()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup integration test buckets: %v\n", err)
+		result = 1
+		return
+	}
+
+	accessPointsCleanup, err := setupAccessPoints()
+	defer accessPointsCleanup()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to setup integration test access points: %v\n", err)
+		result = 1
+		return
+	}
+
 	result = m.Run()
 }
 
-func putTestFile(t *testing.T, filename, key string) {
+func getAccountID() (string, error) {
+	if len(integMetadata.AccountID) != 0 {
+		return integMetadata.AccountID, nil
+	}
+
+	output, err := stsSvc.GetCallerIdentity(nil)
+	if err != nil {
+		return "", fmt.Errorf("faield to get sts caller identity")
+	}
+
+	return *output.Account, nil
+}
+
+func setupBuckets() (func(), error) {
+	var cleanups []func()
+
+	cleanup := func() {
+		for i := range cleanups {
+			cleanups[i]()
+		}
+	}
+
+	bucketCreates := []struct {
+		name *string
+		arn  *string
+	}{
+		{name: &integMetadata.Buckets.Source.Name, arn: &integMetadata.Buckets.Source.ARN},
+		{name: &integMetadata.Buckets.Target.Name, arn: &integMetadata.Buckets.Target.ARN},
+	}
+
+	for _, bucket := range bucketCreates {
+		*bucket.name = s3integ.GenerateBucketName()
+
+		if err := s3integ.SetupBucket(s3Svc, *bucket.name); err != nil {
+			return cleanup, err
+		}
+
+		// Compute ARN
+		bARN := arn.ARN{
+			Partition: "aws",
+			Service:   "s3",
+			Region:    s3Svc.SigningRegion,
+			AccountID: integMetadata.AccountID,
+			Resource:  fmt.Sprintf("bucket_name:%s", *bucket.name),
+		}.String()
+
+		*bucket.arn = bARN
+
+		bucketName := *bucket.name
+		cleanups = append(cleanups, func() {
+			if err := s3integ.CleanupBucket(s3Svc, bucketName); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
+		})
+	}
+
+	return cleanup, nil
+}
+
+func setupAccessPoints() (func(), error) {
+	var cleanups []func()
+
+	cleanup := func() {
+		for i := range cleanups {
+			cleanups[i]()
+		}
+	}
+
+	creates := []struct {
+		bucket string
+		name   *string
+		arn    *string
+	}{
+		{bucket: integMetadata.Buckets.Source.Name, name: &integMetadata.AccessPoints.Source.Name, arn: &integMetadata.AccessPoints.Source.ARN},
+		{bucket: integMetadata.Buckets.Target.Name, name: &integMetadata.AccessPoints.Target.Name, arn: &integMetadata.AccessPoints.Target.ARN},
+	}
+
+	for _, ap := range creates {
+		*ap.name = integration.UniqueID()
+
+		err := s3integ.SetupAccessPoint(s3ControlSvc, integMetadata.AccountID, ap.bucket, *ap.name)
+		if err != nil {
+			return cleanup, err
+		}
+
+		// Compute ARN
+		apARN := arn.ARN{
+			Partition: "aws",
+			Service:   "s3",
+			Region:    s3ControlSvc.SigningRegion,
+			AccountID: integMetadata.AccountID,
+			Resource:  fmt.Sprintf("accesspoint:%s", *ap.name),
+		}.String()
+
+		*ap.arn = apARN
+
+		apName := *ap.name
+		cleanups = append(cleanups, func() {
+			err := s3integ.CleanupAccessPoint(s3ControlSvc, integMetadata.AccountID, apName)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
+		})
+	}
+
+	return cleanup, nil
+}
+
+func putTestFile(t *testing.T, filename, key string, opts ...request.Option) {
 	f, err := os.Open(filename)
 	if err != nil {
 		t.Fatalf("failed to open testfile, %v", err)
 	}
 	defer f.Close()
 
-	putTestContent(t, f, key)
+	putTestContent(t, f, key, opts...)
 }
 
-func putTestContent(t *testing.T, reader io.ReadSeeker, key string) {
-	t.Logf("uploading test file %s/%s", *bucketName, key)
-	_, err := svc.PutObject(&s3.PutObjectInput{
-		Bucket: bucketName,
-		Key:    &key,
-		Body:   reader,
-	})
+func putTestContent(t *testing.T, reader io.ReadSeeker, key string, opts ...request.Option) {
+	t.Logf("uploading test file %s/%s", integMetadata.Buckets.Source.Name, key)
+	_, err := s3Svc.PutObjectWithContext(context.Background(),
+		&s3.PutObjectInput{
+			Bucket: &integMetadata.Buckets.Source.Name,
+			Key:    aws.String(key),
+			Body:   reader,
+		}, opts...)
 	if err != nil {
 		t.Errorf("expect no error, got %v", err)
+	}
+}
+
+func testWriteToObject(t *testing.T, bucket string, opts ...request.Option) {
+	key := integration.UniqueID()
+
+	_, err := s3Svc.PutObjectWithContext(context.Background(),
+		&s3.PutObjectInput{
+			Bucket: &bucket,
+			Key:    &key,
+			Body:   bytes.NewReader([]byte("hello world")),
+		}, opts...)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	resp, err := s3Svc.GetObjectWithContext(context.Background(),
+		&s3.GetObjectInput{
+			Bucket: &bucket,
+			Key:    &key,
+		}, opts...)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, _ := ioutil.ReadAll(resp.Body)
+	if e, a := []byte("hello world"), b; !bytes.Equal(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
+	}
+}
+
+func testPresignedGetPut(t *testing.T, bucket string, opts ...request.Option) {
+	key := integration.UniqueID()
+
+	putreq, _ := s3Svc.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	putreq.ApplyOptions(opts...)
+	var err error
+
+	// Presign a PUT request
+	var puturl string
+	puturl, err = putreq.Presign(5 * time.Minute)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	// PUT to the presigned URL with a body
+	var puthttpreq *http.Request
+	buf := bytes.NewReader([]byte("hello world"))
+	puthttpreq, err = http.NewRequest("PUT", puturl, buf)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	var putresp *http.Response
+	putresp, err = httpClient.Do(puthttpreq)
+	if err != nil {
+		t.Errorf("expect put with presign url no error, got %v", err)
+	}
+	if e, a := 200, putresp.StatusCode; e != a {
+		t.Fatalf("expect %v, got %v", e, a)
+	}
+
+	// Presign a GET on the same URL
+	getreq, _ := s3Svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	getreq.ApplyOptions(opts...)
+
+	var geturl string
+	geturl, err = getreq.Presign(300 * time.Second)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	// Get the body
+	var getresp *http.Response
+	getresp, err = httpClient.Get(geturl)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	var b []byte
+	defer getresp.Body.Close()
+	b, err = ioutil.ReadAll(getresp.Body)
+	if e, a := "hello world", string(b); e != a {
+		t.Fatalf("expect %v, got %v", e, a)
+	}
+}
+
+func testCopyObject(t *testing.T, sourceBucket string, targetBucket string, opts ...request.Option) {
+	key := integration.UniqueID()
+
+	_, err := s3Svc.PutObjectWithContext(context.Background(),
+		&s3.PutObjectInput{
+			Bucket: &sourceBucket,
+			Key:    &key,
+			Body:   bytes.NewReader([]byte("hello world")),
+		}, opts...)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	_, err = s3Svc.CopyObjectWithContext(context.Background(),
+		&s3.CopyObjectInput{
+			Bucket:     &targetBucket,
+			CopySource: aws.String("/" + sourceBucket + "/" + key),
+			Key:        &key,
+		}, opts...)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	resp, err := s3Svc.GetObjectWithContext(context.Background(),
+		&s3.GetObjectInput{
+			Bucket: &targetBucket,
+			Key:    &key,
+		}, opts...)
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	b, _ := ioutil.ReadAll(resp.Body)
+	if e, a := []byte("hello world"), b; !reflect.DeepEqual(e, a) {
+		t.Errorf("expect %v, got %v", e, a)
 	}
 }

--- a/service/s3/cust_integ_test.go
+++ b/service/s3/cust_integ_test.go
@@ -3,95 +3,17 @@
 package s3_test
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
-	"reflect"
 	"testing"
-	"time"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 func TestInteg_WriteToObject(t *testing.T) {
-	_, err := svc.PutObject(&s3.PutObjectInput{
-		Bucket: bucketName,
-		Key:    aws.String("key name"),
-		Body:   bytes.NewReader([]byte("hello world")),
-	})
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	resp, err := svc.GetObject(&s3.GetObjectInput{
-		Bucket: bucketName,
-		Key:    aws.String("key name"),
-	})
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	b, _ := ioutil.ReadAll(resp.Body)
-	if e, a := []byte("hello world"), b; !reflect.DeepEqual(e, a) {
-		t.Errorf("expect %v, got %v", e, a)
-	}
+	testWriteToObject(t, integMetadata.Buckets.Source.Name)
 }
 
 func TestInteg_PresignedGetPut(t *testing.T) {
-	putreq, _ := svc.PutObjectRequest(&s3.PutObjectInput{
-		Bucket: bucketName,
-		Key:    aws.String("presigned-key"),
-	})
-	var err error
+	testPresignedGetPut(t, integMetadata.Buckets.Source.Name)
+}
 
-	// Presign a PUT request
-	var puturl string
-	puturl, err = putreq.Presign(300 * time.Second)
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	// PUT to the presigned URL with a body
-	var puthttpreq *http.Request
-	buf := bytes.NewReader([]byte("hello world"))
-	puthttpreq, err = http.NewRequest("PUT", puturl, buf)
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	var putresp *http.Response
-	putresp, err = http.DefaultClient.Do(puthttpreq)
-	if err != nil {
-		t.Errorf("expect put with presign url no error, got %v", err)
-	}
-	if e, a := 200, putresp.StatusCode; e != a {
-		t.Errorf("expect %v, got %v", e, a)
-	}
-
-	// Presign a GET on the same URL
-	getreq, _ := svc.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: bucketName,
-		Key:    aws.String("presigned-key"),
-	})
-
-	var geturl string
-	geturl, err = getreq.Presign(300 * time.Second)
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	// Get the body
-	var getresp *http.Response
-	getresp, err = http.Get(geturl)
-	if err != nil {
-		t.Errorf("expect no error, got %v", err)
-	}
-
-	var b []byte
-	defer getresp.Body.Close()
-	b, err = ioutil.ReadAll(getresp.Body)
-	if e, a := "hello world", string(b); e != a {
-		t.Errorf("expect %v, got %v", e, a)
-	}
+func TestInteg_CopyObject(t *testing.T) {
+	testCopyObject(t, integMetadata.Buckets.Source.Name, integMetadata.Buckets.Target.Name)
 }

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/s3err"
+	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
 )
 
 func init() {
@@ -13,7 +14,7 @@ func init() {
 
 func defaultInitClientFn(c *client.Client) {
 	// Support building custom endpoints based on config
-	c.Handlers.Build.PushFront(updateEndpointForS3Config)
+	c.Handlers.Build.PushFront(endpointHandler)
 
 	// Require SSL when using SSE keys
 	c.Handlers.Validate.PushBack(validateSSERequiresSSL)
@@ -27,7 +28,7 @@ func defaultInitClientFn(c *client.Client) {
 }
 
 func defaultInitRequestFn(r *request.Request) {
-	// Add reuest handlers for specific platforms.
+	// Add request handlers for specific platforms.
 	// e.g. 100-continue support for PUT requests using Go 1.6
 	platformRequestHandlers(r)
 
@@ -72,4 +73,9 @@ type sseCustomerKeyGetter interface {
 // "CopySourceSSECustomerKey" field from an S3 type.
 type copySourceSSECustomerKeyGetter interface {
 	getCopySourceSSECustomerKey() string
+}
+
+type endpointARNGetter interface {
+	getEndpointARN() (arn.Resource, error)
+	hasEndpointARN() bool
 }

--- a/service/s3/endpoint.go
+++ b/service/s3/endpoint.go
@@ -1,0 +1,233 @@
+package s3
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsarn "github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
+)
+
+// Used by shapes with members decorated as endpoint ARN.
+func parseEndpointARN(v string) (arn.Resource, error) {
+	return arn.ParseResource(v, accessPointResourceParser)
+}
+
+func accessPointResourceParser(a awsarn.ARN) (arn.Resource, error) {
+	resParts := arn.SplitResource(a.Resource)
+	switch resParts[0] {
+	case "accesspoint":
+		return arn.ParseAccessPointResource(a, resParts[1:])
+	default:
+		return nil, arn.InvalidARNError{ARN: a, Reason: "unknown resource type"}
+	}
+}
+
+func endpointHandler(req *request.Request) {
+	endpoint, ok := req.Params.(endpointARNGetter)
+	if !ok || !endpoint.hasEndpointARN() {
+		updateBucketEndpointFromParams(req)
+		return
+	}
+
+	resource, err := endpoint.getEndpointARN()
+	if err != nil {
+		req.Error = newInvalidARNError(nil, err)
+		return
+	}
+
+	resReq := resourceRequest{
+		Resource: resource,
+		Request:  req,
+	}
+
+	if resReq.IsCrossPartition() {
+		req.Error = newClientPartitionMismatchError(resource,
+			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
+		return
+	}
+
+	if !resReq.AllowCrossRegion() && resReq.IsCrossRegion() {
+		req.Error = newClientRegionMismatchError(resource,
+			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
+		return
+	}
+
+	if resReq.HasCustomEndpoint() {
+		req.Error = newInvalidARNWithCustomEndpointError(resource, nil)
+		return
+	}
+
+	switch tv := resource.(type) {
+	case arn.AccessPointARN:
+		err = updateRequestAccessPointEndpoint(req, tv)
+		if err != nil {
+			req.Error = err
+		}
+	default:
+		req.Error = newInvalidARNError(resource, nil)
+	}
+}
+
+type resourceRequest struct {
+	Resource arn.Resource
+	Request  *request.Request
+}
+
+func (r resourceRequest) ARN() awsarn.ARN {
+	return r.Resource.GetARN()
+}
+
+func (r resourceRequest) AllowCrossRegion() bool {
+	return aws.BoolValue(r.Request.Config.S3UseARNRegion)
+}
+
+func (r resourceRequest) UseFIPS() bool {
+	return isFIPS(aws.StringValue(r.Request.Config.Region))
+}
+
+func (r resourceRequest) IsCrossPartition() bool {
+	return r.Request.ClientInfo.PartitionID != r.Resource.GetARN().Partition
+}
+
+func (r resourceRequest) IsCrossRegion() bool {
+	return isCrossRegion(r.Request, r.Resource.GetARN().Region)
+}
+
+func (r resourceRequest) HasCustomEndpoint() bool {
+	return len(aws.StringValue(r.Request.Config.Endpoint)) > 0
+}
+
+func isFIPS(clientRegion string) bool {
+	return strings.HasPrefix(clientRegion, "fips-") || strings.HasSuffix(clientRegion, "-fips")
+}
+func isCrossRegion(req *request.Request, otherRegion string) bool {
+	return req.ClientInfo.SigningRegion != otherRegion
+}
+
+func updateBucketEndpointFromParams(r *request.Request) {
+	bucket, ok := bucketNameFromReqParams(r.Params)
+	if !ok {
+		// Ignore operation requests if the bucket name was not provided
+		// if this is an input validation error the validation handler
+		// will report it.
+		return
+	}
+	updateEndpointForS3Config(r, bucket)
+}
+
+func updateRequestAccessPointEndpoint(req *request.Request, accessPoint arn.AccessPointARN) error {
+	// Accelerate not supported
+	if aws.BoolValue(req.Config.S3UseAccelerate) {
+		return newClientConfiguredForAccelerateError(accessPoint,
+			req.ClientInfo.PartitionID, aws.StringValue(req.Config.Region), nil)
+	}
+
+	// Ignore the disable host prefix for access points since custom endpoints
+	// are not supported.
+	req.Config.DisableEndpointHostPrefix = aws.Bool(false)
+
+	if err := accessPointEndpointBuilder(accessPoint).Build(req); err != nil {
+		return err
+	}
+
+	removeBucketFromPath(req.HTTPRequest.URL)
+
+	return nil
+}
+
+func removeBucketFromPath(u *url.URL) {
+	u.Path = strings.Replace(u.Path, "/{Bucket}", "", -1)
+	if u.Path == "" {
+		u.Path = "/"
+	}
+}
+
+type accessPointEndpointBuilder arn.AccessPointARN
+
+const (
+	accessPointPrefixLabel   = "accesspoint"
+	accountIDPrefixLabel     = "accountID"
+	accesPointPrefixTemplate = "{" + accessPointPrefixLabel + "}-{" + accountIDPrefixLabel + "}."
+)
+
+func (a accessPointEndpointBuilder) Build(req *request.Request) error {
+	resolveRegion := arn.AccessPointARN(a).Region
+	cfgRegion := aws.StringValue(req.Config.Region)
+
+	if isFIPS(cfgRegion) {
+		if aws.BoolValue(req.Config.S3UseARNRegion) && isCrossRegion(req, resolveRegion) {
+			// FIPS with cross region is not supported, the SDK must fail
+			// because there is no well defined method for SDK to construct a
+			// correct FIPS endpoint.
+			return newClientConfiguredForCrossRegionFIPSError(arn.AccessPointARN(a),
+				req.ClientInfo.PartitionID, cfgRegion, nil)
+		}
+		resolveRegion = cfgRegion
+	}
+
+	endpoint, err := resolveRegionalEndpoint(req, resolveRegion)
+	if err != nil {
+		return newFailedToResolveEndpointError(arn.AccessPointARN(a),
+			req.ClientInfo.PartitionID, cfgRegion, err)
+	}
+
+	if err = updateRequestEndpoint(req, endpoint.URL); err != nil {
+		return err
+	}
+
+	const serviceEndpointLabel = "s3-accesspoint"
+
+	// dualstack provided by endpoint resolver
+	cfgHost := req.HTTPRequest.URL.Host
+	if strings.HasPrefix(cfgHost, "s3") {
+		req.HTTPRequest.URL.Host = serviceEndpointLabel + cfgHost[2:]
+	}
+
+	protocol.HostPrefixBuilder{
+		Prefix:   accesPointPrefixTemplate,
+		LabelsFn: a.hostPrefixLabelValues,
+	}.Build(req)
+
+	req.ClientInfo.SigningName = endpoint.SigningName
+	req.ClientInfo.SigningRegion = endpoint.SigningRegion
+
+	err = protocol.ValidateEndpointHost(req.Operation.Name, req.HTTPRequest.URL.Host)
+	if err != nil {
+		return newInvalidARNError(arn.AccessPointARN(a), err)
+	}
+
+	return nil
+}
+
+func (a accessPointEndpointBuilder) hostPrefixLabelValues() map[string]string {
+	return map[string]string{
+		accessPointPrefixLabel: arn.AccessPointARN(a).AccessPointName,
+		accountIDPrefixLabel:   arn.AccessPointARN(a).AccountID,
+	}
+}
+
+func resolveRegionalEndpoint(r *request.Request, region string) (endpoints.ResolvedEndpoint, error) {
+	return r.Config.EndpointResolver.EndpointFor(EndpointsID, region, func(opts *endpoints.Options) {
+		opts.DisableSSL = aws.BoolValue(r.Config.DisableSSL)
+		opts.UseDualStack = aws.BoolValue(r.Config.UseDualStack)
+		opts.S3UsEast1RegionalEndpoint = endpoints.RegionalS3UsEast1Endpoint
+	})
+}
+
+func updateRequestEndpoint(r *request.Request, endpoint string) (err error) {
+	endpoint = endpoints.AddScheme(endpoint, aws.BoolValue(r.Config.DisableSSL))
+
+	r.HTTPRequest.URL, err = url.Parse(endpoint + r.Operation.HTTPPath)
+	if err != nil {
+		return awserr.New(request.ErrCodeSerialization,
+			"failed to parse endpoint URL", err)
+	}
+
+	return nil
+}

--- a/service/s3/endpoint_errors.go
+++ b/service/s3/endpoint_errors.go
@@ -1,0 +1,151 @@
+package s3
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3/internal/arn"
+)
+
+const (
+	invalidARNErrorErrCode    = "InvalidARNError"
+	configurationErrorErrCode = "ConfigurationError"
+)
+
+type invalidARNError struct {
+	message  string
+	resource arn.Resource
+	origErr  error
+}
+
+func (e invalidARNError) Error() string {
+	var extra string
+	if e.resource != nil {
+		extra = "ARN: " + e.resource.String()
+	}
+	return awserr.SprintError(e.Code(), e.Message(), extra, e.origErr)
+}
+
+func (e invalidARNError) Code() string {
+	return invalidARNErrorErrCode
+}
+
+func (e invalidARNError) Message() string {
+	return e.message
+}
+
+func (e invalidARNError) OrigErr() error {
+	return e.origErr
+}
+
+func newInvalidARNError(resource arn.Resource, err error) invalidARNError {
+	return invalidARNError{
+		message:  "invalid ARN",
+		origErr:  err,
+		resource: resource,
+	}
+}
+
+func newInvalidARNWithCustomEndpointError(resource arn.Resource, err error) invalidARNError {
+	return invalidARNError{
+		message:  "resource ARN not supported with custom client endpoints",
+		origErr:  err,
+		resource: resource,
+	}
+}
+
+// ARN not supported for the target partition
+func newInvalidARNWithUnsupportedPartitionError(resource arn.Resource, err error) invalidARNError {
+	return invalidARNError{
+		message:  "resource ARN not supported for the target ARN partition",
+		origErr:  err,
+		resource: resource,
+	}
+}
+
+type configurationError struct {
+	message           string
+	resource          arn.Resource
+	clientPartitionID string
+	clientRegion      string
+	origErr           error
+}
+
+func (e configurationError) Error() string {
+	extra := fmt.Sprintf("ARN: %s, client partition: %s, client region: %s",
+		e.resource, e.clientPartitionID, e.clientRegion)
+
+	return awserr.SprintError(e.Code(), e.Message(), extra, e.origErr)
+}
+
+func (e configurationError) Code() string {
+	return configurationErrorErrCode
+}
+
+func (e configurationError) Message() string {
+	return e.message
+}
+
+func (e configurationError) OrigErr() error {
+	return e.origErr
+}
+
+func newClientPartitionMismatchError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "client partition does not match provided ARN partition",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}
+
+func newClientRegionMismatchError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "client region does not match provided ARN region",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}
+
+func newFailedToResolveEndpointError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "endpoint resolver failed to find an endpoint for the provided ARN region",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}
+
+func newClientConfiguredForFIPSError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "client configured for fips but cross-region resource ARN provided",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}
+
+func newClientConfiguredForAccelerateError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "client configured for S3 Accelerate but is supported with resource ARN",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}
+
+func newClientConfiguredForCrossRegionFIPSError(resource arn.Resource, clientPartitionID, clientRegion string, err error) configurationError {
+	return configurationError{
+		message:           "client configured for FIPS with cross-region enabled but is supported with cross-region resource ARN",
+		origErr:           err,
+		resource:          resource,
+		clientPartitionID: clientPartitionID,
+		clientRegion:      clientRegion,
+	}
+}

--- a/service/s3/endpoint_test.go
+++ b/service/s3/endpoint_test.go
@@ -1,0 +1,232 @@
+// +build go1.7
+
+package s3
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+)
+
+func TestEndpointARN(t *testing.T) {
+	cases := map[string]struct {
+		bucket                string
+		config                *aws.Config
+		expectedEndpoint      string
+		expectedSigningName   string
+		expectedSigningRegion string
+		expectedErr           string
+	}{
+		"AccessPoint": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region: aws.String("us-west-2"),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-west-2",
+		},
+		"AccessPoint other partition": {
+			bucket: "arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region: aws.String("cn-north-1"),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.cn-north-1.amazonaws.com.cn",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "cn-north-1",
+		},
+		"AccessPoint Cross-Region Disabled": {
+			bucket: "arn:aws:s3:ap-south-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region: aws.String("us-west-2"),
+			},
+			expectedErr: "client region does not match provided ARN region",
+		},
+		"AccessPoint Cross-Region Enabled": {
+			bucket: "arn:aws:s3:ap-south-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("us-west-2"),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.ap-south-1.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "ap-south-1",
+		},
+		"AccessPoint us-east-1": {
+			bucket: "arn:aws:s3:us-east-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("us-east-1"),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.us-east-1.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-east-1",
+		},
+		"AccessPoint us-east-1 cross region": {
+			bucket: "arn:aws:s3:us-east-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("us-west-2"),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.us-east-1.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-east-1",
+		},
+		"AccessPoint Cross-Partition not supported": {
+			bucket: "arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("us-west-2"),
+				UseDualStack:   aws.Bool(true),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedErr: "client partition does not match provided ARN partition",
+		},
+		"AccessPoint DualStack": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:       aws.String("us-west-2"),
+				UseDualStack: aws.Bool(true),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.dualstack.us-west-2.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-west-2",
+		},
+		"AccessPoint FIPS same region with cross region disabled": {
+			bucket: "arn:aws-us-gov:s3:us-gov-west-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region: aws.String("fips-us-gov-west-1"),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint-fips-us-gov-west-1.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-gov-west-1",
+		},
+		"AccessPoint FIPS same region with cross region enabled": {
+			bucket: "arn:aws-us-gov:s3:us-gov-west-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("fips-us-gov-west-1"),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint-fips-us-gov-west-1.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-gov-west-1",
+		},
+		"AccessPoint FIPS cross region not supported": {
+			bucket: "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("fips-us-gov-west-1"),
+				S3UseARNRegion: aws.Bool(true),
+			},
+			expectedErr: "client configured for FIPS",
+		},
+		"AccessPoint Accelerate not supported": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:          aws.String("us-west-2"),
+				S3UseAccelerate: aws.Bool(true),
+			},
+			expectedErr: "client configured for S3 Accelerate",
+		},
+		"Custom Resolver Without PartitionID in ClientInfo": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region: aws.String("us-west-2"),
+				EndpointResolver: endpoints.ResolverFunc(
+					func(service, region string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+						switch region {
+						case "us-west-2":
+							return endpoints.ResolvedEndpoint{
+								URL:           "s3.us-west-2.amazonaws.com",
+								SigningRegion: "us-west-2",
+								SigningName:   service,
+								SigningMethod: "s3v4",
+							}, nil
+						}
+						return endpoints.ResolvedEndpoint{}, nil
+					}),
+			},
+			expectedErr: "client partition does not match provided ARN partition",
+		},
+		"Custom Resolver Without PartitionID in Cross-Region Target": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
+			config: &aws.Config{
+				Region:         aws.String("us-east-1"),
+				S3UseARNRegion: aws.Bool(true),
+				EndpointResolver: endpoints.ResolverFunc(
+					func(service, region string, opts ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+						switch region {
+						case "us-west-2":
+							return endpoints.ResolvedEndpoint{
+								URL:           "s3.us-west-2.amazonaws.com",
+								PartitionID:   "aws",
+								SigningRegion: "us-west-2",
+								SigningName:   service,
+								SigningMethod: "s3v4",
+							}, nil
+						case "us-east-1":
+							return endpoints.ResolvedEndpoint{
+								URL:           "s3.us-east-1.amazonaws.com",
+								SigningRegion: "us-east-1",
+								SigningName:   service,
+								SigningMethod: "s3v4",
+							}, nil
+						}
+
+						return endpoints.ResolvedEndpoint{}, nil
+					}),
+			},
+			expectedErr: "client partition does not match provided ARN partition",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			sess := unit.Session.Copy(c.config)
+
+			svc := New(sess)
+			req, _ := svc.GetObjectRequest(&GetObjectInput{
+				Bucket: &c.bucket,
+				Key:    aws.String("testkey"),
+			})
+			req.Handlers.Send.Clear()
+			req.Handlers.Send.PushBack(func(r *request.Request) {
+				defer func() {
+					r.HTTPResponse = &http.Response{
+						StatusCode:    200,
+						ContentLength: 0,
+						Body:          ioutil.NopCloser(bytes.NewReader(nil)),
+					}
+				}()
+				if len(c.expectedErr) != 0 {
+					return
+				}
+
+				endpoint := fmt.Sprintf("%s://%s", r.HTTPRequest.URL.Scheme, r.HTTPRequest.URL.Host)
+				if e, a := c.expectedEndpoint, endpoint; e != a {
+					t.Errorf("expected %v, got %v", e, a)
+				}
+				if e, a := c.expectedSigningName, r.ClientInfo.SigningName; e != a {
+					t.Errorf("expected %v, got %v", e, a)
+				}
+				if e, a := c.expectedSigningRegion, r.ClientInfo.SigningRegion; e != a {
+					t.Errorf("expected %v, got %v", e, a)
+				}
+			})
+			err := req.Send()
+			if len(c.expectedErr) == 0 && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			} else if len(c.expectedErr) != 0 && err == nil {
+				t.Errorf("expected err %q, but got nil", c.expectedErr)
+			} else if len(c.expectedErr) != 0 && err != nil && !strings.Contains(err.Error(), c.expectedErr) {
+				t.Errorf("expected %v, got %v", c.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/service/s3/internal/arn/accesspoint_arn.go
+++ b/service/s3/internal/arn/accesspoint_arn.go
@@ -1,0 +1,45 @@
+package arn
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+// AccessPointARN provides representation
+type AccessPointARN struct {
+	arn.ARN
+	AccessPointName string
+}
+
+// GetARN returns the base ARN for the Access Point resource
+func (a AccessPointARN) GetARN() arn.ARN {
+	return a.ARN
+}
+
+// ParseAccessPointResource attempts to parse the ARN's resource as an
+// AccessPoint resource.
+func ParseAccessPointResource(a arn.ARN, resParts []string) (AccessPointARN, error) {
+	if len(a.Region) == 0 {
+		return AccessPointARN{}, InvalidARNError{a, "region not set"}
+	}
+	if len(a.AccountID) == 0 {
+		return AccessPointARN{}, InvalidARNError{a, "account-id not set"}
+	}
+	if len(resParts) == 0 {
+		return AccessPointARN{}, InvalidARNError{a, "resource-id not set"}
+	}
+	if len(resParts) > 1 {
+		return AccessPointARN{}, InvalidARNError{a, "sub resource not supported"}
+	}
+
+	resID := resParts[0]
+	if len(strings.TrimSpace(resID)) == 0 {
+		return AccessPointARN{}, InvalidARNError{a, "resource-id not set"}
+	}
+
+	return AccessPointARN{
+		ARN:             a,
+		AccessPointName: resID,
+	}, nil
+}

--- a/service/s3/internal/arn/accesspoint_arn_test.go
+++ b/service/s3/internal/arn/accesspoint_arn_test.go
@@ -1,0 +1,109 @@
+// +build go1.7
+
+package arn
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+func TestParseAccessPointResource(t *testing.T) {
+	cases := map[string]struct {
+		ARN       arn.ARN
+		ExpectErr string
+		ExpectARN AccessPointARN
+	}{
+		"region not set": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				AccountID: "012345678901",
+				Resource:  "accesspoint/myendpoint",
+			},
+			ExpectErr: "region not set",
+		},
+		"account-id not set": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				Region:    "us-west-2",
+				Resource:  "accesspoint/myendpoint",
+			},
+			ExpectErr: "account-id not set",
+		},
+		"resource-id not set": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				Region:    "us-west-2",
+				AccountID: "012345678901",
+				Resource:  "accesspoint",
+			},
+			ExpectErr: "resource-id not set",
+		},
+		"resource-id empty": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				Region:    "us-west-2",
+				AccountID: "012345678901",
+				Resource:  "accesspoint:",
+			},
+			ExpectErr: "resource-id not set",
+		},
+		"resource not supported": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				Region:    "us-west-2",
+				AccountID: "012345678901",
+				Resource:  "accesspoint/endpoint/object/key",
+			},
+			ExpectErr: "sub resource not supported",
+		},
+		"valid resource-id": {
+			ARN: arn.ARN{
+				Partition: "aws",
+				Service:   "s3",
+				Region:    "us-west-2",
+				AccountID: "012345678901",
+				Resource:  "accesspoint/endpoint",
+			},
+			ExpectARN: AccessPointARN{
+				ARN: arn.ARN{
+					Partition: "aws",
+					Service:   "s3",
+					Region:    "us-west-2",
+					AccountID: "012345678901",
+					Resource:  "accesspoint/endpoint",
+				},
+				AccessPointName: "endpoint",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			resParts := SplitResource(c.ARN.Resource)
+			a, err := ParseAccessPointResource(c.ARN, resParts[1:])
+
+			if len(c.ExpectErr) == 0 && err != nil {
+				t.Fatalf("expect no error but got %v", err)
+			} else if len(c.ExpectErr) != 0 && err == nil {
+				t.Fatalf("expect error %q, but got nil", c.ExpectErr)
+			} else if len(c.ExpectErr) != 0 && err != nil {
+				if e, a := c.ExpectErr, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect error %q, got %q", e, a)
+				}
+				return
+			}
+
+			if e, a := c.ExpectARN, a; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
+	}
+}

--- a/service/s3/internal/arn/arn.go
+++ b/service/s3/internal/arn/arn.go
@@ -1,0 +1,71 @@
+package arn
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+// Resource provides the interfaces abstracting ARNs of specific resource
+// types.
+type Resource interface {
+	GetARN() arn.ARN
+	String() string
+}
+
+// ResourceParser provides the function for parsing an ARN's resource
+// component into a typed resource.
+type ResourceParser func(arn.ARN) (Resource, error)
+
+// ParseResource parses an AWS ARN into a typed resource for the S3 API.
+func ParseResource(s string, resParser ResourceParser) (resARN Resource, err error) {
+	a, err := arn.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(a.Partition) == 0 {
+		return nil, InvalidARNError{a, "partition not set"}
+	}
+	if a.Service != "s3" {
+		return nil, InvalidARNError{a, "service is not S3"}
+	}
+	if len(a.Resource) == 0 {
+		return nil, InvalidARNError{a, "resource not set"}
+	}
+
+	return resParser(a)
+}
+
+// SplitResource splits the resource components by the ARN resource delimiters.
+func SplitResource(v string) []string {
+	var parts []string
+	var offset int
+
+	for offset <= len(v) {
+		idx := strings.IndexAny(v[offset:], "/:")
+		if idx < 0 {
+			parts = append(parts, v[offset:])
+			break
+		}
+		parts = append(parts, v[offset:idx+offset])
+		offset += idx + 1
+	}
+
+	return parts
+}
+
+// IsARN returns whether the given string is an ARN
+func IsARN(s string) bool {
+	return arn.IsARN(s)
+}
+
+// InvalidARNError provides the error for an invalid ARN error.
+type InvalidARNError struct {
+	ARN    arn.ARN
+	Reason string
+}
+
+func (e InvalidARNError) Error() string {
+	return "invalid Amazon S3 ARN, " + e.Reason + ", " + e.ARN.String()
+}

--- a/service/s3/internal/arn/arn_test.go
+++ b/service/s3/internal/arn/arn_test.go
@@ -1,0 +1,168 @@
+// +build go1.7
+
+package arn
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+func TestParseResource(t *testing.T) {
+	cases := map[string]struct {
+		Input           string
+		MappedResources map[string]func(arn.ARN, []string) (Resource, error)
+		Expect          Resource
+		ExpectErr       string
+	}{
+		"Empty ARN": {
+			Input:     "",
+			ExpectErr: "arn: invalid prefix",
+		},
+		"No Partition": {
+			Input:     "arn::sqs:us-west-2:012345678901:accesspoint",
+			ExpectErr: "partition not set",
+		},
+		"Not S3 ARN": {
+			Input:     "arn:aws:sqs:us-west-2:012345678901:accesspoint",
+			ExpectErr: "service is not S3",
+		},
+		"No Resource": {
+			Input:     "arn:aws:s3:us-west-2:012345678901:",
+			ExpectErr: "resource not set",
+		},
+		"Unknown Resource Type": {
+			Input:     "arn:aws:s3:us-west-2:012345678901:myresource",
+			ExpectErr: "unknown resource type",
+		},
+		"Unknown BucketARN Resource Type": {
+			Input:     "arn:aws:s3:us-west-2:012345678901:bucket_name:mybucket",
+			ExpectErr: "unknown resource type",
+		},
+		"Unknown Resource Type with Resource and Sub-Resource": {
+			Input:     "arn:aws:s3:us-west-2:012345678901:somethingnew:myresource/subresource",
+			ExpectErr: "unknown resource type",
+		},
+		"Access Point with sub resource": {
+			Input: "arn:aws:s3:us-west-2:012345678901:accesspoint:myresource/subresource",
+			MappedResources: map[string]func(arn.ARN, []string) (Resource, error){
+				"accesspoint": func(a arn.ARN, parts []string) (Resource, error) {
+					return ParseAccessPointResource(a, parts)
+				},
+			},
+			ExpectErr: "resource not supported",
+		},
+		"AccessPoint Resource Type": {
+			Input: "arn:aws:s3:us-west-2:012345678901:accesspoint:myendpoint",
+			MappedResources: map[string]func(arn.ARN, []string) (Resource, error){
+				"accesspoint": func(a arn.ARN, parts []string) (Resource, error) {
+					return ParseAccessPointResource(a, parts)
+				},
+			},
+			Expect: AccessPointARN{
+				ARN: arn.ARN{
+					Partition: "aws",
+					Service:   "s3",
+					Region:    "us-west-2",
+					AccountID: "012345678901",
+					Resource:  "accesspoint:myendpoint",
+				},
+				AccessPointName: "myendpoint",
+			},
+		},
+		"AccessPoint Resource Type With Path Syntax": {
+			Input: "arn:aws:s3:us-west-2:012345678901:accesspoint/myendpoint",
+			MappedResources: map[string]func(arn.ARN, []string) (Resource, error){
+				"accesspoint": func(a arn.ARN, parts []string) (Resource, error) {
+					return ParseAccessPointResource(a, parts)
+				},
+			},
+			Expect: AccessPointARN{
+				ARN: arn.ARN{
+					Partition: "aws",
+					Service:   "s3",
+					Region:    "us-west-2",
+					AccountID: "012345678901",
+					Resource:  "accesspoint/myendpoint",
+				},
+				AccessPointName: "myendpoint",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			parsed, err := ParseResource(c.Input, mappedResourceParser(c.MappedResources))
+
+			if len(c.ExpectErr) == 0 && err != nil {
+				t.Fatalf("expect no error but got %v", err)
+			} else if len(c.ExpectErr) != 0 && err == nil {
+				t.Fatalf("expect error but got nil")
+			} else if len(c.ExpectErr) != 0 && err != nil {
+				if e, a := c.ExpectErr, err.Error(); !strings.Contains(a, e) {
+					t.Fatalf("expect error %q, got %q", e, a)
+				}
+				return
+			}
+
+			if e, a := c.Expect, parsed; !reflect.DeepEqual(e, a) {
+				t.Errorf("Expect %v, got %v", e, a)
+			}
+		})
+	}
+}
+
+func mappedResourceParser(kinds map[string]func(arn.ARN, []string) (Resource, error)) ResourceParser {
+	return func(a arn.ARN) (Resource, error) {
+		parts := SplitResource(a.Resource)
+
+		fn, ok := kinds[parts[0]]
+		if !ok {
+			return nil, InvalidARNError{a, "unknown resource type"}
+		}
+		return fn(a, parts[1:])
+	}
+}
+
+func TestSplitResource(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Expect []string
+	}{
+		{
+			Input:  "accesspoint:myendpoint",
+			Expect: []string{"accesspoint", "myendpoint"},
+		},
+		{
+			Input:  "accesspoint/myendpoint",
+			Expect: []string{"accesspoint", "myendpoint"},
+		},
+		{
+			Input:  "accesspoint",
+			Expect: []string{"accesspoint"},
+		},
+		{
+			Input:  "accesspoint:",
+			Expect: []string{"accesspoint", ""},
+		},
+		{
+			Input:  "accesspoint:  ",
+			Expect: []string{"accesspoint", "  "},
+		},
+		{
+			Input:  "accesspoint:endpoint/object/key",
+			Expect: []string{"accesspoint", "endpoint", "object", "key"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Input, func(t *testing.T) {
+			parts := SplitResource(c.Input)
+			if e, a := c.Expect, parts; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect %v, got %v", e, a)
+			}
+		})
+	}
+}

--- a/service/s3/s3manager/integ_shared_test.go
+++ b/service/s3/s3manager/integ_shared_test.go
@@ -28,13 +28,13 @@ var svc *s3.S3
 func TestMain(m *testing.M) {
 	svc = s3.New(integSess)
 	bucketName = aws.String(s3integ.GenerateBucketName())
-	if err := s3integ.SetupTest(svc, *bucketName); err != nil {
+	if err := s3integ.SetupBucket(svc, *bucketName); err != nil {
 		panic(err)
 	}
 
 	var result int
 	defer func() {
-		if err := s3integ.CleanupTest(svc, *bucketName); err != nil {
+		if err := s3integ.CleanupBucket(svc, *bucketName); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 		}
 		if r := recover(); r != nil {

--- a/service/s3control/api.go
+++ b/service/s3control/api.go
@@ -13,6 +13,81 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
+const opCreateAccessPoint = "CreateAccessPoint"
+
+// CreateAccessPointRequest generates a "aws/request.Request" representing the
+// client's request for the CreateAccessPoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateAccessPoint for more information on using the CreateAccessPoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateAccessPointRequest method.
+//    req, resp := client.CreateAccessPointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/CreateAccessPoint
+func (c *S3Control) CreateAccessPointRequest(input *CreateAccessPointInput) (req *request.Request, output *CreateAccessPointOutput) {
+	op := &request.Operation{
+		Name:       opCreateAccessPoint,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/v20180820/accesspoint/{name}",
+	}
+
+	if input == nil {
+		input = &CreateAccessPointInput{}
+	}
+
+	output = &CreateAccessPointOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// CreateAccessPoint API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation CreateAccessPoint for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/CreateAccessPoint
+func (c *S3Control) CreateAccessPoint(input *CreateAccessPointInput) (*CreateAccessPointOutput, error) {
+	req, out := c.CreateAccessPointRequest(input)
+	return out, req.Send()
+}
+
+// CreateAccessPointWithContext is the same as CreateAccessPoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateAccessPoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) CreateAccessPointWithContext(ctx aws.Context, input *CreateAccessPointInput, opts ...request.Option) (*CreateAccessPointOutput, error) {
+	req, out := c.CreateAccessPointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateJob = "CreateJob"
 
 // CreateJobRequest generates a "aws/request.Request" representing the
@@ -94,6 +169,156 @@ func (c *S3Control) CreateJob(input *CreateJobInput) (*CreateJobOutput, error) {
 // for more information on using Contexts.
 func (c *S3Control) CreateJobWithContext(ctx aws.Context, input *CreateJobInput, opts ...request.Option) (*CreateJobOutput, error) {
 	req, out := c.CreateJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteAccessPoint = "DeleteAccessPoint"
+
+// DeleteAccessPointRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteAccessPoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteAccessPoint for more information on using the DeleteAccessPoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteAccessPointRequest method.
+//    req, resp := client.DeleteAccessPointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/DeleteAccessPoint
+func (c *S3Control) DeleteAccessPointRequest(input *DeleteAccessPointInput) (req *request.Request, output *DeleteAccessPointOutput) {
+	op := &request.Operation{
+		Name:       opDeleteAccessPoint,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/v20180820/accesspoint/{name}",
+	}
+
+	if input == nil {
+		input = &DeleteAccessPointInput{}
+	}
+
+	output = &DeleteAccessPointOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// DeleteAccessPoint API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation DeleteAccessPoint for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/DeleteAccessPoint
+func (c *S3Control) DeleteAccessPoint(input *DeleteAccessPointInput) (*DeleteAccessPointOutput, error) {
+	req, out := c.DeleteAccessPointRequest(input)
+	return out, req.Send()
+}
+
+// DeleteAccessPointWithContext is the same as DeleteAccessPoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteAccessPoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) DeleteAccessPointWithContext(ctx aws.Context, input *DeleteAccessPointInput, opts ...request.Option) (*DeleteAccessPointOutput, error) {
+	req, out := c.DeleteAccessPointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteAccessPointPolicy = "DeleteAccessPointPolicy"
+
+// DeleteAccessPointPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteAccessPointPolicy operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteAccessPointPolicy for more information on using the DeleteAccessPointPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteAccessPointPolicyRequest method.
+//    req, resp := client.DeleteAccessPointPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/DeleteAccessPointPolicy
+func (c *S3Control) DeleteAccessPointPolicyRequest(input *DeleteAccessPointPolicyInput) (req *request.Request, output *DeleteAccessPointPolicyOutput) {
+	op := &request.Operation{
+		Name:       opDeleteAccessPointPolicy,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/v20180820/accesspoint/{name}/policy",
+	}
+
+	if input == nil {
+		input = &DeleteAccessPointPolicyInput{}
+	}
+
+	output = &DeleteAccessPointPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// DeleteAccessPointPolicy API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation DeleteAccessPointPolicy for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/DeleteAccessPointPolicy
+func (c *S3Control) DeleteAccessPointPolicy(input *DeleteAccessPointPolicyInput) (*DeleteAccessPointPolicyOutput, error) {
+	req, out := c.DeleteAccessPointPolicyRequest(input)
+	return out, req.Send()
+}
+
+// DeleteAccessPointPolicyWithContext is the same as DeleteAccessPointPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteAccessPointPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) DeleteAccessPointPolicyWithContext(ctx aws.Context, input *DeleteAccessPointPolicyInput, opts ...request.Option) (*DeleteAccessPointPolicyOutput, error) {
+	req, out := c.DeleteAccessPointPolicyRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -263,6 +488,228 @@ func (c *S3Control) DescribeJobWithContext(ctx aws.Context, input *DescribeJobIn
 	return out, req.Send()
 }
 
+const opGetAccessPoint = "GetAccessPoint"
+
+// GetAccessPointRequest generates a "aws/request.Request" representing the
+// client's request for the GetAccessPoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetAccessPoint for more information on using the GetAccessPoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetAccessPointRequest method.
+//    req, resp := client.GetAccessPointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPoint
+func (c *S3Control) GetAccessPointRequest(input *GetAccessPointInput) (req *request.Request, output *GetAccessPointOutput) {
+	op := &request.Operation{
+		Name:       opGetAccessPoint,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v20180820/accesspoint/{name}",
+	}
+
+	if input == nil {
+		input = &GetAccessPointInput{}
+	}
+
+	output = &GetAccessPointOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// GetAccessPoint API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation GetAccessPoint for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPoint
+func (c *S3Control) GetAccessPoint(input *GetAccessPointInput) (*GetAccessPointOutput, error) {
+	req, out := c.GetAccessPointRequest(input)
+	return out, req.Send()
+}
+
+// GetAccessPointWithContext is the same as GetAccessPoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetAccessPoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) GetAccessPointWithContext(ctx aws.Context, input *GetAccessPointInput, opts ...request.Option) (*GetAccessPointOutput, error) {
+	req, out := c.GetAccessPointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetAccessPointPolicy = "GetAccessPointPolicy"
+
+// GetAccessPointPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the GetAccessPointPolicy operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetAccessPointPolicy for more information on using the GetAccessPointPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetAccessPointPolicyRequest method.
+//    req, resp := client.GetAccessPointPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPointPolicy
+func (c *S3Control) GetAccessPointPolicyRequest(input *GetAccessPointPolicyInput) (req *request.Request, output *GetAccessPointPolicyOutput) {
+	op := &request.Operation{
+		Name:       opGetAccessPointPolicy,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v20180820/accesspoint/{name}/policy",
+	}
+
+	if input == nil {
+		input = &GetAccessPointPolicyInput{}
+	}
+
+	output = &GetAccessPointPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// GetAccessPointPolicy API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation GetAccessPointPolicy for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPointPolicy
+func (c *S3Control) GetAccessPointPolicy(input *GetAccessPointPolicyInput) (*GetAccessPointPolicyOutput, error) {
+	req, out := c.GetAccessPointPolicyRequest(input)
+	return out, req.Send()
+}
+
+// GetAccessPointPolicyWithContext is the same as GetAccessPointPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetAccessPointPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) GetAccessPointPolicyWithContext(ctx aws.Context, input *GetAccessPointPolicyInput, opts ...request.Option) (*GetAccessPointPolicyOutput, error) {
+	req, out := c.GetAccessPointPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetAccessPointPolicyStatus = "GetAccessPointPolicyStatus"
+
+// GetAccessPointPolicyStatusRequest generates a "aws/request.Request" representing the
+// client's request for the GetAccessPointPolicyStatus operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetAccessPointPolicyStatus for more information on using the GetAccessPointPolicyStatus
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetAccessPointPolicyStatusRequest method.
+//    req, resp := client.GetAccessPointPolicyStatusRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPointPolicyStatus
+func (c *S3Control) GetAccessPointPolicyStatusRequest(input *GetAccessPointPolicyStatusInput) (req *request.Request, output *GetAccessPointPolicyStatusOutput) {
+	op := &request.Operation{
+		Name:       opGetAccessPointPolicyStatus,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v20180820/accesspoint/{name}/policyStatus",
+	}
+
+	if input == nil {
+		input = &GetAccessPointPolicyStatusInput{}
+	}
+
+	output = &GetAccessPointPolicyStatusOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// GetAccessPointPolicyStatus API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation GetAccessPointPolicyStatus for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/GetAccessPointPolicyStatus
+func (c *S3Control) GetAccessPointPolicyStatus(input *GetAccessPointPolicyStatusInput) (*GetAccessPointPolicyStatusOutput, error) {
+	req, out := c.GetAccessPointPolicyStatusRequest(input)
+	return out, req.Send()
+}
+
+// GetAccessPointPolicyStatusWithContext is the same as GetAccessPointPolicyStatus with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetAccessPointPolicyStatus for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) GetAccessPointPolicyStatusWithContext(ctx aws.Context, input *GetAccessPointPolicyStatusInput, opts ...request.Option) (*GetAccessPointPolicyStatusOutput, error) {
+	req, out := c.GetAccessPointPolicyStatusRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetPublicAccessBlock = "GetPublicAccessBlock"
 
 // GetPublicAccessBlockRequest generates a "aws/request.Request" representing the
@@ -339,6 +786,138 @@ func (c *S3Control) GetPublicAccessBlockWithContext(ctx aws.Context, input *GetP
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+const opListAccessPoints = "ListAccessPoints"
+
+// ListAccessPointsRequest generates a "aws/request.Request" representing the
+// client's request for the ListAccessPoints operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListAccessPoints for more information on using the ListAccessPoints
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListAccessPointsRequest method.
+//    req, resp := client.ListAccessPointsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/ListAccessPoints
+func (c *S3Control) ListAccessPointsRequest(input *ListAccessPointsInput) (req *request.Request, output *ListAccessPointsOutput) {
+	op := &request.Operation{
+		Name:       opListAccessPoints,
+		HTTPMethod: "GET",
+		HTTPPath:   "/v20180820/accesspoint",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListAccessPointsInput{}
+	}
+
+	output = &ListAccessPointsOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// ListAccessPoints API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation ListAccessPoints for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/ListAccessPoints
+func (c *S3Control) ListAccessPoints(input *ListAccessPointsInput) (*ListAccessPointsOutput, error) {
+	req, out := c.ListAccessPointsRequest(input)
+	return out, req.Send()
+}
+
+// ListAccessPointsWithContext is the same as ListAccessPoints with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListAccessPoints for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) ListAccessPointsWithContext(ctx aws.Context, input *ListAccessPointsInput, opts ...request.Option) (*ListAccessPointsOutput, error) {
+	req, out := c.ListAccessPointsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListAccessPointsPages iterates over the pages of a ListAccessPoints operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListAccessPoints method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListAccessPoints operation.
+//    pageNum := 0
+//    err := client.ListAccessPointsPages(params,
+//        func(page *s3control.ListAccessPointsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *S3Control) ListAccessPointsPages(input *ListAccessPointsInput, fn func(*ListAccessPointsOutput, bool) bool) error {
+	return c.ListAccessPointsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListAccessPointsPagesWithContext same as ListAccessPointsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) ListAccessPointsPagesWithContext(ctx aws.Context, input *ListAccessPointsInput, fn func(*ListAccessPointsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListAccessPointsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListAccessPointsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*ListAccessPointsOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
 }
 
 const opListJobs = "ListJobs"
@@ -482,6 +1061,81 @@ func (c *S3Control) ListJobsPagesWithContext(ctx aws.Context, input *ListJobsInp
 	}
 
 	return p.Err()
+}
+
+const opPutAccessPointPolicy = "PutAccessPointPolicy"
+
+// PutAccessPointPolicyRequest generates a "aws/request.Request" representing the
+// client's request for the PutAccessPointPolicy operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutAccessPointPolicy for more information on using the PutAccessPointPolicy
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutAccessPointPolicyRequest method.
+//    req, resp := client.PutAccessPointPolicyRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/PutAccessPointPolicy
+func (c *S3Control) PutAccessPointPolicyRequest(input *PutAccessPointPolicyInput) (req *request.Request, output *PutAccessPointPolicyOutput) {
+	op := &request.Operation{
+		Name:       opPutAccessPointPolicy,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/v20180820/accesspoint/{name}/policy",
+	}
+
+	if input == nil {
+		input = &PutAccessPointPolicyInput{}
+	}
+
+	output = &PutAccessPointPolicyOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(restxml.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	req.Handlers.Build.PushBackNamed(protocol.NewHostPrefixHandler("{AccountId}.", input.hostLabels))
+	req.Handlers.Build.PushBackNamed(protocol.ValidateEndpointHostHandler)
+	return
+}
+
+// PutAccessPointPolicy API operation for AWS S3 Control.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS S3 Control's
+// API operation PutAccessPointPolicy for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/s3control-2018-08-20/PutAccessPointPolicy
+func (c *S3Control) PutAccessPointPolicy(input *PutAccessPointPolicyInput) (*PutAccessPointPolicyOutput, error) {
+	req, out := c.PutAccessPointPolicyRequest(input)
+	return out, req.Send()
+}
+
+// PutAccessPointPolicyWithContext is the same as PutAccessPointPolicy with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutAccessPointPolicy for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *S3Control) PutAccessPointPolicyWithContext(ctx aws.Context, input *PutAccessPointPolicyInput, opts ...request.Option) (*PutAccessPointPolicyOutput, error) {
+	req, out := c.PutAccessPointPolicyRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
 }
 
 const opPutPublicAccessBlock = "PutPublicAccessBlock"
@@ -734,6 +1388,165 @@ func (c *S3Control) UpdateJobStatusWithContext(ctx aws.Context, input *UpdateJob
 	return out, req.Send()
 }
 
+type AccessPoint struct {
+	_ struct{} `type:"structure"`
+
+	// Bucket is a required field
+	Bucket *string `min:"3" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `min:"3" type:"string" required:"true"`
+
+	// NetworkOrigin is a required field
+	NetworkOrigin *string `type:"string" required:"true" enum:"NetworkOrigin"`
+
+	VpcConfiguration *VpcConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s AccessPoint) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AccessPoint) GoString() string {
+	return s.String()
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *AccessPoint) SetBucket(v string) *AccessPoint {
+	s.Bucket = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *AccessPoint) SetName(v string) *AccessPoint {
+	s.Name = &v
+	return s
+}
+
+// SetNetworkOrigin sets the NetworkOrigin field's value.
+func (s *AccessPoint) SetNetworkOrigin(v string) *AccessPoint {
+	s.NetworkOrigin = &v
+	return s
+}
+
+// SetVpcConfiguration sets the VpcConfiguration field's value.
+func (s *AccessPoint) SetVpcConfiguration(v *VpcConfiguration) *AccessPoint {
+	s.VpcConfiguration = v
+	return s
+}
+
+type CreateAccessPointInput struct {
+	_ struct{} `locationName:"CreateAccessPointRequest" type:"structure" xmlURI:"http://awss3control.amazonaws.com/doc/2018-08-20/"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Bucket is a required field
+	Bucket *string `min:"3" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+
+	PublicAccessBlockConfiguration *PublicAccessBlockConfiguration `type:"structure"`
+
+	VpcConfiguration *VpcConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAccessPointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccessPointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateAccessPointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateAccessPointInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 3))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+	if s.VpcConfiguration != nil {
+		if err := s.VpcConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("VpcConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *CreateAccessPointInput) SetAccountId(v string) *CreateAccessPointInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *CreateAccessPointInput) SetBucket(v string) *CreateAccessPointInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateAccessPointInput) SetName(v string) *CreateAccessPointInput {
+	s.Name = &v
+	return s
+}
+
+// SetPublicAccessBlockConfiguration sets the PublicAccessBlockConfiguration field's value.
+func (s *CreateAccessPointInput) SetPublicAccessBlockConfiguration(v *PublicAccessBlockConfiguration) *CreateAccessPointInput {
+	s.PublicAccessBlockConfiguration = v
+	return s
+}
+
+// SetVpcConfiguration sets the VpcConfiguration field's value.
+func (s *CreateAccessPointInput) SetVpcConfiguration(v *VpcConfiguration) *CreateAccessPointInput {
+	s.VpcConfiguration = v
+	return s
+}
+
+func (s *CreateAccessPointInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type CreateAccessPointOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAccessPointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccessPointOutput) GoString() string {
+	return s.String()
+}
+
 type CreateJobInput struct {
 	_ struct{} `locationName:"CreateJobRequest" type:"structure" xmlURI:"http://awss3control.amazonaws.com/doc/2018-08-20/"`
 
@@ -932,6 +1745,154 @@ func (s *CreateJobOutput) SetJobId(v string) *CreateJobOutput {
 	return s
 }
 
+type DeleteAccessPointInput struct {
+	_ struct{} `locationName:"DeleteAccessPointRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteAccessPointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessPointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAccessPointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAccessPointInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteAccessPointInput) SetAccountId(v string) *DeleteAccessPointInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteAccessPointInput) SetName(v string) *DeleteAccessPointInput {
+	s.Name = &v
+	return s
+}
+
+func (s *DeleteAccessPointInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type DeleteAccessPointOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAccessPointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessPointOutput) GoString() string {
+	return s.String()
+}
+
+type DeleteAccessPointPolicyInput struct {
+	_ struct{} `locationName:"DeleteAccessPointPolicyRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteAccessPointPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessPointPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteAccessPointPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteAccessPointPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *DeleteAccessPointPolicyInput) SetAccountId(v string) *DeleteAccessPointPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteAccessPointPolicyInput) SetName(v string) *DeleteAccessPointPolicyInput {
+	s.Name = &v
+	return s
+}
+
+func (s *DeleteAccessPointPolicyInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type DeleteAccessPointPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAccessPointPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessPointPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type DeletePublicAccessBlockInput struct {
 	_ struct{} `locationName:"DeletePublicAccessBlockRequest" type:"structure"`
 
@@ -1077,6 +2038,292 @@ func (s DescribeJobOutput) GoString() string {
 // SetJob sets the Job field's value.
 func (s *DescribeJobOutput) SetJob(v *JobDescriptor) *DescribeJobOutput {
 	s.Job = v
+	return s
+}
+
+type GetAccessPointInput struct {
+	_ struct{} `locationName:"GetAccessPointRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetAccessPointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAccessPointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAccessPointInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *GetAccessPointInput) SetAccountId(v string) *GetAccessPointInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetAccessPointInput) SetName(v string) *GetAccessPointInput {
+	s.Name = &v
+	return s
+}
+
+func (s *GetAccessPointInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type GetAccessPointOutput struct {
+	_ struct{} `type:"structure"`
+
+	Bucket *string `min:"3" type:"string"`
+
+	CreationDate *time.Time `type:"timestamp"`
+
+	Name *string `min:"3" type:"string"`
+
+	NetworkOrigin *string `type:"string" enum:"NetworkOrigin"`
+
+	PublicAccessBlockConfiguration *PublicAccessBlockConfiguration `type:"structure"`
+
+	VpcConfiguration *VpcConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccessPointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointOutput) GoString() string {
+	return s.String()
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetAccessPointOutput) SetBucket(v string) *GetAccessPointOutput {
+	s.Bucket = &v
+	return s
+}
+
+// SetCreationDate sets the CreationDate field's value.
+func (s *GetAccessPointOutput) SetCreationDate(v time.Time) *GetAccessPointOutput {
+	s.CreationDate = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetAccessPointOutput) SetName(v string) *GetAccessPointOutput {
+	s.Name = &v
+	return s
+}
+
+// SetNetworkOrigin sets the NetworkOrigin field's value.
+func (s *GetAccessPointOutput) SetNetworkOrigin(v string) *GetAccessPointOutput {
+	s.NetworkOrigin = &v
+	return s
+}
+
+// SetPublicAccessBlockConfiguration sets the PublicAccessBlockConfiguration field's value.
+func (s *GetAccessPointOutput) SetPublicAccessBlockConfiguration(v *PublicAccessBlockConfiguration) *GetAccessPointOutput {
+	s.PublicAccessBlockConfiguration = v
+	return s
+}
+
+// SetVpcConfiguration sets the VpcConfiguration field's value.
+func (s *GetAccessPointOutput) SetVpcConfiguration(v *VpcConfiguration) *GetAccessPointOutput {
+	s.VpcConfiguration = v
+	return s
+}
+
+type GetAccessPointPolicyInput struct {
+	_ struct{} `locationName:"GetAccessPointPolicyRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetAccessPointPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAccessPointPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAccessPointPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *GetAccessPointPolicyInput) SetAccountId(v string) *GetAccessPointPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetAccessPointPolicyInput) SetName(v string) *GetAccessPointPolicyInput {
+	s.Name = &v
+	return s
+}
+
+func (s *GetAccessPointPolicyInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type GetAccessPointPolicyOutput struct {
+	_ struct{} `type:"structure"`
+
+	Policy *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GetAccessPointPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointPolicyOutput) GoString() string {
+	return s.String()
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *GetAccessPointPolicyOutput) SetPolicy(v string) *GetAccessPointPolicyOutput {
+	s.Policy = &v
+	return s
+}
+
+type GetAccessPointPolicyStatusInput struct {
+	_ struct{} `locationName:"GetAccessPointPolicyStatusRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetAccessPointPolicyStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointPolicyStatusInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAccessPointPolicyStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAccessPointPolicyStatusInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *GetAccessPointPolicyStatusInput) SetAccountId(v string) *GetAccessPointPolicyStatusInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *GetAccessPointPolicyStatusInput) SetName(v string) *GetAccessPointPolicyStatusInput {
+	s.Name = &v
+	return s
+}
+
+func (s *GetAccessPointPolicyStatusInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type GetAccessPointPolicyStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	PolicyStatus *PolicyStatus `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccessPointPolicyStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessPointPolicyStatusOutput) GoString() string {
+	return s.String()
+}
+
+// SetPolicyStatus sets the PolicyStatus field's value.
+func (s *GetAccessPointPolicyStatusOutput) SetPolicyStatus(v *PolicyStatus) *GetAccessPointPolicyStatusOutput {
+	s.PolicyStatus = v
 	return s
 }
 
@@ -1897,6 +3144,114 @@ func (s *LambdaInvokeOperation) SetFunctionArn(v string) *LambdaInvokeOperation 
 	return s
 }
 
+type ListAccessPointsInput struct {
+	_ struct{} `locationName:"ListAccessPointsRequest" type:"structure"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	Bucket *string `location:"querystring" locationName:"bucket" min:"3" type:"string"`
+
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" min:"1" type:"integer"`
+
+	NextToken *string `location:"querystring" locationName:"nextToken" min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListAccessPointsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAccessPointsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListAccessPointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListAccessPointsInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Bucket != nil && len(*s.Bucket) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Bucket", 3))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *ListAccessPointsInput) SetAccountId(v string) *ListAccessPointsInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListAccessPointsInput) SetBucket(v string) *ListAccessPointsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListAccessPointsInput) SetMaxResults(v int64) *ListAccessPointsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAccessPointsInput) SetNextToken(v string) *ListAccessPointsInput {
+	s.NextToken = &v
+	return s
+}
+
+func (s *ListAccessPointsInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type ListAccessPointsOutput struct {
+	_ struct{} `type:"structure"`
+
+	AccessPointList []*AccessPoint `locationNameList:"AccessPoint" type:"list"`
+
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListAccessPointsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListAccessPointsOutput) GoString() string {
+	return s.String()
+}
+
+// SetAccessPointList sets the AccessPointList field's value.
+func (s *ListAccessPointsOutput) SetAccessPointList(v []*AccessPoint) *ListAccessPointsOutput {
+	s.AccessPointList = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListAccessPointsOutput) SetNextToken(v string) *ListAccessPointsOutput {
+	s.NextToken = &v
+	return s
+}
+
 type ListJobsInput struct {
 	_ struct{} `locationName:"ListJobsRequest" type:"structure"`
 
@@ -2014,6 +3369,28 @@ func (s *ListJobsOutput) SetNextToken(v string) *ListJobsOutput {
 	return s
 }
 
+type PolicyStatus struct {
+	_ struct{} `type:"structure"`
+
+	IsPublic *bool `locationName:"IsPublic" type:"boolean"`
+}
+
+// String returns the string representation
+func (s PolicyStatus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PolicyStatus) GoString() string {
+	return s.String()
+}
+
+// SetIsPublic sets the IsPublic field's value.
+func (s *PolicyStatus) SetIsPublic(v bool) *PolicyStatus {
+	s.IsPublic = &v
+	return s
+}
+
 type PublicAccessBlockConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -2058,6 +3435,92 @@ func (s *PublicAccessBlockConfiguration) SetIgnorePublicAcls(v bool) *PublicAcce
 func (s *PublicAccessBlockConfiguration) SetRestrictPublicBuckets(v bool) *PublicAccessBlockConfiguration {
 	s.RestrictPublicBuckets = &v
 	return s
+}
+
+type PutAccessPointPolicyInput struct {
+	_ struct{} `locationName:"PutAccessPointPolicyRequest" type:"structure" xmlURI:"http://awss3control.amazonaws.com/doc/2018-08-20/"`
+
+	// AccountId is a required field
+	AccountId *string `location:"header" locationName:"x-amz-account-id" type:"string" required:"true"`
+
+	// Name is a required field
+	Name *string `location:"uri" locationName:"name" min:"3" type:"string" required:"true"`
+
+	// Policy is a required field
+	Policy *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutAccessPointPolicyInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutAccessPointPolicyInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutAccessPointPolicyInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutAccessPointPolicyInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+	if s.AccountId != nil && len(*s.AccountId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AccountId", 1))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 3))
+	}
+	if s.Policy == nil {
+		invalidParams.Add(request.NewErrParamRequired("Policy"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *PutAccessPointPolicyInput) SetAccountId(v string) *PutAccessPointPolicyInput {
+	s.AccountId = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *PutAccessPointPolicyInput) SetName(v string) *PutAccessPointPolicyInput {
+	s.Name = &v
+	return s
+}
+
+// SetPolicy sets the Policy field's value.
+func (s *PutAccessPointPolicyInput) SetPolicy(v string) *PutAccessPointPolicyInput {
+	s.Policy = &v
+	return s
+}
+
+func (s *PutAccessPointPolicyInput) hostLabels() map[string]string {
+	return map[string]string{
+		"AccountId": aws.StringValue(s.AccountId),
+	}
+}
+
+type PutAccessPointPolicyOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutAccessPointPolicyOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutAccessPointPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutPublicAccessBlockInput struct {
@@ -3117,6 +4580,45 @@ func (s *UpdateJobStatusOutput) SetStatusUpdateReason(v string) *UpdateJobStatus
 	return s
 }
 
+type VpcConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// VpcId is a required field
+	VpcId *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s VpcConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s VpcConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *VpcConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "VpcConfiguration"}
+	if s.VpcId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VpcId"))
+	}
+	if s.VpcId != nil && len(*s.VpcId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("VpcId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetVpcId sets the VpcId field's value.
+func (s *VpcConfiguration) SetVpcId(v string) *VpcConfiguration {
+	s.VpcId = &v
+	return s
+}
+
 const (
 	// JobManifestFieldNameIgnore is a JobManifestFieldName enum value
 	JobManifestFieldNameIgnore = "Ignore"
@@ -3191,6 +4693,14 @@ const (
 
 	// JobStatusSuspended is a JobStatus enum value
 	JobStatusSuspended = "Suspended"
+)
+
+const (
+	// NetworkOriginInternet is a NetworkOrigin enum value
+	NetworkOriginInternet = "Internet"
+
+	// NetworkOriginVpc is a NetworkOrigin enum value
+	NetworkOriginVpc = "VPC"
 )
 
 const (

--- a/service/s3control/s3controliface/interface.go
+++ b/service/s3control/s3controliface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // AWS S3 Control.
 //    func myFunc(svc s3controliface.S3ControlAPI) bool {
-//        // Make svc.CreateJob request
+//        // Make svc.CreateAccessPoint request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockS3ControlClient struct {
 //        s3controliface.S3ControlAPI
 //    }
-//    func (m *mockS3ControlClient) CreateJob(input *s3control.CreateJobInput) (*s3control.CreateJobOutput, error) {
+//    func (m *mockS3ControlClient) CreateAccessPoint(input *s3control.CreateAccessPointInput) (*s3control.CreateAccessPointOutput, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,9 +60,21 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type S3ControlAPI interface {
+	CreateAccessPoint(*s3control.CreateAccessPointInput) (*s3control.CreateAccessPointOutput, error)
+	CreateAccessPointWithContext(aws.Context, *s3control.CreateAccessPointInput, ...request.Option) (*s3control.CreateAccessPointOutput, error)
+	CreateAccessPointRequest(*s3control.CreateAccessPointInput) (*request.Request, *s3control.CreateAccessPointOutput)
+
 	CreateJob(*s3control.CreateJobInput) (*s3control.CreateJobOutput, error)
 	CreateJobWithContext(aws.Context, *s3control.CreateJobInput, ...request.Option) (*s3control.CreateJobOutput, error)
 	CreateJobRequest(*s3control.CreateJobInput) (*request.Request, *s3control.CreateJobOutput)
+
+	DeleteAccessPoint(*s3control.DeleteAccessPointInput) (*s3control.DeleteAccessPointOutput, error)
+	DeleteAccessPointWithContext(aws.Context, *s3control.DeleteAccessPointInput, ...request.Option) (*s3control.DeleteAccessPointOutput, error)
+	DeleteAccessPointRequest(*s3control.DeleteAccessPointInput) (*request.Request, *s3control.DeleteAccessPointOutput)
+
+	DeleteAccessPointPolicy(*s3control.DeleteAccessPointPolicyInput) (*s3control.DeleteAccessPointPolicyOutput, error)
+	DeleteAccessPointPolicyWithContext(aws.Context, *s3control.DeleteAccessPointPolicyInput, ...request.Option) (*s3control.DeleteAccessPointPolicyOutput, error)
+	DeleteAccessPointPolicyRequest(*s3control.DeleteAccessPointPolicyInput) (*request.Request, *s3control.DeleteAccessPointPolicyOutput)
 
 	DeletePublicAccessBlock(*s3control.DeletePublicAccessBlockInput) (*s3control.DeletePublicAccessBlockOutput, error)
 	DeletePublicAccessBlockWithContext(aws.Context, *s3control.DeletePublicAccessBlockInput, ...request.Option) (*s3control.DeletePublicAccessBlockOutput, error)
@@ -72,9 +84,28 @@ type S3ControlAPI interface {
 	DescribeJobWithContext(aws.Context, *s3control.DescribeJobInput, ...request.Option) (*s3control.DescribeJobOutput, error)
 	DescribeJobRequest(*s3control.DescribeJobInput) (*request.Request, *s3control.DescribeJobOutput)
 
+	GetAccessPoint(*s3control.GetAccessPointInput) (*s3control.GetAccessPointOutput, error)
+	GetAccessPointWithContext(aws.Context, *s3control.GetAccessPointInput, ...request.Option) (*s3control.GetAccessPointOutput, error)
+	GetAccessPointRequest(*s3control.GetAccessPointInput) (*request.Request, *s3control.GetAccessPointOutput)
+
+	GetAccessPointPolicy(*s3control.GetAccessPointPolicyInput) (*s3control.GetAccessPointPolicyOutput, error)
+	GetAccessPointPolicyWithContext(aws.Context, *s3control.GetAccessPointPolicyInput, ...request.Option) (*s3control.GetAccessPointPolicyOutput, error)
+	GetAccessPointPolicyRequest(*s3control.GetAccessPointPolicyInput) (*request.Request, *s3control.GetAccessPointPolicyOutput)
+
+	GetAccessPointPolicyStatus(*s3control.GetAccessPointPolicyStatusInput) (*s3control.GetAccessPointPolicyStatusOutput, error)
+	GetAccessPointPolicyStatusWithContext(aws.Context, *s3control.GetAccessPointPolicyStatusInput, ...request.Option) (*s3control.GetAccessPointPolicyStatusOutput, error)
+	GetAccessPointPolicyStatusRequest(*s3control.GetAccessPointPolicyStatusInput) (*request.Request, *s3control.GetAccessPointPolicyStatusOutput)
+
 	GetPublicAccessBlock(*s3control.GetPublicAccessBlockInput) (*s3control.GetPublicAccessBlockOutput, error)
 	GetPublicAccessBlockWithContext(aws.Context, *s3control.GetPublicAccessBlockInput, ...request.Option) (*s3control.GetPublicAccessBlockOutput, error)
 	GetPublicAccessBlockRequest(*s3control.GetPublicAccessBlockInput) (*request.Request, *s3control.GetPublicAccessBlockOutput)
+
+	ListAccessPoints(*s3control.ListAccessPointsInput) (*s3control.ListAccessPointsOutput, error)
+	ListAccessPointsWithContext(aws.Context, *s3control.ListAccessPointsInput, ...request.Option) (*s3control.ListAccessPointsOutput, error)
+	ListAccessPointsRequest(*s3control.ListAccessPointsInput) (*request.Request, *s3control.ListAccessPointsOutput)
+
+	ListAccessPointsPages(*s3control.ListAccessPointsInput, func(*s3control.ListAccessPointsOutput, bool) bool) error
+	ListAccessPointsPagesWithContext(aws.Context, *s3control.ListAccessPointsInput, func(*s3control.ListAccessPointsOutput, bool) bool, ...request.Option) error
 
 	ListJobs(*s3control.ListJobsInput) (*s3control.ListJobsOutput, error)
 	ListJobsWithContext(aws.Context, *s3control.ListJobsInput, ...request.Option) (*s3control.ListJobsOutput, error)
@@ -82,6 +113,10 @@ type S3ControlAPI interface {
 
 	ListJobsPages(*s3control.ListJobsInput, func(*s3control.ListJobsOutput, bool) bool) error
 	ListJobsPagesWithContext(aws.Context, *s3control.ListJobsInput, func(*s3control.ListJobsOutput, bool) bool, ...request.Option) error
+
+	PutAccessPointPolicy(*s3control.PutAccessPointPolicyInput) (*s3control.PutAccessPointPolicyOutput, error)
+	PutAccessPointPolicyWithContext(aws.Context, *s3control.PutAccessPointPolicyInput, ...request.Option) (*s3control.PutAccessPointPolicyOutput, error)
+	PutAccessPointPolicyRequest(*s3control.PutAccessPointPolicyInput) (*request.Request, *s3control.PutAccessPointPolicyOutput)
 
 	PutPublicAccessBlock(*s3control.PutPublicAccessBlockInput) (*s3control.PutPublicAccessBlockOutput, error)
 	PutPublicAccessBlockWithContext(aws.Context, *s3control.PutPublicAccessBlockInput, ...request.Option) (*s3control.PutPublicAccessBlockOutput, error)


### PR DESCRIPTION
Adds support for using Access Point resource with Amazon S3 API operation calls. The Access Point resource are identified by an Amazon Resource Name (ARN).

To make operation calls to an S3 Access Point instead of a S3 Bucket, provide the Access Point ARN string as the value of the Bucket parameter. You can create an Access Point for your bucket with the Amazon S3 Control API. The Access Point ARN can be obtained from the S3 Control API. You should avoid building the ARN directly.

```go
apResp, err := ctrClient.CreateAccessPoint(&s3control.CreateAccessPointInput{
    AccountId: aws.String("123456789012"),
    Bucket:    aws.String("myBucket"),
    Name:      aws.String("myAccessPoint"),
})

resp, err := client.GetObject(&s3.GetObjectInput{
    Bucket: aws.String("arn:aws:s3:us-west-2:123456789012:accesspoint/myAccessPoint"),
    Key: aws.String("myObject"),
})
```

See https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html for more information on ARNs.