### PR TITLE
private/protocol/eventstream: Add support for EventWriter

### DIFF
--- a/private/protocol/eventstream/debug.go
+++ b/private/protocol/eventstream/debug.go
@@ -101,7 +101,7 @@ func (hs *decodedHeaders) UnmarshalJSON(b []byte) error {
 		}
 		headers.Set(h.Name, value)
 	}
-	(*hs) = decodedHeaders(headers)
+	*hs = decodedHeaders(headers)
 
 	return nil
 }

--- a/private/protocol/eventstream/eventstreamapi/reader.go
+++ b/private/protocol/eventstream/eventstreamapi/reader.go
@@ -15,24 +15,6 @@ type Unmarshaler interface {
 	UnmarshalEvent(protocol.PayloadUnmarshaler, eventstream.Message) error
 }
 
-// EventStream headers with specific meaning to async API functionality.
-const (
-	MessageTypeHeader    = `:message-type` // Identifies type of message.
-	EventMessageType     = `event`
-	ErrorMessageType     = `error`
-	ExceptionMessageType = `exception`
-
-	// Message Events
-	EventTypeHeader = `:event-type` // Identifies message event type e.g. "Stats".
-
-	// Message Error
-	ErrorCodeHeader    = `:error-code`
-	ErrorMessageHeader = `:error-message`
-
-	// Message Exception
-	ExceptionTypeHeader = `:exception-type`
-)
-
 // EventReader provides reading from the EventStream of an reader.
 type EventReader struct {
 	reader  io.ReadCloser
@@ -95,8 +77,7 @@ func (r *EventReader) ReadEvent() (event interface{}, err error) {
 	case EventMessageType:
 		return r.unmarshalEventMessage(msg)
 	case ExceptionMessageType:
-		err = r.unmarshalEventException(msg)
-		return nil, err
+		return nil, r.unmarshalEventException(msg)
 	case ErrorMessageType:
 		return nil, r.unmarshalErrorMessage(msg)
 	default:

--- a/private/protocol/eventstream/eventstreamapi/reader_test.go
+++ b/private/protocol/eventstream/eventstreamapi/reader_test.go
@@ -164,9 +164,10 @@ func BenchmarkEventReader(b *testing.B) {
 			eventMessageTypeHeader,
 			eventstream.Header{
 				Name:  EventTypeHeader,
-				Value: eventstream.StringValue("eventABC"),
+				Value: eventstream.StringValue("eventStructured"),
 			},
 		},
+		Payload: []byte(`{"String":"stringfield","Number":123,"Nested":{"String":"fieldstring","Number":321}}`),
 	}
 	if err := encoder.Encode(msg); err != nil {
 		b.Fatalf("failed to encode message, %v", err)
@@ -182,8 +183,8 @@ func BenchmarkEventReader(b *testing.B) {
 		},
 		unmarshalerForEventType,
 	)
-	b.ResetTimer()
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		stream.Seek(0, 0)
 
@@ -201,6 +202,8 @@ func unmarshalerForEventType(eventType string) (Unmarshaler, error) {
 	switch eventType {
 	case "eventABC":
 		return &eventABC{}, nil
+	case "eventStructured":
+		return &eventStructured{}, nil
 	case "exception":
 		return &exceptionType{}, nil
 	default:

--- a/private/protocol/eventstream/eventstreamapi/shared.go
+++ b/private/protocol/eventstream/eventstreamapi/shared.go
@@ -1,0 +1,23 @@
+package eventstreamapi
+
+// EventStream headers with specific meaning to async API functionality.
+const (
+	ChunkSignatureHeader = `:chunk-signature` // chunk signature for message
+	DateHeader           = `:date`            // Date header for signature
+
+	// Message header and values
+	MessageTypeHeader    = `:message-type` // Identifies type of message.
+	EventMessageType     = `event`
+	ErrorMessageType     = `error`
+	ExceptionMessageType = `exception`
+
+	// Message Events
+	EventTypeHeader = `:event-type` // Identifies message event type e.g. "Stats".
+
+	// Message Error
+	ErrorCodeHeader    = `:error-code`
+	ErrorMessageHeader = `:error-message`
+
+	// Message Exception
+	ExceptionTypeHeader = `:exception-type`
+)

--- a/private/protocol/eventstream/eventstreamapi/writer.go
+++ b/private/protocol/eventstream/eventstreamapi/writer.go
@@ -1,0 +1,55 @@
+package eventstreamapi
+
+import (
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
+)
+
+// Marshaler provides a marshaling interface for event types to event stream
+// messages.
+type Marshaler interface {
+	MarshalEvent(protocol.PayloadMarshaler) (eventstream.Message, error)
+}
+
+// EventWriter provides a wrapper around the underlying event stream encoder
+// for an io.Writer.
+type EventWriter struct {
+	writer  io.Writer
+	encoder *eventstream.Encoder
+
+	payloadMarshaler protocol.PayloadMarshaler
+}
+
+// NewEventWriter returns a new event stream writer, that will write to the
+// writer provided. Use the WriteStream method to write an event to the stream.
+func NewEventWriter(writer io.Writer,
+	payloadMarshaler protocol.PayloadMarshaler,
+) *EventWriter {
+	return &EventWriter{
+		writer:           writer,
+		encoder:          eventstream.NewEncoder(writer),
+		payloadMarshaler: payloadMarshaler,
+	}
+}
+
+// UseLogger instructs the EventWriter to use the logger and log level
+// specified.
+func (w *EventWriter) UseLogger(logger aws.Logger, logLevel aws.LogLevelType) {
+	if logger != nil && logLevel.Matches(aws.LogDebugWithEventStreamBody) {
+		w.encoder.UseLogger(logger)
+	}
+}
+
+// WriteEvent writes an event to the stream. Returns an error if the event
+// fails to marshal into a message, or writing to the underlying writer fails.
+func (w *EventWriter) WriteEvent(event Marshaler) error {
+	msg, err := event.MarshalEvent(w.payloadMarshaler)
+	if err != nil {
+		return err
+	}
+
+	return w.encoder.Encode(msg)
+}

--- a/private/protocol/eventstream/eventstreamapi/writer_test.go
+++ b/private/protocol/eventstream/eventstreamapi/writer_test.go
@@ -1,0 +1,128 @@
+package eventstreamapi
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/eventstream"
+	"github.com/aws/aws-sdk-go/private/protocol/restjson"
+)
+
+func TestEventWriter(t *testing.T) {
+	cases := map[string]struct {
+		Event  Marshaler
+		Expect eventstream.Message
+	}{
+		"structured event": {
+			Event: &eventStructured{
+				String: aws.String("stringfield"),
+				Number: aws.Int64(123),
+				Nested: &eventStructured{
+					String: aws.String("fieldstring"),
+					Number: aws.Int64(321),
+				},
+			},
+			Expect: eventstream.Message{
+				Headers: eventstream.Headers{
+					eventMessageTypeHeader,
+					eventstream.Header{
+						Name:  EventTypeHeader,
+						Value: eventstream.StringValue("eventStructured"),
+					},
+				},
+				Payload: []byte(`{"String":"stringfield","Number":123,"Nested":{"String":"fieldstring","Number":321}}`),
+			},
+		},
+	}
+
+	var marshalers request.HandlerList
+	marshalers.PushBackNamed(restjson.BuildHandler)
+
+	var stream bytes.Buffer
+	eventWriter := NewEventWriter(&stream,
+		protocol.HandlerPayloadMarshal{
+			Marshalers: marshalers,
+		},
+	)
+
+	decoder := eventstream.NewDecoder(&stream)
+
+	decodeBuf := make([]byte, 1024)
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			eventWriter.UseLogger(t, aws.LogDebugWithEventStreamBody)
+
+			if err := eventWriter.WriteEvent(c.Event); err != nil {
+				t.Fatalf("expect no write error, got %v", err)
+			}
+
+			msg, err := decoder.Decode(decodeBuf)
+			if err != nil {
+				t.Fatalf("expect no decode error got, %v", err)
+			}
+
+			if e, a := c.Expect, msg; !reflect.DeepEqual(e, a) {
+				t.Errorf("expect:%v\nactual:%v\n", e, a)
+			}
+		})
+	}
+}
+
+func BenchmarkEventWriter(b *testing.B) {
+	var marshalers request.HandlerList
+	marshalers.PushBackNamed(restjson.BuildHandler)
+
+	var stream bytes.Buffer
+	eventWriter := NewEventWriter(&stream,
+		protocol.HandlerPayloadMarshal{
+			Marshalers: marshalers,
+		},
+	)
+
+	event := &eventStructured{
+		String: aws.String("stringfield"),
+		Number: aws.Int64(123),
+		Nested: &eventStructured{
+			String: aws.String("fieldstring"),
+			Number: aws.Int64(321),
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := eventWriter.WriteEvent(event); err != nil {
+			b.Fatalf("expect no write error, got %v", err)
+		}
+	}
+}
+
+type eventStructured struct {
+	_ struct{} `type:"structure"`
+
+	String *string          `type:"string"`
+	Number *int64           `type:"long"`
+	Nested *eventStructured `type:"structure"`
+}
+
+func (e *eventStructured) MarshalEvent(pm protocol.PayloadMarshaler) (eventstream.Message, error) {
+	var msg eventstream.Message
+	msg.Headers.Set(MessageTypeHeader, eventstream.StringValue(EventMessageType))
+	msg.Headers.Set(EventTypeHeader, eventstream.StringValue("eventStructured"))
+
+	var buf bytes.Buffer
+	if err := pm.MarshalPayload(&buf, e); err != nil {
+		return eventstream.Message{}, err
+	}
+
+	msg.Payload = buf.Bytes()
+
+	return msg, nil
+}
+
+func (e *eventStructured) UnmarshalEvent(pm protocol.PayloadUnmarshaler, msg eventstream.Message) error {
+	return pm.UnmarshalPayload(bytes.NewReader(msg.Payload), e)
+}

--- a/private/protocol/eventstream/eventstreamtest/testing.go
+++ b/private/protocol/eventstream/eventstreamtest/testing.go
@@ -94,7 +94,7 @@ var EventMessageTypeHeader = eventstream.Header{
 }
 
 // EventExceptionTypeHeader is an event exception type header for specifying an
-// event is an exeption type.
+// event is an exception type.
 var EventExceptionTypeHeader = eventstream.Header{
 	Name:  eventstreamapi.MessageTypeHeader,
 	Value: eventstream.StringValue(eventstreamapi.ExceptionMessageType),

--- a/private/protocol/payload.go
+++ b/private/protocol/payload.go
@@ -64,7 +64,7 @@ func (h HandlerPayloadMarshal) MarshalPayload(w io.Writer, v interface{}) error 
 		metadata.ClientInfo{},
 		request.Handlers{},
 		nil,
-		&request.Operation{HTTPMethod: "GET"},
+		&request.Operation{HTTPMethod: "PUT"},
 		v,
 		nil,
 	)


### PR DESCRIPTION
Adds an EventWriter to the eventstreamapi package. This type provides the glue between a generate API event stream Event type being marshaled into a event stream Message, and written to the event stream Encoder.

Adds support for logging to evenstream.Encoder.