### PR TITLE
Add support for session tags to AssumeRoleProvider

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
+* Add support for session tags to `AssumeRoleProvider`.
+
 ### SDK Enhancements
 
 ### SDK Bugs

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,8 @@
 ### SDK Features
 
-* Add support for session tags to `AssumeRoleProvider`.
+* `aws/credentials/stscreds`: Add support for session tags to `AssumeRoleProvider` ([#2993](https://github.com/aws/aws-sdk-go/pull/2993))
+  * Adds support for session tags to the AssumeRoleProvider. This feature is used to enable modeling Attribute Based Access Control (ABAC) on top of AWS IAM Policies, User and Roles.
+  * https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html
 
 ### SDK Enhancements
 

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -144,6 +144,13 @@ type AssumeRoleProvider struct {
 	// Session name, if you wish to reuse the credentials elsewhere.
 	RoleSessionName string
 
+	// Optional, you can pass tag key-value pairs to your session. These tags are called session tags.
+	Tags []*sts.Tag
+
+	// A list of keys for session tags that you want to set as transitive.
+	// If you set a tag key as transitive, the corresponding key and value passes to subsequent sessions in a role chain.
+	TransitiveTagKeys []*string
+
 	// Expiry duration of the STS credentials. Defaults to 15 minutes if not set.
 	Duration time.Duration
 
@@ -269,10 +276,12 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 	}
 	jitter := time.Duration(sdkrand.SeededRand.Float64() * p.MaxJitterFrac * float64(p.Duration))
 	input := &sts.AssumeRoleInput{
-		DurationSeconds: aws.Int64(int64((p.Duration - jitter) / time.Second)),
-		RoleArn:         aws.String(p.RoleARN),
-		RoleSessionName: aws.String(p.RoleSessionName),
-		ExternalId:      p.ExternalID,
+		DurationSeconds:   aws.Int64(int64((p.Duration - jitter) / time.Second)),
+		RoleArn:           aws.String(p.RoleARN),
+		RoleSessionName:   aws.String(p.RoleSessionName),
+		ExternalId:        p.ExternalID,
+		Tags:	           p.Tags,
+		TransitiveTagKeys: p.TransitiveTagKeys,
 	}
 	if p.Policy != nil {
 		input.Policy = p.Policy

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -280,7 +280,7 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 		RoleArn:           aws.String(p.RoleARN),
 		RoleSessionName:   aws.String(p.RoleSessionName),
 		ExternalId:        p.ExternalID,
-		Tags:	           p.Tags,
+		Tags:              p.Tags,
 		TransitiveTagKeys: p.TransitiveTagKeys,
 	}
 	if p.Policy != nil {

--- a/aws/credentials/stscreds/assume_role_provider_test.go
+++ b/aws/credentials/stscreds/assume_role_provider_test.go
@@ -208,15 +208,15 @@ func TestAssumeRoleProvider_WithTags(t *testing.T) {
 		},
 	}
 	p := &AssumeRoleProvider{
-		Client:       stub,
-		RoleARN:      "roleARN",
+		Client:  stub,
+		RoleARN: "roleARN",
 		Tags: []*sts.Tag{
-			&sts.Tag {
+			{
 				Key:   aws.String("TagName"),
 				Value: aws.String("TagValue"),
 			},
 		},
-		TransitiveTagKeys: []*string { aws.String("TagName") },
+		TransitiveTagKeys: []*string{aws.String("TagName")},
 	}
 	_, err := p.Retrieve()
 	if err != nil {

--- a/aws/credentials/stscreds/assume_role_provider_test.go
+++ b/aws/credentials/stscreds/assume_role_provider_test.go
@@ -195,3 +195,31 @@ func BenchmarkAssumeRoleProvider(b *testing.B) {
 		}
 	}
 }
+
+func TestAssumeRoleProvider_WithTags(t *testing.T) {
+	stub := &stubSTS{
+		TestInput: func(in *sts.AssumeRoleInput) {
+			if *in.TransitiveTagKeys[0] != "TagName" {
+				t.Errorf("TransitiveTagKeys not passed along")
+			}
+			if *in.Tags[0].Key != "TagName" || *in.Tags[0].Value != "TagValue" {
+				t.Errorf("Tags not passed along")
+			}
+		},
+	}
+	p := &AssumeRoleProvider{
+		Client:       stub,
+		RoleARN:      "roleARN",
+		Tags: []*sts.Tag{
+			&sts.Tag {
+				Key:   aws.String("TagName"),
+				Value: aws.String("TagValue"),
+			},
+		},
+		TransitiveTagKeys: []*string { aws.String("TagName") },
+	}
+	_, err := p.Retrieve()
+	if err != nil {
+		t.Errorf("expect error")
+	}
+}


### PR DESCRIPTION
This is a small PR to add support for [session tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html) to the `AssumeRoleProvider`. This feature is important to enable  modelling Attribute Based Access Control (ABAC) on top of AWS IAM Policies, User and Roles.
