### PR TITLE
service/s3: Fix SDK support for Accesspoint ARNs with slash in resource

### DIFF
--- a/aws/arn/arn.go
+++ b/aws/arn/arn.go
@@ -75,10 +75,11 @@ func Parse(arn string) (ARN, error) {
 	}, nil
 }
 
-// IsARN returns whether the given string is an arn
-// by looking for whether the string starts with arn:
+// IsARN returns whether the given string is an ARN by looking for
+// whether the string starts with "arn:" and contains the correct number
+// of sections delimited by colons(:).
 func IsARN(arn string) bool {
-	return strings.HasPrefix(arn, arnPrefix) && strings.Count(arn, ":") > arnSections-1
+	return strings.HasPrefix(arn, arnPrefix) && strings.Count(arn, ":") >= arnSections-1
 }
 
 // String returns the canonical representation of the ARN

--- a/aws/arn/arn_test.go
+++ b/aws/arn/arn_test.go
@@ -88,3 +88,44 @@ func TestParseARN(t *testing.T) {
 		})
 	}
 }
+
+func TestIsARN(t *testing.T) {
+
+	cases := map[string]struct {
+		In     string
+		Expect bool
+		// Params
+	}{
+		"valid ARN slash resource": {
+			In:     "arn:aws:service:us-west-2:123456789012:restype/resvalue",
+			Expect: true,
+		},
+		"valid ARN colon resource": {
+			In:     "arn:aws:service:us-west-2:123456789012:restype:resvalue",
+			Expect: true,
+		},
+		"valid ARN resource": {
+			In:     "arn:aws:service:us-west-2:123456789012:*",
+			Expect: true,
+		},
+		"empty sections": {
+			In:     "arn:::::",
+			Expect: true,
+		},
+		"invalid ARN": {
+			In: "some random string",
+		},
+		"invalid ARN missing resource": {
+			In: "arn:aws:service:us-west-2:123456789012",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := IsARN(c.In)
+			if e, a := c.Expect, actual; e != a {
+				t.Errorf("expect %s valid %v, got %v", c.In, e, a)
+			}
+		})
+	}
+}

--- a/service/s3/cust_integ_shared_test.go
+++ b/service/s3/cust_integ_shared_test.go
@@ -263,7 +263,7 @@ func setupAccessPoints() (func(), error) {
 			Service:   "s3",
 			Region:    s3ControlSvc.SigningRegion,
 			AccountID: integMetadata.AccountID,
-			Resource:  fmt.Sprintf("accesspoint:%s", *ap.name),
+			Resource:  fmt.Sprintf("accesspoint/%s", *ap.name),
 		}.String()
 
 		*ap.arn = apARN

--- a/service/s3/endpoint_test.go
+++ b/service/s3/endpoint_test.go
@@ -34,6 +34,15 @@ func TestEndpointARN(t *testing.T) {
 			expectedSigningName:   "s3",
 			expectedSigningRegion: "us-west-2",
 		},
+		"AccessPoint slash delimiter": {
+			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint/myendpoint",
+			config: &aws.Config{
+				Region: aws.String("us-west-2"),
+			},
+			expectedEndpoint:      "https://myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com",
+			expectedSigningName:   "s3",
+			expectedSigningRegion: "us-west-2",
+		},
 		"AccessPoint other partition": {
 			bucket: "arn:aws-cn:s3:cn-north-1:123456789012:accesspoint:myendpoint",
 			config: &aws.Config{


### PR DESCRIPTION
Fixes the SDK's handling of S3 Accesspoint ARNs to correctly parse ARNs with slashes in the resource component as valid. Previously the SDK's ARN parsing incorrectly identify ARN resources with slash delimiters as invalid ARNs.