### PR TITLE
private/model/api: Use PackageName when using HasCrossLinks

### DIFF
--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -134,7 +134,6 @@ func (o *Operation) GetSigner() string {
 
 // operationTmpl defines a template for rendering an API Operation
 var operationTmpl = template.Must(template.New("operation").Funcs(template.FuncMap{
-	"GetCrosslinkURL":       GetCrosslinkURL,
 	"EnableStopOnSameToken": enableStopOnSameToken,
 	"GetDeprecatedMsg":      getDeprecatedMessage,
 }).Parse(`
@@ -162,7 +161,7 @@ const op{{ .ExportedName }} = "{{ .Name }}"
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
-{{ $crosslinkURL := GetCrosslinkURL $.API.BaseCrosslinkURL $.API.Metadata.UID $.ExportedName -}}
+{{ $crosslinkURL := $.API.GetCrosslinkURL $.ExportedName -}}
 {{ if ne $crosslinkURL "" -}}
 //
 // See also, {{ $crosslinkURL }}
@@ -274,7 +273,7 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 //
 {{ end -}}
 {{ end -}}
-{{ $crosslinkURL := GetCrosslinkURL $.API.BaseCrosslinkURL $.API.Metadata.UID $.ExportedName -}}
+{{ $crosslinkURL := $.API.GetCrosslinkURL $.ExportedName -}}
 {{ if ne $crosslinkURL "" -}}
 // See also, {{ $crosslinkURL }}
 {{ end -}}

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -634,7 +634,6 @@ var structShapeTmpl = func() *template.Template {
 	shapeTmpl := template.Must(
 		template.New("structShapeTmpl").
 			Funcs(template.FuncMap{
-				"GetCrosslinkURL":  GetCrosslinkURL,
 				"GetDeprecatedMsg": getDeprecatedMessage,
 			}).
 			Parse(structShapeTmplDef),


### PR DESCRIPTION
Modifies GetCrossLinks to lookup whether a service has has cross links by using the go PackageName rather then deriving the ServiceId from the metadata UID.