### PR TITLE
Add "ThrottledException" for Retry

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/request`: Adds `ThrottledException` to the list of retryable request exceptions ([#3006](https://github.com/aws/aws-sdk-go/pull/3006))
 
 ### SDK Bugs

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -83,6 +83,7 @@ var retryableCodes = map[string]struct{}{
 
 var throttleCodes = map[string]struct{}{
 	"ProvisionedThroughputExceededException": {},
+	"ThrottledException":                     {}, // SNS, XRay, ResourceGroupsTagging API
 	"Throttling":                             {},
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},

--- a/aws/request/retryer_test.go
+++ b/aws/request/retryer_test.go
@@ -12,10 +12,43 @@ import (
 
 func TestRequestThrottling(t *testing.T) {
 	req := Request{}
+	cases := []struct {
+		ecode string
+	}{
+		{
+			ecode: "ProvisionedThroughputExceededException",
+		},
+		{
+			ecode: "ThrottledException",
+		},
+		{
+			ecode: "Throttling",
+		},
+		{
+			ecode: "ThrottlingException",
+		},
+		{
+			ecode: "RequestLimitExceeded",
+		},
+		{
+			ecode: "RequestThrottled",
+		},
+		{
+			ecode: "TooManyRequestsException",
+		},
+		{
+			ecode: "PriorRequestNotComplete",
+		},
+		{
+			ecode: "TransactionInProgressException",
+		},
+	}
 
-	req.Error = awserr.New("Throttling", "", nil)
-	if e, a := true, req.IsErrorThrottle(); e != a {
-		t.Errorf("expect %t to be throttled, was %t", e, a)
+	for _, c := range cases {
+		req.Error = awserr.New(c.ecode, "", nil)
+		if e, a := true, req.IsErrorThrottle(); e != a {
+			t.Errorf("expect %s to be throttled, was %t", c.ecode, a)
+		}
 	}
 }
 


### PR DESCRIPTION
It is returned by SNS, XRAY, and ResourceGroupTagging API endpoints

https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_TagResources.html#API_TagResources_Errors

Can also be found in the JSON API spec in this repo
