### PR TITLE
Fix shouldRetry behavior for nested errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/request`: Fix shouldRetry behavior for nested errors ([#3017](https://github.com/aws/aws-sdk-go/pull/3017))

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -177,7 +177,7 @@ func shouldRetryError(origErr error) bool {
 		origErr := err.OrigErr()
 		var shouldRetry bool
 		if origErr != nil {
-			shouldRetry := shouldRetryError(origErr)
+			shouldRetry = shouldRetryError(origErr)
 			if err.Code() == "RequestError" && !shouldRetry {
 				return false
 			}

--- a/aws/request/retryer_test.go
+++ b/aws/request/retryer_test.go
@@ -76,7 +76,7 @@ func TestIsErrorRetryable(t *testing.T) {
 		},
 		{
 			Err:       awserr.New(ErrCodeSerialization, "some error", errors.New("blah")),
-			Retryable: false,
+			Retryable: true,
 		},
 		{
 			Err:       awserr.New("SomeError", "some error", nil),


### PR DESCRIPTION
`shouldRetryError` should be using the `var shouldRetry` defined in outer scope and not declare another.