### PR TITLE
Fixed SecondsTimeValue

### DIFF
--- a/aws/convert_types.go
+++ b/aws/convert_types.go
@@ -846,7 +846,7 @@ func TimeValue(v *time.Time) time.Time {
 // representing seconds since Epoch or time.Time{} if the pointer is nil.
 func SecondsTimeValue(v *int64) time.Time {
 	if v != nil {
-		return time.Unix((*v / 1000), 0)
+		return time.Unix(*v, 0)
 	}
 	return time.Time{}
 }
@@ -855,7 +855,7 @@ func SecondsTimeValue(v *int64) time.Time {
 // representing milliseconds sinch Epoch or time.Time{} if the pointer is nil.
 func MillisecondsTimeValue(v *int64) time.Time {
 	if v != nil {
-		return time.Unix(0, (*v * 1000000))
+		return time.Unix(0, *v*int64(time.Millisecond))
 	}
 	return time.Time{}
 }

--- a/aws/convert_types_test.go
+++ b/aws/convert_types_test.go
@@ -1495,28 +1495,38 @@ func TestTimeMap(t *testing.T) {
 }
 
 type TimeValueTestCase struct {
-	in        int64
+	in        *int64
 	outSecs   time.Time
 	outMillis time.Time
 }
 
 var testCasesTimeValue = []TimeValueTestCase{
 	{
-		in:        int64(1501558289000),
-		outSecs:   time.Unix(1501558289, 0),
+		in:        nil,
+		outSecs:   time.Time{},
+		outMillis: time.Time{},
+	},
+	{
+		in:        Int64(0),
+		outSecs:   time.Unix(0, 0),
+		outMillis: time.Unix(0, 0),
+	},
+	{
+		in:        Int64(1501558289000),
+		outSecs:   time.Unix(1501558289000, 0),
 		outMillis: time.Unix(1501558289, 0),
 	},
 	{
-		in:        int64(1501558289001),
-		outSecs:   time.Unix(1501558289, 0),
-		outMillis: time.Unix(1501558289, 1*1000000),
+		in:        Int64(1501558289001),
+		outSecs:   time.Unix(1501558289001, 0),
+		outMillis: time.Unix(1501558289, 1*int64(time.Millisecond)),
 	},
 }
 
 func TestSecondsTimeValue(t *testing.T) {
 	for idx, testCase := range testCasesTimeValue {
-		out := SecondsTimeValue(&testCase.in)
-		if e, a := testCase.outSecs, out; e != a {
+		out := SecondsTimeValue(testCase.in)
+		if testCase.outSecs != out {
 			t.Errorf("Unexpected value for time value at %d", idx)
 		}
 	}
@@ -1524,8 +1534,8 @@ func TestSecondsTimeValue(t *testing.T) {
 
 func TestMillisecondsTimeValue(t *testing.T) {
 	for idx, testCase := range testCasesTimeValue {
-		out := MillisecondsTimeValue(&testCase.in)
-		if e, a := testCase.outMillis, out; e != a {
+		out := MillisecondsTimeValue(testCase.in)
+		if testCase.outMillis != out {
 			t.Errorf("Unexpected value for time value at %d", idx)
 		}
 	}


### PR DESCRIPTION
* `SecondsTimeValue` now correctly treats the passed in value as a pointer to seconds.
* `MillisecondsTimeValue` now uses the `time.Milliseconds` constant correctly.
* Tests fixed and improved.