### PR TITLE
aws/request: Add const for RequestError error code

### DIFF
--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -161,7 +161,7 @@ func handleSendError(r *request.Request, err error) {
 	}
 	// Catch all request errors, and let the default retrier determine
 	// if the error is retryable.
-	r.Error = awserr.New("RequestError", "send request failed", err)
+	r.Error = awserr.New(request.ErrCodeRequestError, "send request failed", err)
 
 	// Override the error with a context canceled error, if that was canceled.
 	ctx := r.Context()

--- a/aws/csm/reporter.go
+++ b/aws/csm/reporter.go
@@ -89,7 +89,7 @@ func getMetricException(err awserr.Error) metricException {
 	code := err.Code()
 
 	switch code {
-	case "RequestError",
+	case request.ErrCodeRequestError,
 		request.ErrCodeSerialization,
 		request.CanceledErrorCode:
 		return sdkException{

--- a/aws/csm/reporter_test.go
+++ b/aws/csm/reporter_test.go
@@ -147,7 +147,7 @@ func TestReportingMetrics(t *testing.T) {
 				req := request.New(*sess.Config, md, sess.Handlers, client.DefaultRetryer{NumMaxRetries: 3}, op, nil, nil)
 				errs := []error{
 					awserr.New("AWSError", "aws error", nil),
-					awserr.New("RequestError", "sdk error", nil),
+					awserr.New(request.ErrCodeRequestError, "sdk error", nil),
 					nil,
 				}
 				resps := []*http.Response{
@@ -182,8 +182,8 @@ func TestReportingMetrics(t *testing.T) {
 				},
 				{
 					"Type":                "ApiCallAttempt",
-					"SdkException":        "RequestError",
-					"SdkExceptionMessage": "RequestError: sdk error",
+					"SdkException":        request.ErrCodeRequestError,
+					"SdkExceptionMessage": request.ErrCodeRequestError+": sdk error",
 					"HttpStatusCode":      float64(500),
 				},
 				{

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -602,7 +602,7 @@ func TestMetadataNotAvailable(t *testing.T) {
 			Status:     http.StatusText(int(0)),
 			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
 		}
-		r.Error = awserr.New("RequestError", "send request failed", nil)
+		r.Error = awserr.New(request.ErrCodeRequestError, "send request failed", nil)
 		r.Retryable = aws.Bool(true) // network errors are retryable
 	})
 

--- a/aws/ec2metadata/token_provider.go
+++ b/aws/ec2metadata/token_provider.go
@@ -62,7 +62,7 @@ func (t *tokenProvider) fetchTokenHandler(r *request.Request) {
 
 			// Check if request timed out while waiting for response
 			if e, ok := requestFailureError.OrigErr().(awserr.Error); ok {
-				if e.Code() == "RequestError" {
+				if e.Code() == request.ErrCodeRequestError {
 					atomic.StoreUint32(&t.disabled, 1)
 				}
 			}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -36,6 +36,10 @@ const (
 	// API request that was canceled. Requests given a aws.Context may
 	// return this error when canceled.
 	CanceledErrorCode = "RequestCanceled"
+
+	// ErrCodeRequestError is an error preventing the SDK from continuing to
+	// process the request.
+	ErrCodeRequestError = "RequestError"
 )
 
 // A Request is the service request to be made.

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -75,7 +75,7 @@ func (d noOpRetryer) RetryRules(_ *Request) time.Duration {
 // retryableCodes is a collection of service response codes which are retry-able
 // without any further action.
 var retryableCodes = map[string]struct{}{
-	"RequestError":            {},
+	ErrCodeRequestError:       {},
 	"RequestTimeout":          {},
 	ErrCodeResponseTimeout:    {},
 	"RequestTimeoutException": {}, // Glacier's flavor of RequestTimeout
@@ -178,7 +178,7 @@ func shouldRetryError(origErr error) bool {
 		var shouldRetry bool
 		if origErr != nil {
 			shouldRetry = shouldRetryError(origErr)
-			if err.Code() == "RequestError" && !shouldRetry {
+			if err.Code() == ErrCodeRequestError && !shouldRetry {
 				return false
 			}
 		}

--- a/aws/request/retryer_test.go
+++ b/aws/request/retryer_test.go
@@ -83,7 +83,7 @@ func TestIsErrorRetryable(t *testing.T) {
 			Retryable: false,
 		},
 		{
-			Err:       awserr.New("RequestError", "some error", nil),
+			Err:       awserr.New(ErrCodeRequestError, "some error", nil),
 			Retryable: true,
 		},
 		{


### PR DESCRIPTION
Adds a const, `ErrCodeRequestError` for the `RequestError` status code that is used in several places in the SDK's request. Cleans up the SDK's usage of this error to use the constant instead of literal string.