### PR TITLE
Fix deadlock if event reader closed and app is not reading events

### DIFF
--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -138,15 +138,24 @@ func (es *EmptyStreamEventStream) runOnStreamPartClose(r *request.Request) {
 }
 
 func (es *EmptyStreamEventStream) waitStreamPartClose() {
-	var outputC <-chan struct{}
+	var outputErrCh <-chan struct{}
 	if v, ok := es.Reader.(interface{ ErrorSet() <-chan struct{} }); ok {
-		outputC = v.ErrorSet()
+		outputErrCh = v.ErrorSet()
+	}
+	var outputClosedCh <-chan struct{}
+	if v, ok := es.Reader.(interface{ Closed() <-chan struct{} }); ok {
+		outputClosedCh = v.Closed()
 	}
 
 	select {
 	case <-es.done:
-	case <-outputC:
+	case <-outputErrCh:
 		es.err.SetError(es.Reader.Err())
+		es.Close()
+	case <-outputClosedCh:
+		if err := es.Reader.Err(); err != nil {
+			es.err.SetError(es.Reader.Err())
+		}
 		es.Close()
 	}
 }
@@ -361,15 +370,24 @@ func (es *GetEventStreamEventStream) runOnStreamPartClose(r *request.Request) {
 }
 
 func (es *GetEventStreamEventStream) waitStreamPartClose() {
-	var outputC <-chan struct{}
+	var outputErrCh <-chan struct{}
 	if v, ok := es.Reader.(interface{ ErrorSet() <-chan struct{} }); ok {
-		outputC = v.ErrorSet()
+		outputErrCh = v.ErrorSet()
+	}
+	var outputClosedCh <-chan struct{}
+	if v, ok := es.Reader.(interface{ Closed() <-chan struct{} }); ok {
+		outputClosedCh = v.Closed()
 	}
 
 	select {
 	case <-es.done:
-	case <-outputC:
+	case <-outputErrCh:
 		es.err.SetError(es.Reader.Err())
+		es.Close()
+	case <-outputClosedCh:
+		if err := es.Reader.Err(); err != nil {
+			es.err.SetError(es.Reader.Err())
+		}
 		es.Close()
 	}
 }
@@ -642,6 +660,10 @@ func (r *readEmptyEventStream) ErrorSet() <-chan struct{} {
 	return r.err.ErrorSet()
 }
 
+func (r *readEmptyEventStream) Closed() <-chan struct{} {
+	return r.done
+}
+
 func (r *readEmptyEventStream) safeClose() {
 	close(r.done)
 }
@@ -827,6 +849,10 @@ func (r *readEventStream) Close() error {
 
 func (r *readEventStream) ErrorSet() <-chan struct{} {
 	return r.err.ErrorSet()
+}
+
+func (r *readEventStream) Closed() <-chan struct{} {
+	return r.done
 }
 
 func (r *readEventStream) safeClose() {

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -165,6 +165,12 @@ func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 		}
 	{{- end }}
 
+	func (es *{{ $esapi.Name }}) setupInputPipe(r *request.Request) {
+			inputReader, inputWriter := io.Pipe()
+			r.SetStreamingBody(inputReader)
+			es.inputWriter = inputWriter
+	}
+
 	// Send writes the event to the stream blocking until the event is written.
 	// Returns an error if the event was not written.
 	//

--- a/private/model/api/eventstream_tmpl.go
+++ b/private/model/api/eventstream_tmpl.go
@@ -115,15 +115,19 @@ func (es *{{ $esapi.Name }}) runOnStreamPartClose(r *request.Request) {
 
 func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 	{{- if $inputStream }}
-		var inputC <-chan struct{}
+		var inputErrCh <-chan struct{}
 		if v, ok := es.Writer.(interface{ErrorSet() <-chan struct{}}); ok {
-			inputC = v.ErrorSet()
+			inputErrCh = v.ErrorSet()
 		}
 	{{- end }}
 	{{- if $outputStream }}
-		var outputC <-chan struct{}
+		var outputErrCh <-chan struct{}
 		if v, ok := es.Reader.(interface{ErrorSet() <-chan struct{}}); ok {
-			outputC = v.ErrorSet()
+			outputErrCh = v.ErrorSet()
+		}
+		var outputClosedCh <- chan struct{}
+		if v, ok := es.Reader.(interface{Closed() <-chan struct{}}); ok {
+			outputClosedCh = v.Closed()
 		}
 	{{- end }}
 
@@ -131,14 +135,19 @@ func (es *{{ $esapi.Name }}) waitStreamPartClose() {
 		case <-es.done:
 
 		{{- if $inputStream }}
-		case <-inputC:
+		case <-inputErrCh:
 			es.err.SetError(es.Writer.Err())
 			es.Close()
 		{{- end }}
 
 		{{- if $outputStream }}
-		case <-outputC:
+		case <-outputErrCh:
 			es.err.SetError(es.Reader.Err())
+			es.Close()
+		case <-outputClosedCh:
+			if err := es.Reader.Err(); err != nil {
+				es.err.SetError(es.Reader.Err())
+			}
 			es.Close()
 		{{- end }}
 	}

--- a/private/model/api/eventstream_tmpl_reader.go
+++ b/private/model/api/eventstream_tmpl_reader.go
@@ -60,6 +60,10 @@ func (r *{{ $es.StreamReaderImplName }}) ErrorSet() <-chan struct{} {
 	return r.err.ErrorSet()
 }
 
+func (r *{{ $es.StreamReaderImplName }}) Closed() <-chan struct{} {
+	return r.done
+}
+
 func (r *{{ $es.StreamReaderImplName }}) safeClose() {
 	close(r.done)
 }

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -235,10 +235,7 @@ func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
 
 			{{- if $inputStream }}
 
-				inputReader, inputWriter := io.Pipe()
-				req.SetReaderBody(aws.ReadSeekCloser(inputReader))
-				es.inputWriter = inputWriter
-
+				req.Handlers.Sign.PushFront(es.setupInputPipe)
 				req.Handlers.Build.PushBack(request.WithSetRequestHeaders(map[string]string{
 					"Content-Type": "application/vnd.amazon.eventstream",
 					"X-Amz-Content-Sha256": "STREAMING-AWS4-HMAC-SHA256-EVENTS",

--- a/private/model/api/shape.go
+++ b/private/model/api/shape.go
@@ -766,6 +766,7 @@ type {{ $.ShapeName }} struct {
 	{{- if $.OutputEventStreamAPI.Legacy }}
 		func (s *{{ $.ShapeName }}) Set{{ $esMemberName }}(v *{{ $.OutputEventStreamAPI.Name }}) *{{ $.ShapeName }} {
 			s.{{ $esMemberName }} = v
+			return s
 		}
 		func (s *{{ $.ShapeName }}) Get{{ $esMemberName }}() *{{ $.OutputEventStreamAPI.Name }} {
 			return s.{{ $esMemberName }}


### PR DESCRIPTION
Fixes a deadlock in the event stream writer, if the connection is closed but the application is not reading from the stream, and does not close the stream.