### PR TITLE
Fix race condition in stream writer close

### DIFF
--- a/private/protocol/eventstream/eventstreamapi/stream_writer.go
+++ b/private/protocol/eventstream/eventstreamapi/stream_writer.go
@@ -44,9 +44,6 @@ func (w *StreamWriter) Close() error {
 
 func (w *StreamWriter) safeClose() {
 	close(w.done)
-	if err := w.streamCloser.Close(); err != nil {
-		w.err.SetError(err)
-	}
 }
 
 func (w *StreamWriter) ErrorSet() <-chan struct{} {
@@ -107,6 +104,9 @@ func (w *StreamWriter) writeStream() {
 			}
 
 		case <-w.done:
+			if err := w.streamCloser.Close(); err != nil {
+				w.err.SetError(err)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Fixes race condition in stream writer's close of underlying encoder. Ensures that close of stream writer's encoder happens in same goroutine as other event writes.