### PR TITLE
service/dynamodb/expression: Allow AttributeValue as a value to BuildOperand.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/dynamodb/expression`: Allow AttributeValue as a value to BuildOperand. ([#3057](https://github.com/aws/aws-sdk-go/pull/3057))
+  * This change fixes the SDK's behavior with DynamoDB Expression builder to not double marshal AttributeValues when used as BuildOperands, `Value` type. The AttributeValue will be used in the expression as the specific value set in the AttributeValue, instead of encoded as another AttributeValue.

--- a/service/dynamodb/expression/operand.go
+++ b/service/dynamodb/expression/operand.go
@@ -519,9 +519,21 @@ func (nb NameBuilder) BuildOperand() (Operand, error) {
 // words.
 // More information on reserved words at http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html
 func (vb ValueBuilder) BuildOperand() (Operand, error) {
-	expr, err := dynamodbattribute.Marshal(vb.value)
-	if err != nil {
-		return Operand{}, newInvalidParameterError("BuildOperand", "ValueBuilder")
+	var (
+		expr *dynamodb.AttributeValue
+		err  error
+	)
+
+	switch v := vb.value.(type) {
+	case *dynamodb.AttributeValue:
+		expr = v
+	case dynamodb.AttributeValue:
+		expr = &v
+	default:
+		expr, err = dynamodbattribute.Marshal(vb.value)
+		if err != nil {
+			return Operand{}, newInvalidParameterError("BuildOperand", "ValueBuilder")
+		}
 	}
 
 	// Create a string with special characters that can be substituted later: $v

--- a/service/dynamodb/expression/operand_test.go
+++ b/service/dynamodb/expression/operand_test.go
@@ -61,6 +61,30 @@ func TestBuildOperand(t *testing.T) {
 			},
 		},
 		{
+			name:  "dynamodb.AttributeValue as value",
+			input: Value(dynamodb.AttributeValue{N: aws.String("5")}),
+			expected: exprNode{
+				values: []dynamodb.AttributeValue{
+					{
+						N: aws.String("5"),
+					},
+				},
+				fmtExpr: "$v",
+			},
+		},
+		{
+			name:  "*dynamodb.AttributeValue as value",
+			input: Value(&dynamodb.AttributeValue{N: aws.String("5")}),
+			expected: exprNode{
+				values: []dynamodb.AttributeValue{
+					{
+						N: aws.String("5"),
+					},
+				},
+				fmtExpr: "$v",
+			},
+		},
+		{
 			name:  "nested name",
 			input: Name("foo.bar"),
 			expected: exprNode{


### PR DESCRIPTION
Now you have no way to specify a dynamodb.AttributeValue as a parameter to `expression.BuildOperand` method.
If you do so, it will be treated as any other struct, and instead of just passing a value, it will Marshal it's inner struct (all the {...BOOL: true, NULL: true, ...} fields that are needed for inner implementation).

That is a problem when you (for **example**) have a struct that was already been Marshalled:

```go
package main

import (
	"fmt"

	"github.com/aws/aws-sdk-go/service/dynamodb"
	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
)

type T struct {
	ID    uint64  `dynamodbav:"id"`
	Code  string  `dynamodbav:"code"`
	Total float32 `dynamodbav:"amount"`
}

func main() {
	t := T{
		ID:    1,
		Code:  "code",
		Total: 10.5,
		// it can have dozens of fields
	}

	// it is now Marshalled into proper structs
	av, err := dynamodbattribute.MarshalMap(t)
	if err != nil {
		panic(err)
	}

	updateExpr := buildUpdateExpressionFrom(av)

	builder := expression.NewBuilder().
		WithUpdate(updateExpr)

	expr, err := builder.Build()
	if err != nil {
		panic(err)
	}

	fmt.Printf("%q", expr) // it will have a mess now. fixed in this PR
}

func buildUpdateExpressionFrom(av map[string]*dynamodb.AttributeValue) expression.UpdateBuilder {
	var expr expression.UpdateBuilder

	for attr, value := range av {
		expr = expr.Set(expression.Name(attr), expression.Value(value)) // <--- here is a problem now
	}

	return expr
}

```

