### PR TITLE
updating session.go

### DIFF
--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -291,6 +291,7 @@ func NewSessionWithOptions(opts Options) (*Session, error) {
 
 	if len(opts.Profile) != 0 {
 		envCfg.Profile = opts.Profile
+		envCfg.EnableSharedConfig = true
 	}
 
 	switch opts.SharedConfigState {


### PR DESCRIPTION
Changing the behaviour of NewSessionWithOptions()

When a profile is specified in the creation shouldn't the SharedConfigEnable be set the true by default ?

from this issue : https://github.com/aws/aws-sdk-go/issues/3008 