### PR TITLE
aws/session: Fix client init not exposing endpoint resolve error

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/session`: Fix client init not exposing endpoint resolve error ([#3059](https://github.com/aws/aws-sdk-go/pull/3059))
+  * Fixes the SDK API clients not surfacing endpoint resolution errors, when the EndpointResolver is unable to resolve an endpoint for the client and region.

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -642,10 +642,16 @@ func (s *Session) ClientConfig(service string, cfgs ...*aws.Config) client.Confi
 
 	region := aws.StringValue(s.Config.Region)
 	resolved, err := s.resolveEndpoint(service, region, s.Config)
-	if err != nil && s.Config.Logger != nil {
-		s.Config.Logger.Log(fmt.Sprintf(
-			"ERROR: unable to resolve endpoint for service %q, region %q, err: %v",
-			service, region, err))
+	if err != nil {
+		s.Handlers.Validate.PushBack(func(r *request.Request) {
+			if len(r.ClientInfo.Endpoint) != 0 {
+				// Error occurred while resolving endpoint, but the request
+				// being invoked has had an endpoint specified after the client
+				// was created.
+				return
+			}
+			r.Error = err
+		})
 	}
 
 	return client.Config{

--- a/aws/session/session_test.go
+++ b/aws/session/session_test.go
@@ -68,7 +68,10 @@ func TestNew_WithSessionLoadError(t *testing.T) {
 	os.Setenv("AWS_PROFILE", "assume_role_invalid_source_profile")
 
 	logger := bytes.Buffer{}
-	s := New(&aws.Config{Logger: &mockLogger{&logger}})
+	s := New(&aws.Config{
+		Region: aws.String("us-west-2"),
+		Logger: &mockLogger{&logger},
+	})
 
 	if s == nil {
 		t.Errorf("expect not nil")
@@ -178,8 +181,8 @@ func TestNewSession_ResolveEndpointError(t *testing.T) {
 		t.Errorf("expect %v validation error, got %v", e, a)
 	}
 
-	if e, a := "unable to resolve", logger.Buffer.String(); !strings.Contains(a, e) {
-		t.Errorf("expect %v logged, got %v", e, a)
+	if v := logger.Buffer.String(); len(v) != 0 {
+		t.Errorf("expect nothing logged, got %s", v)
 	}
 }
 


### PR DESCRIPTION
Fixes the SDK API clients not surfacing endpoint resolution errors, when the EndpointResolver is unable to resolve an endpoint for the client and region.