### PR TITLE
`aws/ec2metadata`: Reduces timeout and number of max retries for EC2Metadata client

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `aws/ec2metadata` : Reduces request timeout for EC2Metadata client along with maximum number of retries ([#3066](https://github.com/aws/aws-sdk-go/pull/3066))
+  * Reduces latency while fetching response from EC2Metadata client running in a container to around 3 seconds
+  * Fixes [#2972](https://github.com/aws/aws-sdk-go/issues/2972)

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -997,9 +997,12 @@ func TestRequestTimeOut(t *testing.T) {
 
 	c.Handlers.Complete.PushBack(op.addToOperationPerformedList)
 
+	start := time.Now()
 	resp, err := c.GetMetadata("/some/path")
 
-	expectedOperationsPerformed := []string{"GetToken", "GetMetadata"}
+	if e, a := 1*time.Second, time.Since(start); e < a {
+		t.Fatalf("expected duration of test to be less than %v, got %v", e, a)
+	}
 
 	if e, a := "IMDSProfileForSDKGo", resp; e != a {
 		t.Fatalf("Expected %v, got %v", e, a)
@@ -1009,13 +1012,16 @@ func TestRequestTimeOut(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
+	expectedOperationsPerformed := []string{"GetToken", "GetMetadata"}
 	if e, a := expectedOperationsPerformed, op.operationsPerformed; !reflect.DeepEqual(e, a) {
 		t.Fatalf("expect %v operations, got %v", e, a)
 	}
 
+	start = time.Now()
 	resp, err = c.GetMetadata("/some/path")
-
-	expectedOperationsPerformed = []string{"GetToken", "GetMetadata", "GetMetadata"}
+	if e, a := 1*time.Second, time.Since(start); e < a {
+		t.Fatalf("expected duration of test to be less than %v, got %v", e, a)
+	}
 
 	if e, a := "IMDSProfileForSDKGo", resp; e != a {
 		t.Fatalf("Expected %v, got %v", e, a)
@@ -1025,6 +1031,7 @@ func TestRequestTimeOut(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
+	expectedOperationsPerformed = []string{"GetToken", "GetMetadata", "GetMetadata"}
 	if e, a := expectedOperationsPerformed, op.operationsPerformed; !reflect.DeepEqual(e, a) {
 		t.Fatalf("expect %v operations, got %v", e, a)
 	}

--- a/aws/ec2metadata/service.go
+++ b/aws/ec2metadata/service.go
@@ -80,8 +80,10 @@ func NewClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 			// use a shorter timeout than default because the metadata
 			// service is local if it is running, and to fail faster
 			// if not running on an ec2 instance.
-			Timeout: 5 * time.Second,
+			Timeout: 1 * time.Second,
 		}
+		// max number of retries on the client operation
+		cfg.MaxRetries = aws.Int(2)
 	}
 
 	svc := &EC2Metadata{

--- a/aws/ec2metadata/service_test.go
+++ b/aws/ec2metadata/service_test.go
@@ -24,7 +24,7 @@ func TestClientOverrideDefaultHTTPClientTimeout(t *testing.T) {
 		t.Errorf("expect %v, not to equal %v", e, a)
 	}
 
-	if e, a := 5*time.Second, svc.Config.HTTPClient.Timeout; e != a {
+	if e, a := 1*time.Second, svc.Config.HTTPClient.Timeout; e != a {
 		t.Errorf("expect %v to be %v", e, a)
 	}
 }


### PR DESCRIPTION
The PR address the issues related to EC2Metadata client having long timeouts in case of failure in obtaining EC2Metadata token, while making a request to IMDS.

The PR reduces the timeout to 1 sec, and number of max retries to 2 for the EC2Metadata client. This would help reduce the long timeouts faced by the customers.

Fixes #2972