### PR TITLE
service/s3/s3manager: Fix resource leak on failed CreateMultipartUpload calls

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* `service/s3/s3manager`: Fix resource leak on failed CreateMultipartUpload calls ([#3069](https://github.com/aws/aws-sdk-go/pull/3069))
+  * Fixes [#3000](https://github.com/aws/aws-sdk-go/issues/3000), [#3035](https://github.com/aws/aws-sdk-go/issues/3035)

--- a/service/s3/internal/s3testing/s3testing.go
+++ b/service/s3/internal/s3testing/s3testing.go
@@ -1,0 +1,28 @@
+package s3testing
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/internal/sdkrand"
+)
+
+var randBytes = func() []byte {
+	rr := rand.New(rand.NewSource(0))
+	b := make([]byte, 10*sdkio.MebiByte)
+
+	if _, err := sdkrand.Read(rr, b); err != nil {
+		panic(fmt.Sprintf("failed to read random bytes, %v", err))
+	}
+	return b
+}()
+
+func GetTestBytes(size int) []byte {
+	if len(randBytes) >= size {
+		return randBytes[:size]
+	}
+
+	b := append(randBytes, GetTestBytes(size-len(randBytes))...)
+	return b
+}

--- a/service/s3/internal/s3testing/s3testing.go
+++ b/service/s3/internal/s3testing/s3testing.go
@@ -18,6 +18,7 @@ var randBytes = func() []byte {
 	return b
 }()
 
+// GetTestBytes returns a pseudo-random []byte of length size
 func GetTestBytes(size int) []byte {
 	if len(randBytes) >= size {
 		return randBytes[:size]

--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -167,7 +167,7 @@ type Uploader struct {
 	BufferProvider ReadSeekerWriteToProvider
 
 	// partPool allows for the re-usage of streaming payload part buffers between upload calls
-	partPool *partPool
+	partPool byteSlicePool
 }
 
 // NewUploader creates a new Uploader instance to upload objects to S3. Pass In
@@ -204,7 +204,7 @@ func newUploader(client s3iface.S3API, options ...func(*Uploader)) *Uploader {
 		option(u)
 	}
 
-	u.partPool = newPartPool(u.PartSize)
+	u.partPool = newByteSlicePool(u.PartSize)
 
 	return u
 }
@@ -404,8 +404,8 @@ func (u *uploader) init() error {
 
 	// If PartSize was changed or partPool was never setup then we need to allocated a new pool
 	// so that we return []byte slices of the correct size
-	if u.cfg.partPool == nil || u.cfg.partPool.partSize != u.cfg.PartSize {
-		u.cfg.partPool = newPartPool(u.cfg.PartSize)
+	if u.cfg.partPool == nil || u.cfg.partPool.Size() != u.cfg.PartSize {
+		u.cfg.partPool = newByteSlicePool(u.cfg.PartSize)
 	}
 
 	return nil
@@ -476,7 +476,7 @@ func (u *uploader) nextReader() (io.ReadSeeker, int, func(), error) {
 		return reader, int(n), cleanup, err
 
 	default:
-		part := u.cfg.partPool.Get().([]byte)
+		part := u.cfg.partPool.Get()
 		n, err := readFillBuf(r, part)
 		u.readerPos += int64(n)
 
@@ -558,6 +558,7 @@ func (u *multiuploader) upload(firstBuf io.ReadSeeker, cleanup func()) (*UploadO
 	// Create the multipart
 	resp, err := u.cfg.S3.CreateMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
 	if err != nil {
+		cleanup()
 		return nil, err
 	}
 	u.uploadID = *resp.UploadId
@@ -762,9 +763,27 @@ func (u *multiuploader) complete() *s3.CompleteMultipartUploadOutput {
 	return resp
 }
 
+type byteSlicePool interface {
+	Get() []byte
+	Put([]byte)
+	Size() int64
+}
+
 type partPool struct {
 	partSize int64
 	sync.Pool
+}
+
+func (p *partPool) Get() []byte {
+	return p.Pool.Get().([]byte)
+}
+
+func (p *partPool) Put(b []byte) {
+	p.Pool.Put(b)
+}
+
+func (p *partPool) Size() int64 {
+	return p.partSize
 }
 
 func newPartPool(partSize int64) *partPool {
@@ -775,4 +794,8 @@ func newPartPool(partSize int64) *partPool {
 	}
 
 	return p
+}
+
+var newByteSlicePool = func(partSize int64) byteSlicePool {
+	return newPartPool(partSize)
 }

--- a/service/s3/s3manager/upload_internal_test.go
+++ b/service/s3/s3manager/upload_internal_test.go
@@ -1,0 +1,147 @@
+// +build go1.7
+
+package s3manager
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	random "math/rand"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/internal/sdkio"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/internal/s3testing"
+)
+
+type recordedPartPool struct {
+	outstanding int64
+	*partPool
+}
+
+func (r *recordedPartPool) Get() []byte {
+	atomic.AddInt64(&r.outstanding, 1)
+	return r.partPool.Get()
+}
+
+func (r *recordedPartPool) Put(b []byte) {
+	atomic.AddInt64(&r.outstanding, -1)
+	r.partPool.Put(b)
+}
+
+func swapByteSlicePool(f func(partSize int64) byteSlicePool) func() {
+	orig := newByteSlicePool
+
+	newByteSlicePool = f
+
+	return func() {
+		newByteSlicePool = orig
+	}
+}
+
+func TestUploadByteSlicePool(t *testing.T) {
+	cases := map[string]struct {
+		PartSize   int64
+		FileSize   int64
+		Operations []string
+	}{
+		"single part": {
+			PartSize: sdkio.MebiByte * 5,
+			FileSize: sdkio.MebiByte * 5,
+			Operations: []string{
+				"PutObject",
+			},
+		},
+		"multi-part": {
+			PartSize: sdkio.MebiByte * 5,
+			FileSize: sdkio.MebiByte * 10,
+			Operations: []string{
+				"CreateMultipartUpload",
+				"UploadPart",
+				"CompleteMultipartUpload",
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			for _, operation := range tt.Operations {
+				t.Run(operation, func(t *testing.T) {
+					var p *recordedPartPool
+
+					unswap := swapByteSlicePool(func(partSize int64) byteSlicePool {
+						p = &recordedPartPool{
+							partPool: newPartPool(partSize),
+						}
+						return p
+					})
+					defer unswap()
+
+					sess := unit.Session.Copy()
+					svc := s3.New(sess)
+					svc.Handlers.Unmarshal.Clear()
+					svc.Handlers.UnmarshalMeta.Clear()
+					svc.Handlers.UnmarshalError.Clear()
+					svc.Handlers.Send.Clear()
+					svc.Handlers.Send.PushFront(func(r *request.Request) {
+						if r.Body != nil {
+							io.Copy(ioutil.Discard, r.Body)
+						}
+
+						if r.Operation.Name == operation {
+							r.Retryable = aws.Bool(false)
+							r.Error = fmt.Errorf("request error")
+							r.HTTPResponse = &http.Response{
+								StatusCode: 500,
+								Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+							}
+							return
+						}
+
+						r.HTTPResponse = &http.Response{
+							StatusCode: 200,
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+						}
+
+						switch data := r.Data.(type) {
+						case *s3.CreateMultipartUploadOutput:
+							data.UploadId = aws.String("UPLOAD-ID")
+						case *s3.UploadPartOutput:
+							data.ETag = aws.String(fmt.Sprintf("ETAG%d", random.Int()))
+						case *s3.CompleteMultipartUploadOutput:
+							data.Location = aws.String("https://location")
+							data.VersionId = aws.String("VERSION-ID")
+						case *s3.PutObjectOutput:
+							data.VersionId = aws.String("VERSION-ID")
+						}
+					})
+
+					uploader := NewUploaderWithClient(svc, func(u *Uploader) {
+						u.Concurrency = 1
+						u.PartSize = tt.PartSize
+					})
+
+					expected := s3testing.GetTestBytes(int(tt.FileSize))
+					_, err := uploader.Upload(&UploadInput{
+						Bucket: aws.String("bucket"),
+						Key:    aws.String("key"),
+						Body:   bytes.NewReader(expected),
+					})
+					if err == nil {
+						t.Fatalf("expected error but got none")
+					}
+
+					if v := atomic.LoadInt64(&p.outstanding); v != 0 {
+						t.Fatalf("expected zero outsnatding pool parts, got %d", v)
+					}
+				})
+			}
+		})
+	}
+}

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/awstesting"
 	"github.com/aws/aws-sdk-go/awstesting/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/internal/s3testing"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
@@ -1211,7 +1212,7 @@ func TestUploadBufferStrategy(t *testing.T) {
 				u.Concurrency = 1
 			})
 
-			expected := getTestBytes(int(tCase.Size))
+			expected := s3testing.GetTestBytes(int(tCase.Size))
 			_, err := uploader.Upload(&s3manager.UploadInput{
 				Bucket: aws.String("bucket"),
 				Key:    aws.String("key"),


### PR DESCRIPTION
* Fixes resource leak if CreateMultipartUpload call fails which would result in the first `[]byte` never being returned to the `sync.Pool`
* Adds unit-test which fails defined S3 APIs to ensure that parts are correctly returned to the pool.
* Fixes #3000
* Fixes #3035 