### PR TITLE
dynamodbattribute: cache struct type info, refactor fieldsByIndex

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 ### SDK Features
-* `service/dynamodb/dynamodbattribute`: Add caching of struct serialization ([#3070](https://github.com/aws/aws-sdk-go/pull/3070))
-  * Adds struct field caching to the SDK's DynamoDB AttributeValue marshalers and unmarshalers. This significantly reduces time, and overall allocations of the (un)marshalers by caching the reflected structure's fields. This should improve the performance of applications using DynamoDB AttributeValue (un)marshallers.
+* `service/dynamodb/dynamodbattribute`: Go 1.9+, Add caching of struct serialization ([#3070](https://github.com/aws/aws-sdk-go/pull/3070))
+  * For Go 1.9 and above, adds struct field caching to the SDK's DynamoDB AttributeValue marshalers and unmarshalers. This significantly reduces time, and overall allocations of the (un)marshalers by caching the reflected structure's fields. This should improve the performance of applications using DynamoDB AttributeValue (un)marshalers.
 
 ### SDK Enhancements
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,6 @@
 ### SDK Features
+* `service/dynamodb/dynamodbattribute`: Add caching of struct serialization ([#3070](https://github.com/aws/aws-sdk-go/pull/3070))
+  * Adds struct field caching to the SDK's DynamoDB AttributeValue marshalers and unmarshalers. This significantly reduces time, and overall allocations of the (un)marshalers by caching the reflected structure's fields. This should improve the performance of applications using DynamoDB AttributeValue (un)marshallers.
 
 ### SDK Enhancements
 

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -501,10 +501,7 @@ func (d *Decoder) decodeMap(avMap map[string]*dynamodb.AttributeValue, v reflect
 		fields := unionStructFields(v.Type(), d.MarshalOptions)
 		for k, av := range avMap {
 			if f, ok := fields.FieldByName(k); ok {
-				fv := fieldByIndex(v, f.Index, func(v *reflect.Value) bool {
-					v.Set(reflect.New(v.Type().Elem()))
-					return true // to continue the loop.
-				})
+				fv := decoderFieldByIndex(v, f.Index)
 				if err := d.decode(av, fv, f.tag); err != nil {
 					return err
 				}
@@ -612,6 +609,21 @@ func decodeUnixTime(n string) (time.Time, error) {
 	}
 
 	return time.Unix(v, 0), nil
+}
+
+// decoderFieldByIndex finds the field with the provided nested index, allocating
+// embedded parent structs if needed
+func decoderFieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for i, x := range index {
+		if i > 0 && v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct {
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v
 }
 
 // indirect will walk a value's interface or pointer value types. Returning

--- a/service/dynamodb/dynamodbattribute/decode.go
+++ b/service/dynamodb/dynamodbattribute/decode.go
@@ -500,7 +500,7 @@ func (d *Decoder) decodeMap(avMap map[string]*dynamodb.AttributeValue, v reflect
 	} else if v.Kind() == reflect.Struct {
 		fields := unionStructFields(v.Type(), d.MarshalOptions)
 		for k, av := range avMap {
-			if f, ok := fieldByName(fields, k); ok {
+			if f, ok := fields.FieldByName(k); ok {
 				fv := fieldByIndex(v, f.Index, func(v *reflect.Value) bool {
 					v.Set(reflect.New(v.Type().Elem()))
 					return true // to continue the loop.

--- a/service/dynamodb/dynamodbattribute/decode_test.go
+++ b/service/dynamodb/dynamodbattribute/decode_test.go
@@ -620,3 +620,24 @@ func TestDecodeAliasedUnixTime(t *testing.T) {
 		t.Errorf("expect %v, got %v", expect, actual)
 	}
 }
+
+func TestDecoderFieldByIndex(t *testing.T) {
+	type (
+		Middle struct{ Inner int }
+		Outer  struct{ *Middle }
+	)
+	var outer Outer
+
+	outerType := reflect.TypeOf(outer)
+	outerValue := reflect.ValueOf(&outer)
+	outerFields := unionStructFields(outerType, MarshalOptions{})
+	innerField, _ := outerFields.FieldByName("Inner")
+
+	f := decoderFieldByIndex(outerValue.Elem(), innerField.Index)
+	if outer.Middle == nil {
+		t.Errorf("expected outer.Middle to be non-nil")
+	}
+	if f.Kind() != reflect.Int || f.Int() != int64(outer.Inner) {
+		t.Error("expected f to be an int with value equal to outer.Inner")
+	}
+}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -310,7 +310,7 @@ func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value, fie
 
 	av.M = map[string]*dynamodb.AttributeValue{}
 	fields := unionStructFields(v.Type(), e.MarshalOptions)
-	for _, f := range fields {
+	for _, f := range fields.All() {
 		if f.Name == "" {
 			return &InvalidMarshalError{msg: "map key cannot be empty"}
 		}

--- a/service/dynamodb/dynamodbattribute/encode.go
+++ b/service/dynamodb/dynamodbattribute/encode.go
@@ -243,23 +243,6 @@ func (e *Encoder) Encode(in interface{}) (*dynamodb.AttributeValue, error) {
 	return av, nil
 }
 
-func fieldByIndex(v reflect.Value, index []int,
-	OnEmbeddedNilStruct func(*reflect.Value) bool) reflect.Value {
-	fv := v
-	for i, x := range index {
-		if i > 0 {
-			if fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct {
-				if fv.IsNil() && !OnEmbeddedNilStruct(&fv) {
-					break
-				}
-				fv = fv.Elem()
-			}
-		}
-		fv = fv.Field(x)
-	}
-	return fv
-}
-
 func (e *Encoder) encode(av *dynamodb.AttributeValue, v reflect.Value, fieldTag tag) error {
 	// We should check for omitted values first before dereferencing.
 	if fieldTag.OmitEmpty && emptyValue(v, e.EnableEmptyCollections) {
@@ -315,11 +298,7 @@ func (e *Encoder) encodeStruct(av *dynamodb.AttributeValue, v reflect.Value, fie
 			return &InvalidMarshalError{msg: "map key cannot be empty"}
 		}
 
-		found := true
-		fv := fieldByIndex(v, f.Index, func(v *reflect.Value) bool {
-			found = false
-			return false // to break the loop.
-		})
+		fv, found := encoderFieldByIndex(v, f.Index)
 		if !found {
 			continue
 		}
@@ -547,6 +526,20 @@ func encodeFloat(f float64, bitSize int) string {
 func encodeNull(av *dynamodb.AttributeValue) {
 	t := true
 	*av = dynamodb.AttributeValue{NULL: &t}
+}
+
+// encoderFieldByIndex finds the field with the provided nested index
+func encoderFieldByIndex(v reflect.Value, index []int) (reflect.Value, bool) {
+	for i, x := range index {
+		if i > 0 && v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct {
+			if v.IsNil() {
+				return reflect.Value{}, false
+			}
+			v = v.Elem()
+		}
+		v = v.Field(x)
+	}
+	return v, true
 }
 
 func valueElem(v reflect.Value) reflect.Value {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -292,7 +292,7 @@ func TestEncoderFieldByIndex(t *testing.T) {
 	innerField, _ = outerFields.FieldByName("Inner")
 
 	f, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
-	if found != true {
+	if !found {
 		t.Error("expected found to be true")
 	}
 	if f.Kind() != reflect.Int || f.Int() != int64(outer.Inner) {

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -269,3 +269,37 @@ func TestEncodeAliasedUnixTime(t *testing.T) {
 		t.Errorf("expect %v, got %v", e, a)
 	}
 }
+
+func TestEncoderFieldByIndex(t *testing.T) {
+	type (
+		Middle struct{ Inner int }
+		Outer  struct{ *Middle }
+	)
+
+	t.Run("nil embedded struct", func(t *testing.T) {
+		outer := Outer{}
+
+		outerFields := unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
+		innerField, _ := outerFields.FieldByName("Inner")
+
+		_, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
+		if found != false {
+			t.Error("expected found to be false when embedded struct is nil")
+		}
+	})
+
+	t.Run("non-nil embedded struct", func(t *testing.T) {
+		outer := Outer{Middle: &Middle{Inner: 3}}
+
+		outerFields := unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
+		innerField, _ := outerFields.FieldByName("Inner")
+
+		f, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
+		if found != true {
+			t.Error("expected found to be true")
+		}
+		if f.Kind() != reflect.Int || f.Int() != int64(outer.Inner) {
+			t.Error("expected f to be of kind Int with value equal to outer.Inner")
+		}
+	})
+}

--- a/service/dynamodb/dynamodbattribute/encode_test.go
+++ b/service/dynamodb/dynamodbattribute/encode_test.go
@@ -276,30 +276,26 @@ func TestEncoderFieldByIndex(t *testing.T) {
 		Outer  struct{ *Middle }
 	)
 
-	t.Run("nil embedded struct", func(t *testing.T) {
-		outer := Outer{}
+	// nil embedded struct
+	outer := Outer{}
+	outerFields := unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
+	innerField, _ := outerFields.FieldByName("Inner")
 
-		outerFields := unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
-		innerField, _ := outerFields.FieldByName("Inner")
+	_, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
+	if found != false {
+		t.Error("expected found to be false when embedded struct is nil")
+	}
 
-		_, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
-		if found != false {
-			t.Error("expected found to be false when embedded struct is nil")
-		}
-	})
+	// non-nil embedded struct
+	outer = Outer{Middle: &Middle{Inner: 3}}
+	outerFields = unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
+	innerField, _ = outerFields.FieldByName("Inner")
 
-	t.Run("non-nil embedded struct", func(t *testing.T) {
-		outer := Outer{Middle: &Middle{Inner: 3}}
-
-		outerFields := unionStructFields(reflect.TypeOf(outer), MarshalOptions{})
-		innerField, _ := outerFields.FieldByName("Inner")
-
-		f, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
-		if found != true {
-			t.Error("expected found to be true")
-		}
-		if f.Kind() != reflect.Int || f.Int() != int64(outer.Inner) {
-			t.Error("expected f to be of kind Int with value equal to outer.Inner")
-		}
-	})
+	f, found := encoderFieldByIndex(reflect.ValueOf(&outer).Elem(), innerField.Index)
+	if found != true {
+		t.Error("expected found to be true")
+	}
+	if f.Kind() != reflect.Int || f.Int() != int64(outer.Inner) {
+		t.Error("expected f to be of kind Int with value equal to outer.Inner")
+	}
 }

--- a/service/dynamodb/dynamodbattribute/field.go
+++ b/service/dynamodb/dynamodbattribute/field.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 )
 
 type field struct {
@@ -16,22 +17,28 @@ type field struct {
 	Type  reflect.Type
 }
 
-func fieldByName(fields []field, name string) (field, bool) {
-	foldExists := false
-	foldField := field{}
+type cachedFields struct {
+	fields       []field
+	fieldsByName map[string]int
+}
 
-	for _, f := range fields {
-		if f.Name == name {
+func (f *cachedFields) All() []field {
+	return f.fields
+}
+
+func (f *cachedFields) FieldByName(name string) (field, bool) {
+	if i, ok := f.fieldsByName[name]; ok {
+		return f.fields[i], ok
+	}
+	for _, f := range f.fields {
+		if strings.EqualFold(f.Name, name) {
 			return f, true
 		}
-		if !foldExists && strings.EqualFold(f.Name, name) {
-			foldField = f
-			foldExists = true
-		}
 	}
-
-	return foldField, foldExists
+	return field{}, false
 }
+
+var fieldCache sync.Map
 
 func buildField(pIdx []int, i int, sf reflect.StructField, fieldTag tag) field {
 	f := field{
@@ -51,14 +58,26 @@ func buildField(pIdx []int, i int, sf reflect.StructField, fieldTag tag) field {
 	return f
 }
 
-func unionStructFields(t reflect.Type, opts MarshalOptions) []field {
-	fields := enumFields(t, opts)
+// unionStructFields returns a list of fields for the given type. Type info is cached
+// to avoid repeated calls into the reflect package
+func unionStructFields(t reflect.Type, opts MarshalOptions) cachedFields {
+	if cached, ok := fieldCache.Load(t); ok {
+		return cached.(cachedFields)
+	}
 
-	sort.Sort(fieldsByName(fields))
+	f := enumFields(t, opts)
+	sort.Sort(fieldsByName(f))
+	f = visibleFields(f)
 
-	fields = visibleFields(fields)
-
-	return fields
+	fs := cachedFields{
+		fields:       f,
+		fieldsByName: make(map[string]int, len(f)),
+	}
+	for i, f := range fs.fields {
+		fs.fieldsByName[f.Name] = i
+	}
+	cached, _ := fieldCache.LoadOrStore(t, fs)
+	return cached.(cachedFields)
 }
 
 // enumFields will recursively iterate through a structure and its nested

--- a/service/dynamodb/dynamodbattribute/field_test.go
+++ b/service/dynamodb/dynamodbattribute/field_test.go
@@ -95,38 +95,34 @@ func TestCachedFields(t *testing.T) {
 
 	fields := unionStructFields(reflect.TypeOf(myStruct{}), MarshalOptions{})
 
-	t.Run("all fields", func(t *testing.T) {
-		const expectedNumFields = 2
-		if numFields := len(fields.All()); numFields != expectedNumFields {
-			t.Errorf("expected number of fields to be %d but got %d", expectedNumFields, numFields)
-		}
-	})
+	const expectedNumFields = 2
+	if numFields := len(fields.All()); numFields != expectedNumFields {
+		t.Errorf("expected number of fields to be %d but got %d", expectedNumFields, numFields)
+	}
 
-	t.Run("fields by name", func(t *testing.T) {
-		cases := []struct {
-			Name      string
-			FieldName string
-			Found     bool
-		}{
-			{"Dog", "Dog", true},
-			{"dog", "Dog", true},
-			{"DOG", "Dog", true},
-			{"Yorkie", "", false},
-			{"Cat", "CAT", true},
-			{"cat", "CAT", true},
-			{"CAT", "CAT", true},
-			{"tiger", "", false},
-			{"bird", "", false},
-		}
+	cases := []struct {
+		Name      string
+		FieldName string
+		Found     bool
+	}{
+		{"Dog", "Dog", true},
+		{"dog", "Dog", true},
+		{"DOG", "Dog", true},
+		{"Yorkie", "", false},
+		{"Cat", "CAT", true},
+		{"cat", "CAT", true},
+		{"CAT", "CAT", true},
+		{"tiger", "", false},
+		{"bird", "", false},
+	}
 
-		for _, c := range cases {
-			f, found := fields.FieldByName(c.Name)
-			if found != c.Found {
-				t.Errorf("expected found to be %v but got %v", c.Found, found)
-			}
-			if found && f.Name != c.FieldName {
-				t.Errorf("expected field name to be %s but got %s", c.FieldName, f.Name)
-			}
+	for _, c := range cases {
+		f, found := fields.FieldByName(c.Name)
+		if found != c.Found {
+			t.Errorf("expected found to be %v but got %v", c.Found, found)
 		}
-	})
+		if found && f.Name != c.FieldName {
+			t.Errorf("expected field name to be %s but got %s", c.FieldName, f.Name)
+		}
+	}
 }

--- a/service/dynamodb/dynamodbattribute/fields_go1.9.go
+++ b/service/dynamodb/dynamodbattribute/fields_go1.9.go
@@ -1,0 +1,23 @@
+// +build go1.9
+
+package dynamodbattribute
+
+import "sync"
+
+var fieldCache fieldCacher
+
+type fieldCacher struct {
+	cache sync.Map
+}
+
+func (c *fieldCacher) Load(t interface{}) (*cachedFields, bool) {
+	if v, ok := c.cache.Load(t); ok {
+		return v.(*cachedFields), true
+	}
+	return nil, false
+}
+
+func (c *fieldCacher) LoadOrStore(t interface{}, fs *cachedFields) (*cachedFields, bool) {
+	v, ok := c.cache.LoadOrStore(t, fs)
+	return v.(*cachedFields), ok
+}

--- a/service/dynamodb/dynamodbattribute/fields_go_old.go
+++ b/service/dynamodb/dynamodbattribute/fields_go_old.go
@@ -1,0 +1,15 @@
+// +build !go1.9
+
+package dynamodbattribute
+
+var fieldCache fieldCacher
+
+type fieldCacher struct{}
+
+func (c fieldCacher) Load(t interface{}) (*cachedFields, bool) {
+	return nil, false
+}
+
+func (c fieldCacher) LoadOrStore(t interface{}, fs *cachedFields) (*cachedFields, bool) {
+	return fs, false
+}

--- a/service/dynamodb/dynamodbattribute/marshaler_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_test.go
@@ -3,6 +3,7 @@ package dynamodbattribute
 import (
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -555,6 +556,8 @@ func compareObjects(t *testing.T, expected interface{}, actual interface{}) {
 }
 
 func BenchmarkMarshal(b *testing.B) {
+	clearCache := func() { fieldCache = sync.Map{} }
+
 	simple := simpleMarshalStruct{
 		String:  "abc",
 		Int:     123,
@@ -565,6 +568,8 @@ func BenchmarkMarshal(b *testing.B) {
 		Null:    nil,
 	}
 	b.Run("one composite member", func(b *testing.B) {
+		clearCache()
+
 		type MyCompositeStruct struct {
 			A simpleMarshalStruct `dynamodbav:"a"`
 		}
@@ -580,6 +585,8 @@ func BenchmarkMarshal(b *testing.B) {
 	})
 
 	b.Run("two composite members", func(b *testing.B) {
+		clearCache()
+
 		type MyCompositeStruct struct {
 			A simpleMarshalStruct `dynamodbav:"a"`
 			B simpleMarshalStruct `dynamodbav:"b"`
@@ -598,6 +605,8 @@ func BenchmarkMarshal(b *testing.B) {
 }
 
 func BenchmarkUnmarshal(b *testing.B) {
+	clearCache := func() { fieldCache = sync.Map{} }
+
 	myStructAVMap, _ := Marshal(simpleMarshalStruct{
 		String:  "abc",
 		Int:     123,
@@ -609,6 +618,8 @@ func BenchmarkUnmarshal(b *testing.B) {
 	})
 
 	b.Run("one composite member", func(b *testing.B) {
+		clearCache()
+
 		type MyCompositeStructOne struct {
 			A simpleMarshalStruct `dynamodbav:"a"`
 		}
@@ -626,6 +637,8 @@ func BenchmarkUnmarshal(b *testing.B) {
 	})
 
 	b.Run("two composite members", func(b *testing.B) {
+		clearCache()
+
 		type MyCompositeStructTwo struct {
 			A simpleMarshalStruct `dynamodbav:"a"`
 			B simpleMarshalStruct `dynamodbav:"b"`

--- a/service/dynamodb/dynamodbattribute/marshaler_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_test.go
@@ -555,7 +555,7 @@ func compareObjects(t *testing.T, expected interface{}, actual interface{}) {
 }
 
 func BenchmarkMarshal(b *testing.B) {
-	d := simpleMarshalStruct{
+	simple := simpleMarshalStruct{
 		String:  "abc",
 		Int:     123,
 		Uint:    123,
@@ -564,12 +564,85 @@ func BenchmarkMarshal(b *testing.B) {
 		Bool:    true,
 		Null:    nil,
 	}
-	for i := 0; i < b.N; i++ {
-		_, err := Marshal(d)
-		if err != nil {
-			b.Fatal("unexpected error", err)
+	b.Run("one composite member", func(b *testing.B) {
+		type MyCompositeStruct struct {
+			A simpleMarshalStruct `dynamodbav:"a"`
 		}
-	}
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if _, err := Marshal(MyCompositeStruct{
+					A: simple,
+				}); err != nil {
+					b.Error("unexpected error:", err)
+				}
+			}
+		})
+	})
+
+	b.Run("two composite members", func(b *testing.B) {
+		type MyCompositeStruct struct {
+			A simpleMarshalStruct `dynamodbav:"a"`
+			B simpleMarshalStruct `dynamodbav:"b"`
+		}
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if _, err := Marshal(MyCompositeStruct{
+					A: simple,
+					B: simple,
+				}); err != nil {
+					b.Error("unexpected error:", err)
+				}
+			}
+		})
+	})
+}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	myStructAVMap, _ := Marshal(simpleMarshalStruct{
+		String:  "abc",
+		Int:     123,
+		Uint:    123,
+		Float32: 123.321,
+		Float64: 123.321,
+		Bool:    true,
+		Null:    nil,
+	})
+
+	b.Run("one composite member", func(b *testing.B) {
+		type MyCompositeStructOne struct {
+			A simpleMarshalStruct `dynamodbav:"a"`
+		}
+		var out MyCompositeStructOne
+		avMap := map[string]*dynamodb.AttributeValue{
+			"a": myStructAVMap,
+		}
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := Unmarshal(&dynamodb.AttributeValue{M: avMap}, &out); err != nil {
+					b.Error("unexpected error:", err)
+				}
+			}
+		})
+	})
+
+	b.Run("two composite members", func(b *testing.B) {
+		type MyCompositeStructTwo struct {
+			A simpleMarshalStruct `dynamodbav:"a"`
+			B simpleMarshalStruct `dynamodbav:"b"`
+		}
+		var out MyCompositeStructTwo
+		avMap := map[string]*dynamodb.AttributeValue{
+			"a": myStructAVMap,
+			"b": myStructAVMap,
+		}
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := Unmarshal(&dynamodb.AttributeValue{M: avMap}, &out); err != nil {
+					b.Error("unexpected error:", err)
+				}
+			}
+		})
+	})
 }
 
 func Test_Encode_YAML_TagKey(t *testing.T) {

--- a/service/dynamodb/dynamodbattribute/marshaler_test.go
+++ b/service/dynamodb/dynamodbattribute/marshaler_test.go
@@ -3,7 +3,6 @@ package dynamodbattribute
 import (
 	"math"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -556,7 +555,7 @@ func compareObjects(t *testing.T, expected interface{}, actual interface{}) {
 }
 
 func BenchmarkMarshal(b *testing.B) {
-	clearCache := func() { fieldCache = sync.Map{} }
+	clearCache := func() { fieldCache = fieldCacher{} }
 
 	simple := simpleMarshalStruct{
 		String:  "abc",
@@ -605,7 +604,7 @@ func BenchmarkMarshal(b *testing.B) {
 }
 
 func BenchmarkUnmarshal(b *testing.B) {
-	clearCache := func() { fieldCache = sync.Map{} }
+	clearCache := func() { fieldCache = fieldCacher{} }
 
 	myStructAVMap, _ := Marshal(simpleMarshalStruct{
 		String:  "abc",


### PR DESCRIPTION
Currently struct type information is recomputed on every call to `dynamodbattribute.Marshal` and `dynamodbattribute.Unmarshal`.  To avoid this repeated work, I've added a `sync.Map`-backed cache to the reflection pass so that struct type info is only computed once.  In addition to caching fields per type, I've also included an index for each type that maps field names to fields to avoid linear searches by name in the Decoder.  On the whole, this approach basically the same as what the stdlib's `encoding/json` [does to solve the same problem](https://github.com/golang/go/blob/25a14b19abd3b9e16f47c6249fda1998431ce5be/src/encoding/json/encode.go#L1379).

`dynamodbattribute.fieldsByIndex` has been refactored into two functions, `decoderFieldsByIndex` and `encoderFieldsByIndex`.  This approach eliminates the need for the `OnEmbeddedNilStruct` callback and as a result no longer requires that the instance of `reflect.Value` in the search loop be moved to the heap.    

I've added a couple of benchmarks to quantify the impact of the changes.  Here's `benchcmp` diff of the results before and after:

```
goos: darwin
goarch: amd64

benchmark                                      old ns/op     new ns/op     delta
BenchmarkMarshal/one_composite_member          8919          3486          -60.91%
BenchmarkMarshal/one_composite_member-2        4939          1972          -60.07%
BenchmarkMarshal/one_composite_member-4        2987          1245          -58.32%
BenchmarkMarshal/one_composite_member-8        2949          1293          -56.15%
BenchmarkMarshal/two_composite_members         16569         6599          -60.17%
BenchmarkMarshal/two_composite_members-2       9201          3693          -59.86%
BenchmarkMarshal/two_composite_members-4       5762          2380          -58.69%
BenchmarkMarshal/two_composite_members-8       5678          2467          -56.55%
BenchmarkUnmarshal/one_composite_member        7219          1833          -74.61%
BenchmarkUnmarshal/one_composite_member-2      3881          995           -74.36%
BenchmarkUnmarshal/one_composite_member-4      2330          571           -75.49%
BenchmarkUnmarshal/one_composite_member-8      2349          572           -75.65%
BenchmarkUnmarshal/two_composite_members       14010         3223          -77.00%
BenchmarkUnmarshal/two_composite_members-2     7598          1707          -77.53%
BenchmarkUnmarshal/two_composite_members-4     4455          1022          -77.06%
BenchmarkUnmarshal/two_composite_members-8     4591          1041          -77.33%

benchmark                                      old allocs     new allocs     delta
BenchmarkMarshal/one_composite_member          70             31             -55.71%
BenchmarkMarshal/one_composite_member-2        70             31             -55.71%
BenchmarkMarshal/one_composite_member-4        70             31             -55.71%
BenchmarkMarshal/one_composite_member-8        70             31             -55.71%
BenchmarkMarshal/two_composite_members         132            57             -56.82%
BenchmarkMarshal/two_composite_members-2       132            57             -56.82%
BenchmarkMarshal/two_composite_members-4       132            57             -56.82%
BenchmarkMarshal/two_composite_members-8       132            57             -56.82%
BenchmarkUnmarshal/one_composite_member        42             3              -92.86%
BenchmarkUnmarshal/one_composite_member-2      42             3              -92.86%
BenchmarkUnmarshal/one_composite_member-4      42             3              -92.86%
BenchmarkUnmarshal/one_composite_member-8      42             3              -92.86%
BenchmarkUnmarshal/two_composite_members       79             4              -94.94%
BenchmarkUnmarshal/two_composite_members-2     79             4              -94.94%
BenchmarkUnmarshal/two_composite_members-4     79             4              -94.94%
BenchmarkUnmarshal/two_composite_members-8     79             4              -94.94%

benchmark                                      old bytes     new bytes     delta
BenchmarkMarshal/one_composite_member          4560          2456          -46.14%
BenchmarkMarshal/one_composite_member-2        4560          2456          -46.14%
BenchmarkMarshal/one_composite_member-4        4559          2456          -46.13%
BenchmarkMarshal/one_composite_member-8        4560          2456          -46.14%
BenchmarkMarshal/two_composite_members         8608          4432          -48.51%
BenchmarkMarshal/two_composite_members-2       8608          4432          -48.51%
BenchmarkMarshal/two_composite_members-4       8607          4432          -48.51%
BenchmarkMarshal/two_composite_members-8       8608          4432          -48.51%
BenchmarkUnmarshal/one_composite_member        2336          240           -89.73%
BenchmarkUnmarshal/one_composite_member-2      2336          240           -89.73%
BenchmarkUnmarshal/one_composite_member-4      2336          240           -89.73%
BenchmarkUnmarshal/one_composite_member-8      2336          240           -89.73%
BenchmarkUnmarshal/two_composite_members       4432          272           -93.86%
BenchmarkUnmarshal/two_composite_members-2     4432          272           -93.86%
BenchmarkUnmarshal/two_composite_members-4     4432          272           -93.86%
BenchmarkUnmarshal/two_composite_members-8     4432          272           -93.86%
```