### PR TITLE
aws/request: Add support for EC2 specific throttle exception code

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/request`: Add support for EC2 specific throttle exception code
+  * Adds support for the EC2ThrottledException throttling exception code. The SDK will now treat this error code as throttling.
 
 ### SDK Bugs

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -92,6 +92,7 @@ var throttleCodes = map[string]struct{}{
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 	"TransactionInProgressException":         {},
+	"EC2ThrottledException":                  {}, // EC2
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials

--- a/aws/request/retryer_test.go
+++ b/aws/request/retryer_test.go
@@ -42,6 +42,9 @@ func TestRequestThrottling(t *testing.T) {
 		{
 			ecode: "TransactionInProgressException",
 		},
+		{
+			ecode: "EC2ThrottledException",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Adds support for the EC2ThrottledException throttling exception code. The SDK will now treat this error code as throttling.