### PR TITLE
Fix generated errors for some JSON APIs not including message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
-* Fix generated errors for some JSON APIs not including a message ([#3088](https://github.com/aws/aws-sdk-go/issues/3088))
+* Fix generated errors for some JSON APIs not including a message ([#3089](https://github.com/aws/aws-sdk-go/issues/3089))
   * Fixes the SDK's generated errors to all include the `Message` member regardless if it was modeled on the error shape. This fixes the bug identified in #3088 where some JSON errors were not modeled with the Message member.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 ### SDK Enhancements
 
 ### SDK Bugs
+* Fix generated errors for some JSON APIs not including a message ([#3088](https://github.com/aws/aws-sdk-go/issues/3088))
+  * Fixes the SDK's generated errors to all include the `Message` member regardless if it was modeled on the error shape. This fixes the bug identified in #3088 where some JSON errors were not modeled with the Message member.

--- a/private/model/api/codegentest/service/restjsonservice/api.go
+++ b/private/model/api/codegentest/service/restjsonservice/api.go
@@ -938,6 +938,8 @@ func (s ExceptionEvent) RequestID() string {
 type ExceptionEvent2 struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -959,11 +961,21 @@ func (s *ExceptionEvent2) UnmarshalEvent(
 	payloadUnmarshaler protocol.PayloadUnmarshaler,
 	msg eventstream.Message,
 ) error {
+	if err := payloadUnmarshaler.UnmarshalPayload(
+		bytes.NewReader(msg.Payload), s,
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
+	var buf bytes.Buffer
+	if err = pm.MarshalPayload(&buf, s); err != nil {
+		return eventstream.Message{}, err
+	}
+	msg.Payload = buf.Bytes()
 	return msg, err
 }
 
@@ -980,6 +992,9 @@ func (s ExceptionEvent2) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent2) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/private/model/api/codegentest/service/restxmlservice/api.go
+++ b/private/model/api/codegentest/service/restxmlservice/api.go
@@ -938,6 +938,8 @@ func (s ExceptionEvent) RequestID() string {
 type ExceptionEvent2 struct {
 	_            struct{} `locationName:"ExceptionEvent2" type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"Message" type:"string"`
 }
 
 // String returns the string representation
@@ -959,11 +961,21 @@ func (s *ExceptionEvent2) UnmarshalEvent(
 	payloadUnmarshaler protocol.PayloadUnmarshaler,
 	msg eventstream.Message,
 ) error {
+	if err := payloadUnmarshaler.UnmarshalPayload(
+		bytes.NewReader(msg.Payload), s,
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
+	var buf bytes.Buffer
+	if err = pm.MarshalPayload(&buf, s); err != nil {
+		return eventstream.Message{}, err
+	}
+	msg.Payload = buf.Bytes()
 	return msg, err
 }
 
@@ -980,6 +992,9 @@ func (s ExceptionEvent2) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent2) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/private/model/api/codegentest/service/rpcservice/api.go
+++ b/private/model/api/codegentest/service/rpcservice/api.go
@@ -1051,6 +1051,8 @@ func (s ExceptionEvent) RequestID() string {
 type ExceptionEvent2 struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1072,11 +1074,21 @@ func (s *ExceptionEvent2) UnmarshalEvent(
 	payloadUnmarshaler protocol.PayloadUnmarshaler,
 	msg eventstream.Message,
 ) error {
+	if err := payloadUnmarshaler.UnmarshalPayload(
+		bytes.NewReader(msg.Payload), s,
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (s *ExceptionEvent2) MarshalEvent(pm protocol.PayloadMarshaler) (msg eventstream.Message, err error) {
 	msg.Headers.Set(eventstreamapi.MessageTypeHeader, eventstream.StringValue(eventstreamapi.ExceptionMessageType))
+	var buf bytes.Buffer
+	if err = pm.MarshalPayload(&buf, s); err != nil {
+		return eventstream.Message{}, err
+	}
+	msg.Payload = buf.Bytes()
 	return msg, err
 }
 
@@ -1093,6 +1105,9 @@ func (s ExceptionEvent2) Code() string {
 
 // Message returns the exception's message.
 func (s ExceptionEvent2) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/private/model/api/load.go
+++ b/private/model/api/load.go
@@ -203,6 +203,7 @@ func (a *API) Setup() error {
 	a.setMetadataEndpointsKey()
 	a.writeShapeNames()
 	a.resolveReferences()
+	a.backfillErrorMembers()
 
 	if !a.NoRemoveUnusedShapes {
 		a.removeUnusedShapes()

--- a/private/model/api/smoke.go
+++ b/private/model/api/smoke.go
@@ -113,6 +113,9 @@ var smokeTestTmpl = template.Must(template.New(`smokeTestTmpl`).Parse(`
 			if len(aerr.Code()) == 0 {
 				t.Errorf("expect non-empty error code")
 			}
+			if len(aerr.Message()) == 0 {
+				t.Errorf("expect non-empty error message")
+			}
 			if v := aerr.Code(); v == request.ErrCodeSerialization {
 				t.Errorf("expect API error code got serialization failure")
 			}

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -127,6 +128,14 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 		name := field.Name
 		if locName := field.Tag.Get("locationName"); locName != "" {
 			name = locName
+		}
+		if _, ok := mapData[name]; !ok {
+			// Fallback to uncased name search if the exact name didn't match.
+			for kn, v := range mapData {
+				if strings.EqualFold(kn, name) {
+					mapData[name] = v
+				}
+			}
 		}
 
 		member := value.FieldByIndex(field.Index)

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -46,10 +46,31 @@ func UnmarshalJSON(v interface{}, stream io.Reader) error {
 		return err
 	}
 
-	return unmarshalAny(reflect.ValueOf(v), out, "")
+	return unmarshaler{}.unmarshalAny(reflect.ValueOf(v), out, "")
 }
 
-func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+// UnmarshalJSONCaseInsensitive reads a stream and unmarshals the result into the
+// object v. Ignores casing for structure members.
+func UnmarshalJSONCaseInsensitive(v interface{}, stream io.Reader) error {
+	var out interface{}
+
+	err := json.NewDecoder(stream).Decode(&out)
+	if err == io.EOF {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return unmarshaler{
+		caseInsensitive: true,
+	}.unmarshalAny(reflect.ValueOf(v), out, "")
+}
+
+type unmarshaler struct {
+	caseInsensitive bool
+}
+
+func (u unmarshaler) unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) error {
 	vtype := value.Type()
 	if vtype.Kind() == reflect.Ptr {
 		vtype = vtype.Elem() // check kind of actual element type
@@ -81,17 +102,17 @@ func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) 
 		if field, ok := vtype.FieldByName("_"); ok {
 			tag = field.Tag
 		}
-		return unmarshalStruct(value, data, tag)
+		return u.unmarshalStruct(value, data, tag)
 	case "list":
-		return unmarshalList(value, data, tag)
+		return u.unmarshalList(value, data, tag)
 	case "map":
-		return unmarshalMap(value, data, tag)
+		return u.unmarshalMap(value, data, tag)
 	default:
-		return unmarshalScalar(value, data, tag)
+		return u.unmarshalScalar(value, data, tag)
 	}
 }
 
-func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+func (u unmarshaler) unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTag) error {
 	if data == nil {
 		return nil
 	}
@@ -115,7 +136,7 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 	// unwrap any payloads
 	if payload := tag.Get("payload"); payload != "" {
 		field, _ := t.FieldByName(payload)
-		return unmarshalAny(value.FieldByName(payload), data, field.Tag)
+		return u.unmarshalAny(value.FieldByName(payload), data, field.Tag)
 	}
 
 	for i := 0; i < t.NumField(); i++ {
@@ -129,17 +150,19 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 		if locName := field.Tag.Get("locationName"); locName != "" {
 			name = locName
 		}
-		if _, ok := mapData[name]; !ok {
-			// Fallback to uncased name search if the exact name didn't match.
-			for kn, v := range mapData {
-				if strings.EqualFold(kn, name) {
-					mapData[name] = v
+		if u.caseInsensitive {
+			if _, ok := mapData[name]; !ok {
+				// Fallback to uncased name search if the exact name didn't match.
+				for kn, v := range mapData {
+					if strings.EqualFold(kn, name) {
+						mapData[name] = v
+					}
 				}
 			}
 		}
 
 		member := value.FieldByIndex(field.Index)
-		err := unmarshalAny(member, mapData[name], field.Tag)
+		err := u.unmarshalAny(member, mapData[name], field.Tag)
 		if err != nil {
 			return err
 		}
@@ -147,7 +170,7 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 	return nil
 }
 
-func unmarshalList(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+func (u unmarshaler) unmarshalList(value reflect.Value, data interface{}, tag reflect.StructTag) error {
 	if data == nil {
 		return nil
 	}
@@ -162,7 +185,7 @@ func unmarshalList(value reflect.Value, data interface{}, tag reflect.StructTag)
 	}
 
 	for i, c := range listData {
-		err := unmarshalAny(value.Index(i), c, "")
+		err := u.unmarshalAny(value.Index(i), c, "")
 		if err != nil {
 			return err
 		}
@@ -171,7 +194,7 @@ func unmarshalList(value reflect.Value, data interface{}, tag reflect.StructTag)
 	return nil
 }
 
-func unmarshalMap(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+func (u unmarshaler) unmarshalMap(value reflect.Value, data interface{}, tag reflect.StructTag) error {
 	if data == nil {
 		return nil
 	}
@@ -188,14 +211,14 @@ func unmarshalMap(value reflect.Value, data interface{}, tag reflect.StructTag) 
 		kvalue := reflect.ValueOf(k)
 		vvalue := reflect.New(value.Type().Elem()).Elem()
 
-		unmarshalAny(vvalue, v, "")
+		u.unmarshalAny(vvalue, v, "")
 		value.SetMapIndex(kvalue, vvalue)
 	}
 
 	return nil
 }
 
-func unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+func (u unmarshaler) unmarshalScalar(value reflect.Value, data interface{}, tag reflect.StructTag) error {
 
 	switch d := data.(type) {
 	case nil:

--- a/private/protocol/jsonrpc/unmarshal_error.go
+++ b/private/protocol/jsonrpc/unmarshal_error.go
@@ -54,7 +54,7 @@ func (u *UnmarshalTypedError) UnmarshalError(
 		// If exception code is know, use associated constructor to get a value
 		// for the exception that the JSON body can be unmarshaled into.
 		v := fn(respMeta)
-		err := jsonutil.UnmarshalJSON(v, body)
+		err := jsonutil.UnmarshalJSONCaseInsensitive(v, body)
 		if err != nil {
 			return nil, err
 		}

--- a/private/protocol/jsonrpc/unmarshal_error_test.go
+++ b/private/protocol/jsonrpc/unmarshal_error_test.go
@@ -19,6 +19,7 @@ import (
 
 const unknownErrJSON = `{"__type":"UnknownError", "message":"error message", "something":123}`
 const simpleErrJSON = `{"__type":"SimpleError", "message":"some message", "foo":123}`
+const simpleCasedErrJSON = `{"__type":"SimpleError", "Message":"some message", "foo":123}`
 
 type SimpleError struct {
 	_ struct{} `type:"structure"`
@@ -137,6 +138,16 @@ func TestUnmarshalTypedError(t *testing.T) {
 				Body:       ioutil.NopCloser(strings.NewReader(`{`)),
 			},
 			Err: "failed decoding",
+		},
+		"mixed case fields": {
+			Response: &http.Response{
+				Header: http.Header{},
+				Body:   ioutil.NopCloser(strings.NewReader(simpleCasedErrJSON)),
+			},
+			Expect: &SimpleError{
+				Message2: aws.String("some message"),
+				Foo:      aws.Int64(123),
+			},
 		},
 	}
 

--- a/private/protocol/restjson/unmarshal_error.go
+++ b/private/protocol/restjson/unmarshal_error.go
@@ -69,7 +69,7 @@ func (u *UnmarshalTypedError) UnmarshalError(
 		// If exception code is know, use associated constructor to get a value
 		// for the exception that the JSON body can be unmarshaled into.
 		v := fn(respMeta)
-		if err := jsonutil.UnmarshalJSON(v, body); err != nil {
+		if err := jsonutil.UnmarshalJSONCaseInsensitive(v, body); err != nil {
 			return nil, err
 		}
 

--- a/service/acm/integ_test.go
+++ b/service/acm/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetCertificate(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/apigateway/integ_test.go
+++ b/service/apigateway/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_CreateUsagePlanKey(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/apigatewaymanagementapi/api.go
+++ b/service/apigatewaymanagementapi/api.go
@@ -333,6 +333,8 @@ func (s DeleteConnectionOutput) GoString() string {
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -358,6 +360,9 @@ func (s ForbiddenException) Code() string {
 
 // Message returns the exception's message.
 func (s ForbiddenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -461,6 +466,8 @@ func (s *GetConnectionOutput) SetLastActiveAt(v time.Time) *GetConnectionOutput 
 type GoneException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -486,6 +493,9 @@ func (s GoneException) Code() string {
 
 // Message returns the exception's message.
 func (s GoneException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -549,6 +559,8 @@ func (s *Identity) SetUserAgent(v string) *Identity {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -574,6 +586,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/autoscaling/integ_test.go
+++ b/service/autoscaling/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_CreateLaunchConfiguration(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloud9/api.go
+++ b/service/cloud9/api.go
@@ -1111,6 +1111,8 @@ func (c *Cloud9) UpdateEnvironmentMembershipWithContext(ctx aws.Context, input *
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1136,6 +1138,9 @@ func (s BadRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s BadRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1162,6 +1167,8 @@ func (s BadRequestException) RequestID() string {
 type ConflictException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1187,6 +1194,9 @@ func (s ConflictException) Code() string {
 
 // Message returns the exception's message.
 func (s ConflictException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2030,6 +2040,8 @@ func (s *EnvironmentMember) SetUserId(v string) *EnvironmentMember {
 type ForbiddenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2055,6 +2067,9 @@ func (s ForbiddenException) Code() string {
 
 // Message returns the exception's message.
 func (s ForbiddenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2081,6 +2096,8 @@ func (s ForbiddenException) RequestID() string {
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2106,6 +2123,9 @@ func (s InternalServerErrorException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerErrorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2132,6 +2152,8 @@ func (s InternalServerErrorException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2157,6 +2179,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2255,6 +2280,8 @@ func (s *ListEnvironmentsOutput) SetNextToken(v string) *ListEnvironmentsOutput 
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2280,6 +2307,9 @@ func (s NotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s NotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2306,6 +2336,8 @@ func (s NotFoundException) RequestID() string {
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2331,6 +2363,9 @@ func (s TooManyRequestsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyRequestsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cloudformation/integ_test.go
+++ b/service/cloudformation/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_CreateStack(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudfront/integ_test.go
+++ b/service/cloudfront/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_GetDistribution(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -2020,6 +2020,8 @@ func (s *AddTagsToResourceOutput) SetStatus(v string) *AddTagsToResourceOutput {
 type CloudHsmInternalException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2045,6 +2047,9 @@ func (s CloudHsmInternalException) Code() string {
 
 // Message returns the exception's message.
 func (s CloudHsmInternalException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3192,6 +3197,8 @@ func (s *GetConfigOutput) SetConfigType(v string) *GetConfigOutput {
 type InvalidRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3217,6 +3224,9 @@ func (s InvalidRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cloudhsmv2/integ_test.go
+++ b/service/cloudhsmv2/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ListTags(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudsearch/integ_test.go
+++ b/service/cloudsearch/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeIndexFields(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -2526,6 +2526,8 @@ func (c *CloudTrail) UpdateTrailWithContext(ctx aws.Context, input *UpdateTrailI
 type ARNInvalidException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2551,6 +2553,9 @@ func (s ARNInvalidException) Code() string {
 
 // Message returns the exception's message.
 func (s ARNInvalidException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2580,6 +2585,8 @@ func (s ARNInvalidException) RequestID() string {
 type AccessNotEnabledException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2605,6 +2612,9 @@ func (s AccessNotEnabledException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessNotEnabledException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2708,6 +2718,8 @@ func (s AddTagsOutput) GoString() string {
 type CloudWatchLogsDeliveryUnavailableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2733,6 +2745,9 @@ func (s CloudWatchLogsDeliveryUnavailableException) Code() string {
 
 // Message returns the exception's message.
 func (s CloudWatchLogsDeliveryUnavailableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4013,6 +4028,8 @@ func (s *GetTrailStatusOutput) SetTimeLoggingStopped(v string) *GetTrailStatusOu
 type InsightNotEnabledException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4038,6 +4055,9 @@ func (s InsightNotEnabledException) Code() string {
 
 // Message returns the exception's message.
 func (s InsightNotEnabledException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4093,6 +4113,8 @@ func (s *InsightSelector) SetInsightType(v string) *InsightSelector {
 type InsufficientDependencyServiceAccessPermissionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4118,6 +4140,9 @@ func (s InsufficientDependencyServiceAccessPermissionException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientDependencyServiceAccessPermissionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4145,6 +4170,8 @@ func (s InsufficientDependencyServiceAccessPermissionException) RequestID() stri
 type InsufficientEncryptionPolicyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4170,6 +4197,9 @@ func (s InsufficientEncryptionPolicyException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientEncryptionPolicyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4196,6 +4226,8 @@ func (s InsufficientEncryptionPolicyException) RequestID() string {
 type InsufficientS3BucketPolicyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4221,6 +4253,9 @@ func (s InsufficientS3BucketPolicyException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientS3BucketPolicyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4247,6 +4282,8 @@ func (s InsufficientS3BucketPolicyException) RequestID() string {
 type InsufficientSnsTopicPolicyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4272,6 +4309,9 @@ func (s InsufficientSnsTopicPolicyException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientSnsTopicPolicyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4298,6 +4338,8 @@ func (s InsufficientSnsTopicPolicyException) RequestID() string {
 type InvalidCloudWatchLogsLogGroupArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4323,6 +4365,9 @@ func (s InvalidCloudWatchLogsLogGroupArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCloudWatchLogsLogGroupArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4349,6 +4394,8 @@ func (s InvalidCloudWatchLogsLogGroupArnException) RequestID() string {
 type InvalidCloudWatchLogsRoleArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4374,6 +4421,9 @@ func (s InvalidCloudWatchLogsRoleArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCloudWatchLogsRoleArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4401,6 +4451,8 @@ func (s InvalidCloudWatchLogsRoleArnException) RequestID() string {
 type InvalidEventCategoryException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4426,6 +4478,9 @@ func (s InvalidEventCategoryException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEventCategoryException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4470,6 +4525,8 @@ func (s InvalidEventCategoryException) RequestID() string {
 type InvalidEventSelectorsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4495,6 +4552,9 @@ func (s InvalidEventSelectorsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEventSelectorsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4522,6 +4582,8 @@ func (s InvalidEventSelectorsException) RequestID() string {
 type InvalidHomeRegionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4547,6 +4609,9 @@ func (s InvalidHomeRegionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidHomeRegionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4575,6 +4640,8 @@ func (s InvalidHomeRegionException) RequestID() string {
 type InvalidInsightSelectorsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4600,6 +4667,9 @@ func (s InvalidInsightSelectorsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInsightSelectorsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4626,6 +4696,8 @@ func (s InvalidInsightSelectorsException) RequestID() string {
 type InvalidKmsKeyIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4651,6 +4723,9 @@ func (s InvalidKmsKeyIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidKmsKeyIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4677,6 +4752,8 @@ func (s InvalidKmsKeyIdException) RequestID() string {
 type InvalidLookupAttributesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4702,6 +4779,9 @@ func (s InvalidLookupAttributesException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidLookupAttributesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4728,6 +4808,8 @@ func (s InvalidLookupAttributesException) RequestID() string {
 type InvalidMaxResultsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4753,6 +4835,9 @@ func (s InvalidMaxResultsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMaxResultsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4780,6 +4865,8 @@ func (s InvalidMaxResultsException) RequestID() string {
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4805,6 +4892,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4832,6 +4922,8 @@ func (s InvalidNextTokenException) RequestID() string {
 type InvalidParameterCombinationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4857,6 +4949,9 @@ func (s InvalidParameterCombinationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterCombinationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4883,6 +4978,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 type InvalidS3BucketNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4908,6 +5005,9 @@ func (s InvalidS3BucketNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidS3BucketNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4934,6 +5034,8 @@ func (s InvalidS3BucketNameException) RequestID() string {
 type InvalidS3PrefixException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4959,6 +5061,9 @@ func (s InvalidS3PrefixException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidS3PrefixException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4985,6 +5090,8 @@ func (s InvalidS3PrefixException) RequestID() string {
 type InvalidSnsTopicNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5010,6 +5117,9 @@ func (s InvalidSnsTopicNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSnsTopicNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5037,6 +5147,8 @@ func (s InvalidSnsTopicNameException) RequestID() string {
 type InvalidTagParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5062,6 +5174,9 @@ func (s InvalidTagParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5089,6 +5204,8 @@ func (s InvalidTagParameterException) RequestID() string {
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5114,6 +5231,9 @@ func (s InvalidTimeRangeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTimeRangeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5140,6 +5260,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 type InvalidTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5165,6 +5287,9 @@ func (s InvalidTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5204,6 +5329,8 @@ func (s InvalidTokenException) RequestID() string {
 type InvalidTrailNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5229,6 +5356,9 @@ func (s InvalidTrailNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTrailNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5256,6 +5386,8 @@ func (s InvalidTrailNameException) RequestID() string {
 type KmsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5281,6 +5413,9 @@ func (s KmsException) Code() string {
 
 // Message returns the exception's message.
 func (s KmsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5309,6 +5444,8 @@ func (s KmsException) RequestID() string {
 type KmsKeyDisabledException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5334,6 +5471,9 @@ func (s KmsKeyDisabledException) Code() string {
 
 // Message returns the exception's message.
 func (s KmsKeyDisabledException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5361,6 +5501,8 @@ func (s KmsKeyDisabledException) RequestID() string {
 type KmsKeyNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5386,6 +5528,9 @@ func (s KmsKeyNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s KmsKeyNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5838,6 +5983,8 @@ func (s *LookupEventsOutput) SetNextToken(v string) *LookupEventsOutput {
 type MaximumNumberOfTrailsExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5863,6 +6010,9 @@ func (s MaximumNumberOfTrailsExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumNumberOfTrailsExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5892,6 +6042,8 @@ func (s MaximumNumberOfTrailsExceededException) RequestID() string {
 type NotOrganizationMasterAccountException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5917,6 +6069,9 @@ func (s NotOrganizationMasterAccountException) Code() string {
 
 // Message returns the exception's message.
 func (s NotOrganizationMasterAccountException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5943,6 +6098,8 @@ func (s NotOrganizationMasterAccountException) RequestID() string {
 type OperationNotPermittedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5968,6 +6125,9 @@ func (s OperationNotPermittedException) Code() string {
 
 // Message returns the exception's message.
 func (s OperationNotPermittedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5997,6 +6157,8 @@ func (s OperationNotPermittedException) RequestID() string {
 type OrganizationNotInAllFeaturesModeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6022,6 +6184,9 @@ func (s OrganizationNotInAllFeaturesModeException) Code() string {
 
 // Message returns the exception's message.
 func (s OrganizationNotInAllFeaturesModeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6050,6 +6215,8 @@ func (s OrganizationNotInAllFeaturesModeException) RequestID() string {
 type OrganizationsNotInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6075,6 +6242,9 @@ func (s OrganizationsNotInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s OrganizationsNotInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6464,6 +6634,8 @@ func (s *Resource) SetResourceType(v string) *Resource {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6489,6 +6661,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6549,6 +6724,8 @@ func (s *ResourceTag) SetTagsList(v []*Tag) *ResourceTag {
 type ResourceTypeNotSupportedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6574,6 +6751,9 @@ func (s ResourceTypeNotSupportedException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceTypeNotSupportedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6600,6 +6780,8 @@ func (s ResourceTypeNotSupportedException) RequestID() string {
 type S3BucketDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6625,6 +6807,9 @@ func (s S3BucketDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s S3BucketDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6819,6 +7004,8 @@ func (s *Tag) SetValue(v string) *Tag {
 type TagsLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6844,6 +7031,9 @@ func (s TagsLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s TagsLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7047,6 +7237,8 @@ func (s *Trail) SetTrailARN(v string) *Trail {
 type TrailAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7072,6 +7264,9 @@ func (s TrailAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s TrailAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7141,6 +7336,8 @@ func (s *TrailInfo) SetTrailARN(v string) *TrailInfo {
 type TrailNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7166,6 +7363,9 @@ func (s TrailNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s TrailNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7192,6 +7392,8 @@ func (s TrailNotFoundException) RequestID() string {
 type TrailNotProvidedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7217,6 +7419,9 @@ func (s TrailNotProvidedException) Code() string {
 
 // Message returns the exception's message.
 func (s TrailNotProvidedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7243,6 +7448,8 @@ func (s TrailNotProvidedException) RequestID() string {
 type UnsupportedOperationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7268,6 +7475,9 @@ func (s UnsupportedOperationException) Code() string {
 
 // Message returns the exception's message.
 func (s UnsupportedOperationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cloudtrail/integ_test.go
+++ b/service/cloudtrail/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DeleteTrail(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudwatch/integ_test.go
+++ b/service/cloudwatch/integ_test.go
@@ -60,6 +60,9 @@ func TestInteg_01_SetAlarmState(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudwatchevents/api.go
+++ b/service/cloudwatchevents/api.go
@@ -3245,6 +3245,8 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3270,6 +3272,9 @@ func (s ConcurrentModificationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentModificationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4687,6 +4692,8 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 type InternalException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4712,6 +4719,9 @@ func (s InternalException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4738,6 +4748,8 @@ func (s InternalException) RequestID() string {
 type InvalidEventPatternException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4763,6 +4775,9 @@ func (s InvalidEventPatternException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEventPatternException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4789,6 +4804,8 @@ func (s InvalidEventPatternException) RequestID() string {
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4814,6 +4831,9 @@ func (s InvalidStateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4884,6 +4904,8 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4909,6 +4931,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5726,6 +5751,8 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 type ManagedRuleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5751,6 +5778,9 @@ func (s ManagedRuleException) Code() string {
 
 // Message returns the exception's message.
 func (s ManagedRuleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5909,6 +5939,8 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 type PolicyLengthExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5934,6 +5966,9 @@ func (s PolicyLengthExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s PolicyLengthExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7021,6 +7056,8 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7046,6 +7083,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7072,6 +7112,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7097,6 +7139,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cloudwatchevents/integ_test.go
+++ b/service/cloudwatchevents/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeRule(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -4487,6 +4487,8 @@ type DataAlreadyAcceptedException struct {
 	respMetadata protocol.ResponseMetadata
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4512,6 +4514,9 @@ func (s DataAlreadyAcceptedException) Code() string {
 
 // Message returns the exception's message.
 func (s DataAlreadyAcceptedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6835,6 +6840,8 @@ func (s *InputLogEvent) SetTimestamp(v int64) *InputLogEvent {
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6860,6 +6867,9 @@ func (s InvalidOperationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOperationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6886,6 +6896,8 @@ func (s InvalidOperationException) RequestID() string {
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6911,6 +6923,9 @@ func (s InvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6940,6 +6955,8 @@ type InvalidSequenceTokenException struct {
 	respMetadata protocol.ResponseMetadata
 
 	ExpectedSequenceToken *string `locationName:"expectedSequenceToken" min:"1" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6965,6 +6982,9 @@ func (s InvalidSequenceTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSequenceTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6991,6 +7011,8 @@ func (s InvalidSequenceTokenException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7016,6 +7038,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7327,6 +7352,8 @@ type MalformedQueryException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	// Reserved.
 	QueryCompileError *QueryCompileError `locationName:"queryCompileError" type:"structure"`
 }
@@ -7354,6 +7381,9 @@ func (s MalformedQueryException) Code() string {
 
 // Message returns the exception's message.
 func (s MalformedQueryException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7567,6 +7597,8 @@ func (s *MetricTransformation) SetMetricValue(v string) *MetricTransformation {
 type OperationAbortedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7592,6 +7624,9 @@ func (s OperationAbortedException) Code() string {
 
 // Message returns the exception's message.
 func (s OperationAbortedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8589,6 +8624,8 @@ func (s *RejectedLogEventsInfo) SetTooOldLogEventEndIndex(v int64) *RejectedLogE
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8614,6 +8651,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8640,6 +8680,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8665,6 +8707,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8802,6 +8847,8 @@ func (s *SearchedLogStream) SetSearchedCompletely(v bool) *SearchedLogStream {
 type ServiceUnavailableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8827,6 +8874,9 @@ func (s ServiceUnavailableException) Code() string {
 
 // Message returns the exception's message.
 func (s ServiceUnavailableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9285,6 +9335,8 @@ func (s *TestMetricFilterOutput) SetMatches(v []*MetricFilterMatchRecord) *TestM
 type UnrecognizedClientException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9310,6 +9362,9 @@ func (s UnrecognizedClientException) Code() string {
 
 // Message returns the exception's message.
 func (s UnrecognizedClientException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cloudwatchlogs/integ_test.go
+++ b/service/cloudwatchlogs/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_GetLogEvents(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codebuild/api.go
+++ b/service/codebuild/api.go
@@ -2800,6 +2800,8 @@ func (c *CodeBuild) UpdateWebhookWithContext(ctx aws.Context, input *UpdateWebho
 type AccountLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2825,6 +2827,9 @@ func (s AccountLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s AccountLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5307,6 +5312,8 @@ func (s *ImportSourceCredentialsOutput) SetArn(v string) *ImportSourceCredential
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5332,6 +5339,9 @@ func (s InvalidInputException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInputException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6557,6 +6567,8 @@ func (s *NetworkInterface) SetSubnetId(v string) *NetworkInterface {
 type OAuthProviderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6582,6 +6594,9 @@ func (s OAuthProviderException) Code() string {
 
 // Message returns the exception's message.
 func (s OAuthProviderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8136,6 +8151,8 @@ func (s *ReportGroup) SetType(v string) *ReportGroup {
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8161,6 +8178,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8187,6 +8207,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8212,6 +8234,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -10356,6 +10356,8 @@ func (c *CodeCommit) UpdateRepositoryNameWithContext(ctx aws.Context, input *Upd
 type ActorDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10381,6 +10383,9 @@ func (s ActorDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ActorDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10529,6 +10534,8 @@ func (s *ApprovalRule) SetRuleContentSha256(v string) *ApprovalRule {
 type ApprovalRuleContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10554,6 +10561,9 @@ func (s ApprovalRuleContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10580,6 +10590,8 @@ func (s ApprovalRuleContentRequiredException) RequestID() string {
 type ApprovalRuleDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10605,6 +10617,9 @@ func (s ApprovalRuleDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10674,6 +10689,8 @@ func (s *ApprovalRuleEventMetadata) SetApprovalRuleName(v string) *ApprovalRuleE
 type ApprovalRuleNameAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10699,6 +10716,9 @@ func (s ApprovalRuleNameAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleNameAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10725,6 +10745,8 @@ func (s ApprovalRuleNameAlreadyExistsException) RequestID() string {
 type ApprovalRuleNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10750,6 +10772,9 @@ func (s ApprovalRuleNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10900,6 +10925,8 @@ func (s *ApprovalRuleTemplate) SetRuleContentSha256(v string) *ApprovalRuleTempl
 type ApprovalRuleTemplateContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10925,6 +10952,9 @@ func (s ApprovalRuleTemplateContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleTemplateContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10953,6 +10983,8 @@ func (s ApprovalRuleTemplateContentRequiredException) RequestID() string {
 type ApprovalRuleTemplateDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10978,6 +11010,9 @@ func (s ApprovalRuleTemplateDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleTemplateDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11006,6 +11041,8 @@ func (s ApprovalRuleTemplateDoesNotExistException) RequestID() string {
 type ApprovalRuleTemplateInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11031,6 +11068,9 @@ func (s ApprovalRuleTemplateInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleTemplateInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11059,6 +11099,8 @@ func (s ApprovalRuleTemplateInUseException) RequestID() string {
 type ApprovalRuleTemplateNameAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11084,6 +11126,9 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleTemplateNameAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11110,6 +11155,8 @@ func (s ApprovalRuleTemplateNameAlreadyExistsException) RequestID() string {
 type ApprovalRuleTemplateNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11135,6 +11182,9 @@ func (s ApprovalRuleTemplateNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalRuleTemplateNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11194,6 +11244,8 @@ func (s *ApprovalStateChangedEventMetadata) SetRevisionId(v string) *ApprovalSta
 type ApprovalStateRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11219,6 +11271,9 @@ func (s ApprovalStateRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalStateRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11317,6 +11372,8 @@ func (s AssociateApprovalRuleTemplateWithRepositoryOutput) GoString() string {
 type AuthorDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11342,6 +11399,9 @@ func (s AuthorDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s AuthorDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12137,6 +12197,8 @@ func (s *BatchGetRepositoriesOutput) SetRepositoriesNotFound(v []*string) *Batch
 type BeforeCommitIdAndAfterCommitIdAreSameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12162,6 +12224,9 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) Code() string {
 
 // Message returns the exception's message.
 func (s BeforeCommitIdAndAfterCommitIdAreSameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12188,6 +12253,8 @@ func (s BeforeCommitIdAndAfterCommitIdAreSameException) RequestID() string {
 type BlobIdDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12213,6 +12280,9 @@ func (s BlobIdDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s BlobIdDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12239,6 +12309,8 @@ func (s BlobIdDoesNotExistException) RequestID() string {
 type BlobIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12264,6 +12336,9 @@ func (s BlobIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s BlobIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12340,6 +12415,8 @@ func (s *BlobMetadata) SetPath(v string) *BlobMetadata {
 type BranchDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12365,6 +12442,9 @@ func (s BranchDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s BranchDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12424,6 +12504,8 @@ func (s *BranchInfo) SetCommitId(v string) *BranchInfo {
 type BranchNameExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12449,6 +12531,9 @@ func (s BranchNameExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s BranchNameExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12477,6 +12562,8 @@ func (s BranchNameExistsException) RequestID() string {
 type BranchNameIsTagNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12502,6 +12589,9 @@ func (s BranchNameIsTagNameException) Code() string {
 
 // Message returns the exception's message.
 func (s BranchNameIsTagNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12528,6 +12618,8 @@ func (s BranchNameIsTagNameException) RequestID() string {
 type BranchNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12553,6 +12645,9 @@ func (s BranchNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s BranchNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12580,6 +12675,8 @@ func (s BranchNameRequiredException) RequestID() string {
 type CannotDeleteApprovalRuleFromTemplateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12605,6 +12702,9 @@ func (s CannotDeleteApprovalRuleFromTemplateException) Code() string {
 
 // Message returns the exception's message.
 func (s CannotDeleteApprovalRuleFromTemplateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12632,6 +12732,8 @@ func (s CannotDeleteApprovalRuleFromTemplateException) RequestID() string {
 type CannotModifyApprovalRuleFromTemplateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12657,6 +12759,9 @@ func (s CannotModifyApprovalRuleFromTemplateException) Code() string {
 
 // Message returns the exception's message.
 func (s CannotModifyApprovalRuleFromTemplateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12687,6 +12792,8 @@ func (s CannotModifyApprovalRuleFromTemplateException) RequestID() string {
 type ClientRequestTokenRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12712,6 +12819,9 @@ func (s ClientRequestTokenRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ClientRequestTokenRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12829,6 +12939,8 @@ func (s *Comment) SetLastModifiedDate(v time.Time) *Comment {
 type CommentContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12854,6 +12966,9 @@ func (s CommentContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12880,6 +12995,8 @@ func (s CommentContentRequiredException) RequestID() string {
 type CommentContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12905,6 +13022,9 @@ func (s CommentContentSizeLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentContentSizeLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12932,6 +13052,8 @@ func (s CommentContentSizeLimitExceededException) RequestID() string {
 type CommentDeletedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12957,6 +13079,9 @@ func (s CommentDeletedException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentDeletedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12984,6 +13109,8 @@ func (s CommentDeletedException) RequestID() string {
 type CommentDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13009,6 +13136,9 @@ func (s CommentDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13035,6 +13165,8 @@ func (s CommentDoesNotExistException) RequestID() string {
 type CommentIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13060,6 +13192,9 @@ func (s CommentIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13087,6 +13222,8 @@ func (s CommentIdRequiredException) RequestID() string {
 type CommentNotCreatedByCallerException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13112,6 +13249,9 @@ func (s CommentNotCreatedByCallerException) Code() string {
 
 // Message returns the exception's message.
 func (s CommentNotCreatedByCallerException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13403,6 +13543,8 @@ func (s *Commit) SetTreeId(v string) *Commit {
 type CommitDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13428,6 +13570,9 @@ func (s CommitDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13454,6 +13599,8 @@ func (s CommitDoesNotExistException) RequestID() string {
 type CommitIdDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13479,6 +13626,9 @@ func (s CommitIdDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitIdDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13505,6 +13655,8 @@ func (s CommitIdDoesNotExistException) RequestID() string {
 type CommitIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13530,6 +13682,9 @@ func (s CommitIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13558,6 +13713,8 @@ func (s CommitIdRequiredException) RequestID() string {
 type CommitIdsLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13583,6 +13740,9 @@ func (s CommitIdsLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitIdsLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13610,6 +13770,8 @@ func (s CommitIdsLimitExceededException) RequestID() string {
 type CommitIdsListRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13635,6 +13797,9 @@ func (s CommitIdsListRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitIdsListRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13661,6 +13826,8 @@ func (s CommitIdsListRequiredException) RequestID() string {
 type CommitMessageLengthExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13686,6 +13853,9 @@ func (s CommitMessageLengthExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitMessageLengthExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13712,6 +13882,8 @@ func (s CommitMessageLengthExceededException) RequestID() string {
 type CommitRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13737,6 +13909,9 @@ func (s CommitRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s CommitRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13765,6 +13940,8 @@ func (s CommitRequiredException) RequestID() string {
 type ConcurrentReferenceUpdateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13790,6 +13967,9 @@ func (s ConcurrentReferenceUpdateException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentReferenceUpdateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15008,6 +15188,8 @@ func (s *CreateUnreferencedMergeCommitOutput) SetTreeId(v string) *CreateUnrefer
 type DefaultBranchCannotBeDeletedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15033,6 +15215,9 @@ func (s DefaultBranchCannotBeDeletedException) Code() string {
 
 // Message returns the exception's message.
 func (s DefaultBranchCannotBeDeletedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16040,6 +16225,8 @@ func (s *Difference) SetChangeType(v string) *Difference {
 type DirectoryNameConflictsWithFileNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16065,6 +16252,9 @@ func (s DirectoryNameConflictsWithFileNameException) Code() string {
 
 // Message returns the exception's message.
 func (s DirectoryNameConflictsWithFileNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16163,6 +16353,8 @@ func (s DisassociateApprovalRuleTemplateFromRepositoryOutput) GoString() string 
 type EncryptionIntegrityChecksFailedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16188,6 +16380,9 @@ func (s EncryptionIntegrityChecksFailedException) Code() string {
 
 // Message returns the exception's message.
 func (s EncryptionIntegrityChecksFailedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16214,6 +16409,8 @@ func (s EncryptionIntegrityChecksFailedException) RequestID() string {
 type EncryptionKeyAccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16239,6 +16436,9 @@ func (s EncryptionKeyAccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s EncryptionKeyAccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16265,6 +16465,8 @@ func (s EncryptionKeyAccessDeniedException) RequestID() string {
 type EncryptionKeyDisabledException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16290,6 +16492,9 @@ func (s EncryptionKeyDisabledException) Code() string {
 
 // Message returns the exception's message.
 func (s EncryptionKeyDisabledException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16316,6 +16521,8 @@ func (s EncryptionKeyDisabledException) RequestID() string {
 type EncryptionKeyNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16341,6 +16548,9 @@ func (s EncryptionKeyNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s EncryptionKeyNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16367,6 +16577,8 @@ func (s EncryptionKeyNotFoundException) RequestID() string {
 type EncryptionKeyUnavailableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16392,6 +16604,9 @@ func (s EncryptionKeyUnavailableException) Code() string {
 
 // Message returns the exception's message.
 func (s EncryptionKeyUnavailableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16606,6 +16821,8 @@ func (s *File) SetRelativePath(v string) *File {
 type FileContentAndSourceFileSpecifiedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16631,6 +16848,9 @@ func (s FileContentAndSourceFileSpecifiedException) Code() string {
 
 // Message returns the exception's message.
 func (s FileContentAndSourceFileSpecifiedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16658,6 +16878,8 @@ func (s FileContentAndSourceFileSpecifiedException) RequestID() string {
 type FileContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16683,6 +16905,9 @@ func (s FileContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s FileContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16711,6 +16936,8 @@ func (s FileContentRequiredException) RequestID() string {
 type FileContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16736,6 +16963,9 @@ func (s FileContentSizeLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s FileContentSizeLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16763,6 +16993,8 @@ func (s FileContentSizeLimitExceededException) RequestID() string {
 type FileDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16788,6 +17020,9 @@ func (s FileDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s FileDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16815,6 +17050,8 @@ func (s FileDoesNotExistException) RequestID() string {
 type FileEntryRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16840,6 +17077,9 @@ func (s FileEntryRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s FileEntryRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16911,6 +17151,8 @@ func (s *FileMetadata) SetFileMode(v string) *FileMetadata {
 type FileModeRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16936,6 +17178,9 @@ func (s FileModeRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s FileModeRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17007,6 +17252,8 @@ func (s *FileModes) SetSource(v string) *FileModes {
 type FileNameConflictsWithDirectoryNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17032,6 +17279,9 @@ func (s FileNameConflictsWithDirectoryNameException) Code() string {
 
 // Message returns the exception's message.
 func (s FileNameConflictsWithDirectoryNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17060,6 +17310,8 @@ func (s FileNameConflictsWithDirectoryNameException) RequestID() string {
 type FilePathConflictsWithSubmodulePathException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17085,6 +17337,9 @@ func (s FilePathConflictsWithSubmodulePathException) Code() string {
 
 // Message returns the exception's message.
 func (s FilePathConflictsWithSubmodulePathException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17155,6 +17410,8 @@ func (s *FileSizes) SetSource(v int64) *FileSizes {
 type FileTooLargeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17180,6 +17437,9 @@ func (s FileTooLargeException) Code() string {
 
 // Message returns the exception's message.
 func (s FileTooLargeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17253,6 +17513,8 @@ func (s *Folder) SetTreeId(v string) *Folder {
 type FolderContentSizeLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17278,6 +17540,9 @@ func (s FolderContentSizeLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s FolderContentSizeLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17305,6 +17570,8 @@ func (s FolderContentSizeLimitExceededException) RequestID() string {
 type FolderDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17330,6 +17597,9 @@ func (s FolderDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s FolderDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19303,6 +19573,8 @@ func (s *GetRepositoryTriggersOutput) SetTriggers(v []*RepositoryTrigger) *GetRe
 type IdempotencyParameterMismatchException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19328,6 +19600,9 @@ func (s IdempotencyParameterMismatchException) Code() string {
 
 // Message returns the exception's message.
 func (s IdempotencyParameterMismatchException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19356,6 +19631,8 @@ func (s IdempotencyParameterMismatchException) RequestID() string {
 type InvalidActorArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19381,6 +19658,9 @@ func (s InvalidActorArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidActorArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19407,6 +19687,8 @@ func (s InvalidActorArnException) RequestID() string {
 type InvalidApprovalRuleContentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19432,6 +19714,9 @@ func (s InvalidApprovalRuleContentException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalRuleContentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19458,6 +19743,8 @@ func (s InvalidApprovalRuleContentException) RequestID() string {
 type InvalidApprovalRuleNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19483,6 +19770,9 @@ func (s InvalidApprovalRuleNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalRuleNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19509,6 +19799,8 @@ func (s InvalidApprovalRuleNameException) RequestID() string {
 type InvalidApprovalRuleTemplateContentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19534,6 +19826,9 @@ func (s InvalidApprovalRuleTemplateContentException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalRuleTemplateContentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19562,6 +19857,8 @@ func (s InvalidApprovalRuleTemplateContentException) RequestID() string {
 type InvalidApprovalRuleTemplateDescriptionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19587,6 +19884,9 @@ func (s InvalidApprovalRuleTemplateDescriptionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalRuleTemplateDescriptionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19615,6 +19915,8 @@ func (s InvalidApprovalRuleTemplateDescriptionException) RequestID() string {
 type InvalidApprovalRuleTemplateNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19640,6 +19942,9 @@ func (s InvalidApprovalRuleTemplateNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalRuleTemplateNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19667,6 +19972,8 @@ func (s InvalidApprovalRuleTemplateNameException) RequestID() string {
 type InvalidApprovalStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19692,6 +19999,9 @@ func (s InvalidApprovalStateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19719,6 +20029,8 @@ func (s InvalidApprovalStateException) RequestID() string {
 type InvalidAuthorArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19744,6 +20056,9 @@ func (s InvalidAuthorArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidAuthorArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19770,6 +20085,8 @@ func (s InvalidAuthorArnException) RequestID() string {
 type InvalidBlobIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19795,6 +20112,9 @@ func (s InvalidBlobIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidBlobIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19821,6 +20141,8 @@ func (s InvalidBlobIdException) RequestID() string {
 type InvalidBranchNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19846,6 +20168,9 @@ func (s InvalidBranchNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidBranchNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19872,6 +20197,8 @@ func (s InvalidBranchNameException) RequestID() string {
 type InvalidClientRequestTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19897,6 +20224,9 @@ func (s InvalidClientRequestTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidClientRequestTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19924,6 +20254,8 @@ func (s InvalidClientRequestTokenException) RequestID() string {
 type InvalidCommentIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19949,6 +20281,9 @@ func (s InvalidCommentIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCommentIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19975,6 +20310,8 @@ func (s InvalidCommentIdException) RequestID() string {
 type InvalidCommitException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20000,6 +20337,9 @@ func (s InvalidCommitException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCommitException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20026,6 +20366,8 @@ func (s InvalidCommitException) RequestID() string {
 type InvalidCommitIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20051,6 +20393,9 @@ func (s InvalidCommitIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCommitIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20077,6 +20422,8 @@ func (s InvalidCommitIdException) RequestID() string {
 type InvalidConflictDetailLevelException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20102,6 +20449,9 @@ func (s InvalidConflictDetailLevelException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidConflictDetailLevelException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20128,6 +20478,8 @@ func (s InvalidConflictDetailLevelException) RequestID() string {
 type InvalidConflictResolutionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20153,6 +20505,9 @@ func (s InvalidConflictResolutionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidConflictResolutionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20179,6 +20534,8 @@ func (s InvalidConflictResolutionException) RequestID() string {
 type InvalidConflictResolutionStrategyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20204,6 +20561,9 @@ func (s InvalidConflictResolutionStrategyException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidConflictResolutionStrategyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20230,6 +20590,8 @@ func (s InvalidConflictResolutionStrategyException) RequestID() string {
 type InvalidContinuationTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20255,6 +20617,9 @@ func (s InvalidContinuationTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidContinuationTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20281,6 +20646,8 @@ func (s InvalidContinuationTokenException) RequestID() string {
 type InvalidDeletionParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20306,6 +20673,9 @@ func (s InvalidDeletionParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeletionParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20333,6 +20703,8 @@ func (s InvalidDeletionParameterException) RequestID() string {
 type InvalidDescriptionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20358,6 +20730,9 @@ func (s InvalidDescriptionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDescriptionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20385,6 +20760,8 @@ func (s InvalidDescriptionException) RequestID() string {
 type InvalidDestinationCommitSpecifierException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20410,6 +20787,9 @@ func (s InvalidDestinationCommitSpecifierException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDestinationCommitSpecifierException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20438,6 +20818,8 @@ func (s InvalidDestinationCommitSpecifierException) RequestID() string {
 type InvalidEmailException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20463,6 +20845,9 @@ func (s InvalidEmailException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEmailException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20490,6 +20875,8 @@ func (s InvalidEmailException) RequestID() string {
 type InvalidFileLocationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20515,6 +20902,9 @@ func (s InvalidFileLocationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidFileLocationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20542,6 +20932,8 @@ func (s InvalidFileLocationException) RequestID() string {
 type InvalidFileModeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20567,6 +20959,9 @@ func (s InvalidFileModeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidFileModeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20594,6 +20989,8 @@ func (s InvalidFileModeException) RequestID() string {
 type InvalidFilePositionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20619,6 +21016,9 @@ func (s InvalidFilePositionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidFilePositionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20645,6 +21045,8 @@ func (s InvalidFilePositionException) RequestID() string {
 type InvalidMaxConflictFilesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20670,6 +21072,9 @@ func (s InvalidMaxConflictFilesException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMaxConflictFilesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20696,6 +21101,8 @@ func (s InvalidMaxConflictFilesException) RequestID() string {
 type InvalidMaxMergeHunksException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20721,6 +21128,9 @@ func (s InvalidMaxMergeHunksException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMaxMergeHunksException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20747,6 +21157,8 @@ func (s InvalidMaxMergeHunksException) RequestID() string {
 type InvalidMaxResultsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20772,6 +21184,9 @@ func (s InvalidMaxResultsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMaxResultsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20799,6 +21214,8 @@ func (s InvalidMaxResultsException) RequestID() string {
 type InvalidMergeOptionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20824,6 +21241,9 @@ func (s InvalidMergeOptionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMergeOptionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20850,6 +21270,8 @@ func (s InvalidMergeOptionException) RequestID() string {
 type InvalidOrderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20875,6 +21297,9 @@ func (s InvalidOrderException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOrderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20901,6 +21326,8 @@ func (s InvalidOrderException) RequestID() string {
 type InvalidOverrideStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20926,6 +21353,9 @@ func (s InvalidOverrideStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOverrideStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -20954,6 +21384,8 @@ func (s InvalidOverrideStatusException) RequestID() string {
 type InvalidParentCommitIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -20979,6 +21411,9 @@ func (s InvalidParentCommitIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParentCommitIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21005,6 +21440,8 @@ func (s InvalidParentCommitIdException) RequestID() string {
 type InvalidPathException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21030,6 +21467,9 @@ func (s InvalidPathException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPathException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21056,6 +21496,8 @@ func (s InvalidPathException) RequestID() string {
 type InvalidPullRequestEventTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21081,6 +21523,9 @@ func (s InvalidPullRequestEventTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPullRequestEventTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21109,6 +21554,8 @@ func (s InvalidPullRequestEventTypeException) RequestID() string {
 type InvalidPullRequestIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21134,6 +21581,9 @@ func (s InvalidPullRequestIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPullRequestIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21161,6 +21611,8 @@ func (s InvalidPullRequestIdException) RequestID() string {
 type InvalidPullRequestStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21186,6 +21638,9 @@ func (s InvalidPullRequestStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPullRequestStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21213,6 +21668,8 @@ func (s InvalidPullRequestStatusException) RequestID() string {
 type InvalidPullRequestStatusUpdateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21238,6 +21695,9 @@ func (s InvalidPullRequestStatusUpdateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPullRequestStatusUpdateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21267,6 +21727,8 @@ func (s InvalidPullRequestStatusUpdateException) RequestID() string {
 type InvalidReferenceNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21292,6 +21754,9 @@ func (s InvalidReferenceNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidReferenceNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21319,6 +21784,8 @@ func (s InvalidReferenceNameException) RequestID() string {
 type InvalidRelativeFileVersionEnumException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21344,6 +21811,9 @@ func (s InvalidRelativeFileVersionEnumException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRelativeFileVersionEnumException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21371,6 +21841,8 @@ func (s InvalidRelativeFileVersionEnumException) RequestID() string {
 type InvalidReplacementContentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21396,6 +21868,9 @@ func (s InvalidReplacementContentException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidReplacementContentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21423,6 +21898,8 @@ func (s InvalidReplacementContentException) RequestID() string {
 type InvalidReplacementTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21448,6 +21925,9 @@ func (s InvalidReplacementTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidReplacementTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21474,6 +21954,8 @@ func (s InvalidReplacementTypeException) RequestID() string {
 type InvalidRepositoryDescriptionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21499,6 +21981,9 @@ func (s InvalidRepositoryDescriptionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryDescriptionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21529,6 +22014,8 @@ func (s InvalidRepositoryDescriptionException) RequestID() string {
 type InvalidRepositoryNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21554,6 +22041,9 @@ func (s InvalidRepositoryNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21580,6 +22070,8 @@ func (s InvalidRepositoryNameException) RequestID() string {
 type InvalidRepositoryTriggerBranchNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21605,6 +22097,9 @@ func (s InvalidRepositoryTriggerBranchNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerBranchNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21631,6 +22126,8 @@ func (s InvalidRepositoryTriggerBranchNameException) RequestID() string {
 type InvalidRepositoryTriggerCustomDataException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21656,6 +22153,9 @@ func (s InvalidRepositoryTriggerCustomDataException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerCustomDataException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21684,6 +22184,8 @@ func (s InvalidRepositoryTriggerCustomDataException) RequestID() string {
 type InvalidRepositoryTriggerDestinationArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21709,6 +22211,9 @@ func (s InvalidRepositoryTriggerDestinationArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerDestinationArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21736,6 +22241,8 @@ func (s InvalidRepositoryTriggerDestinationArnException) RequestID() string {
 type InvalidRepositoryTriggerEventsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21761,6 +22268,9 @@ func (s InvalidRepositoryTriggerEventsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerEventsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21787,6 +22297,8 @@ func (s InvalidRepositoryTriggerEventsException) RequestID() string {
 type InvalidRepositoryTriggerNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21812,6 +22324,9 @@ func (s InvalidRepositoryTriggerNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21840,6 +22355,8 @@ func (s InvalidRepositoryTriggerNameException) RequestID() string {
 type InvalidRepositoryTriggerRegionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21865,6 +22382,9 @@ func (s InvalidRepositoryTriggerRegionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRepositoryTriggerRegionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21893,6 +22413,8 @@ func (s InvalidRepositoryTriggerRegionException) RequestID() string {
 type InvalidResourceArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21918,6 +22440,9 @@ func (s InvalidResourceArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidResourceArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21944,6 +22469,8 @@ func (s InvalidResourceArnException) RequestID() string {
 type InvalidRevisionIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21969,6 +22496,9 @@ func (s InvalidRevisionIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRevisionIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21995,6 +22525,8 @@ func (s InvalidRevisionIdException) RequestID() string {
 type InvalidRuleContentSha256Exception struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22020,6 +22552,9 @@ func (s InvalidRuleContentSha256Exception) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRuleContentSha256Exception) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22046,6 +22581,8 @@ func (s InvalidRuleContentSha256Exception) RequestID() string {
 type InvalidSortByException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22071,6 +22608,9 @@ func (s InvalidSortByException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSortByException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22098,6 +22638,8 @@ func (s InvalidSortByException) RequestID() string {
 type InvalidSourceCommitSpecifierException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22123,6 +22665,9 @@ func (s InvalidSourceCommitSpecifierException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSourceCommitSpecifierException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22149,6 +22694,8 @@ func (s InvalidSourceCommitSpecifierException) RequestID() string {
 type InvalidSystemTagUsageException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22174,6 +22721,9 @@ func (s InvalidSystemTagUsageException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSystemTagUsageException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22200,6 +22750,8 @@ func (s InvalidSystemTagUsageException) RequestID() string {
 type InvalidTagKeysListException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22225,6 +22777,9 @@ func (s InvalidTagKeysListException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagKeysListException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22251,6 +22806,8 @@ func (s InvalidTagKeysListException) RequestID() string {
 type InvalidTagsMapException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22276,6 +22833,9 @@ func (s InvalidTagsMapException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagsMapException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22302,6 +22862,8 @@ func (s InvalidTagsMapException) RequestID() string {
 type InvalidTargetBranchException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22327,6 +22889,9 @@ func (s InvalidTargetBranchException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetBranchException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22355,6 +22920,8 @@ func (s InvalidTargetBranchException) RequestID() string {
 type InvalidTargetException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22380,6 +22947,9 @@ func (s InvalidTargetException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22409,6 +22979,8 @@ func (s InvalidTargetException) RequestID() string {
 type InvalidTargetsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22434,6 +23006,9 @@ func (s InvalidTargetsException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22461,6 +23036,8 @@ func (s InvalidTargetsException) RequestID() string {
 type InvalidTitleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22486,6 +23063,9 @@ func (s InvalidTitleException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTitleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23223,6 +23803,8 @@ func (s *Location) SetRelativeFileVersion(v string) *Location {
 type ManualMergeRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23248,6 +23830,9 @@ func (s ManualMergeRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ManualMergeRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23274,6 +23859,8 @@ func (s ManualMergeRequiredException) RequestID() string {
 type MaximumBranchesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23299,6 +23886,9 @@ func (s MaximumBranchesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumBranchesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23325,6 +23915,8 @@ func (s MaximumBranchesExceededException) RequestID() string {
 type MaximumConflictResolutionEntriesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23350,6 +23942,9 @@ func (s MaximumConflictResolutionEntriesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumConflictResolutionEntriesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23376,6 +23971,8 @@ func (s MaximumConflictResolutionEntriesExceededException) RequestID() string {
 type MaximumFileContentToLoadExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23401,6 +23998,9 @@ func (s MaximumFileContentToLoadExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumFileContentToLoadExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23429,6 +24029,8 @@ func (s MaximumFileContentToLoadExceededException) RequestID() string {
 type MaximumFileEntriesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23454,6 +24056,9 @@ func (s MaximumFileEntriesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumFileEntriesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23481,6 +24086,8 @@ func (s MaximumFileEntriesExceededException) RequestID() string {
 type MaximumItemsToCompareExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23506,6 +24113,9 @@ func (s MaximumItemsToCompareExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumItemsToCompareExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23533,6 +24143,8 @@ func (s MaximumItemsToCompareExceededException) RequestID() string {
 type MaximumNumberOfApprovalsExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23558,6 +24170,9 @@ func (s MaximumNumberOfApprovalsExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumNumberOfApprovalsExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23586,6 +24201,8 @@ func (s MaximumNumberOfApprovalsExceededException) RequestID() string {
 type MaximumOpenPullRequestsExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23611,6 +24228,9 @@ func (s MaximumOpenPullRequestsExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumOpenPullRequestsExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23638,6 +24258,8 @@ func (s MaximumOpenPullRequestsExceededException) RequestID() string {
 type MaximumRepositoryNamesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23663,6 +24285,9 @@ func (s MaximumRepositoryNamesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumRepositoryNamesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23689,6 +24314,8 @@ func (s MaximumRepositoryNamesExceededException) RequestID() string {
 type MaximumRepositoryTriggersExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23714,6 +24341,9 @@ func (s MaximumRepositoryTriggersExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumRepositoryTriggersExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23741,6 +24371,8 @@ func (s MaximumRepositoryTriggersExceededException) RequestID() string {
 type MaximumRuleTemplatesAssociatedWithRepositoryException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23766,6 +24398,9 @@ func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Code() string {
 
 // Message returns the exception's message.
 func (s MaximumRuleTemplatesAssociatedWithRepositoryException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -24481,6 +25116,8 @@ func (s *MergeOperations) SetSource(v string) *MergeOperations {
 type MergeOptionRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -24506,6 +25143,9 @@ func (s MergeOptionRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s MergeOptionRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -24958,6 +25598,8 @@ func (s *MergePullRequestByThreeWayOutput) SetPullRequest(v *PullRequest) *Merge
 type MultipleConflictResolutionEntriesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -24983,6 +25625,9 @@ func (s MultipleConflictResolutionEntriesException) Code() string {
 
 // Message returns the exception's message.
 func (s MultipleConflictResolutionEntriesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25011,6 +25656,8 @@ func (s MultipleConflictResolutionEntriesException) RequestID() string {
 type MultipleRepositoriesInPullRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25036,6 +25683,9 @@ func (s MultipleRepositoriesInPullRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s MultipleRepositoriesInPullRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25063,6 +25713,8 @@ func (s MultipleRepositoriesInPullRequestException) RequestID() string {
 type NameLengthExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25088,6 +25740,9 @@ func (s NameLengthExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s NameLengthExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25115,6 +25770,8 @@ func (s NameLengthExceededException) RequestID() string {
 type NoChangeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25140,6 +25797,9 @@ func (s NoChangeException) Code() string {
 
 // Message returns the exception's message.
 func (s NoChangeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25167,6 +25827,8 @@ func (s NoChangeException) RequestID() string {
 type NumberOfRuleTemplatesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25192,6 +25854,9 @@ func (s NumberOfRuleTemplatesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s NumberOfRuleTemplatesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25219,6 +25884,8 @@ func (s NumberOfRuleTemplatesExceededException) RequestID() string {
 type NumberOfRulesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25244,6 +25911,9 @@ func (s NumberOfRulesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s NumberOfRulesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25346,6 +26016,8 @@ func (s *OriginApprovalRuleTemplate) SetApprovalRuleTemplateName(v string) *Orig
 type OverrideAlreadySetException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25371,6 +26043,9 @@ func (s OverrideAlreadySetException) Code() string {
 
 // Message returns the exception's message.
 func (s OverrideAlreadySetException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25483,6 +26158,8 @@ func (s OverridePullRequestApprovalRulesOutput) GoString() string {
 type OverrideStatusRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25508,6 +26185,9 @@ func (s OverrideStatusRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s OverrideStatusRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25535,6 +26215,8 @@ func (s OverrideStatusRequiredException) RequestID() string {
 type ParentCommitDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25560,6 +26242,9 @@ func (s ParentCommitDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ParentCommitDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25588,6 +26273,8 @@ func (s ParentCommitDoesNotExistException) RequestID() string {
 type ParentCommitIdOutdatedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25613,6 +26300,9 @@ func (s ParentCommitIdOutdatedException) Code() string {
 
 // Message returns the exception's message.
 func (s ParentCommitIdOutdatedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25641,6 +26331,8 @@ func (s ParentCommitIdOutdatedException) RequestID() string {
 type ParentCommitIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25666,6 +26358,9 @@ func (s ParentCommitIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ParentCommitIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25692,6 +26387,8 @@ func (s ParentCommitIdRequiredException) RequestID() string {
 type PathDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25717,6 +26414,9 @@ func (s PathDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s PathDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -25743,6 +26443,8 @@ func (s PathDoesNotExistException) RequestID() string {
 type PathRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -25768,6 +26470,9 @@ func (s PathRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s PathRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26396,6 +27101,8 @@ func (s *PullRequest) SetTitle(v string) *PullRequest {
 type PullRequestAlreadyClosedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26421,6 +27128,9 @@ func (s PullRequestAlreadyClosedException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestAlreadyClosedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26448,6 +27158,8 @@ func (s PullRequestAlreadyClosedException) RequestID() string {
 type PullRequestApprovalRulesNotSatisfiedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26473,6 +27185,9 @@ func (s PullRequestApprovalRulesNotSatisfiedException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestApprovalRulesNotSatisfiedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26501,6 +27216,8 @@ func (s PullRequestApprovalRulesNotSatisfiedException) RequestID() string {
 type PullRequestCannotBeApprovedByAuthorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26526,6 +27243,9 @@ func (s PullRequestCannotBeApprovedByAuthorException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestCannotBeApprovedByAuthorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26607,6 +27327,8 @@ func (s *PullRequestCreatedEventMetadata) SetSourceCommitId(v string) *PullReque
 type PullRequestDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26632,6 +27354,9 @@ func (s PullRequestDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26775,6 +27500,8 @@ func (s *PullRequestEvent) SetPullRequestStatusChangedEventMetadata(v *PullReque
 type PullRequestIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26800,6 +27527,9 @@ func (s PullRequestIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -26947,6 +27677,8 @@ func (s *PullRequestStatusChangedEventMetadata) SetPullRequestStatus(v string) *
 type PullRequestStatusRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -26972,6 +27704,9 @@ func (s PullRequestStatusRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s PullRequestStatusRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27160,6 +27895,8 @@ func (s *PutFileEntry) SetSourceFile(v *SourceFileSpecifier) *PutFileEntry {
 type PutFileEntryConflictException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27185,6 +27922,9 @@ func (s PutFileEntryConflictException) Code() string {
 
 // Message returns the exception's message.
 func (s PutFileEntryConflictException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27495,6 +28235,8 @@ func (s *PutRepositoryTriggersOutput) SetConfigurationId(v string) *PutRepositor
 type ReferenceDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27520,6 +28262,9 @@ func (s ReferenceDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ReferenceDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27546,6 +28291,8 @@ func (s ReferenceDoesNotExistException) RequestID() string {
 type ReferenceNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27571,6 +28318,9 @@ func (s ReferenceNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ReferenceNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27597,6 +28347,8 @@ func (s ReferenceNameRequiredException) RequestID() string {
 type ReferenceTypeNotSupportedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27622,6 +28374,9 @@ func (s ReferenceTypeNotSupportedException) Code() string {
 
 // Message returns the exception's message.
 func (s ReferenceTypeNotSupportedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27722,6 +28477,8 @@ func (s *ReplaceContentEntry) SetReplacementType(v string) *ReplaceContentEntry 
 type ReplacementContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27747,6 +28504,9 @@ func (s ReplacementContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ReplacementContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27773,6 +28533,8 @@ func (s ReplacementContentRequiredException) RequestID() string {
 type ReplacementTypeRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27798,6 +28560,9 @@ func (s ReplacementTypeRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ReplacementTypeRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27824,6 +28589,8 @@ func (s ReplacementTypeRequiredException) RequestID() string {
 type RepositoryDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27849,6 +28616,9 @@ func (s RepositoryDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -27875,6 +28645,8 @@ func (s RepositoryDoesNotExistException) RequestID() string {
 type RepositoryLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -27900,6 +28672,9 @@ func (s RepositoryLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28031,6 +28806,8 @@ func (s *RepositoryMetadata) SetRepositoryName(v string) *RepositoryMetadata {
 type RepositoryNameExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28056,6 +28833,9 @@ func (s RepositoryNameExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryNameExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28115,6 +28895,8 @@ func (s *RepositoryNameIdPair) SetRepositoryName(v string) *RepositoryNameIdPair
 type RepositoryNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28140,6 +28922,9 @@ func (s RepositoryNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28166,6 +28951,8 @@ func (s RepositoryNameRequiredException) RequestID() string {
 type RepositoryNamesRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28191,6 +28978,9 @@ func (s RepositoryNamesRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryNamesRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28219,6 +29009,8 @@ func (s RepositoryNamesRequiredException) RequestID() string {
 type RepositoryNotAssociatedWithPullRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28244,6 +29036,9 @@ func (s RepositoryNotAssociatedWithPullRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryNotAssociatedWithPullRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28365,6 +29160,8 @@ func (s *RepositoryTrigger) SetName(v string) *RepositoryTrigger {
 type RepositoryTriggerBranchNameListRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28390,6 +29187,9 @@ func (s RepositoryTriggerBranchNameListRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryTriggerBranchNameListRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28417,6 +29217,8 @@ func (s RepositoryTriggerBranchNameListRequiredException) RequestID() string {
 type RepositoryTriggerDestinationArnRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28442,6 +29244,9 @@ func (s RepositoryTriggerDestinationArnRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryTriggerDestinationArnRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28468,6 +29273,8 @@ func (s RepositoryTriggerDestinationArnRequiredException) RequestID() string {
 type RepositoryTriggerEventsListRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28493,6 +29300,9 @@ func (s RepositoryTriggerEventsListRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryTriggerEventsListRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28552,6 +29362,8 @@ func (s *RepositoryTriggerExecutionFailure) SetTrigger(v string) *RepositoryTrig
 type RepositoryTriggerNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28577,6 +29389,9 @@ func (s RepositoryTriggerNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryTriggerNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28603,6 +29418,8 @@ func (s RepositoryTriggerNameRequiredException) RequestID() string {
 type RepositoryTriggersListRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28628,6 +29445,9 @@ func (s RepositoryTriggersListRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RepositoryTriggersListRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28657,6 +29477,8 @@ func (s RepositoryTriggersListRequiredException) RequestID() string {
 type ResourceArnRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28682,6 +29504,9 @@ func (s ResourceArnRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceArnRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28709,6 +29534,8 @@ func (s ResourceArnRequiredException) RequestID() string {
 type RestrictedSourceFileException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28734,6 +29561,9 @@ func (s RestrictedSourceFileException) Code() string {
 
 // Message returns the exception's message.
 func (s RestrictedSourceFileException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28760,6 +29590,8 @@ func (s RestrictedSourceFileException) RequestID() string {
 type RevisionIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28785,6 +29617,9 @@ func (s RevisionIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RevisionIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28812,6 +29647,8 @@ func (s RevisionIdRequiredException) RequestID() string {
 type RevisionNotCurrentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28837,6 +29674,9 @@ func (s RevisionNotCurrentException) Code() string {
 
 // Message returns the exception's message.
 func (s RevisionNotCurrentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28865,6 +29705,8 @@ func (s RevisionNotCurrentException) RequestID() string {
 type SameFileContentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28890,6 +29732,9 @@ func (s SameFileContentException) Code() string {
 
 // Message returns the exception's message.
 func (s SameFileContentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28919,6 +29764,8 @@ func (s SameFileContentException) RequestID() string {
 type SamePathRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28944,6 +29791,9 @@ func (s SamePathRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s SamePathRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29024,6 +29874,8 @@ func (s *SetFileModeEntry) SetFilePath(v string) *SetFileModeEntry {
 type SourceAndDestinationAreSameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29049,6 +29901,9 @@ func (s SourceAndDestinationAreSameException) Code() string {
 
 // Message returns the exception's message.
 func (s SourceAndDestinationAreSameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29076,6 +29931,8 @@ func (s SourceAndDestinationAreSameException) RequestID() string {
 type SourceFileOrContentRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29101,6 +29958,9 @@ func (s SourceFileOrContentRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s SourceFileOrContentRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29270,6 +30130,8 @@ func (s *SymbolicLink) SetRelativePath(v string) *SymbolicLink {
 type TagKeysListRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29295,6 +30157,9 @@ func (s TagKeysListRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TagKeysListRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29321,6 +30186,8 @@ func (s TagKeysListRequiredException) RequestID() string {
 type TagPolicyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29346,6 +30213,9 @@ func (s TagPolicyException) Code() string {
 
 // Message returns the exception's message.
 func (s TagPolicyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29439,6 +30309,8 @@ func (s TagResourceOutput) GoString() string {
 type TagsMapRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29464,6 +30336,9 @@ func (s TagsMapRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TagsMapRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29559,6 +30434,8 @@ func (s *Target) SetSourceReference(v string) *Target {
 type TargetRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29584,6 +30461,9 @@ func (s TargetRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TargetRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29610,6 +30490,8 @@ func (s TargetRequiredException) RequestID() string {
 type TargetsRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29635,6 +30517,9 @@ func (s TargetsRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TargetsRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29764,6 +30649,8 @@ func (s *TestRepositoryTriggersOutput) SetSuccessfulExecutions(v []*string) *Tes
 type TipOfSourceReferenceIsDifferentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29789,6 +30676,9 @@ func (s TipOfSourceReferenceIsDifferentException) Code() string {
 
 // Message returns the exception's message.
 func (s TipOfSourceReferenceIsDifferentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29817,6 +30707,8 @@ func (s TipOfSourceReferenceIsDifferentException) RequestID() string {
 type TipsDivergenceExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29842,6 +30734,9 @@ func (s TipsDivergenceExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s TipsDivergenceExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29868,6 +30763,8 @@ func (s TipsDivergenceExceededException) RequestID() string {
 type TitleRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29893,6 +30790,9 @@ func (s TitleRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TitleRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29919,6 +30819,8 @@ func (s TitleRequiredException) RequestID() string {
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29944,6 +30846,9 @@ func (s TooManyTagsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyTagsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/codecommit/integ_test.go
+++ b/service/codecommit/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ListBranches(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -5178,6 +5178,8 @@ func (s *AlarmConfiguration) SetIgnorePollAlarmFailure(v bool) *AlarmConfigurati
 type AlarmsLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5203,6 +5205,9 @@ func (s AlarmsLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s AlarmsLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5277,6 +5282,8 @@ func (s *AppSpecContent) SetSha256(v string) *AppSpecContent {
 type ApplicationAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5302,6 +5309,9 @@ func (s ApplicationAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ApplicationAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5328,6 +5338,8 @@ func (s ApplicationAlreadyExistsException) RequestID() string {
 type ApplicationDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5353,6 +5365,9 @@ func (s ApplicationDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s ApplicationDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5450,6 +5465,8 @@ func (s *ApplicationInfo) SetLinkedToGitHub(v bool) *ApplicationInfo {
 type ApplicationLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5475,6 +5492,9 @@ func (s ApplicationLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s ApplicationLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5501,6 +5521,8 @@ func (s ApplicationLimitExceededException) RequestID() string {
 type ApplicationNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5526,6 +5548,9 @@ func (s ApplicationNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ApplicationNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5553,6 +5578,8 @@ func (s ApplicationNameRequiredException) RequestID() string {
 type ArnNotSupportedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5578,6 +5605,9 @@ func (s ArnNotSupportedException) Code() string {
 
 // Message returns the exception's message.
 func (s ArnNotSupportedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6217,6 +6247,8 @@ func (s *BatchGetOnPremisesInstancesOutput) SetInstanceInfos(v []*InstanceInfo) 
 type BatchLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6242,6 +6274,9 @@ func (s BatchLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s BatchLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6361,6 +6396,8 @@ func (s *BlueInstanceTerminationOption) SetTerminationWaitTimeInMinutes(v int64)
 type BucketNameFilterRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6386,6 +6423,9 @@ func (s BucketNameFilterRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s BucketNameFilterRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7364,6 +7404,8 @@ func (s *DeleteGitHubAccountTokenOutput) SetTokenName(v string) *DeleteGitHubAcc
 type DeploymentAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7389,6 +7431,9 @@ func (s DeploymentAlreadyCompletedException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentAlreadyCompletedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7416,6 +7461,8 @@ func (s DeploymentAlreadyCompletedException) RequestID() string {
 type DeploymentConfigAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7441,6 +7488,9 @@ func (s DeploymentConfigAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentConfigAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7467,6 +7517,8 @@ func (s DeploymentConfigAlreadyExistsException) RequestID() string {
 type DeploymentConfigDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7492,6 +7544,9 @@ func (s DeploymentConfigDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentConfigDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7518,6 +7573,8 @@ func (s DeploymentConfigDoesNotExistException) RequestID() string {
 type DeploymentConfigInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7543,6 +7600,9 @@ func (s DeploymentConfigInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentConfigInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7639,6 +7699,8 @@ func (s *DeploymentConfigInfo) SetTrafficRoutingConfig(v *TrafficRoutingConfig) 
 type DeploymentConfigLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7664,6 +7726,9 @@ func (s DeploymentConfigLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentConfigLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7690,6 +7755,8 @@ func (s DeploymentConfigLimitExceededException) RequestID() string {
 type DeploymentConfigNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7715,6 +7782,9 @@ func (s DeploymentConfigNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentConfigNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7741,6 +7811,8 @@ func (s DeploymentConfigNameRequiredException) RequestID() string {
 type DeploymentDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7766,6 +7838,9 @@ func (s DeploymentDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7793,6 +7868,8 @@ func (s DeploymentDoesNotExistException) RequestID() string {
 type DeploymentGroupAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7818,6 +7895,9 @@ func (s DeploymentGroupAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentGroupAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7844,6 +7924,8 @@ func (s DeploymentGroupAlreadyExistsException) RequestID() string {
 type DeploymentGroupDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7869,6 +7951,9 @@ func (s DeploymentGroupDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentGroupDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8116,6 +8201,8 @@ func (s *DeploymentGroupInfo) SetTriggerConfigurations(v []*TriggerConfig) *Depl
 type DeploymentGroupLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8141,6 +8228,9 @@ func (s DeploymentGroupLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentGroupLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8167,6 +8257,8 @@ func (s DeploymentGroupLimitExceededException) RequestID() string {
 type DeploymentGroupNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8192,6 +8284,9 @@ func (s DeploymentGroupNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentGroupNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8218,6 +8313,8 @@ func (s DeploymentGroupNameRequiredException) RequestID() string {
 type DeploymentIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8243,6 +8340,9 @@ func (s DeploymentIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8581,6 +8681,8 @@ func (s *DeploymentInfo) SetUpdateOutdatedInstancesOnly(v bool) *DeploymentInfo 
 type DeploymentIsNotInReadyStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8606,6 +8708,9 @@ func (s DeploymentIsNotInReadyStateException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentIsNotInReadyStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8632,6 +8737,8 @@ func (s DeploymentIsNotInReadyStateException) RequestID() string {
 type DeploymentLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8657,6 +8764,9 @@ func (s DeploymentLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8683,6 +8793,8 @@ func (s DeploymentLimitExceededException) RequestID() string {
 type DeploymentNotStartedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8708,6 +8820,9 @@ func (s DeploymentNotStartedException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentNotStartedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8939,6 +9054,8 @@ func (s *DeploymentTarget) SetLambdaTarget(v *LambdaTarget) *DeploymentTarget {
 type DeploymentTargetDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8964,6 +9081,9 @@ func (s DeploymentTargetDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentTargetDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8990,6 +9110,8 @@ func (s DeploymentTargetDoesNotExistException) RequestID() string {
 type DeploymentTargetIdRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9015,6 +9137,9 @@ func (s DeploymentTargetIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentTargetIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9044,6 +9169,8 @@ func (s DeploymentTargetIdRequiredException) RequestID() string {
 type DeploymentTargetListSizeExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9069,6 +9196,9 @@ func (s DeploymentTargetListSizeExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s DeploymentTargetListSizeExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9148,6 +9278,8 @@ func (s DeregisterOnPremisesInstanceOutput) GoString() string {
 type DescriptionTooLongException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9173,6 +9305,9 @@ func (s DescriptionTooLongException) Code() string {
 
 // Message returns the exception's message.
 func (s DescriptionTooLongException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9376,6 +9511,8 @@ func (s *ECSService) SetServiceName(v string) *ECSService {
 type ECSServiceMappingLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9401,6 +9538,9 @@ func (s ECSServiceMappingLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s ECSServiceMappingLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10353,6 +10493,8 @@ func (s *GetOnPremisesInstanceOutput) SetInstanceInfo(v *InstanceInfo) *GetOnPre
 type GitHubAccountTokenDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10378,6 +10520,9 @@ func (s GitHubAccountTokenDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s GitHubAccountTokenDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10404,6 +10549,8 @@ func (s GitHubAccountTokenDoesNotExistException) RequestID() string {
 type GitHubAccountTokenNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10429,6 +10576,9 @@ func (s GitHubAccountTokenNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s GitHubAccountTokenNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10524,6 +10674,8 @@ func (s *GreenFleetProvisioningOption) SetAction(v string) *GreenFleetProvisioni
 type IamArnRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10549,6 +10701,9 @@ func (s IamArnRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s IamArnRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10576,6 +10731,8 @@ func (s IamArnRequiredException) RequestID() string {
 type IamSessionArnAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10601,6 +10758,9 @@ func (s IamSessionArnAlreadyRegisteredException) Code() string {
 
 // Message returns the exception's message.
 func (s IamSessionArnAlreadyRegisteredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10627,6 +10787,8 @@ func (s IamSessionArnAlreadyRegisteredException) RequestID() string {
 type IamUserArnAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10652,6 +10814,9 @@ func (s IamUserArnAlreadyRegisteredException) Code() string {
 
 // Message returns the exception's message.
 func (s IamUserArnAlreadyRegisteredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10678,6 +10843,8 @@ func (s IamUserArnAlreadyRegisteredException) RequestID() string {
 type IamUserArnRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10703,6 +10870,9 @@ func (s IamUserArnRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s IamUserArnRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10731,6 +10901,8 @@ func (s IamUserArnRequiredException) RequestID() string {
 type InstanceDoesNotExistException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10756,6 +10928,9 @@ func (s InstanceDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10784,6 +10959,8 @@ func (s InstanceDoesNotExistException) RequestID() string {
 type InstanceIdRequiredException struct {
 	_            struct{} `deprecated:"true" type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10809,6 +10986,9 @@ func (s InstanceIdRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceIdRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10915,6 +11095,8 @@ func (s *InstanceInfo) SetTags(v []*Tag) *InstanceInfo {
 type InstanceLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10940,6 +11122,9 @@ func (s InstanceLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10966,6 +11151,8 @@ func (s InstanceLimitExceededException) RequestID() string {
 type InstanceNameAlreadyRegisteredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10991,6 +11178,9 @@ func (s InstanceNameAlreadyRegisteredException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceNameAlreadyRegisteredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11017,6 +11207,8 @@ func (s InstanceNameAlreadyRegisteredException) RequestID() string {
 type InstanceNameRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11042,6 +11234,9 @@ func (s InstanceNameRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceNameRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11068,6 +11263,8 @@ func (s InstanceNameRequiredException) RequestID() string {
 type InstanceNotRegisteredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11093,6 +11290,9 @@ func (s InstanceNotRegisteredException) Code() string {
 
 // Message returns the exception's message.
 func (s InstanceNotRegisteredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11297,6 +11497,8 @@ func (s *InstanceTarget) SetTargetId(v string) *InstanceTarget {
 type InvalidAlarmConfigException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11322,6 +11524,9 @@ func (s InvalidAlarmConfigException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidAlarmConfigException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11348,6 +11553,8 @@ func (s InvalidAlarmConfigException) RequestID() string {
 type InvalidApplicationNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11373,6 +11580,9 @@ func (s InvalidApplicationNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApplicationNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11399,6 +11609,8 @@ func (s InvalidApplicationNameException) RequestID() string {
 type InvalidArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11424,6 +11636,9 @@ func (s InvalidArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11452,6 +11667,8 @@ func (s InvalidArnException) RequestID() string {
 type InvalidAutoRollbackConfigException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11477,6 +11694,9 @@ func (s InvalidAutoRollbackConfigException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidAutoRollbackConfigException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11503,6 +11723,8 @@ func (s InvalidAutoRollbackConfigException) RequestID() string {
 type InvalidAutoScalingGroupException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11528,6 +11750,9 @@ func (s InvalidAutoScalingGroupException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidAutoScalingGroupException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11556,6 +11781,8 @@ func (s InvalidAutoScalingGroupException) RequestID() string {
 type InvalidBlueGreenDeploymentConfigurationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11581,6 +11808,9 @@ func (s InvalidBlueGreenDeploymentConfigurationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidBlueGreenDeploymentConfigurationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11607,6 +11837,8 @@ func (s InvalidBlueGreenDeploymentConfigurationException) RequestID() string {
 type InvalidBucketNameFilterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11632,6 +11864,9 @@ func (s InvalidBucketNameFilterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidBucketNameFilterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11658,6 +11893,8 @@ func (s InvalidBucketNameFilterException) RequestID() string {
 type InvalidComputePlatformException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11683,6 +11920,9 @@ func (s InvalidComputePlatformException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidComputePlatformException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11709,6 +11949,8 @@ func (s InvalidComputePlatformException) RequestID() string {
 type InvalidDeployedStateFilterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11734,6 +11976,9 @@ func (s InvalidDeployedStateFilterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeployedStateFilterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11760,6 +12005,8 @@ func (s InvalidDeployedStateFilterException) RequestID() string {
 type InvalidDeploymentConfigNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11785,6 +12032,9 @@ func (s InvalidDeploymentConfigNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentConfigNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11811,6 +12061,8 @@ func (s InvalidDeploymentConfigNameException) RequestID() string {
 type InvalidDeploymentGroupNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11836,6 +12088,9 @@ func (s InvalidDeploymentGroupNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentGroupNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11862,6 +12117,8 @@ func (s InvalidDeploymentGroupNameException) RequestID() string {
 type InvalidDeploymentIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11887,6 +12144,9 @@ func (s InvalidDeploymentIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11914,6 +12174,8 @@ func (s InvalidDeploymentIdException) RequestID() string {
 type InvalidDeploymentInstanceTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11939,6 +12201,9 @@ func (s InvalidDeploymentInstanceTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentInstanceTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11965,6 +12230,8 @@ func (s InvalidDeploymentInstanceTypeException) RequestID() string {
 type InvalidDeploymentStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11990,6 +12257,9 @@ func (s InvalidDeploymentStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12018,6 +12288,8 @@ func (s InvalidDeploymentStatusException) RequestID() string {
 type InvalidDeploymentStyleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12043,6 +12315,9 @@ func (s InvalidDeploymentStyleException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentStyleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12069,6 +12344,8 @@ func (s InvalidDeploymentStyleException) RequestID() string {
 type InvalidDeploymentTargetIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12094,6 +12371,9 @@ func (s InvalidDeploymentTargetIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentTargetIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12120,6 +12400,8 @@ func (s InvalidDeploymentTargetIdException) RequestID() string {
 type InvalidDeploymentWaitTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12145,6 +12427,9 @@ func (s InvalidDeploymentWaitTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeploymentWaitTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12172,6 +12457,8 @@ func (s InvalidDeploymentWaitTypeException) RequestID() string {
 type InvalidEC2TagCombinationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12197,6 +12484,9 @@ func (s InvalidEC2TagCombinationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEC2TagCombinationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12223,6 +12513,8 @@ func (s InvalidEC2TagCombinationException) RequestID() string {
 type InvalidEC2TagException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12248,6 +12540,9 @@ func (s InvalidEC2TagException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEC2TagException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12274,6 +12569,8 @@ func (s InvalidEC2TagException) RequestID() string {
 type InvalidECSServiceException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12299,6 +12596,9 @@ func (s InvalidECSServiceException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidECSServiceException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12328,6 +12628,8 @@ func (s InvalidECSServiceException) RequestID() string {
 type InvalidFileExistsBehaviorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12353,6 +12655,9 @@ func (s InvalidFileExistsBehaviorException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidFileExistsBehaviorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12379,6 +12684,8 @@ func (s InvalidFileExistsBehaviorException) RequestID() string {
 type InvalidGitHubAccountTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12404,6 +12711,9 @@ func (s InvalidGitHubAccountTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidGitHubAccountTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12430,6 +12740,8 @@ func (s InvalidGitHubAccountTokenException) RequestID() string {
 type InvalidGitHubAccountTokenNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12455,6 +12767,9 @@ func (s InvalidGitHubAccountTokenNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidGitHubAccountTokenNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12481,6 +12796,8 @@ func (s InvalidGitHubAccountTokenNameException) RequestID() string {
 type InvalidIamSessionArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12506,6 +12823,9 @@ func (s InvalidIamSessionArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidIamSessionArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12532,6 +12852,8 @@ func (s InvalidIamSessionArnException) RequestID() string {
 type InvalidIamUserArnException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12557,6 +12879,9 @@ func (s InvalidIamUserArnException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidIamUserArnException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12584,6 +12909,8 @@ func (s InvalidIamUserArnException) RequestID() string {
 type InvalidIgnoreApplicationStopFailuresValueException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12609,6 +12936,9 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidIgnoreApplicationStopFailuresValueException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12635,6 +12965,8 @@ func (s InvalidIgnoreApplicationStopFailuresValueException) RequestID() string {
 type InvalidInputException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12660,6 +12992,9 @@ func (s InvalidInputException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInputException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12686,6 +13021,8 @@ func (s InvalidInputException) RequestID() string {
 type InvalidInstanceNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12711,6 +13048,9 @@ func (s InvalidInstanceNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInstanceNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12737,6 +13077,8 @@ func (s InvalidInstanceNameException) RequestID() string {
 type InvalidInstanceStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12762,6 +13104,9 @@ func (s InvalidInstanceStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInstanceStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12790,6 +13135,8 @@ func (s InvalidInstanceStatusException) RequestID() string {
 type InvalidInstanceTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12815,6 +13162,9 @@ func (s InvalidInstanceTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidInstanceTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12841,6 +13191,8 @@ func (s InvalidInstanceTypeException) RequestID() string {
 type InvalidKeyPrefixFilterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12866,6 +13218,9 @@ func (s InvalidKeyPrefixFilterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidKeyPrefixFilterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12893,6 +13248,8 @@ func (s InvalidKeyPrefixFilterException) RequestID() string {
 type InvalidLifecycleEventHookExecutionIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12918,6 +13275,9 @@ func (s InvalidLifecycleEventHookExecutionIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidLifecycleEventHookExecutionIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12945,6 +13305,8 @@ func (s InvalidLifecycleEventHookExecutionIdException) RequestID() string {
 type InvalidLifecycleEventHookExecutionStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12970,6 +13332,9 @@ func (s InvalidLifecycleEventHookExecutionStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidLifecycleEventHookExecutionStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12996,6 +13361,8 @@ func (s InvalidLifecycleEventHookExecutionStatusException) RequestID() string {
 type InvalidLoadBalancerInfoException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13021,6 +13388,9 @@ func (s InvalidLoadBalancerInfoException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidLoadBalancerInfoException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13047,6 +13417,8 @@ func (s InvalidLoadBalancerInfoException) RequestID() string {
 type InvalidMinimumHealthyHostValueException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13072,6 +13444,9 @@ func (s InvalidMinimumHealthyHostValueException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidMinimumHealthyHostValueException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13098,6 +13473,8 @@ func (s InvalidMinimumHealthyHostValueException) RequestID() string {
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13123,6 +13500,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13150,6 +13530,8 @@ func (s InvalidNextTokenException) RequestID() string {
 type InvalidOnPremisesTagCombinationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13175,6 +13557,9 @@ func (s InvalidOnPremisesTagCombinationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOnPremisesTagCombinationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13201,6 +13586,8 @@ func (s InvalidOnPremisesTagCombinationException) RequestID() string {
 type InvalidOperationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13226,6 +13613,9 @@ func (s InvalidOperationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOperationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13252,6 +13642,8 @@ func (s InvalidOperationException) RequestID() string {
 type InvalidRegistrationStatusException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13277,6 +13669,9 @@ func (s InvalidRegistrationStatusException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRegistrationStatusException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13303,6 +13698,8 @@ func (s InvalidRegistrationStatusException) RequestID() string {
 type InvalidRevisionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13328,6 +13725,9 @@ func (s InvalidRevisionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRevisionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13356,6 +13756,8 @@ func (s InvalidRevisionException) RequestID() string {
 type InvalidRoleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13381,6 +13783,9 @@ func (s InvalidRoleException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRoleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13408,6 +13813,8 @@ func (s InvalidRoleException) RequestID() string {
 type InvalidSortByException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13433,6 +13840,9 @@ func (s InvalidSortByException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSortByException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13459,6 +13869,8 @@ func (s InvalidSortByException) RequestID() string {
 type InvalidSortOrderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13484,6 +13896,9 @@ func (s InvalidSortOrderException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSortOrderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13510,6 +13925,8 @@ func (s InvalidSortOrderException) RequestID() string {
 type InvalidTagException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13535,6 +13952,9 @@ func (s InvalidTagException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13561,6 +13981,8 @@ func (s InvalidTagException) RequestID() string {
 type InvalidTagFilterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13586,6 +14008,9 @@ func (s InvalidTagFilterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagFilterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13612,6 +14037,8 @@ func (s InvalidTagFilterException) RequestID() string {
 type InvalidTagsToAddException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13637,6 +14064,9 @@ func (s InvalidTagsToAddException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTagsToAddException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13663,6 +14093,8 @@ func (s InvalidTagsToAddException) RequestID() string {
 type InvalidTargetFilterNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13688,6 +14120,9 @@ func (s InvalidTargetFilterNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetFilterNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13714,6 +14149,8 @@ func (s InvalidTargetFilterNameException) RequestID() string {
 type InvalidTargetGroupPairException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13739,6 +14176,9 @@ func (s InvalidTargetGroupPairException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetGroupPairException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13774,6 +14214,8 @@ func (s InvalidTargetGroupPairException) RequestID() string {
 type InvalidTargetInstancesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13799,6 +14241,9 @@ func (s InvalidTargetInstancesException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTargetInstancesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13825,6 +14270,8 @@ func (s InvalidTargetInstancesException) RequestID() string {
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13850,6 +14297,9 @@ func (s InvalidTimeRangeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTimeRangeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13877,6 +14327,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 type InvalidTrafficRoutingConfigurationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13902,6 +14354,9 @@ func (s InvalidTrafficRoutingConfigurationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTrafficRoutingConfigurationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13928,6 +14383,8 @@ func (s InvalidTrafficRoutingConfigurationException) RequestID() string {
 type InvalidTriggerConfigException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13953,6 +14410,9 @@ func (s InvalidTriggerConfigException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTriggerConfigException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13980,6 +14440,8 @@ func (s InvalidTriggerConfigException) RequestID() string {
 type InvalidUpdateOutdatedInstancesOnlyValueException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14005,6 +14467,9 @@ func (s InvalidUpdateOutdatedInstancesOnlyValueException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidUpdateOutdatedInstancesOnlyValueException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14299,6 +14764,8 @@ func (s *LifecycleEvent) SetStatus(v string) *LifecycleEvent {
 type LifecycleEventAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14324,6 +14791,9 @@ func (s LifecycleEventAlreadyCompletedException) Code() string {
 
 // Message returns the exception's message.
 func (s LifecycleEventAlreadyCompletedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14350,6 +14820,8 @@ func (s LifecycleEventAlreadyCompletedException) RequestID() string {
 type LifecycleHookLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14375,6 +14847,9 @@ func (s LifecycleHookLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LifecycleHookLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15452,6 +15927,8 @@ func (s *MinimumHealthyHosts) SetValue(v int64) *MinimumHealthyHosts {
 type MultipleIamArnsProvidedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15477,6 +15954,9 @@ func (s MultipleIamArnsProvidedException) Code() string {
 
 // Message returns the exception's message.
 func (s MultipleIamArnsProvidedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15529,6 +16009,8 @@ func (s *OnPremisesTagSet) SetOnPremisesTagSetList(v [][]*TagFilter) *OnPremises
 type OperationNotSupportedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15554,6 +16036,9 @@ func (s OperationNotSupportedException) Code() string {
 
 // Message returns the exception's message.
 func (s OperationNotSupportedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15906,6 +16391,8 @@ func (s RemoveTagsFromOnPremisesInstancesOutput) GoString() string {
 type ResourceArnRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15931,6 +16418,9 @@ func (s ResourceArnRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceArnRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15957,6 +16447,8 @@ func (s ResourceArnRequiredException) RequestID() string {
 type ResourceValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15982,6 +16474,9 @@ func (s ResourceValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16008,6 +16503,8 @@ func (s ResourceValidationException) RequestID() string {
 type RevisionDoesNotExistException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16033,6 +16530,9 @@ func (s RevisionDoesNotExistException) Code() string {
 
 // Message returns the exception's message.
 func (s RevisionDoesNotExistException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16163,6 +16663,8 @@ func (s *RevisionLocation) SetString_(v *RawString) *RevisionLocation {
 type RevisionRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16188,6 +16690,9 @@ func (s RevisionRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RevisionRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16214,6 +16719,8 @@ func (s RevisionRequiredException) RequestID() string {
 type RoleRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16239,6 +16746,9 @@ func (s RoleRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s RoleRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16591,6 +17101,8 @@ func (s *TagFilter) SetValue(v string) *TagFilter {
 type TagLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16616,6 +17128,9 @@ func (s TagLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s TagLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16642,6 +17157,8 @@ func (s TagLimitExceededException) RequestID() string {
 type TagRequiredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16667,6 +17184,9 @@ func (s TagRequiredException) Code() string {
 
 // Message returns the exception's message.
 func (s TagRequiredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16764,6 +17284,8 @@ func (s TagResourceOutput) GoString() string {
 type TagSetListLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16789,6 +17311,9 @@ func (s TagSetListLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s TagSetListLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16942,6 +17467,8 @@ func (s *TargetInstances) SetTagFilters(v []*EC2TagFilter) *TargetInstances {
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16967,6 +17494,9 @@ func (s ThrottlingException) Code() string {
 
 // Message returns the exception's message.
 func (s ThrottlingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17224,6 +17754,8 @@ func (s *TriggerConfig) SetTriggerTargetArn(v string) *TriggerConfig {
 type TriggerTargetsLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17249,6 +17781,9 @@ func (s TriggerTargetsLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s TriggerTargetsLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17275,6 +17810,8 @@ func (s TriggerTargetsLimitExceededException) RequestID() string {
 type UnsupportedActionForDeploymentTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17300,6 +17837,9 @@ func (s UnsupportedActionForDeploymentTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s UnsupportedActionForDeploymentTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/codedeploy/integ_test.go
+++ b/service/codedeploy/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetDeployment(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -4588,6 +4588,8 @@ func (s *ActionExecutionResult) SetExternalExecutionUrl(v string) *ActionExecuti
 type ActionNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4613,6 +4615,9 @@ func (s ActionNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ActionNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4936,6 +4941,8 @@ func (s *ActionTypeId) SetVersion(v string) *ActionTypeId {
 type ActionTypeNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4961,6 +4968,9 @@ func (s ActionTypeNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ActionTypeNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5070,6 +5080,8 @@ func (s *ActionTypeSettings) SetThirdPartyConfigurationUrl(v string) *ActionType
 type ApprovalAlreadyCompletedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5095,6 +5107,9 @@ func (s ApprovalAlreadyCompletedException) Code() string {
 
 // Message returns the exception's message.
 func (s ApprovalAlreadyCompletedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7176,6 +7191,8 @@ func (s *InputArtifact) SetName(v string) *InputArtifact {
 type InvalidActionDeclarationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7201,6 +7218,9 @@ func (s InvalidActionDeclarationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidActionDeclarationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7227,6 +7247,8 @@ func (s InvalidActionDeclarationException) RequestID() string {
 type InvalidApprovalTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7252,6 +7274,9 @@ func (s InvalidApprovalTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidApprovalTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7334,6 +7359,8 @@ func (s InvalidArnException) RequestID() string {
 type InvalidBlockerDeclarationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7359,6 +7386,9 @@ func (s InvalidBlockerDeclarationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidBlockerDeclarationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7385,6 +7415,8 @@ func (s InvalidBlockerDeclarationException) RequestID() string {
 type InvalidClientTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7410,6 +7442,9 @@ func (s InvalidClientTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidClientTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7436,6 +7471,8 @@ func (s InvalidClientTokenException) RequestID() string {
 type InvalidJobException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7461,6 +7498,9 @@ func (s InvalidJobException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidJobException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7487,6 +7527,8 @@ func (s InvalidJobException) RequestID() string {
 type InvalidJobStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7512,6 +7554,9 @@ func (s InvalidJobStateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidJobStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7539,6 +7584,8 @@ func (s InvalidJobStateException) RequestID() string {
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7564,6 +7611,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7590,6 +7640,8 @@ func (s InvalidNextTokenException) RequestID() string {
 type InvalidNonceException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7615,6 +7667,9 @@ func (s InvalidNonceException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNonceException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7641,6 +7696,8 @@ func (s InvalidNonceException) RequestID() string {
 type InvalidStageDeclarationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7666,6 +7723,9 @@ func (s InvalidStageDeclarationException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidStageDeclarationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7692,6 +7752,8 @@ func (s InvalidStageDeclarationException) RequestID() string {
 type InvalidStructureException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7717,6 +7779,9 @@ func (s InvalidStructureException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidStructureException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7799,6 +7864,8 @@ func (s InvalidTagsException) RequestID() string {
 type InvalidWebhookAuthenticationParametersException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7824,6 +7891,9 @@ func (s InvalidWebhookAuthenticationParametersException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidWebhookAuthenticationParametersException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7850,6 +7920,8 @@ func (s InvalidWebhookAuthenticationParametersException) RequestID() string {
 type InvalidWebhookFilterPatternException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7875,6 +7947,9 @@ func (s InvalidWebhookFilterPatternException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidWebhookFilterPatternException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8092,6 +8167,8 @@ func (s *JobDetails) SetId(v string) *JobDetails {
 type JobNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8117,6 +8194,9 @@ func (s JobNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s JobNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8144,6 +8224,8 @@ func (s JobNotFoundException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8169,6 +8251,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8845,6 +8930,8 @@ func (s *ListWebhooksOutput) SetWebhooks(v []*ListWebhookItem) *ListWebhooksOutp
 type NotLatestPipelineExecutionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8870,6 +8957,9 @@ func (s NotLatestPipelineExecutionException) Code() string {
 
 // Message returns the exception's message.
 func (s NotLatestPipelineExecutionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9277,6 +9367,8 @@ func (s *PipelineExecution) SetStatus(v string) *PipelineExecution {
 type PipelineExecutionNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9302,6 +9394,9 @@ func (s PipelineExecutionNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s PipelineExecutionNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9451,6 +9546,8 @@ func (s *PipelineMetadata) SetUpdated(v time.Time) *PipelineMetadata {
 type PipelineNameInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9476,6 +9573,9 @@ func (s PipelineNameInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s PipelineNameInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9502,6 +9602,8 @@ func (s PipelineNameInUseException) RequestID() string {
 type PipelineNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9527,6 +9629,9 @@ func (s PipelineNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s PipelineNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9604,6 +9709,8 @@ func (s *PipelineSummary) SetVersion(v int64) *PipelineSummary {
 type PipelineVersionNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9629,6 +9736,9 @@ func (s PipelineVersionNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s PipelineVersionNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10630,6 +10740,8 @@ func (s RegisterWebhookWithThirdPartyOutput) GoString() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10655,6 +10767,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11072,6 +11187,8 @@ func (s *StageExecution) SetStatus(v string) *StageExecution {
 type StageNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11097,6 +11214,9 @@ func (s StageNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s StageNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11124,6 +11244,8 @@ func (s StageNotFoundException) RequestID() string {
 type StageNotRetryableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11149,6 +11271,9 @@ func (s StageNotRetryableException) Code() string {
 
 // Message returns the exception's message.
 func (s StageNotRetryableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11860,6 +11985,8 @@ func (s *UpdatePipelineOutput) SetPipeline(v *PipelineDeclaration) *UpdatePipeli
 type ValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11885,6 +12012,9 @@ func (s ValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12179,6 +12309,8 @@ func (s *WebhookFilterRule) SetMatchEquals(v string) *WebhookFilterRule {
 type WebhookNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12204,6 +12336,9 @@ func (s WebhookNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s WebhookNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/codepipeline/integ_test.go
+++ b/service/codepipeline/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetPipeline(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/codestar/api.go
+++ b/service/codestar/api.go
@@ -1950,6 +1950,8 @@ func (s *CodeSource) SetS3(v *S3Location) *CodeSource {
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1975,6 +1977,9 @@ func (s ConcurrentModificationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentModificationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2981,6 +2986,8 @@ func (s *GitHubCodeDestination) SetType(v string) *GitHubCodeDestination {
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3006,6 +3013,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3032,6 +3042,8 @@ func (s InvalidNextTokenException) RequestID() string {
 type InvalidServiceRoleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3057,6 +3069,9 @@ func (s InvalidServiceRoleException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidServiceRoleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3083,6 +3098,8 @@ func (s InvalidServiceRoleException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3108,6 +3125,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3601,6 +3621,8 @@ func (s *ListUserProfilesOutput) SetUserProfiles(v []*UserProfileSummary) *ListU
 type ProjectAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3626,6 +3648,9 @@ func (s ProjectAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ProjectAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3652,6 +3677,8 @@ func (s ProjectAlreadyExistsException) RequestID() string {
 type ProjectConfigurationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3677,6 +3704,9 @@ func (s ProjectConfigurationException) Code() string {
 
 // Message returns the exception's message.
 func (s ProjectConfigurationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3705,6 +3735,8 @@ func (s ProjectConfigurationException) RequestID() string {
 type ProjectCreationFailedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3730,6 +3762,9 @@ func (s ProjectCreationFailedException) Code() string {
 
 // Message returns the exception's message.
 func (s ProjectCreationFailedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3756,6 +3791,8 @@ func (s ProjectCreationFailedException) RequestID() string {
 type ProjectNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3781,6 +3818,9 @@ func (s ProjectNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ProjectNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4077,6 +4117,8 @@ func (s *TeamMember) SetUserArn(v string) *TeamMember {
 type TeamMemberAlreadyAssociatedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4102,6 +4144,9 @@ func (s TeamMemberAlreadyAssociatedException) Code() string {
 
 // Message returns the exception's message.
 func (s TeamMemberAlreadyAssociatedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4128,6 +4173,8 @@ func (s TeamMemberAlreadyAssociatedException) RequestID() string {
 type TeamMemberNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4153,6 +4200,9 @@ func (s TeamMemberNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s TeamMemberNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4719,6 +4769,8 @@ func (s *UpdateUserProfileOutput) SetUserArn(v string) *UpdateUserProfileOutput 
 type UserProfileAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4744,6 +4796,9 @@ func (s UserProfileAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s UserProfileAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4770,6 +4825,8 @@ func (s UserProfileAlreadyExistsException) RequestID() string {
 type UserProfileNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4795,6 +4852,9 @@ func (s UserProfileNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s UserProfileNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4882,6 +4942,8 @@ func (s *UserProfileSummary) SetUserArn(v string) *UserProfileSummary {
 type ValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4907,6 +4969,9 @@ func (s ValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/cognitoidentityprovider/integ_test.go
+++ b/service/cognitoidentityprovider/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_DescribeUserPool(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -10420,6 +10420,8 @@ func (s *ConformancePackStatusDetail) SetStackArn(v string) *ConformancePackStat
 type ConformancePackTemplateValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10445,6 +10447,9 @@ func (s ConformancePackTemplateValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConformancePackTemplateValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15437,6 +15442,8 @@ func (s *GroupedResourceCount) SetResourceCount(v int64) *GroupedResourceCount {
 type InsufficientDeliveryPolicyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15462,6 +15469,9 @@ func (s InsufficientDeliveryPolicyException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientDeliveryPolicyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15502,6 +15512,8 @@ func (s InsufficientDeliveryPolicyException) RequestID() string {
 type InsufficientPermissionsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15527,6 +15539,9 @@ func (s InsufficientPermissionsException) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientPermissionsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15553,6 +15568,8 @@ func (s InsufficientPermissionsException) RequestID() string {
 type InvalidConfigurationRecorderNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15578,6 +15595,9 @@ func (s InvalidConfigurationRecorderNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidConfigurationRecorderNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15604,6 +15624,8 @@ func (s InvalidConfigurationRecorderNameException) RequestID() string {
 type InvalidDeliveryChannelNameException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15629,6 +15651,9 @@ func (s InvalidDeliveryChannelNameException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidDeliveryChannelNameException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15655,6 +15680,8 @@ func (s InvalidDeliveryChannelNameException) RequestID() string {
 type InvalidExpressionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15680,6 +15707,9 @@ func (s InvalidExpressionException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidExpressionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15706,6 +15736,8 @@ func (s InvalidExpressionException) RequestID() string {
 type InvalidLimitException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15731,6 +15763,9 @@ func (s InvalidLimitException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidLimitException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15758,6 +15793,8 @@ func (s InvalidLimitException) RequestID() string {
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15783,6 +15820,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15810,6 +15850,8 @@ func (s InvalidNextTokenException) RequestID() string {
 type InvalidParameterValueException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15835,6 +15877,9 @@ func (s InvalidParameterValueException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterValueException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15862,6 +15907,8 @@ func (s InvalidParameterValueException) RequestID() string {
 type InvalidRecordingGroupException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15887,6 +15934,9 @@ func (s InvalidRecordingGroupException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRecordingGroupException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15913,6 +15963,8 @@ func (s InvalidRecordingGroupException) RequestID() string {
 type InvalidResultTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15938,6 +15990,9 @@ func (s InvalidResultTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidResultTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15964,6 +16019,8 @@ func (s InvalidResultTokenException) RequestID() string {
 type InvalidRoleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15989,6 +16046,9 @@ func (s InvalidRoleException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRoleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16015,6 +16075,8 @@ func (s InvalidRoleException) RequestID() string {
 type InvalidS3KeyPrefixException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16040,6 +16102,9 @@ func (s InvalidS3KeyPrefixException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidS3KeyPrefixException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16066,6 +16131,8 @@ func (s InvalidS3KeyPrefixException) RequestID() string {
 type InvalidSNSTopicARNException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16091,6 +16158,9 @@ func (s InvalidSNSTopicARNException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSNSTopicARNException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16118,6 +16188,8 @@ func (s InvalidSNSTopicARNException) RequestID() string {
 type InvalidTimeRangeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16143,6 +16215,9 @@ func (s InvalidTimeRangeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTimeRangeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16170,6 +16245,8 @@ func (s InvalidTimeRangeException) RequestID() string {
 type LastDeliveryChannelDeleteFailedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16195,6 +16272,9 @@ func (s LastDeliveryChannelDeleteFailedException) Code() string {
 
 // Message returns the exception's message.
 func (s LastDeliveryChannelDeleteFailedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16226,6 +16306,8 @@ func (s LastDeliveryChannelDeleteFailedException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16251,6 +16333,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16623,6 +16708,8 @@ func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput
 type MaxActiveResourcesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16648,6 +16735,9 @@ func (s MaxActiveResourcesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxActiveResourcesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16676,6 +16766,8 @@ func (s MaxActiveResourcesExceededException) RequestID() string {
 type MaxNumberOfConfigRulesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16701,6 +16793,9 @@ func (s MaxNumberOfConfigRulesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfConfigRulesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16727,6 +16822,8 @@ func (s MaxNumberOfConfigRulesExceededException) RequestID() string {
 type MaxNumberOfConfigurationRecordersExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16752,6 +16849,9 @@ func (s MaxNumberOfConfigurationRecordersExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfConfigurationRecordersExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16779,6 +16879,8 @@ func (s MaxNumberOfConfigurationRecordersExceededException) RequestID() string {
 type MaxNumberOfConformancePacksExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16804,6 +16906,9 @@ func (s MaxNumberOfConformancePacksExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfConformancePacksExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16830,6 +16935,8 @@ func (s MaxNumberOfConformancePacksExceededException) RequestID() string {
 type MaxNumberOfDeliveryChannelsExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16855,6 +16962,9 @@ func (s MaxNumberOfDeliveryChannelsExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfDeliveryChannelsExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16882,6 +16992,8 @@ func (s MaxNumberOfDeliveryChannelsExceededException) RequestID() string {
 type MaxNumberOfOrganizationConfigRulesExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16907,6 +17019,9 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfOrganizationConfigRulesExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16935,6 +17050,8 @@ func (s MaxNumberOfOrganizationConfigRulesExceededException) RequestID() string 
 type MaxNumberOfOrganizationConformancePacksExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16960,6 +17077,9 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) Code() string 
 
 // Message returns the exception's message.
 func (s MaxNumberOfOrganizationConformancePacksExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16987,6 +17107,8 @@ func (s MaxNumberOfOrganizationConformancePacksExceededException) RequestID() st
 type MaxNumberOfRetentionConfigurationsExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17012,6 +17134,9 @@ func (s MaxNumberOfRetentionConfigurationsExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s MaxNumberOfRetentionConfigurationsExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17143,6 +17268,8 @@ func (s *MemberAccountStatus) SetMemberAccountRuleStatus(v string) *MemberAccoun
 type NoAvailableConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17168,6 +17295,9 @@ func (s NoAvailableConfigurationRecorderException) Code() string {
 
 // Message returns the exception's message.
 func (s NoAvailableConfigurationRecorderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17194,6 +17324,8 @@ func (s NoAvailableConfigurationRecorderException) RequestID() string {
 type NoAvailableDeliveryChannelException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17219,6 +17351,9 @@ func (s NoAvailableDeliveryChannelException) Code() string {
 
 // Message returns the exception's message.
 func (s NoAvailableDeliveryChannelException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17245,6 +17380,8 @@ func (s NoAvailableDeliveryChannelException) RequestID() string {
 type NoAvailableOrganizationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17270,6 +17407,9 @@ func (s NoAvailableOrganizationException) Code() string {
 
 // Message returns the exception's message.
 func (s NoAvailableOrganizationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17296,6 +17436,8 @@ func (s NoAvailableOrganizationException) RequestID() string {
 type NoRunningConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17321,6 +17463,9 @@ func (s NoRunningConfigurationRecorderException) Code() string {
 
 // Message returns the exception's message.
 func (s NoRunningConfigurationRecorderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17347,6 +17492,8 @@ func (s NoRunningConfigurationRecorderException) RequestID() string {
 type NoSuchBucketException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17372,6 +17519,9 @@ func (s NoSuchBucketException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchBucketException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17399,6 +17549,8 @@ func (s NoSuchBucketException) RequestID() string {
 type NoSuchConfigRuleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17424,6 +17576,9 @@ func (s NoSuchConfigRuleException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchConfigRuleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17450,6 +17605,8 @@ func (s NoSuchConfigRuleException) RequestID() string {
 type NoSuchConfigRuleInConformancePackException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17475,6 +17632,9 @@ func (s NoSuchConfigRuleInConformancePackException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchConfigRuleInConformancePackException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17501,6 +17661,8 @@ func (s NoSuchConfigRuleInConformancePackException) RequestID() string {
 type NoSuchConfigurationAggregatorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17526,6 +17688,9 @@ func (s NoSuchConfigurationAggregatorException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchConfigurationAggregatorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17552,6 +17717,8 @@ func (s NoSuchConfigurationAggregatorException) RequestID() string {
 type NoSuchConfigurationRecorderException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17577,6 +17744,9 @@ func (s NoSuchConfigurationRecorderException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchConfigurationRecorderException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17603,6 +17773,8 @@ func (s NoSuchConfigurationRecorderException) RequestID() string {
 type NoSuchConformancePackException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17628,6 +17800,9 @@ func (s NoSuchConformancePackException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchConformancePackException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17654,6 +17829,8 @@ func (s NoSuchConformancePackException) RequestID() string {
 type NoSuchDeliveryChannelException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17679,6 +17856,9 @@ func (s NoSuchDeliveryChannelException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchDeliveryChannelException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17705,6 +17885,8 @@ func (s NoSuchDeliveryChannelException) RequestID() string {
 type NoSuchOrganizationConfigRuleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17730,6 +17912,9 @@ func (s NoSuchOrganizationConfigRuleException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchOrganizationConfigRuleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17760,6 +17945,8 @@ func (s NoSuchOrganizationConfigRuleException) RequestID() string {
 type NoSuchOrganizationConformancePackException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17785,6 +17972,9 @@ func (s NoSuchOrganizationConformancePackException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchOrganizationConformancePackException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17811,6 +18001,8 @@ func (s NoSuchOrganizationConformancePackException) RequestID() string {
 type NoSuchRemediationConfigurationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17836,6 +18028,9 @@ func (s NoSuchRemediationConfigurationException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchRemediationConfigurationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17862,6 +18057,8 @@ func (s NoSuchRemediationConfigurationException) RequestID() string {
 type NoSuchRemediationExceptionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17887,6 +18084,9 @@ func (s NoSuchRemediationExceptionException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchRemediationExceptionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17913,6 +18113,8 @@ func (s NoSuchRemediationExceptionException) RequestID() string {
 type NoSuchRetentionConfigurationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17938,6 +18140,9 @@ func (s NoSuchRetentionConfigurationException) Code() string {
 
 // Message returns the exception's message.
 func (s NoSuchRetentionConfigurationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17969,6 +18174,8 @@ func (s NoSuchRetentionConfigurationException) RequestID() string {
 type OrganizationAccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17994,6 +18201,9 @@ func (s OrganizationAccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s OrganizationAccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18083,6 +18293,8 @@ func (s *OrganizationAggregationSource) SetRoleArn(v string) *OrganizationAggreg
 type OrganizationAllFeaturesNotEnabledException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18108,6 +18320,9 @@ func (s OrganizationAllFeaturesNotEnabledException) Code() string {
 
 // Message returns the exception's message.
 func (s OrganizationAllFeaturesNotEnabledException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18612,6 +18827,8 @@ func (s *OrganizationConformancePackStatus) SetStatus(v string) *OrganizationCon
 type OrganizationConformancePackTemplateValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18637,6 +18854,9 @@ func (s OrganizationConformancePackTemplateValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s OrganizationConformancePackTemplateValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -19018,6 +19238,8 @@ func (s *OrganizationResourceDetailedStatusFilters) SetStatus(v string) *Organiz
 type OversizedConfigurationItemException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -19043,6 +19265,9 @@ func (s OversizedConfigurationItemException) Code() string {
 
 // Message returns the exception's message.
 func (s OversizedConfigurationItemException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21002,6 +21227,8 @@ func (s *RemediationExecutionStep) SetStopTime(v time.Time) *RemediationExecutio
 type RemediationInProgressException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21027,6 +21254,9 @@ func (s RemediationInProgressException) Code() string {
 
 // Message returns the exception's message.
 func (s RemediationInProgressException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21339,6 +21569,8 @@ func (s *ResourceIdentifier) SetResourceType(v string) *ResourceIdentifier {
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21364,6 +21596,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21447,6 +21682,8 @@ func (s *ResourceKey) SetResourceType(v string) *ResourceKey {
 type ResourceNotDiscoveredException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21472,6 +21709,9 @@ func (s ResourceNotDiscoveredException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotDiscoveredException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -21498,6 +21738,8 @@ func (s ResourceNotDiscoveredException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -21523,6 +21765,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22520,6 +22765,8 @@ func (s TagResourceOutput) GoString() string {
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22545,6 +22792,9 @@ func (s TooManyTagsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyTagsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -22645,6 +22895,8 @@ func (s UntagResourceOutput) GoString() string {
 type ValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -22670,6 +22922,9 @@ func (s ValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/configservice/integ_test.go
+++ b/service/configservice/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_GetResourceConfigHistory(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/databasemigrationservice/integ_test.go
+++ b/service/databasemigrationservice/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeTableStatistics(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/dax/api.go
+++ b/service/dax/api.go
@@ -2190,6 +2190,8 @@ func (s *Cluster) SetTotalNodes(v int64) *Cluster {
 type ClusterAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2215,6 +2217,9 @@ func (s ClusterAlreadyExistsFault) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterAlreadyExistsFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2241,6 +2246,8 @@ func (s ClusterAlreadyExistsFault) RequestID() string {
 type ClusterNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2266,6 +2273,9 @@ func (s ClusterNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2293,6 +2303,8 @@ func (s ClusterNotFoundFault) RequestID() string {
 type ClusterQuotaForCustomerExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2318,6 +2330,9 @@ func (s ClusterQuotaForCustomerExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterQuotaForCustomerExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3731,6 +3746,8 @@ func (s *IncreaseReplicationFactorOutput) SetCluster(v *Cluster) *IncreaseReplic
 type InsufficientClusterCapacityFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3756,6 +3773,9 @@ func (s InsufficientClusterCapacityFault) Code() string {
 
 // Message returns the exception's message.
 func (s InsufficientClusterCapacityFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3782,6 +3802,8 @@ func (s InsufficientClusterCapacityFault) RequestID() string {
 type InvalidARNFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3807,6 +3829,9 @@ func (s InvalidARNFault) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidARNFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3833,6 +3858,8 @@ func (s InvalidARNFault) RequestID() string {
 type InvalidClusterStateFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3858,6 +3885,9 @@ func (s InvalidClusterStateFault) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidClusterStateFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3940,6 +3970,8 @@ func (s InvalidParameterCombinationException) RequestID() string {
 type InvalidParameterGroupStateFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3965,6 +3997,9 @@ func (s InvalidParameterGroupStateFault) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterGroupStateFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4047,6 +4082,8 @@ func (s InvalidParameterValueException) RequestID() string {
 type InvalidSubnet struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4072,6 +4109,9 @@ func (s InvalidSubnet) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidSubnet) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4098,6 +4138,8 @@ func (s InvalidSubnet) RequestID() string {
 type InvalidVPCNetworkStateFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4123,6 +4165,9 @@ func (s InvalidVPCNetworkStateFault) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidVPCNetworkStateFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4304,6 +4349,8 @@ func (s *Node) SetParameterGroupStatus(v string) *Node {
 type NodeNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4329,6 +4376,9 @@ func (s NodeNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s NodeNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4355,6 +4405,8 @@ func (s NodeNotFoundFault) RequestID() string {
 type NodeQuotaForClusterExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4380,6 +4432,9 @@ func (s NodeQuotaForClusterExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s NodeQuotaForClusterExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4406,6 +4461,8 @@ func (s NodeQuotaForClusterExceededFault) RequestID() string {
 type NodeQuotaForCustomerExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4431,6 +4488,9 @@ func (s NodeQuotaForCustomerExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s NodeQuotaForCustomerExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4667,6 +4727,8 @@ func (s *ParameterGroup) SetParameterGroupName(v string) *ParameterGroup {
 type ParameterGroupAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4692,6 +4754,9 @@ func (s ParameterGroupAlreadyExistsFault) Code() string {
 
 // Message returns the exception's message.
 func (s ParameterGroupAlreadyExistsFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4718,6 +4783,8 @@ func (s ParameterGroupAlreadyExistsFault) RequestID() string {
 type ParameterGroupNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4743,6 +4810,9 @@ func (s ParameterGroupNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s ParameterGroupNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4769,6 +4839,8 @@ func (s ParameterGroupNotFoundFault) RequestID() string {
 type ParameterGroupQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4794,6 +4866,9 @@ func (s ParameterGroupQuotaExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s ParameterGroupQuotaExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5076,6 +5151,8 @@ func (s *SecurityGroupMembership) SetStatus(v string) *SecurityGroupMembership {
 type ServiceLinkedRoleNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5101,6 +5178,9 @@ func (s ServiceLinkedRoleNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s ServiceLinkedRoleNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5217,6 +5297,8 @@ func (s *SubnetGroup) SetVpcId(v string) *SubnetGroup {
 type SubnetGroupAlreadyExistsFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5242,6 +5324,9 @@ func (s SubnetGroupAlreadyExistsFault) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetGroupAlreadyExistsFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5268,6 +5353,8 @@ func (s SubnetGroupAlreadyExistsFault) RequestID() string {
 type SubnetGroupInUseFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5293,6 +5380,9 @@ func (s SubnetGroupInUseFault) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetGroupInUseFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5319,6 +5409,8 @@ func (s SubnetGroupInUseFault) RequestID() string {
 type SubnetGroupNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5344,6 +5436,9 @@ func (s SubnetGroupNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetGroupNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5371,6 +5466,8 @@ func (s SubnetGroupNotFoundFault) RequestID() string {
 type SubnetGroupQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5396,6 +5493,9 @@ func (s SubnetGroupQuotaExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetGroupQuotaExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5422,6 +5522,8 @@ func (s SubnetGroupQuotaExceededFault) RequestID() string {
 type SubnetInUse struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5447,6 +5549,9 @@ func (s SubnetInUse) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetInUse) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5474,6 +5579,8 @@ func (s SubnetInUse) RequestID() string {
 type SubnetQuotaExceededFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5499,6 +5606,9 @@ func (s SubnetQuotaExceededFault) Code() string {
 
 // Message returns the exception's message.
 func (s SubnetQuotaExceededFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5567,6 +5677,8 @@ func (s *Tag) SetValue(v string) *Tag {
 type TagNotFoundFault struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5592,6 +5704,9 @@ func (s TagNotFoundFault) Code() string {
 
 // Message returns the exception's message.
 func (s TagNotFoundFault) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5618,6 +5733,8 @@ func (s TagNotFoundFault) RequestID() string {
 type TagQuotaPerResourceExceeded struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5643,6 +5760,9 @@ func (s TagQuotaPerResourceExceeded) Code() string {
 
 // Message returns the exception's message.
 func (s TagQuotaPerResourceExceeded) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/devicefarm/integ_test.go
+++ b/service/devicefarm/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetDevice(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -8716,6 +8716,8 @@ func (s *DisassociateConnectionFromLagInput) SetLagId(v string) *DisassociateCon
 type DuplicateTagKeysException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8741,6 +8743,9 @@ func (s DuplicateTagKeysException) Code() string {
 
 // Message returns the exception's message.
 func (s DuplicateTagKeysException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10717,6 +10722,8 @@ func (s TagResourceOutput) GoString() string {
 type TooManyTagsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10742,6 +10749,9 @@ func (s TooManyTagsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyTagsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/directconnect/integ_test.go
+++ b/service/directconnect/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeConnections(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/directoryservice/integ_test.go
+++ b/service/directoryservice/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_CreateDirectory(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/docdb/integ_test.go
+++ b/service/docdb/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/dynamodb/integ_test.go
+++ b/service/dynamodb/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_DescribeTable(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ec2/integ_test.go
+++ b/service/ec2/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_DescribeInstances(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ecr/integ_test.go
+++ b/service/ecr/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ListImages(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -5518,6 +5518,8 @@ func (c *ECS) UpdateTaskSetWithContext(ctx aws.Context, input *UpdateTaskSetInpu
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5543,6 +5545,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5753,6 +5758,8 @@ func (s *Attribute) SetValue(v string) *Attribute {
 type AttributeLimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5778,6 +5785,9 @@ func (s AttributeLimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s AttributeLimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5947,6 +5957,8 @@ func (s *AwsVpcConfiguration) SetSubnets(v []*string) *AwsVpcConfiguration {
 type BlockedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5972,6 +5984,9 @@ func (s BlockedException) Code() string {
 
 // Message returns the exception's message.
 func (s BlockedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6449,6 +6464,8 @@ func (s *Cluster) SetTags(v []*Tag) *Cluster {
 type ClusterContainsContainerInstancesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6474,6 +6491,9 @@ func (s ClusterContainsContainerInstancesException) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterContainsContainerInstancesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6502,6 +6522,8 @@ func (s ClusterContainsContainerInstancesException) RequestID() string {
 type ClusterContainsServicesException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6527,6 +6549,9 @@ func (s ClusterContainsServicesException) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterContainsServicesException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6553,6 +6578,8 @@ func (s ClusterContainsServicesException) RequestID() string {
 type ClusterContainsTasksException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6578,6 +6605,9 @@ func (s ClusterContainsTasksException) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterContainsTasksException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6605,6 +6635,8 @@ func (s ClusterContainsTasksException) RequestID() string {
 type ClusterNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6630,6 +6662,9 @@ func (s ClusterNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ClusterNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11426,6 +11461,8 @@ func (s *InferenceAcceleratorOverride) SetDeviceType(v string) *InferenceAcceler
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11451,6 +11488,9 @@ func (s InvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11580,6 +11620,8 @@ func (s *KeyValuePair) SetValue(v string) *KeyValuePair {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11605,6 +11647,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13093,6 +13138,8 @@ func (s *ManagedScaling) SetTargetCapacity(v int64) *ManagedScaling {
 type MissingVersionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13118,6 +13165,9 @@ func (s MissingVersionException) Code() string {
 
 // Message returns the exception's message.
 func (s MissingVersionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13329,6 +13379,8 @@ func (s *NetworkInterface) SetPrivateIpv4Address(v string) *NetworkInterface {
 type NoUpdateAvailableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13354,6 +13406,9 @@ func (s NoUpdateAvailableException) Code() string {
 
 // Message returns the exception's message.
 func (s NoUpdateAvailableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13527,6 +13582,8 @@ func (s *PlatformDevice) SetType(v string) *PlatformDevice {
 type PlatformTaskDefinitionIncompatibilityException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13552,6 +13609,9 @@ func (s PlatformTaskDefinitionIncompatibilityException) Code() string {
 
 // Message returns the exception's message.
 func (s PlatformTaskDefinitionIncompatibilityException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13578,6 +13638,8 @@ func (s PlatformTaskDefinitionIncompatibilityException) RequestID() string {
 type PlatformUnknownException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13603,6 +13665,9 @@ func (s PlatformUnknownException) Code() string {
 
 // Message returns the exception's message.
 func (s PlatformUnknownException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14947,6 +15012,8 @@ func (s *Resource) SetType(v string) *Resource {
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14972,6 +15039,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14998,6 +15068,8 @@ func (s ResourceInUseException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15023,6 +15095,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15995,6 +16070,8 @@ func (s *ServiceEvent) SetMessage(v string) *ServiceEvent {
 type ServiceNotActiveException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16020,6 +16097,9 @@ func (s ServiceNotActiveException) Code() string {
 
 // Message returns the exception's message.
 func (s ServiceNotActiveException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -16047,6 +16127,8 @@ func (s ServiceNotActiveException) RequestID() string {
 type ServiceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -16072,6 +16154,9 @@ func (s ServiceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ServiceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17085,6 +17170,8 @@ func (s TagResourceOutput) GoString() string {
 type TargetNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17110,6 +17197,9 @@ func (s TargetNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s TargetNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18309,6 +18399,8 @@ func (s *TaskSet) SetUpdatedAt(v time.Time) *TaskSet {
 type TaskSetNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18334,6 +18426,9 @@ func (s TaskSetNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s TaskSetNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18496,6 +18591,8 @@ func (s *Ulimit) SetSoftLimit(v int64) *Ulimit {
 type UnsupportedFeatureException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18521,6 +18618,9 @@ func (s UnsupportedFeatureException) Code() string {
 
 // Message returns the exception's message.
 func (s UnsupportedFeatureException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18873,6 +18973,8 @@ func (s *UpdateContainerInstancesStateOutput) SetFailures(v []*Failure) *UpdateC
 type UpdateInProgressException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18898,6 +19000,9 @@ func (s UpdateInProgressException) Code() string {
 
 // Message returns the exception's message.
 func (s UpdateInProgressException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/ecs/integ_test.go
+++ b/service/ecs/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_StopTask(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/efs/integ_test.go
+++ b/service/efs/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DeleteFileSystem(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticache/integ_test.go
+++ b/service/elasticache/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeCacheClusters(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticbeanstalk/integ_test.go
+++ b/service/elasticbeanstalk/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeEnvironmentResources(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elasticsearchservice/api.go
+++ b/service/elasticsearchservice/api.go
@@ -3663,6 +3663,8 @@ func (s *DescribeReservedElasticsearchInstancesOutput) SetReservedElasticsearchI
 type DisabledOperationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3688,6 +3690,9 @@ func (s DisabledOperationException) Code() string {
 
 // Message returns the exception's message.
 func (s DisabledOperationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4872,6 +4877,8 @@ func (s *InstanceLimits) SetInstanceCountLimits(v *InstanceCountLimits) *Instanc
 type InternalException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4897,6 +4904,9 @@ func (s InternalException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4924,6 +4934,8 @@ func (s InternalException) RequestID() string {
 type InvalidTypeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4949,6 +4961,9 @@ func (s InvalidTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4976,6 +4991,8 @@ func (s InvalidTypeException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5001,6 +5018,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6006,6 +6026,8 @@ func (s *ReservedElasticsearchInstanceOffering) SetUsagePrice(v float64) *Reserv
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6031,6 +6053,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6058,6 +6083,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6083,6 +6110,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7007,6 +7037,8 @@ func (s *VPCOptions) SetSubnetIds(v []*string) *VPCOptions {
 type ValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7032,6 +7064,9 @@ func (s ValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/elasticsearchservice/integ_test.go
+++ b/service/elasticsearchservice/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeElasticsearchDomain(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -1867,6 +1867,8 @@ func (c *ElasticTranscoder) UpdatePipelineStatusWithContext(ctx aws.Context, inp
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1892,6 +1894,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4092,6 +4097,8 @@ func (s *HlsContentProtection) SetMethod(v string) *HlsContentProtection {
 type IncompatibleVersionException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4117,6 +4124,9 @@ func (s IncompatibleVersionException) Code() string {
 
 // Message returns the exception's message.
 func (s IncompatibleVersionException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4216,6 +4226,8 @@ func (s *InputCaptions) SetMergePolicy(v string) *InputCaptions {
 type InternalServiceException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4241,6 +4253,9 @@ func (s InternalServiceException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServiceException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5118,6 +5133,8 @@ func (s *JobWatermark) SetPresetWatermarkId(v string) *JobWatermark {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5143,6 +5160,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6745,6 +6765,8 @@ func (s *ReadPresetOutput) SetPreset(v *Preset) *ReadPresetOutput {
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6770,6 +6792,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -6798,6 +6823,8 @@ func (s ResourceInUseException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6823,6 +6850,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7680,6 +7710,8 @@ func (s *UpdatePipelineStatusOutput) SetPipeline(v *Pipeline) *UpdatePipelineSta
 type ValidationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7705,6 +7737,9 @@ func (s ValidationException) Code() string {
 
 // Message returns the exception's message.
 func (s ValidationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/elastictranscoder/integ_test.go
+++ b/service/elastictranscoder/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ReadJob(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elb/integ_test.go
+++ b/service/elb/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/elbv2/integ_test.go
+++ b/service/elbv2/integ_test.go
@@ -58,6 +58,9 @@ func TestInteg_01_DescribeLoadBalancers(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7394,6 +7394,8 @@ func (s *InstanceTypeSpecification) SetWeightedCapacity(v int64) *InstanceTypeSp
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7419,6 +7421,9 @@ func (s InternalServerError) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerError) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/emr/integ_test.go
+++ b/service/emr/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeCluster(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/eventbridge/api.go
+++ b/service/eventbridge/api.go
@@ -3245,6 +3245,8 @@ func (s *BatchRetryStrategy) SetAttempts(v int64) *BatchRetryStrategy {
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3270,6 +3272,9 @@ func (s ConcurrentModificationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentModificationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4687,6 +4692,8 @@ func (s *InputTransformer) SetInputTemplate(v string) *InputTransformer {
 type InternalException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4712,6 +4719,9 @@ func (s InternalException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4738,6 +4748,8 @@ func (s InternalException) RequestID() string {
 type InvalidEventPatternException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4763,6 +4775,9 @@ func (s InvalidEventPatternException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidEventPatternException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4789,6 +4804,8 @@ func (s InvalidEventPatternException) RequestID() string {
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4814,6 +4831,9 @@ func (s InvalidStateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4884,6 +4904,8 @@ func (s *KinesisParameters) SetPartitionKeyPath(v string) *KinesisParameters {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4909,6 +4931,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5726,6 +5751,8 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 type ManagedRuleException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5751,6 +5778,9 @@ func (s ManagedRuleException) Code() string {
 
 // Message returns the exception's message.
 func (s ManagedRuleException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5909,6 +5939,8 @@ func (s *PartnerEventSourceAccount) SetState(v string) *PartnerEventSourceAccoun
 type PolicyLengthExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5934,6 +5966,9 @@ func (s PolicyLengthExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s PolicyLengthExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7028,6 +7063,8 @@ func (s *RemoveTargetsResultEntry) SetTargetId(v string) *RemoveTargetsResultEnt
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7053,6 +7090,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7079,6 +7119,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7104,6 +7146,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/eventbridge/integ_test.go
+++ b/service/eventbridge/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeRule(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/firehose/integ_test.go
+++ b/service/firehose/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeDeliveryStream(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/gamelift/integ_test.go
+++ b/service/gamelift/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribePlayerSessions(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/glacier/integ_test.go
+++ b/service/glacier/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ListVaults(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/iam/integ_test.go
+++ b/service/iam/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetUser(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/inspector/integ_test.go
+++ b/service/inspector/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_ListTagsForResource(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/iot/integ_test.go
+++ b/service/iot/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeThing(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/kinesis/integ_test.go
+++ b/service/kinesis/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeStream(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/kms/integ_test.go
+++ b/service/kms/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_GetKeyPolicy(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/lambda/integ_test.go
+++ b/service/lambda/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_Invoke(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/lexmodelbuildingservice/api.go
+++ b/service/lexmodelbuildingservice/api.go
@@ -10859,6 +10859,8 @@ type ResourceInUseException struct {
 	// exception.
 	ExampleReference *ResourceReference `locationName:"exampleReference" type:"structure"`
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	ReferenceType *string `locationName:"referenceType" type:"string" enum:"ReferenceType"`
 }
 
@@ -10885,6 +10887,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/managedblockchain/api.go
+++ b/service/managedblockchain/api.go
@@ -2163,6 +2163,8 @@ func (c *ManagedBlockchain) VoteOnProposalWithContext(ctx aws.Context, input *Vo
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2188,6 +2190,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3367,6 +3372,8 @@ func (s IllegalActionException) RequestID() string {
 type InternalServiceErrorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3392,6 +3399,9 @@ func (s InternalServiceErrorException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServiceErrorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5873,6 +5883,8 @@ func (s ResourceNotReadyException) RequestID() string {
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5898,6 +5910,9 @@ func (s ThrottlingException) Code() string {
 
 // Message returns the exception's message.
 func (s ThrottlingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/marketplacecommerceanalytics/integ_test.go
+++ b/service/marketplacecommerceanalytics/integ_test.go
@@ -53,6 +53,9 @@ func TestInteg_00_GenerateDataSet(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/neptune/integ_test.go
+++ b/service/neptune/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/opsworks/integ_test.go
+++ b/service/opsworks/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeLayers(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/pinpointemail/api.go
+++ b/service/pinpointemail/api.go
@@ -4190,6 +4190,8 @@ func (c *PinpointEmail) UpdateConfigurationSetEventDestinationWithContext(ctx aw
 type AccountSuspendedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4215,6 +4217,9 @@ func (s AccountSuspendedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccountSuspendedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4241,6 +4246,8 @@ func (s AccountSuspendedException) RequestID() string {
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4266,6 +4273,9 @@ func (s AlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s AlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4292,6 +4302,8 @@ func (s AlreadyExistsException) RequestID() string {
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4317,6 +4329,9 @@ func (s BadRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s BadRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4582,6 +4597,8 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4607,6 +4624,9 @@ func (s ConcurrentModificationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentModificationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -7603,6 +7623,8 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -7628,6 +7650,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8234,6 +8259,8 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 type MailFromDomainNotVerifiedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8259,6 +8286,9 @@ func (s MailFromDomainNotVerifiedException) Code() string {
 
 // Message returns the exception's message.
 func (s MailFromDomainNotVerifiedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8352,6 +8382,8 @@ func (s *Message) SetSubject(v *Content) *Message {
 type MessageRejected struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8377,6 +8409,9 @@ func (s MessageRejected) Code() string {
 
 // Message returns the exception's message.
 func (s MessageRejected) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8469,6 +8504,8 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8494,6 +8531,9 @@ func (s NotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s NotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9826,6 +9866,8 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 type SendingPausedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9851,6 +9893,9 @@ func (s SendingPausedException) Code() string {
 
 // Message returns the exception's message.
 func (s SendingPausedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10119,6 +10164,8 @@ func (s *Template) SetTemplateData(v string) *Template {
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10144,6 +10191,9 @@ func (s TooManyRequestsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyRequestsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/pinpointemail/integ_test.go
+++ b/service/pinpointemail/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_PutConfigurationSetTrackingOptions(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/rds/integ_test.go
+++ b/service/rds/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeDBInstances(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/rdsdataservice/api.go
+++ b/service/rdsdataservice/api.go
@@ -1659,6 +1659,8 @@ func (s ForbiddenException) RequestID() string {
 type InternalServerErrorException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1684,6 +1686,9 @@ func (s InternalServerErrorException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerErrorException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1987,6 +1992,8 @@ func (s *RollbackTransactionOutput) SetTransactionStatus(v string) *RollbackTran
 type ServiceUnavailableError struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2012,6 +2019,9 @@ func (s ServiceUnavailableError) Code() string {
 
 // Message returns the exception's message.
 func (s ServiceUnavailableError) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/redshift/integ_test.go
+++ b/service/redshift/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeClusters(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/rekognition/api.go
+++ b/service/rekognition/api.go
@@ -5540,6 +5540,8 @@ func (c *Rekognition) StopStreamProcessorWithContext(ctx aws.Context, input *Sto
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5565,6 +5567,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9718,6 +9723,8 @@ type HumanLoopQuotaExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	QuotaCode *string `type:"string"`
 
 	ResourceType *string `type:"string"`
@@ -9748,6 +9755,9 @@ func (s HumanLoopQuotaExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s HumanLoopQuotaExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9776,6 +9786,8 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9801,6 +9813,9 @@ func (s IdempotentParameterMismatchException) Code() string {
 
 // Message returns the exception's message.
 func (s IdempotentParameterMismatchException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9941,6 +9956,8 @@ func (s *ImageQuality) SetSharpness(v float64) *ImageQuality {
 type ImageTooLargeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9966,6 +9983,9 @@ func (s ImageTooLargeException) Code() string {
 
 // Message returns the exception's message.
 func (s ImageTooLargeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10246,6 +10266,8 @@ func (s *Instance) SetConfidence(v float64) *Instance {
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10271,6 +10293,9 @@ func (s InternalServerError) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerError) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10297,6 +10322,8 @@ func (s InternalServerError) RequestID() string {
 type InvalidImageFormatException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10322,6 +10349,9 @@ func (s InvalidImageFormatException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidImageFormatException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10348,6 +10378,8 @@ func (s InvalidImageFormatException) RequestID() string {
 type InvalidPaginationTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10373,6 +10405,9 @@ func (s InvalidPaginationTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPaginationTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10400,6 +10435,8 @@ func (s InvalidPaginationTokenException) RequestID() string {
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10425,6 +10462,9 @@ func (s InvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10451,6 +10491,8 @@ func (s InvalidParameterException) RequestID() string {
 type InvalidS3ObjectException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10476,6 +10518,9 @@ func (s InvalidS3ObjectException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidS3ObjectException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10692,6 +10737,8 @@ func (s *Landmark) SetY(v float64) *Landmark {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10717,6 +10764,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11626,6 +11676,8 @@ func (s *ProjectVersionDescription) SetTrainingEndTimestamp(v time.Time) *Projec
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11651,6 +11703,9 @@ func (s ProvisionedThroughputExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s ProvisionedThroughputExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11778,6 +11833,8 @@ func (s *RecognizeCelebritiesOutput) SetUnrecognizedFaces(v []*ComparedFace) *Re
 type ResourceAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11803,6 +11860,9 @@ func (s ResourceAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11828,6 +11888,8 @@ func (s ResourceAlreadyExistsException) RequestID() string {
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11853,6 +11915,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11879,6 +11944,8 @@ func (s ResourceInUseException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11904,6 +11971,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11931,6 +12001,8 @@ func (s ResourceNotFoundException) RequestID() string {
 type ResourceNotReadyException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11956,6 +12028,9 @@ func (s ResourceNotReadyException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotReadyException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13755,6 +13830,8 @@ func (s *TextDetection) SetType(v string) *TextDetection {
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13780,6 +13857,9 @@ func (s ThrottlingException) Code() string {
 
 // Message returns the exception's message.
 func (s ThrottlingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14047,6 +14127,8 @@ func (s *VideoMetadata) SetFrameWidth(v int64) *VideoMetadata {
 type VideoTooLargeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14072,6 +14154,9 @@ func (s VideoTooLargeException) Code() string {
 
 // Message returns the exception's message.
 func (s VideoTooLargeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/route53/integ_test.go
+++ b/service/route53/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetHostedZone(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/route53resolver/integ_test.go
+++ b/service/route53resolver/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetResolverRule(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/secretsmanager/integ_test.go
+++ b/service/secretsmanager/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeSecret(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/servicecatalog/api.go
+++ b/service/servicecatalog/api.go
@@ -12955,6 +12955,8 @@ func (s DisassociateTagOptionFromResourceOutput) GoString() string {
 type DuplicateResourceException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12980,6 +12982,9 @@ func (s DuplicateResourceException) Code() string {
 
 // Message returns the exception's message.
 func (s DuplicateResourceException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13383,6 +13388,8 @@ func (s *GetAWSOrganizationsAccessStatusOutput) SetAccessStatus(v string) *GetAW
 type InvalidParametersException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13408,6 +13415,9 @@ func (s InvalidParametersException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParametersException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13436,6 +13446,8 @@ func (s InvalidParametersException) RequestID() string {
 type InvalidStateException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13461,6 +13473,9 @@ func (s InvalidStateException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidStateException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13540,6 +13555,8 @@ func (s *LaunchPathSummary) SetTags(v []*Tag) *LaunchPathSummary {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13565,6 +13582,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -15557,6 +15577,8 @@ func (s *ListTagOptionsOutput) SetTagOptionDetails(v []*TagOptionDetail) *ListTa
 type OperationNotSupportedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -15582,6 +15604,9 @@ func (s OperationNotSupportedException) Code() string {
 
 // Message returns the exception's message.
 func (s OperationNotSupportedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17902,6 +17927,8 @@ func (s *ResourceDetail) SetName(v string) *ResourceDetail {
 type ResourceInUseException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17927,6 +17954,9 @@ func (s ResourceInUseException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceInUseException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -17953,6 +17983,8 @@ func (s ResourceInUseException) RequestID() string {
 type ResourceNotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -17978,6 +18010,9 @@ func (s ResourceNotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceNotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -18940,6 +18975,8 @@ func (s *TagOptionDetail) SetValue(v string) *TagOptionDetail {
 type TagOptionNotMigratedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -18965,6 +19002,9 @@ func (s TagOptionNotMigratedException) Code() string {
 
 // Message returns the exception's message.
 func (s TagOptionNotMigratedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/ses/integ_test.go
+++ b/service/ses/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_VerifyEmailIdentity(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sesv2/api.go
+++ b/service/sesv2/api.go
@@ -4857,6 +4857,8 @@ func (c *SESV2) UpdateConfigurationSetEventDestinationWithContext(ctx aws.Contex
 type AccountSuspendedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4882,6 +4884,9 @@ func (s AccountSuspendedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccountSuspendedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4908,6 +4913,8 @@ func (s AccountSuspendedException) RequestID() string {
 type AlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4933,6 +4940,9 @@ func (s AlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s AlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -4959,6 +4969,8 @@ func (s AlreadyExistsException) RequestID() string {
 type BadRequestException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -4984,6 +4996,9 @@ func (s BadRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s BadRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -5248,6 +5263,8 @@ func (s *CloudWatchDimensionConfiguration) SetDimensionValueSource(v string) *Cl
 type ConcurrentModificationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5273,6 +5290,9 @@ func (s ConcurrentModificationException) Code() string {
 
 // Message returns the exception's message.
 func (s ConcurrentModificationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8438,6 +8458,8 @@ func (s *InboxPlacementTrackingOption) SetTrackedIsps(v []*string) *InboxPlaceme
 type InvalidNextTokenException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8463,6 +8485,9 @@ func (s InvalidNextTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidNextTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -8580,6 +8605,8 @@ func (s *KinesisFirehoseDestination) SetIamRoleArn(v string) *KinesisFirehoseDes
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -8605,6 +8632,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9313,6 +9343,8 @@ func (s *MailFromAttributes) SetMailFromDomainStatus(v string) *MailFromAttribut
 type MailFromDomainNotVerifiedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9338,6 +9370,9 @@ func (s MailFromDomainNotVerifiedException) Code() string {
 
 // Message returns the exception's message.
 func (s MailFromDomainNotVerifiedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9431,6 +9466,8 @@ func (s *Message) SetSubject(v *Content) *Message {
 type MessageRejected struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9456,6 +9493,9 @@ func (s MessageRejected) Code() string {
 
 // Message returns the exception's message.
 func (s MessageRejected) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -9548,6 +9588,8 @@ func (s *MessageTag) SetValue(v string) *MessageTag {
 type NotFoundException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -9573,6 +9615,9 @@ func (s NotFoundException) Code() string {
 
 // Message returns the exception's message.
 func (s NotFoundException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11249,6 +11294,8 @@ func (s *SendingOptions) SetSendingEnabled(v bool) *SendingOptions {
 type SendingPausedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11274,6 +11321,9 @@ func (s SendingPausedException) Code() string {
 
 // Message returns the exception's message.
 func (s SendingPausedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -11759,6 +11809,8 @@ func (s *Template) SetTemplateData(v string) *Template {
 type TooManyRequestsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -11784,6 +11836,9 @@ func (s TooManyRequestsException) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyRequestsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/sms/api.go
+++ b/service/sms/api.go
@@ -6011,6 +6011,8 @@ func (s *Tag) SetValue(v string) *Tag {
 type TemporarilyUnavailableException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -6036,6 +6038,9 @@ func (s TemporarilyUnavailableException) Code() string {
 
 // Message returns the exception's message.
 func (s TemporarilyUnavailableException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/sms/integ_test.go
+++ b/service/sms/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DeleteReplicationJob(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sns/integ_test.go
+++ b/service/sns/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_Publish(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/sqs/integ_test.go
+++ b/service/sqs/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetQueueUrl(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -12385,6 +12385,8 @@ func (s AlreadyExistsException) RequestID() string {
 type AssociatedInstances struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12410,6 +12412,9 @@ func (s AssociatedInstances) Code() string {
 
 // Message returns the exception's message.
 func (s AssociatedInstances) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -12542,6 +12547,8 @@ func (s *Association) SetTargets(v []*Target) *Association {
 type AssociationAlreadyExists struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -12567,6 +12574,9 @@ func (s AssociationAlreadyExists) Code() string {
 
 // Message returns the exception's message.
 func (s AssociationAlreadyExists) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -13287,6 +13297,8 @@ func (s *AssociationFilter) SetValue(v string) *AssociationFilter {
 type AssociationLimitExceeded struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -13312,6 +13324,9 @@ func (s AssociationLimitExceeded) Code() string {
 
 // Message returns the exception's message.
 func (s AssociationLimitExceeded) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -23482,6 +23497,8 @@ func (s DuplicateDocumentVersionName) RequestID() string {
 type DuplicateInstanceId struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -23507,6 +23524,9 @@ func (s DuplicateInstanceId) Code() string {
 
 // Message returns the exception's message.
 func (s DuplicateInstanceId) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -28466,6 +28486,8 @@ func (s InvalidAutomationStatusUpdateException) RequestID() string {
 type InvalidCommandId struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -28491,6 +28513,9 @@ func (s InvalidCommandId) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidCommandId) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29031,6 +29056,8 @@ func (s InvalidFilter) RequestID() string {
 type InvalidFilterKey struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29056,6 +29083,9 @@ func (s InvalidFilterKey) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidFilterKey) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29771,6 +29801,8 @@ func (s InvalidOptionException) RequestID() string {
 type InvalidOutputFolder struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29796,6 +29828,9 @@ func (s InvalidOutputFolder) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOutputFolder) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29822,6 +29857,8 @@ func (s InvalidOutputFolder) RequestID() string {
 type InvalidOutputLocation struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -29847,6 +29884,9 @@ func (s InvalidOutputLocation) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidOutputLocation) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -29988,6 +30028,8 @@ func (s InvalidPermissionType) RequestID() string {
 type InvalidPluginName struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -30013,6 +30055,9 @@ func (s InvalidPluginName) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidPluginName) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -30153,6 +30198,8 @@ func (s InvalidPolicyTypeException) RequestID() string {
 type InvalidResourceId struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -30178,6 +30225,9 @@ func (s InvalidResourceId) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidResourceId) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -30205,6 +30255,8 @@ func (s InvalidResourceId) RequestID() string {
 type InvalidResourceType struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -30230,6 +30282,9 @@ func (s InvalidResourceType) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidResourceType) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -31300,6 +31355,8 @@ func (s *InventoryResultItem) SetTypeName(v string) *InventoryResultItem {
 type InvocationDoesNotExist struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -31325,6 +31382,9 @@ func (s InvocationDoesNotExist) Code() string {
 
 // Message returns the exception's message.
 func (s InvocationDoesNotExist) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -38726,6 +38786,8 @@ type ResourceDataSyncAlreadyExistsException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	SyncName *string `min:"1" type:"string"`
 }
 
@@ -38752,6 +38814,9 @@ func (s ResourceDataSyncAlreadyExistsException) Code() string {
 
 // Message returns the exception's message.
 func (s ResourceDataSyncAlreadyExistsException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -41091,6 +41156,8 @@ func (s *StartSessionOutput) SetTokenValue(v string) *StartSessionOutput {
 type StatusUnchanged struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -41116,6 +41183,9 @@ func (s StatusUnchanged) Code() string {
 
 // Message returns the exception's message.
 func (s StatusUnchanged) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -41964,6 +42034,8 @@ func (s *TerminateSessionOutput) SetSessionId(v string) *TerminateSessionOutput 
 type TooManyTagsError struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -41989,6 +42061,9 @@ func (s TooManyTagsError) Code() string {
 
 // Message returns the exception's message.
 func (s TooManyTagsError) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/ssm/integ_test.go
+++ b/service/ssm/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_GetDocument(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/ssooidc/api.go
+++ b/service/ssooidc/api.go
@@ -333,6 +333,8 @@ type AccessDeniedException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -358,6 +360,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -389,6 +394,8 @@ type AuthorizationPendingException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -414,6 +421,9 @@ func (s AuthorizationPendingException) Code() string {
 
 // Message returns the exception's message.
 func (s AuthorizationPendingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -632,6 +642,8 @@ type ExpiredTokenException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -657,6 +669,9 @@ func (s ExpiredTokenException) Code() string {
 
 // Message returns the exception's message.
 func (s ExpiredTokenException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -688,6 +703,8 @@ type InternalServerException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -713,6 +730,9 @@ func (s InternalServerException) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -745,6 +765,8 @@ type InvalidClientException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -770,6 +792,9 @@ func (s InvalidClientException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidClientException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -801,6 +826,8 @@ type InvalidClientMetadataException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -826,6 +853,9 @@ func (s InvalidClientMetadataException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidClientMetadataException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -857,6 +887,8 @@ type InvalidGrantException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -882,6 +914,9 @@ func (s InvalidGrantException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidGrantException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -913,6 +948,8 @@ type InvalidRequestException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -938,6 +975,9 @@ func (s InvalidRequestException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidRequestException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -968,6 +1008,8 @@ type InvalidScopeException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -993,6 +1035,9 @@ func (s InvalidScopeException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidScopeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1157,6 +1202,8 @@ type SlowDownException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1182,6 +1229,9 @@ func (s SlowDownException) Code() string {
 
 // Message returns the exception's message.
 func (s SlowDownException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1359,6 +1409,8 @@ type UnauthorizedClientException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1384,6 +1436,9 @@ func (s UnauthorizedClientException) Code() string {
 
 // Message returns the exception's message.
 func (s UnauthorizedClientException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1414,6 +1469,8 @@ type UnsupportedGrantTypeException struct {
 	Error_ *string `locationName:"error" type:"string"`
 
 	Error_description *string `locationName:"error_description" type:"string"`
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1439,6 +1496,9 @@ func (s UnsupportedGrantTypeException) Code() string {
 
 // Message returns the exception's message.
 func (s UnsupportedGrantTypeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/sts/integ_test.go
+++ b/service/sts/integ_test.go
@@ -57,6 +57,9 @@ func TestInteg_01_GetFederationToken(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/support/integ_test.go
+++ b/service/support/integ_test.go
@@ -60,6 +60,9 @@ func TestInteg_01_CreateCase(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/textract/api.go
+++ b/service/textract/api.go
@@ -833,6 +833,8 @@ func (c *Textract) StartDocumentTextDetectionWithContext(ctx aws.Context, input 
 type AccessDeniedException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -858,6 +860,9 @@ func (s AccessDeniedException) Code() string {
 
 // Message returns the exception's message.
 func (s AccessDeniedException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1015,6 +1020,8 @@ func (s *AnalyzeDocumentOutput) SetHumanLoopActivationOutput(v *HumanLoopActivat
 type BadDocumentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1040,6 +1047,9 @@ func (s BadDocumentException) Code() string {
 
 // Message returns the exception's message.
 func (s BadDocumentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -1581,6 +1591,8 @@ func (s *DocumentMetadata) SetPages(v int64) *DocumentMetadata {
 type DocumentTooLargeException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -1606,6 +1618,9 @@ func (s DocumentTooLargeException) Code() string {
 
 // Message returns the exception's message.
 func (s DocumentTooLargeException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2109,6 +2124,8 @@ type HumanLoopQuotaExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	QuotaCode *string `type:"string"`
 
 	ResourceType *string `type:"string"`
@@ -2139,6 +2156,9 @@ func (s HumanLoopQuotaExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s HumanLoopQuotaExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2167,6 +2187,8 @@ func (s HumanLoopQuotaExceededException) RequestID() string {
 type IdempotentParameterMismatchException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2192,6 +2214,9 @@ func (s IdempotentParameterMismatchException) Code() string {
 
 // Message returns the exception's message.
 func (s IdempotentParameterMismatchException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2218,6 +2243,8 @@ func (s IdempotentParameterMismatchException) RequestID() string {
 type InternalServerError struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2243,6 +2270,9 @@ func (s InternalServerError) Code() string {
 
 // Message returns the exception's message.
 func (s InternalServerError) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2269,6 +2299,8 @@ func (s InternalServerError) RequestID() string {
 type InvalidJobIdException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2294,6 +2326,9 @@ func (s InvalidJobIdException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidJobIdException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2323,6 +2358,8 @@ func (s InvalidJobIdException) RequestID() string {
 type InvalidParameterException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2348,6 +2385,9 @@ func (s InvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2375,6 +2415,8 @@ func (s InvalidParameterException) RequestID() string {
 type InvalidS3ObjectException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2400,6 +2442,9 @@ func (s InvalidS3ObjectException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidS3ObjectException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2430,6 +2475,8 @@ func (s InvalidS3ObjectException) RequestID() string {
 type LimitExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2455,6 +2502,9 @@ func (s LimitExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s LimitExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2584,6 +2634,8 @@ func (s *Point) SetY(v float64) *Point {
 type ProvisionedThroughputExceededException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -2609,6 +2661,9 @@ func (s ProvisionedThroughputExceededException) Code() string {
 
 // Message returns the exception's message.
 func (s ProvisionedThroughputExceededException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -2995,6 +3050,8 @@ func (s *StartDocumentTextDetectionOutput) SetJobId(v string) *StartDocumentText
 type ThrottlingException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3020,6 +3077,9 @@ func (s ThrottlingException) Code() string {
 
 // Message returns the exception's message.
 func (s ThrottlingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -3048,6 +3108,8 @@ func (s ThrottlingException) RequestID() string {
 type UnsupportedDocumentException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -3073,6 +3135,9 @@ func (s UnsupportedDocumentException) Code() string {
 
 // Message returns the exception's message.
 func (s UnsupportedDocumentException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/transfer/api.go
+++ b/service/transfer/api.go
@@ -4613,6 +4613,8 @@ type ThrottlingException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	RetryAfterSeconds *string `type:"string"`
 }
 
@@ -4639,6 +4641,9 @@ func (s ThrottlingException) Code() string {
 
 // Message returns the exception's message.
 func (s ThrottlingException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/waf/api.go
+++ b/service/waf/api.go
@@ -14591,6 +14591,8 @@ func (s InternalErrorException) RequestID() string {
 type InvalidAccountException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -14616,6 +14618,9 @@ func (s InvalidAccountException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidAccountException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -14742,6 +14747,8 @@ type InvalidParameterException struct {
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	Parameter *string `locationName:"parameter" min:"1" type:"string"`
 
 	Reason *string `locationName:"reason" type:"string" enum:"ParameterExceptionReason"`
@@ -14770,6 +14777,9 @@ func (s InvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s InvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/waf/integ_test.go
+++ b/service/waf/integ_test.go
@@ -59,6 +59,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/wafregional/api.go
+++ b/service/wafregional/api.go
@@ -10268,6 +10268,8 @@ func (s WAFInternalErrorException) RequestID() string {
 type WAFInvalidAccountException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10293,6 +10295,9 @@ func (s WAFInvalidAccountException) Code() string {
 
 // Message returns the exception's message.
 func (s WAFInvalidAccountException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10419,6 +10424,8 @@ type WAFInvalidParameterException struct {
 
 	Field *string `locationName:"field" type:"string" enum:"ParameterExceptionField"`
 
+	Message_ *string `locationName:"message" type:"string"`
+
 	Parameter *string `locationName:"parameter" min:"1" type:"string"`
 
 	Reason *string `locationName:"reason" type:"string" enum:"ParameterExceptionReason"`
@@ -10447,6 +10454,9 @@ func (s WAFInvalidParameterException) Code() string {
 
 // Message returns the exception's message.
 func (s WAFInvalidParameterException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/wafregional/integ_test.go
+++ b/service/wafregional/integ_test.go
@@ -60,6 +60,9 @@ func TestInteg_01_CreateSqlInjectionMatchSet(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/wafv2/integ_test.go
+++ b/service/wafv2/integ_test.go
@@ -43,6 +43,9 @@ func TestInteg_00_CreateRegexPatternSet(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}

--- a/service/workdocs/api.go
+++ b/service/workdocs/api.go
@@ -5708,6 +5708,8 @@ func (s DeactivateUserOutput) GoString() string {
 type DeactivatingLastSystemUserException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -5733,6 +5735,9 @@ func (s DeactivatingLastSystemUserException) Code() string {
 
 // Message returns the exception's message.
 func (s DeactivatingLastSystemUserException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 
@@ -10597,6 +10602,8 @@ func (s TooManySubscriptionsException) RequestID() string {
 type UnauthorizedOperationException struct {
 	_            struct{} `type:"structure"`
 	respMetadata protocol.ResponseMetadata
+
+	Message_ *string `locationName:"message" type:"string"`
 }
 
 // String returns the string representation
@@ -10622,6 +10629,9 @@ func (s UnauthorizedOperationException) Code() string {
 
 // Message returns the exception's message.
 func (s UnauthorizedOperationException) Message() string {
+	if s.Message_ != nil {
+		return *s.Message_
+	}
 	return ""
 }
 

--- a/service/workspaces/integ_test.go
+++ b/service/workspaces/integ_test.go
@@ -56,6 +56,9 @@ func TestInteg_01_DescribeWorkspaces(t *testing.T) {
 	if len(aerr.Code()) == 0 {
 		t.Errorf("expect non-empty error code")
 	}
+	if len(aerr.Message()) == 0 {
+		t.Errorf("expect non-empty error message")
+	}
 	if v := aerr.Code(); v == request.ErrCodeSerialization {
 		t.Errorf("expect API error code got serialization failure")
 	}


### PR DESCRIPTION
Fixes the SDK's generated errors to all include the `Message` member regardless if it was modeled on the error shape. This fixes the bug identified in #3088 where some JSON errors were not modeled with the Message member. This caused the errors message to be dropped, and not retrievable.

This change also updates the SDK's generated smoke test to expect the Message member of an error unmarshaled not to be empty.

Fixes #3088