### PR TITLE
service/ec2: Treat stopped as fatal in WaitUntilInstanceRunningXXX

### DIFF
--- a/service/ec2/waiters.go
+++ b/service/ec2/waiters.go
@@ -544,6 +544,11 @@ func (c *EC2) WaitUntilInstanceRunningWithContext(ctx aws.Context, input *Descri
 			{
 				State:   request.FailureWaiterState,
 				Matcher: request.PathAnyWaiterMatch, Argument: "Reservations[].Instances[].State.Name",
+				Expected: "stopped",
+			},
+			{
+				State:   request.FailureWaiterState,
+				Matcher: request.PathAnyWaiterMatch, Argument: "Reservations[].Instances[].State.Name",
 				Expected: "terminated",
 			},
 			{


### PR DESCRIPTION
Treat an instance which has transitioned to "stopped" as fatal instead of retrying until the timeout within `WaitUntilInstanceRunning` and `WaitUntilInstanceRunningWithContext`.

Fixes #3096