### PR TITLE
Add 400 status as retry-able requests

### DIFF
--- a/aws/client/default_retryer.go
+++ b/aws/client/default_retryer.go
@@ -106,6 +106,7 @@ func getRetryDelay(r *request.Request) (time.Duration, bool) {
 // the status code.
 func canUseRetryAfterHeader(r *request.Request) bool {
 	switch r.HTTPResponse.StatusCode {
+	case 400:
 	case 429:
 	case 503:
 	default:

--- a/aws/client/default_retryer_test.go
+++ b/aws/client/default_retryer_test.go
@@ -92,6 +92,12 @@ func TestCanUseRetryAfter(t *testing.T) {
 		},
 		{
 			request.Request{
+				HTTPResponse: &http.Response{StatusCode: 400},
+			},
+			true,
+		},
+		{
+			request.Request{
 				HTTPResponse: &http.Response{StatusCode: 429},
 			},
 			true,


### PR DESCRIPTION
When the ASG service responds with `Throttling: Rate exceeded`, it is returning a 400 status.
This means the request is not considered retry-able since this client expects a 429.

One way to address this is for the client to include 400s (Bad Requests) as retry-able until the service starts returning 429 in this case. This would allow use of the retrier and prevent a flood of requests to AWS.