### PR TITLE
aws/request: Add nil check on http.Request.URL in getHost(...)

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -639,6 +639,10 @@ func getHost(r *http.Request) string {
 		return r.Host
 	}
 
+	if r.URL == nil {
+		return ""
+	}
+
 	return r.URL.Host
 }
 


### PR DESCRIPTION
Adds a nil check on http.Request.URL which can occur in partially mocked http.Request structures.