### PR TITLE
Support Discovered Endpoints that don't specify Scheme

### DIFF
--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -696,3 +696,28 @@ func isDefaultPort(scheme, port string) bool {
 
 	return false
 }
+
+// GetScheme returns the scheme of the url
+// (Scheme must be [a-zA-Z][a-zA-Z0-9+-.]*)
+// Based on net/url.getscheme
+func GetScheme(url string) (scheme string) {
+	for i := 0; i < len(url); i++ {
+		c := url[i]
+		switch {
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z':
+		// do nothing
+		case '0' <= c && c <= '9' || c == '+' || c == '-' || c == '.':
+			if i == 0 {
+				return ""
+			}
+		case c == ':':
+			if i == 0 {
+				return ""
+			}
+			return url[:i]
+		default:
+			return ""
+		}
+	}
+	return ""
+}

--- a/aws/request/request.go
+++ b/aws/request/request.go
@@ -696,28 +696,3 @@ func isDefaultPort(scheme, port string) bool {
 
 	return false
 }
-
-// GetScheme returns the scheme of the url
-// (Scheme must be [a-zA-Z][a-zA-Z0-9+-.]*)
-// Based on net/url.getscheme
-func GetScheme(url string) (scheme string) {
-	for i := 0; i < len(url); i++ {
-		c := url[i]
-		switch {
-		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z':
-		// do nothing
-		case '0' <= c && c <= '9' || c == '+' || c == '-' || c == '.':
-			if i == 0 {
-				return ""
-			}
-		case c == ':':
-			if i == 0 {
-				return ""
-			}
-			return url[:i]
-		default:
-			return ""
-		}
-	}
-	return ""
-}

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
@@ -5,6 +5,7 @@ package awsendpointdiscoverytest
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -111,7 +112,11 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 		}
 
 		address := *e.Address
-		scheme := request.GetScheme(address)
+
+		var scheme string
+		if idx := strings.Index(address, "://"); idx != -1 {
+			scheme = address[:idx]
+		}
 
 		if len(scheme) == 0 {
 			address = fmt.Sprintf("%s://%s", d.req.HTTPRequest.URL.Scheme, address)

--- a/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
+++ b/private/model/api/codegentest/service/awsendpointdiscoverytest/api.go
@@ -3,6 +3,7 @@
 package awsendpointdiscoverytest
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 
@@ -87,6 +88,7 @@ type discovererDescribeEndpoints struct {
 	EndpointCache *crr.EndpointCache
 	Params        map[string]*string
 	Key           string
+	req           *request.Request
 }
 
 func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
@@ -108,8 +110,15 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 			continue
 		}
 
+		address := *e.Address
+		scheme := request.GetScheme(address)
+
+		if len(scheme) == 0 {
+			address = fmt.Sprintf("%s://%s", d.req.HTTPRequest.URL.Scheme, address)
+		}
+
 		cachedInMinutes := aws.Int64Value(e.CachePeriodInMinutes)
-		u, err := url.Parse(*e.Address)
+		u, err := url.Parse(address)
 		if err != nil {
 			continue
 		}
@@ -130,6 +139,7 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 func (d *discovererDescribeEndpoints) Handler(r *request.Request) {
 	endpointKey := crr.BuildEndpointKey(d.Params)
 	d.Key = endpointKey
+	d.req = r
 
 	endpoint, err := d.EndpointCache.Get(d, endpointKey, d.Required)
 	if err != nil {

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -472,7 +472,11 @@ func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
 		}
 
 		address := *e.Address
-		scheme := request.GetScheme(address)
+
+		var scheme string
+		if idx := strings.Index(address, "://"); idx != -1 {
+			scheme = address[:idx]
+		}
 
 		if len(scheme) == 0 {
 			address = fmt.Sprintf("%s://%s", d.req.HTTPRequest.URL.Scheme, address)
@@ -524,6 +528,7 @@ func (o *Operation) GoCode() string {
 		o.API.AddImport("time")
 		o.API.AddImport("net/url")
 		o.API.AddImport("fmt")
+		o.API.AddImport("strings")
 	}
 
 	if o.Endpoint != nil && len(o.Endpoint.HostPrefix) != 0 {

--- a/private/model/api/operation.go
+++ b/private/model/api/operation.go
@@ -444,6 +444,7 @@ type discoverer{{ .ExportedName }} struct {
 	EndpointCache *crr.EndpointCache
 	Params map[string]*string
 	Key string
+	req *request.Request
 }
 
 func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
@@ -470,8 +471,15 @@ func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
 			continue
 		}
 
+		address := *e.Address
+		scheme := request.GetScheme(address)
+
+		if len(scheme) == 0 {
+			address = fmt.Sprintf("%s://%s", d.req.HTTPRequest.URL.Scheme, address)
+		}
+
 		cachedInMinutes := aws.Int64Value(e.CachePeriodInMinutes)
-		u, err := url.Parse(*e.Address)
+		u, err := url.Parse(address)
 		if err != nil {
 			continue
 		}
@@ -492,6 +500,7 @@ func (d *discoverer{{ .ExportedName }}) Discover() (crr.Endpoint, error) {
 func (d *discoverer{{ .ExportedName }}) Handler(r *request.Request) {
 	endpointKey := crr.BuildEndpointKey(d.Params)
 	d.Key = endpointKey
+	d.req = r
 
 	endpoint, err := d.EndpointCache.Get(d, endpointKey, d.Required)
 	if err != nil {
@@ -514,6 +523,7 @@ func (o *Operation) GoCode() string {
 		o.API.AddSDKImport("aws/crr")
 		o.API.AddImport("time")
 		o.API.AddImport("net/url")
+		o.API.AddImport("fmt")
 	}
 
 	if o.Endpoint != nil && len(o.Endpoint.HostPrefix) != 0 {

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -5,6 +5,7 @@ package dynamodb
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -1682,7 +1683,11 @@ func (d *discovererDescribeEndpoints) Discover() (crr.Endpoint, error) {
 		}
 
 		address := *e.Address
-		scheme := request.GetScheme(address)
+
+		var scheme string
+		if idx := strings.Index(address, "://"); idx != -1 {
+			scheme = address[:idx]
+		}
 
 		if len(scheme) == 0 {
 			address = fmt.Sprintf("%s://%s", d.req.HTTPRequest.URL.Scheme, address)

--- a/service/dynamodb/integ_cust_test.go
+++ b/service/dynamodb/integ_cust_test.go
@@ -1,0 +1,38 @@
+// +build go1.10,integration
+
+package dynamodb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/awstesting/integration"
+)
+
+func TestEndpointDiscovery(t *testing.T) {
+	sess := integration.SessionWithDefaultRegion("us-west-2")
+	svc := New(sess, &aws.Config{EnableEndpointDiscovery: aws.Bool(true)})
+
+	req, _ := svc.ListTablesRequest(nil)
+	err := req.Send()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	timeLimit := time.NewTimer(time.Second * 5)
+	defer timeLimit.Stop()
+	for !svc.endpointCache.Has(req.Operation.Name) {
+		select {
+		case <-timeLimit.C:
+			t.Fatalf("timed out waiting for endpoint")
+		default:
+		}
+	}
+
+	req, _ = svc.ListTablesRequest(nil)
+	err = req.Send()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes and endpoint discovery bug where the SDK would fail to use a discovered endpoint if the scheme was not specified. The SDK will now default to using the clients original endpoint scheme if the discovered endpoint did not include one.