### PR TITLE
service/dynamodb: Add feature update for Amazon DynamoDB

### DIFF
--- a/models/apis/dynamodb/2012-08-10/api-2.json
+++ b/models/apis/dynamodb/2012-08-10/api-2.json
@@ -2494,7 +2494,8 @@
         "BillingModeOverride":{"shape":"BillingMode"},
         "GlobalSecondaryIndexOverride":{"shape":"GlobalSecondaryIndexList"},
         "LocalSecondaryIndexOverride":{"shape":"LocalSecondaryIndexList"},
-        "ProvisionedThroughputOverride":{"shape":"ProvisionedThroughput"}
+        "ProvisionedThroughputOverride":{"shape":"ProvisionedThroughput"},
+        "SSESpecificationOverride":{"shape":"SSESpecification"}
       }
     },
     "RestoreTableFromBackupOutput":{
@@ -2505,11 +2506,9 @@
     },
     "RestoreTableToPointInTimeInput":{
       "type":"structure",
-      "required":[
-        "SourceTableName",
-        "TargetTableName"
-      ],
+      "required":["TargetTableName"],
       "members":{
+        "SourceTableArn":{"shape":"TableArn"},
         "SourceTableName":{"shape":"TableName"},
         "TargetTableName":{"shape":"TableName"},
         "UseLatestRestorableTime":{"shape":"BooleanObject"},
@@ -2517,7 +2516,8 @@
         "BillingModeOverride":{"shape":"BillingMode"},
         "GlobalSecondaryIndexOverride":{"shape":"GlobalSecondaryIndexList"},
         "LocalSecondaryIndexOverride":{"shape":"LocalSecondaryIndexList"},
-        "ProvisionedThroughputOverride":{"shape":"ProvisionedThroughput"}
+        "ProvisionedThroughputOverride":{"shape":"ProvisionedThroughput"},
+        "SSESpecificationOverride":{"shape":"SSESpecification"}
       }
     },
     "RestoreTableToPointInTimeOutput":{

--- a/models/apis/dynamodb/2012-08-10/docs-2.json
+++ b/models/apis/dynamodb/2012-08-10/docs-2.json
@@ -1528,7 +1528,7 @@
     "PositiveIntegerObject": {
       "base": null,
       "refs": {
-        "ListGlobalTablesInput$Limit": "<p>The maximum number of table names to return.</p>",
+        "ListGlobalTablesInput$Limit": "<p>The maximum number of table names to return, if the parameter is not specified DynamoDB defaults to 100.</p> <p>If the number of global tables DynamoDB finds reaches this limit, it stops the operation and returns the table names collected up to that point, with a table name in the <code>LastEvaluatedGlobalTableName</code> to apply in a subsequent operation to the <code>ExclusiveStartGlobalTableName</code> parameter.</p>",
         "QueryInput$Limit": "<p>The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the number of items up to the limit while processing the results, it stops the operation and returns the matching values up to that point, and a key in <code>LastEvaluatedKey</code> to apply in a subsequent operation, so that you can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation and returns the matching values up to the limit, and a key in <code>LastEvaluatedKey</code> to apply in a subsequent operation to continue the operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html\">Query and Scan</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>",
         "ScanInput$Limit": "<p>The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the number of items up to the limit while processing the results, it stops the operation and returns the matching values up to that point, and a key in <code>LastEvaluatedKey</code> to apply in a subsequent operation, so that you can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation and returns the matching values up to the limit, and a key in <code>LastEvaluatedKey</code> to apply in a subsequent operation to continue the operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html\">Working with Queries</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
       }
@@ -1993,6 +1993,8 @@
       "base": "<p>Represents the settings used to enable server-side encryption.</p>",
       "refs": {
         "CreateTableInput$SSESpecification": "<p>Represents the settings used to enable server-side encryption.</p>",
+        "RestoreTableFromBackupInput$SSESpecificationOverride": "<p>The new server-side encryption settings for the restored table.</p>",
+        "RestoreTableToPointInTimeInput$SSESpecificationOverride": "<p>The new server-side encryption settings for the restored table.</p>",
         "UpdateTableInput$SSESpecification": "<p>The new server-side encryption settings for the specified table.</p>"
       }
     },
@@ -2125,6 +2127,7 @@
       "refs": {
         "BackupSummary$TableArn": "<p>ARN associated with the table.</p>",
         "RestoreSummary$SourceTableArn": "<p>The ARN of the source table of the backup that is being restored.</p>",
+        "RestoreTableToPointInTimeInput$SourceTableArn": "<p>The DynamoDB table that will be restored. This value is an Amazon Resource Name (ARN).</p>",
         "SourceTableDetails$TableArn": "<p>ARN of the table for which backup was created. </p>"
       }
     },

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -12252,7 +12252,13 @@ type ListGlobalTablesInput struct {
 	// The first global table name that this operation will evaluate.
 	ExclusiveStartGlobalTableName *string `min:"3" type:"string"`
 
-	// The maximum number of table names to return.
+	// The maximum number of table names to return, if the parameter is not specified
+	// DynamoDB defaults to 100.
+	//
+	// If the number of global tables DynamoDB finds reaches this limit, it stops
+	// the operation and returns the table names collected up to that point, with
+	// a table name in the LastEvaluatedGlobalTableName to apply in a subsequent
+	// operation to the ExclusiveStartGlobalTableName parameter.
 	Limit *int64 `min:"1" type:"integer"`
 
 	// Lists the global tables in a specific Region.
@@ -15504,6 +15510,9 @@ type RestoreTableFromBackupInput struct {
 	// Provisioned throughput settings for the restored table.
 	ProvisionedThroughputOverride *ProvisionedThroughput `type:"structure"`
 
+	// The new server-side encryption settings for the restored table.
+	SSESpecificationOverride *SSESpecification `type:"structure"`
+
 	// The name of the new table to which the backup must be restored.
 	//
 	// TargetTableName is a required field
@@ -15597,6 +15606,12 @@ func (s *RestoreTableFromBackupInput) SetProvisionedThroughputOverride(v *Provis
 	return s
 }
 
+// SetSSESpecificationOverride sets the SSESpecificationOverride field's value.
+func (s *RestoreTableFromBackupInput) SetSSESpecificationOverride(v *SSESpecification) *RestoreTableFromBackupInput {
+	s.SSESpecificationOverride = v
+	return s
+}
+
 // SetTargetTableName sets the TargetTableName field's value.
 func (s *RestoreTableFromBackupInput) SetTargetTableName(v string) *RestoreTableFromBackupInput {
 	s.TargetTableName = &v
@@ -15648,10 +15663,15 @@ type RestoreTableToPointInTimeInput struct {
 	// Time in the past to restore the table to.
 	RestoreDateTime *time.Time `type:"timestamp"`
 
+	// The new server-side encryption settings for the restored table.
+	SSESpecificationOverride *SSESpecification `type:"structure"`
+
+	// The DynamoDB table that will be restored. This value is an Amazon Resource
+	// Name (ARN).
+	SourceTableArn *string `type:"string"`
+
 	// Name of the source table that is being restored.
-	//
-	// SourceTableName is a required field
-	SourceTableName *string `min:"3" type:"string" required:"true"`
+	SourceTableName *string `min:"3" type:"string"`
 
 	// The name of the new table to which it must be restored to.
 	//
@@ -15676,9 +15696,6 @@ func (s RestoreTableToPointInTimeInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *RestoreTableToPointInTimeInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "RestoreTableToPointInTimeInput"}
-	if s.SourceTableName == nil {
-		invalidParams.Add(request.NewErrParamRequired("SourceTableName"))
-	}
 	if s.SourceTableName != nil && len(*s.SourceTableName) < 3 {
 		invalidParams.Add(request.NewErrParamMinLen("SourceTableName", 3))
 	}
@@ -15747,6 +15764,18 @@ func (s *RestoreTableToPointInTimeInput) SetProvisionedThroughputOverride(v *Pro
 // SetRestoreDateTime sets the RestoreDateTime field's value.
 func (s *RestoreTableToPointInTimeInput) SetRestoreDateTime(v time.Time) *RestoreTableToPointInTimeInput {
 	s.RestoreDateTime = &v
+	return s
+}
+
+// SetSSESpecificationOverride sets the SSESpecificationOverride field's value.
+func (s *RestoreTableToPointInTimeInput) SetSSESpecificationOverride(v *SSESpecification) *RestoreTableToPointInTimeInput {
+	s.SSESpecificationOverride = v
+	return s
+}
+
+// SetSourceTableArn sets the SourceTableArn field's value.
+func (s *RestoreTableToPointInTimeInput) SetSourceTableArn(v string) *RestoreTableToPointInTimeInput {
+	s.SourceTableArn = &v
 	return s
 }
 


### PR DESCRIPTION
Amazon DynamoDB enables you to restore your DynamoDB backup or table data across AWS Regions such that the restored table is created in a different AWS Region from where the source table or backup resides. You can do cross-region restores between AWS commercial Regions, AWS China Regions, and AWS GovCloud (US) Regions.