### PR TITLE
SharedCredsProvider: Expire using aws_session_expiration

### DIFF
--- a/aws/credentials/example.ini
+++ b/aws/credentials/example.ini
@@ -10,3 +10,21 @@ aws_secret_access_key = secret
 [with_colon]
 aws_access_key_id: accessKey
 aws_secret_access_key: secret
+
+[expired]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret
+aws_session_token = token
+aws_session_expiration = 1990-01-01T00:00:00.000Z
+
+[not_expired]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret
+aws_session_token = token
+aws_session_expiration = 2200-01-01T00:00:00.000Z
+
+[invalid_expiration]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret
+aws_session_token = token
+aws_session_expiration = 2200-01-01T00:00:00.000Z

--- a/aws/credentials/shared_credentials_provider_test.go
+++ b/aws/credentials/shared_credentials_provider_test.go
@@ -50,6 +50,54 @@ func TestSharedCredentialsProviderIsExpired(t *testing.T) {
 	}
 }
 
+func TestSharedCredentialsProviderIsExpiredSessionExpired(t *testing.T) {
+	restoreEnvFn := sdktesting.StashEnv()
+	defer restoreEnvFn()
+
+	p := SharedCredentialsProvider{Filename: "example.ini", Profile: "expired"}
+	_, err := p.Retrieve()
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+
+	if !p.IsExpired() {
+		t.Errorf("Expect creds to be expired, when aws_session_expiration is in the past")
+	}
+}
+
+func TestSharedCredentialsProviderIsExpiredSessionNotExpired(t *testing.T) {
+	restoreEnvFn := sdktesting.StashEnv()
+	defer restoreEnvFn()
+
+	p := SharedCredentialsProvider{Filename: "example.ini", Profile: "not_expired"}
+	_, err := p.Retrieve()
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+
+	if p.IsExpired() {
+		t.Errorf("Expect creds to not be expired, when aws_session_expiration is in the future")
+	}
+}
+
+func TestSharedCredentialsProviderIsExpiredInvalidExpiration(t *testing.T) {
+	restoreEnvFn := sdktesting.StashEnv()
+	defer restoreEnvFn()
+
+	p := SharedCredentialsProvider{Filename: "example.ini", Profile: "invalid_expiration"}
+	_, err := p.Retrieve()
+
+	if err != nil {
+		t.Errorf("expect nil, got %v", err)
+	}
+
+	if p.IsExpired() {
+		t.Errorf("Expect creds to not be expired after retrieve (same behavior as missing expiration)")
+	}
+}
+
 func TestSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) {
 	restoreEnvFn := sdktesting.StashEnv()
 	defer restoreEnvFn()


### PR DESCRIPTION
Resolves #3163 

Load the session expiration time from the AWS credentials/config file, and use to answer `SharedCredentialsProvider.IsExpired()`. 

If the expiration time is missing or unparseable, defaults to current behavior (marks as not expired if the credentials have been previously loaded successfully).