### PR TITLE
Docs: Clarifying token usage in NewStaticCredentials

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### SDK Features
 
 ### SDK Enhancements
+* `aws/credentials`: Clarify `token` usage in `NewStaticCredentials` documentation.
+    * Related to [#3162](https://github.com/aws/aws-sdk-go/issues/3162).
 
 ### SDK Bugs

--- a/aws/credentials/static_provider.go
+++ b/aws/credentials/static_provider.go
@@ -19,7 +19,9 @@ type StaticProvider struct {
 }
 
 // NewStaticCredentials returns a pointer to a new Credentials object
-// wrapping a static credentials value provider.
+// wrapping a static credentials value provider. Token is only required
+// for temporary security credentials retrieved via STS, otherwise an empty
+// string can be passed for this parameter.
 func NewStaticCredentials(id, secret, token string) *Credentials {
 	return NewCredentials(&StaticProvider{Value: Value{
 		AccessKeyID:     id,


### PR DESCRIPTION
Updating documentation for NewStaticCredentials to specify when the `token` parameter should be populated.

Fixes #3162 
