### PR TITLE
aws/session: Support Shared Config Role Duration Config Option

### DIFF
--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -3,6 +3,7 @@ package session
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -206,7 +207,14 @@ func credsFromAssumeRole(cfg aws.Config,
 		sharedCfg.RoleARN,
 		func(opt *stscreds.AssumeRoleProvider) {
 			opt.RoleSessionName = sharedCfg.RoleSessionName
-			opt.Duration = sessOpts.AssumeRoleDuration
+
+			if sessOpts.AssumeRoleDuration == 0 &&
+				sharedCfg.RoleDurationSeconds != nil &&
+				*sharedCfg.RoleDurationSeconds/time.Minute > 15 {
+				opt.Duration = *sharedCfg.RoleDurationSeconds
+			} else if sessOpts.AssumeRoleDuration != 0 {
+				opt.Duration = sessOpts.AssumeRoleDuration
+			}
 
 			// Assume role with external ID
 			if len(sharedCfg.ExternalID) > 0 {

--- a/aws/session/credentials.go
+++ b/aws/session/credentials.go
@@ -209,9 +209,9 @@ func credsFromAssumeRole(cfg aws.Config,
 			opt.RoleSessionName = sharedCfg.RoleSessionName
 
 			if sessOpts.AssumeRoleDuration == 0 &&
-				sharedCfg.RoleDurationSeconds != nil &&
-				*sharedCfg.RoleDurationSeconds/time.Minute > 15 {
-				opt.Duration = *sharedCfg.RoleDurationSeconds
+				sharedCfg.AssumeRoleDuration != nil &&
+				*sharedCfg.AssumeRoleDuration/time.Minute > 15 {
+				opt.Duration = *sharedCfg.AssumeRoleDuration
 			} else if sessOpts.AssumeRoleDuration != 0 {
 				opt.Duration = sessOpts.AssumeRoleDuration
 			}

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -75,11 +75,11 @@ type sharedConfig struct {
 	CredentialProcess    string
 	WebIdentityTokenFile string
 
-	RoleARN             string
-	RoleSessionName     string
-	ExternalID          string
-	MFASerial           string
-	RoleDurationSeconds *time.Duration
+	RoleARN            string
+	RoleSessionName    string
+	ExternalID         string
+	MFASerial          string
+	AssumeRoleDuration *time.Duration
 
 	SourceProfileName string
 	SourceProfile     *sharedConfig
@@ -279,7 +279,7 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 
 		if section.Has(roleDurationSecondsKey) {
 			d := time.Duration(section.Int(roleDurationSecondsKey)) * time.Second
-			cfg.RoleDurationSeconds = &d
+			cfg.AssumeRoleDuration = &d
 		}
 
 		if v := section.String(stsRegionalEndpointSharedKey); len(v) != 0 {

--- a/aws/session/shared_config.go
+++ b/aws/session/shared_config.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -16,12 +17,13 @@ const (
 	sessionTokenKey = `aws_session_token`     // optional
 
 	// Assume Role Credentials group
-	roleArnKey          = `role_arn`          // group required
-	sourceProfileKey    = `source_profile`    // group required (or credential_source)
-	credentialSourceKey = `credential_source` // group required (or source_profile)
-	externalIDKey       = `external_id`       // optional
-	mfaSerialKey        = `mfa_serial`        // optional
-	roleSessionNameKey  = `role_session_name` // optional
+	roleArnKey             = `role_arn`          // group required
+	sourceProfileKey       = `source_profile`    // group required (or credential_source)
+	credentialSourceKey    = `credential_source` // group required (or source_profile)
+	externalIDKey          = `external_id`       // optional
+	mfaSerialKey           = `mfa_serial`        // optional
+	roleSessionNameKey     = `role_session_name` // optional
+	roleDurationSecondsKey = "duration_seconds"  // optional
 
 	// CSM options
 	csmEnabledKey  = `csm_enabled`
@@ -73,10 +75,11 @@ type sharedConfig struct {
 	CredentialProcess    string
 	WebIdentityTokenFile string
 
-	RoleARN         string
-	RoleSessionName string
-	ExternalID      string
-	MFASerial       string
+	RoleARN             string
+	RoleSessionName     string
+	ExternalID          string
+	MFASerial           string
+	RoleDurationSeconds *time.Duration
 
 	SourceProfileName string
 	SourceProfile     *sharedConfig
@@ -273,6 +276,11 @@ func (cfg *sharedConfig) setFromIniFile(profile string, file sharedConfigFile, e
 		updateString(&cfg.SourceProfileName, section, sourceProfileKey)
 		updateString(&cfg.CredentialSource, section, credentialSourceKey)
 		updateString(&cfg.Region, section, regionKey)
+
+		if section.Has(roleDurationSecondsKey) {
+			d := time.Duration(section.Int(roleDurationSecondsKey)) * time.Second
+			cfg.RoleDurationSeconds = &d
+		}
 
 		if v := section.String(stsRegionalEndpointSharedKey); len(v) != 0 {
 			sre, err := endpoints.GetSTSRegionalEndpoint(v)

--- a/aws/session/testdata/shared_config
+++ b/aws/session/testdata/shared_config
@@ -60,6 +60,24 @@ role_session_name = assume_role_w_creds_session_name
 aws_access_key_id = assume_role_w_creds_akid
 aws_secret_access_key = assume_role_w_creds_secret
 
+[assume_role_w_creds_w_duration]
+role_arn = assume_role_w_creds_role_arn
+source_profile = assume_role_w_creds_w_duration
+duration_seconds = 1800
+external_id = 1234
+role_session_name = assume_role_w_creds_session_name
+aws_access_key_id = assume_role_w_creds_akid
+aws_secret_access_key = assume_role_w_creds_secret
+
+[assume_role_w_creds_w_invalid_duration]
+role_arn = assume_role_w_creds_role_arn
+source_profile = assume_role_w_creds_w_invalid_duration
+duration_seconds = 600
+external_id = 1234
+role_session_name = assume_role_w_creds_session_name
+aws_access_key_id = assume_role_w_creds_akid
+aws_secret_access_key = assume_role_w_creds_secret
+
 [assume_role_wo_creds]
 role_arn = assume_role_wo_creds_role_arn
 source_profile = assume_role_wo_creds


### PR DESCRIPTION
Adds support for the `duration_seconds` shared config option for assume role credential provider.